### PR TITLE
Privileged XPC helper tool

### DIFF
--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -1,0 +1,41 @@
+// HelperProtocol.swift
+// Shared @objc XPC protocol and mach service name used by both VaderCleaner and VaderCleanerHelper.
+
+import Foundation
+
+/// The mach service name used by both ends of the XPC connection.
+/// Must match the launchd plist `MachServices` key, the helper's NSXPCListener,
+/// and the app's NSXPCConnection. Defined here as the single source of truth.
+let kHelperMachServiceName = "com.personal.VaderCleaner.helper"
+
+/// XPC protocol implemented by VaderCleanerHelper and consumed by the main app.
+///
+/// All methods are reply-block based — NSXPCConnection requires @objc protocols
+/// and the standard async pattern is `(reply: @escaping (Error?) -> Void)`.
+/// Selectors are declared explicitly with @objc(...) so that runtime checks and
+/// the helper's listener delegate match exactly without depending on Swift's
+/// implicit selector mangling rules.
+@objc(VaderCleanerHelperProtocol)
+protocol VaderCleanerHelperProtocol {
+
+    /// Removes the files at the given absolute paths.
+    /// Reports the first error encountered (if any) via the reply block.
+    @objc(deleteFiles:reply:)
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void)
+
+    /// Runs the standard system maintenance scripts: `periodic daily weekly monthly`.
+    @objc(runMaintenanceScriptsWithReply:)
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void)
+
+    /// Removes the file at the given login-item path (typically a launch agent plist).
+    @objc(removeLoginItemAtPath:reply:)
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void)
+
+    /// Removes the launch agent plist at the given path.
+    @objc(removeLaunchAgentAtPath:reply:)
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void)
+
+    /// Frees inactive memory by invoking the system `purge` command.
+    @objc(flushInactiveMemoryWithReply:)
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void)
+}

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -8,6 +8,19 @@ import Foundation
 /// and the app's NSXPCConnection. Defined here as the single source of truth.
 let kHelperMachServiceName = "com.personal.VaderCleaner.helper"
 
+/// Code-signing requirement applied by the helper to incoming XPC connections.
+/// Restricts the privileged interface to processes whose code-signing identifier
+/// matches the main app's bundle identifier. Without this guard, any local process
+/// that can reach the mach service name would be able to invoke privileged ops.
+///
+/// Production hardening: append `and certificate leaf[subject.OU] = "TEAMID"`
+/// once a Developer ID team is wired up so that ad-hoc-signed impostors are rejected.
+let kHelperClientCodeSigningRequirement = "identifier \"com.personal.VaderCleaner\""
+
+/// Code-signing requirement applied by the app to the helper connection — the
+/// symmetric check that protects the app from a substituted helper binary.
+let kHelperServerCodeSigningRequirement = "identifier \"com.personal.VaderCleaner.helper\""
+
 /// XPC protocol implemented by VaderCleanerHelper and consumed by the main app.
 ///
 /// All methods are reply-block based — NSXPCConnection requires @objc protocols

--- a/VaderCleaner/HelperConnectionManager.swift
+++ b/VaderCleaner/HelperConnectionManager.swift
@@ -36,11 +36,28 @@ final class HelperConnectionManager {
             }
             let new = NSXPCConnection(machServiceName: kHelperMachServiceName, options: .privileged)
             new.remoteObjectInterface = NSXPCInterface(with: VaderCleanerHelperProtocol.self)
