### PR TITLE
feat: app shell + NavigationSection enum + sidebar navigation

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -14,11 +14,7 @@ struct ContentView: View {
             }
             .navigationSplitViewColumnWidth(min: 200, ideal: 220)
         } detail: {
-            if let section = selectedSection {
-                PlaceholderDetailView(section: section)
-            } else {
-                PlaceholderDetailView(section: .smartScan)
-            }
+            PlaceholderDetailView(section: selectedSection ?? .smartScan)
         }
         .frame(minWidth: 900, minHeight: 600)
     }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -1,13 +1,46 @@
 // ContentView.swift
-// Root view placeholder — will be replaced with full sidebar navigation in Prompt 2.
+// Root view — NavigationSplitView with sidebar listing all 11 sections and placeholder detail views.
 
 import SwiftUI
 
 struct ContentView: View {
+    @State private var selectedSection: NavigationSection? = .smartScan
+
     var body: some View {
-        Text("VaderCleaner")
-            .font(.largeTitle)
-            .padding()
+        NavigationSplitView {
+            List(NavigationSection.allCases, selection: $selectedSection) { section in
+                Label(section.title, systemImage: section.icon)
+                    .tag(section)
+            }
+            .navigationSplitViewColumnWidth(min: 200, ideal: 220)
+        } detail: {
+            if let section = selectedSection {
+                PlaceholderDetailView(section: section)
+            } else {
+                PlaceholderDetailView(section: .smartScan)
+            }
+        }
+        .frame(minWidth: 900, minHeight: 600)
+    }
+}
+
+private struct PlaceholderDetailView: View {
+    let section: NavigationSection
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: section.icon)
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(section.title)
+                .font(.title2)
+                .fontWeight(.semibold)
+            Text("Coming Soon")
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle(section.title)
     }
 }
 

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-enum NavigationSection: String, CaseIterable, Hashable, Identifiable {
+enum NavigationSection: CaseIterable, Hashable, Identifiable {
     case smartScan
     case systemJunk
     case largeOldFiles
@@ -20,17 +20,17 @@ enum NavigationSection: String, CaseIterable, Hashable, Identifiable {
 
     var title: String {
         switch self {
-        case .smartScan:       return "Smart Scan"
-        case .systemJunk:      return "System Junk"
-        case .largeOldFiles:   return "Large & Old Files"
-        case .spaceLens:       return "Space Lens"
-        case .malwareRemoval:  return "Malware Removal"
-        case .privacy:         return "Privacy"
-        case .extensions:      return "Extensions"
-        case .appUninstaller:  return "App Uninstaller"
-        case .appUpdater:      return "App Updater"
-        case .optimization:    return "Optimization"
-        case .healthMonitor:   return "Health Monitor"
+        case .smartScan:       return String(localized: "Smart Scan")
+        case .systemJunk:      return String(localized: "System Junk")
+        case .largeOldFiles:   return String(localized: "Large & Old Files")
+        case .spaceLens:       return String(localized: "Space Lens")
+        case .malwareRemoval:  return String(localized: "Malware Removal")
+        case .privacy:         return String(localized: "Privacy")
+        case .extensions:      return String(localized: "Extensions")
+        case .appUninstaller:  return String(localized: "App Uninstaller")
+        case .appUpdater:      return String(localized: "App Updater")
+        case .optimization:    return String(localized: "Optimization")
+        case .healthMonitor:   return String(localized: "Health Monitor")
         }
     }
 

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -1,0 +1,52 @@
+// NavigationSection.swift
+// Defines the sidebar navigation sections for the VaderCleaner app.
+
+import Foundation
+
+enum NavigationSection: String, CaseIterable, Hashable, Identifiable {
+    case smartScan
+    case systemJunk
+    case largeOldFiles
+    case spaceLens
+    case malwareRemoval
+    case privacy
+    case extensions
+    case appUninstaller
+    case appUpdater
+    case optimization
+    case healthMonitor
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .smartScan:       return "Smart Scan"
+        case .systemJunk:      return "System Junk"
+        case .largeOldFiles:   return "Large & Old Files"
+        case .spaceLens:       return "Space Lens"
+        case .malwareRemoval:  return "Malware Removal"
+        case .privacy:         return "Privacy"
+        case .extensions:      return "Extensions"
+        case .appUninstaller:  return "App Uninstaller"
+        case .appUpdater:      return "App Updater"
+        case .optimization:    return "Optimization"
+        case .healthMonitor:   return "Health Monitor"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .smartScan:       return "sparkles"
+        case .systemJunk:      return "trash"
+        case .largeOldFiles:   return "doc.text.magnifyingglass"
+        case .spaceLens:       return "square.split.2x2"
+        case .malwareRemoval:  return "shield.lefthalf.filled"
+        case .privacy:         return "lock.shield"
+        case .extensions:      return "puzzlepiece.extension"
+        case .appUninstaller:  return "xmark.app"
+        case .appUpdater:      return "arrow.triangle.2.circlepath.circle"
+        case .optimization:    return "gauge.with.needle"
+        case .healthMonitor:   return "heart.text.square"
+        }
+    }
+}

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -24,7 +24,10 @@ final class NavigationSectionTests: XCTestCase {
         }
     }
 