-            new.invalidationHandler = { [weak self] in
-                self?.handleInvalidation()
+            // Reject any helper whose code-signing identity does not match — protects
+            // the app from a substituted/swapped binary at the same mach service name.
+            try? new.setCodeSigningRequirement(kHelperServerCodeSigningRequirement)
+            // Capture the connection's identity in the handler. If invalidate() runs
+            // and a new connect() races ahead before the stale handler fires, the
+            // identity check below prevents the stale handler from clearing the new
+            // connection. queue.async (not sync) avoids re-entrancy if the XPC runtime
+            // dispatches the handler synchronously while invalidate() is mid-flight.
+            new.invalidationHandler = { [weak self, weak new] in
+                guard let self, let conn = new else { return }
+                os_log("Helper XPC connection invalidated", log: self.log, type: .info)
+                self.queue.async {
+                    if self.connection === conn { self.connection = nil }
+                }
             }
-            new.interruptionHandler = { [weak self] in
-                self?.handleInterruption()
+            new.interruptionHandler = { [weak self, weak new] in
+                guard let self, let conn = new else { return }
+                os_log("Helper XPC connection interrupted; will reconnect on next use",
+                       log: self.log, type: .info)
+                self.queue.async {
+                    if self.connection === conn { self.connection = nil }
+                }
             }
             new.resume()
             connection = new
@@ -65,13 +82,4 @@ final class HelperConnectionManager {
         }
     }
 
-    private func handleInvalidation() {
-        os_log("Helper XPC connection invalidated", log: log, type: .info)
-        queue.sync { connection = nil }
-    }
-
-    private func handleInterruption() {
-        os_log("Helper XPC connection interrupted; will reconnect on next use", log: log, type: .info)
-        queue.sync { connection = nil }
-    }
 }

--- a/VaderCleaner/HelperConnectionManager.swift
+++ b/VaderCleaner/HelperConnectionManager.swift
@@ -1,0 +1,77 @@
+// HelperConnectionManager.swift
+// Singleton that owns the NSXPCConnection to VaderCleanerHelper and exposes a typed proxy.
+
+import Foundation
+import os.log
+
+/// Manages the lifecycle of the privileged XPC connection to VaderCleanerHelper.
+///
+/// MANUAL CODESIGN STEP (required for the helper daemon to actually run):
+///
+///     codesign --force --sign - --identifier com.personal.VaderCleaner.helper \
+///       "$BUILT_PRODUCTS_DIR/VaderCleaner.app/Contents/MacOS/VaderCleanerHelper"
+///     codesign --force --sign - "$BUILT_PRODUCTS_DIR/VaderCleaner.app"
+///
+/// SMAppService.daemon().register() throws errSecCSUnsigned without ad-hoc signatures.
+/// Failures are logged via os_log and do not crash the app — the architecture lives
+/// regardless, but XPC calls will return connection errors until signing is in place.
+final class HelperConnectionManager {
+
+    static let shared = HelperConnectionManager()
+
+    private let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "HelperConnection")
+    private var connection: NSXPCConnection?
+    private let queue = DispatchQueue(label: "com.personal.VaderCleaner.helper-connection")
+
+    private init() {}
+
+    /// Returns the active NSXPCConnection, lazily constructing it on first use.
+    /// Idempotent — subsequent calls return the same connection until invalidate() is called
+    /// or the remote process invalidates the connection.
+    @discardableResult
+    func connect() -> NSXPCConnection {
+        queue.sync {
+            if let existing = connection {
+                return existing
+            }
+            let new = NSXPCConnection(machServiceName: kHelperMachServiceName, options: .privileged)
+            new.remoteObjectInterface = NSXPCInterface(with: VaderCleanerHelperProtocol.self)
+            new.invalidationHandler = { [weak self] in
+                self?.handleInvalidation()
+            }
+            new.interruptionHandler = { [weak self] in
+                self?.handleInterruption()
+            }
+            new.resume()
+            connection = new
+            return new
+        }
+    }
+
+    /// Returns a synchronous proxy to the helper. The errorHandler is invoked when
+    /// the underlying XPC call fails (e.g. when the daemon is not registered).
+    func helper(errorHandler: @escaping (Error) -> Void) -> VaderCleanerHelperProtocol? {
+        let proxy = connect().remoteObjectProxyWithErrorHandler { error in
+            errorHandler(error)
+        }
+        return proxy as? VaderCleanerHelperProtocol
+    }
+
+    /// Tears down the cached connection. Subsequent connect() calls will build a new one.
+    func invalidate() {
+        queue.sync {
+            connection?.invalidate()
+            connection = nil
+        }
+    }
+
+    private func handleInvalidation() {
+        os_log("Helper XPC connection invalidated", log: log, type: .info)
+        queue.sync { connection = nil }
+    }
+
+    private func handleInterruption() {
+        os_log("Helper XPC connection interrupted; will reconnect on next use", log: log, type: .info)
+        queue.sync { connection = nil }
+    }
+}

--- a/VaderCleaner/HelperRegistration.swift
+++ b/VaderCleaner/HelperRegistration.swift
@@ -18,6 +18,13 @@ enum HelperRegistration {
 
     static func registerIfNeeded() {
         let service = SMAppService.daemon(plistName: plistName)
+        // Skip if already registered — register() throws when the service is already
+        // enabled, which would generate noise in Console on every launch.
+        guard service.status != .enabled else {
+            os_log("Helper daemon already registered (status=%{public}@)",
+                   log: log, type: .debug, String(describing: service.status))
+            return
+        }
         do {
             try service.register()
             os_log("Registered helper daemon (status=%{public}@)",

--- a/VaderCleaner/HelperRegistration.swift
+++ b/VaderCleaner/HelperRegistration.swift
@@ -1,0 +1,30 @@
+// HelperRegistration.swift
+// Registers VaderCleanerHelper as a privileged daemon via SMAppService at app launch.
+
+import Foundation
+import ServiceManagement
+import os.log
+
+/// Registers the VaderCleanerHelper daemon with launchd via SMAppService.
+///
+/// Registration requires the helper executable and the host app to be code-signed —
+/// see HelperConnectionManager for the manual ad-hoc signing step in development.
+/// Failures are logged but do not propagate; the app continues to run normally and
+/// the helper simply remains unavailable until signing is in place.
+enum HelperRegistration {
+
+    private static let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "HelperRegistration")
+    private static let plistName = "com.personal.VaderCleaner.helper.plist"
+
+    static func registerIfNeeded() {
+        let service = SMAppService.daemon(plistName: plistName)
+        do {
+            try service.register()
+            os_log("Registered helper daemon (status=%{public}@)",
+                   log: log, type: .info, String(describing: service.status))
+        } catch {
+            os_log("Helper daemon registration failed: %{public}@",
+                   log: log, type: .error, String(describing: error))
+        }
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -5,6 +5,10 @@ import SwiftUI
 
 @main
 struct VaderCleanerApp: App {
+    init() {
+        HelperRegistration.registerIfNeeded()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/VaderCleanerHelper/com.personal.VaderCleaner.helper.plist
+++ b/VaderCleanerHelper/com.personal.VaderCleaner.helper.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  com.personal.VaderCleaner.helper.plist
+  launchd configuration for the VaderCleaner privileged XPC daemon. Embedded into the app
+  bundle at Contents/Library/LaunchDaemons/ and registered via SMAppService.daemon().
+
+  IMPORTANT — manual codesigning step (development):
+    The daemon will not register or launch unless both the helper executable and the host
+    app are code-signed (an ad-hoc signature is sufficient locally). With CODE_SIGNING_REQUIRED
+    set to NO in project.yml, builds produce unsigned binaries — sign them after each build:
+
+      codesign --force --sign - --identifier com.personal.VaderCleaner.helper \
+        "$BUILT_PRODUCTS_DIR/VaderCleaner.app/Contents/MacOS/VaderCleanerHelper"
+      codesign --force --sign - "$BUILT_PRODUCTS_DIR/VaderCleaner.app"
+
+    Without this, SMAppService.daemon().register() throws errSecCSUnsigned. The failure
+    is logged but does not crash the app.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.personal.VaderCleaner.helper</string>
+    <key>BundleProgram</key>
+    <string>Contents/MacOS/VaderCleanerHelper</string>
+    <key>MachServices</key>
+    <dict>
+        <key>com.personal.VaderCleaner.helper</key>
+        <true/>
+    </dict>
+    <key>AssociatedBundleIdentifiers</key>
+    <array>
+        <string>com.personal.VaderCleaner</string>
+    </array>
+</dict>
+</plist>

--- a/VaderCleanerHelper/main.swift
+++ b/VaderCleanerHelper/main.swift
@@ -1,0 +1,89 @@
+// main.swift
+// Entry point for VaderCleanerHelper — the privileged XPC daemon that performs root-level operations.
+
+import Foundation
+
+/// NSXPCListener delegate that vends a HelperService for each new XPC connection
+/// and implements the privileged operations defined in VaderCleanerHelperProtocol.
+final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperProtocol {
+
+    // MARK: - NSXPCListenerDelegate
+
+    func listener(
+        _ listener: NSXPCListener,
+        shouldAcceptNewConnection newConnection: NSXPCConnection
+    ) -> Bool {
+        newConnection.exportedInterface = NSXPCInterface(with: VaderCleanerHelperProtocol.self)
+        newConnection.exportedObject = self
+        newConnection.resume()
+        return true
+    }
+
+    // MARK: - VaderCleanerHelperProtocol
+
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
+        let fileManager = FileManager.default
+        for path in paths {
+            do {
+                try fileManager.removeItem(atPath: path)
+            } catch {
+                reply(error)
+                return
+            }
+        }
+        reply(nil)
+    }
+
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {
+        runProcess(
+            launchPath: "/usr/sbin/periodic",
+            arguments: ["daily", "weekly", "monthly"],
+            reply: reply
+        )
+    }
+
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {
+        deleteFiles([path], reply: reply)
+    }
+
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {
+        deleteFiles([path], reply: reply)
+    }
+
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) {
+        runProcess(launchPath: "/usr/sbin/purge", arguments: [], reply: reply)
+    }
+
+    // MARK: - Private
+
+    private func runProcess(
+        launchPath: String,
+        arguments: [String],
+        reply: @escaping (Error?) -> Void
+    ) {
+        let process = Process()
+        process.launchPath = launchPath
+        process.arguments = arguments
+        do {
+            try process.run()
+            process.waitUntilExit()
+            if process.terminationStatus != 0 {
+                reply(NSError(
+                    domain: "com.personal.VaderCleaner.helper",
+                    code: Int(process.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: "\(launchPath) exited with status \(process.terminationStatus)"]
+                ))
+                return
+            }
+            reply(nil)
+        } catch {
+            reply(error)
+        }
+    }
+}
+
+let delegate = HelperService()
+let listener = NSXPCListener(machServiceName: kHelperMachServiceName)
+listener.delegate = delegate
+listener.resume()
+RunLoop.current.run()

--- a/VaderCleanerHelper/main.swift
+++ b/VaderCleanerHelper/main.swift
@@ -13,6 +13,15 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
         _ listener: NSXPCListener,
         shouldAcceptNewConnection newConnection: NSXPCConnection
     ) -> Bool {
+        // Reject any caller whose code-signing identity does not match the main app.
+        // Without this check, any local process able to reach the mach service name could
+        // invoke privileged operations (file deletion, /usr/sbin/purge, periodic scripts).
+        // setCodeSigningRequirement is macOS 13+ — well within the macOS 14.0 deployment target.
+        do {
+            try newConnection.setCodeSigningRequirement(kHelperClientCodeSigningRequirement)
+        } catch {
+            return false
+        }
         newConnection.exportedInterface = NSXPCInterface(with: VaderCleanerHelperProtocol.self)
         newConnection.exportedObject = self
         newConnection.resume()
@@ -23,20 +32,20 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
 
     func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
         let fileManager = FileManager.default
+        var firstError: Error?
         for path in paths {
             do {
                 try fileManager.removeItem(atPath: path)
             } catch {
-                reply(error)
-                return
+                if firstError == nil { firstError = error }
             }
         }
-        reply(nil)
+        reply(firstError)
     }
 
     func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {
         runProcess(
-            launchPath: "/usr/sbin/periodic",
+            executable: "/usr/sbin/periodic",
             arguments: ["daily", "weekly", "monthly"],
             reply: reply
         )
@@ -51,18 +60,18 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
     }
 
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) {
-        runProcess(launchPath: "/usr/sbin/purge", arguments: [], reply: reply)
+        runProcess(executable: "/usr/sbin/purge", arguments: [], reply: reply)
     }
 
     // MARK: - Private
 
     private func runProcess(
-        launchPath: String,
+        executable: String,
         arguments: [String],
         reply: @escaping (Error?) -> Void
     ) {
         let process = Process()
-        process.launchPath = launchPath
+        process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
         do {
             try process.run()
@@ -71,7 +80,7 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
                 reply(NSError(
                     domain: "com.personal.VaderCleaner.helper",
                     code: Int(process.terminationStatus),
-                    userInfo: [NSLocalizedDescriptionKey: "\(launchPath) exited with status \(process.terminationStatus)"]
+                    userInfo: [NSLocalizedDescriptionKey: "\(executable) exited with status \(process.terminationStatus)"]
                 ))
                 return
             }
@@ -86,4 +95,4 @@ let delegate = HelperService()
 let listener = NSXPCListener(machServiceName: kHelperMachServiceName)
 listener.delegate = delegate
 listener.resume()
-RunLoop.current.run()
+dispatchMain()

--- a/VaderCleanerTests/HelperConnectionManagerTests.swift
+++ b/VaderCleanerTests/HelperConnectionManagerTests.swift
@@ -1,0 +1,54 @@
+// HelperConnectionManagerTests.swift
+// Tests that HelperConnectionManager builds an NSXPCConnection wired to the shared mach service name and protocol.
+
+import XCTest
+@testable import VaderCleaner
+
+final class HelperConnectionManagerTests: XCTestCase {
+
+    func test_singleton_isSameInstance() {
+        let first = HelperConnectionManager.shared
+        let second = HelperConnectionManager.shared
+        XCTAssertTrue(first === second, "HelperConnectionManager.shared must return a single instance")
+    }
+
+    func test_connect_returnsConnection_withMatchingMachServiceName() {
+        let manager = HelperConnectionManager.shared
+        let connection = manager.connect()
+        addTeardownBlock { manager.invalidate() }
+        XCTAssertEqual(
+            connection.serviceName,
+            kHelperMachServiceName,
+            "Connection must use the shared mach service name constant"
+        )
+    }
+
+    func test_connect_isIdempotent() {
+        let manager = HelperConnectionManager.shared
+        addTeardownBlock { manager.invalidate() }
+        let first = manager.connect()
+        let second = manager.connect()
+        XCTAssertTrue(first === second, "connect() must reuse the existing connection until invalidated")
+    }
+
+    func test_connect_setsRemoteObjectInterface_toHelperProtocol() {
+        let manager = HelperConnectionManager.shared
+        let connection = manager.connect()
+        addTeardownBlock { manager.invalidate() }
+        let proto = NSProtocolFromString("VaderCleanerHelperProtocol")
+        XCTAssertNotNil(connection.remoteObjectInterface, "remoteObjectInterface must be set before XPC use")
+        XCTAssertTrue(
+            connection.remoteObjectInterface?.protocol === proto,
+            "remoteObjectInterface must wrap VaderCleanerHelperProtocol"
+        )
+    }
+
+    func test_invalidate_clearsCachedConnection() {
+        let manager = HelperConnectionManager.shared
+        let first = manager.connect()
+        manager.invalidate()
+        let second = manager.connect()
+        addTeardownBlock { manager.invalidate() }
+        XCTAssertFalse(first === second, "After invalidate(), connect() must return a new connection")
+    }
+}

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -1,0 +1,41 @@
+// HelperProtocolTests.swift
+// Tests for the shared XPC helper protocol — selector presence, @objc visibility, and mach service constant.
+
+import XCTest
+@testable import VaderCleaner
+
+final class HelperProtocolTests: XCTestCase {
+
+    func test_machServiceName_constant_isCorrect() {
+        XCTAssertEqual(kHelperMachServiceName, "com.personal.VaderCleaner.helper")
+    }
+
+    func test_protocol_isVisibleToObjCRuntime() {
+        // NSXPCConnection requires @objc protocols. NSProtocolFromString resolves them via the
+        // ObjC runtime — a Swift-only protocol would return nil here.
+        let proto = NSProtocolFromString("VaderCleanerHelperProtocol")
+        XCTAssertNotNil(proto, "VaderCleanerHelperProtocol must be @objc to be usable with NSXPCConnection")
+    }
+
+    func test_protocol_hasAllRequiredSelectors() throws {
+        let proto = try XCTUnwrap(NSProtocolFromString("VaderCleanerHelperProtocol"))
+
+        let expectedSelectors = [
+            "deleteFiles:reply:",
+            "runMaintenanceScriptsWithReply:",
+            "removeLoginItemAtPath:reply:",
+            "removeLaunchAgentAtPath:reply:",
+            "flushInactiveMemoryWithReply:"
+        ]
+
+        for selectorName in expectedSelectors {
+            let selector = NSSelectorFromString(selectorName)
+            // protocol_getMethodDescription returns a non-null .name when the selector is required.
+            let description = protocol_getMethodDescription(proto, selector, true, true)
+            XCTAssertNotNil(
+                description.name,
+                "Expected protocol to declare selector '\(selectorName)'"
+            )
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -27,6 +27,16 @@ targets:
       - path: VaderCleaner
         excludes:
           - "**/*.md"
+      - path: Shared
+      - path: VaderCleanerHelper/com.personal.VaderCleaner.helper.plist
+        buildPhase:
+          copyFiles:
+            destination: wrapper
+            subpath: Contents/Library/LaunchDaemons
+    dependencies:
+      - target: VaderCleanerHelper
+        copy:
+          destination: executables
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.personal.VaderCleaner
@@ -47,6 +57,20 @@ targets:
         NSPrincipalClass: NSApplication
         NSSupportsAutomaticTermination: false
         NSSupportsSuddenTermination: false
+
+  VaderCleanerHelper:
+    type: tool
+    platform: macOS
+    sources:
+      - path: VaderCleanerHelper
+        excludes:
+          - "**/*.plist"
+      - path: Shared
+    settings:
+      base:
+        PRODUCT_NAME: VaderCleanerHelper
+        PRODUCT_BUNDLE_IDENTIFIER: com.personal.VaderCleaner.helper
+        SKIP_INSTALL: YES
 
   VaderCleanerTests:
     type: bundle.unit-test

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,7 @@
 
 - [x] **Prompt 1** — Xcode project + XCTest + XCUITest targets + TestHelpers
 - [x] **Prompt 2** — App shell + NavigationSection enum + sidebar navigation (11 sections)
-- [ ] **Prompt 3** — Privileged XPC helper tool (VaderCleanerHelper target + HelperConnectionManager)
+- [x] **Prompt 3** — Privileged XPC helper tool (VaderCleanerHelper target + HelperConnectionManager)
 - [ ] **Prompt 4** — Full Disk Access detection + onboarding sheet
 - [ ] **Prompt 5** — Menu bar extra (basic, placeholder stats)
 - [ ] **Prompt 6** — PreferencesStore + ExclusionsStore + Preferences window (4 tabs)


### PR DESCRIPTION
## Summary

- Establishes the **VaderCleanerHelper** command-line target embedded inside the app at `Contents/MacOS/` and the launchd plist at `Contents/Library/LaunchDaemons/`.
- Adds the shared `@objc(VaderCleanerHelperProtocol)` XPC protocol with 5 reply-block selectors (`deleteFiles`, `runMaintenanceScripts`, `removeLoginItem`, `removeLaunchAgent`, `flushInactiveMemory`) and the `kHelperMachServiceName` constant — single source of truth for both ends.
- `HelperConnectionManager` singleton owns the privileged `NSXPCConnection`, with reconnect on interruption / invalidation.
- `HelperRegistration` invokes `SMAppService.daemon().register()` at app init, wrapped with `try?` + `os_log` so the dev loop is not broken by the unsigned-binary failure (documented trade-off).

Closes #5

## Test plan

- [x] `xcodegen generate` succeeds
- [x] `xcodebuild test` — 26 unit + 1 UI test pass
- [x] HelperProtocol tests verify @objc visibility, all 5 selectors present, mach service name constant
- [x] HelperConnectionManager tests verify singleton identity, idempotent `connect()`, mach service name on connection, remoteObjectInterface wiring, invalidation behavior
- [x] Verified bundle layout: `VaderCleaner.app/Contents/MacOS/VaderCleanerHelper` and `VaderCleaner.app/Contents/Library/LaunchDaemons/com.personal.VaderCleaner.helper.plist` both present
- [x] Confirmed expected `SMAppServiceErrorDomain Code=1 "Operation not permitted"` log on launch (signing required for daemon registration to succeed — documented in `HelperConnectionManager.swift` and the plist header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced privileged helper service that enables elevated-permission operations: file deletion, system maintenance scripts, startup item management, and memory optimization. Helper launches automatically with the app.

* **Tests**
  * Added tests validating helper service configuration, connection management, and protocol compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->