-    func test_eachSection_hasValidSFSymbol() {
+    func test_eachSection_hasValidSFSymbol() throws {
+        guard #available(macOS 14.0, *) else {
+            throw XCTSkip("SF Symbol validation requires macOS 14.0 (the app's minimum deployment target)")
+        }
         for section in NavigationSection.allCases {
             let image = NSImage(systemSymbolName: section.icon, accessibilityDescription: nil)
             XCTAssertNotNil(

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -1,0 +1,36 @@
+// NavigationSectionTests.swift
+// Tests that verify NavigationSection enum structure and SF Symbol validity.
+
+import XCTest
+import AppKit
+@testable import VaderCleaner
+
+final class NavigationSectionTests: XCTestCase {
+
+    func test_allCasesCount_is11() {
+        XCTAssertEqual(NavigationSection.allCases.count, 11)
+    }
+
+    func test_firstCase_isSmartScan() {
+        XCTAssertEqual(NavigationSection.allCases.first, .smartScan)
+    }
+
+    func test_eachSection_hasNonEmptyTitle() {
+        for section in NavigationSection.allCases {
+            XCTAssertFalse(
+                section.title.isEmpty,
+                "Expected non-empty title for section: \(section)"
+            )
+        }
+    }
+
+    func test_eachSection_hasValidSFSymbol() {
+        for section in NavigationSection.allCases {
+            let image = NSImage(systemSymbolName: section.icon, accessibilityDescription: nil)
+            XCTAssertNotNil(
+                image,
+                "Expected valid SF Symbol '\(section.icon)' for section: \(section)"
+            )
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -10,7 +10,7 @@
 ## Phase 0 — Foundation
 
 - [x] **Prompt 1** — Xcode project + XCTest + XCUITest targets + TestHelpers
-- [ ] **Prompt 2** — App shell + NavigationSection enum + sidebar navigation (11 sections)
+- [x] **Prompt 2** — App shell + NavigationSection enum + sidebar navigation (11 sections)
 - [ ] **Prompt 3** — Privileged XPC helper tool (VaderCleanerHelper target + HelperConnectionManager)
 - [ ] **Prompt 4** — Full Disk Access detection + onboarding sheet
 - [ ] **Prompt 5** — Menu bar extra (basic, placeholder stats)


### PR DESCRIPTION
## Summary

- Adds `NavigationSection` enum with all 11 sidebar cases (Smart Scan, System Junk, Large & Old Files, Space Lens, Malware Removal, Privacy, Extensions, App Uninstaller, App Updater, Optimization, Health Monitor)
- Replaces placeholder `ContentView` with a `NavigationSplitView` sidebar layout; each section shows a "Coming Soon" placeholder detail view
- Default selection is Smart Scan; minimum window size is 900×600
- Adds `NavigationSectionTests` with 4 tests (case count, first case, non-empty titles, valid SF Symbols)

## Test plan

- [x] `test_allCasesCount_is11` — passes
- [x] `test_firstCase_isSmartScan` — passes
- [x] `test_eachSection_hasNonEmptyTitle` — passes
- [x] `test_eachSection_hasValidSFSymbol` — passes
- [x] All 14 existing `TestHelpersTests` continue to pass
- [x] App builds without errors (`BUILD SUCCEEDED`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar navigation with entries for Smart Scan, System Junk, Large & Old Files, Space Lens, Malware Removal, Privacy, Extensions, App Uninstaller, App Updater, Optimization, and Health Monitor.
  * Introduced a split-view layout and a placeholder detail view with “Coming Soon” messaging and improved minimum window sizing.

* **Tests**
  * Added tests validating navigation entries, titles, and associated icons.

* **Chores**
  * Updated project task status in the todo file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->