### PR TITLE
Prompt 4 — Full Disk Access detection + onboarding sheet

### DIFF
--- a/VaderCleaner/AppState.swift
+++ b/VaderCleaner/AppState.swift
@@ -10,6 +10,7 @@ import Combine
 ///
 /// The FDA checker is injected as a closure so tests can stub the result without
 /// depending on the host machine's TCC state.
+@MainActor
 final class AppState: ObservableObject {
 
     @Published private(set) var hasFullDiskAccess: Bool

--- a/VaderCleaner/AppState.swift
+++ b/VaderCleaner/AppState.swift
@@ -1,0 +1,29 @@
+// AppState.swift
+// Process-wide observable state — currently tracks Full Disk Access; will accumulate other app-wide flags.
+
+import Foundation
+import Combine
+
+/// Holds app-wide state that views need to observe. Today this is just the cached
+/// Full Disk Access flag; other always-needed flags (notification permission, helper
+/// availability, etc.) will land here as later prompts add them.
+///
+/// The FDA checker is injected as a closure so tests can stub the result without
+/// depending on the host machine's TCC state.
+final class AppState: ObservableObject {
+
+    @Published private(set) var hasFullDiskAccess: Bool
+
+    private let checker: () -> Bool
+
+    init(checker: @escaping () -> Bool = { PrivacyPermissionChecker.hasFullDiskAccess() }) {
+        self.checker = checker
+        self.hasFullDiskAccess = checker()
+    }
+
+    /// Re-runs the FDA check. Called when the app foregrounds (`scenePhase == .active`)
+    /// so that granting access in System Settings reflects without a relaunch.
+    func refresh() {
+        hasFullDiskAccess = checker()
+    }
+}

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -4,6 +4,9 @@
 import SwiftUI
 
 struct ContentView: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var onboarding = PermissionOnboardingViewModel()
+    @Environment(\.scenePhase) private var scenePhase
     @State private var selectedSection: NavigationSection? = .smartScan
 
     var body: some View {
@@ -17,6 +20,27 @@ struct ContentView: View {
             PlaceholderDetailView(section: selectedSection ?? .smartScan)
         }
         .frame(minWidth: 900, minHeight: 600)
+        .sheet(isPresented: shouldShowOnboarding) {
+            PermissionOnboardingView(viewModel: onboarding)
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                appState.refresh()
+            }
+        }
+    }
+
+    /// Shown until either FDA is granted (which the foreground refresh will detect)
+    /// or the user dismisses for the session — either via the explicit "Continue
+    /// Without Access" button or via Esc / programmatic sheet dismissal, both of
+    /// which route through `viewModel.dismiss()` so the sheet stays suppressed.
+    private var shouldShowOnboarding: Binding<Bool> {
+        Binding(
+            get: { !appState.hasFullDiskAccess && !onboarding.isDismissed },
+            set: { newValue in
+                if newValue == false { onboarding.dismiss() }
+            }
+        )
     }
 }
 
@@ -42,4 +66,5 @@ private struct PlaceholderDetailView: View {
 
 #Preview {
     ContentView()
+        .environmentObject(AppState(checker: { true }))
 }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject private var appState: AppState
-    @StateObject private var onboarding = PermissionOnboardingViewModel()
+    @EnvironmentObject private var onboarding: PermissionOnboardingViewModel
     @Environment(\.scenePhase) private var scenePhase
     @State private var selectedSection: NavigationSection? = .smartScan
 
@@ -21,7 +21,9 @@ struct ContentView: View {
         }
         .frame(minWidth: 900, minHeight: 600)
         .sheet(isPresented: shouldShowOnboarding) {
-            PermissionOnboardingView(viewModel: onboarding)
+            PermissionOnboardingView()
+                .environmentObject(appState)
+                .environmentObject(onboarding)
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
@@ -67,4 +69,5 @@ private struct PlaceholderDetailView: View {
 #Preview {
     ContentView()
         .environmentObject(AppState(checker: { true }))
+        .environmentObject(PermissionOnboardingViewModel())
 }

--- a/VaderCleaner/PermissionOnboardingView.swift
+++ b/VaderCleaner/PermissionOnboardingView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 struct PermissionOnboardingView: View {
     @EnvironmentObject private var appState: AppState
-    @ObservedObject var viewModel: PermissionOnboardingViewModel
+    @EnvironmentObject private var viewModel: PermissionOnboardingViewModel
 
     var body: some View {
         VStack(spacing: 20) {
@@ -62,6 +62,7 @@ struct PermissionOnboardingView: View {
 }
 
 #Preview {
-    PermissionOnboardingView(viewModel: PermissionOnboardingViewModel())
+    PermissionOnboardingView()
         .environmentObject(AppState(checker: { false }))
+        .environmentObject(PermissionOnboardingViewModel())
 }

--- a/VaderCleaner/PermissionOnboardingView.swift
+++ b/VaderCleaner/PermissionOnboardingView.swift
@@ -1,0 +1,67 @@
+// PermissionOnboardingView.swift
+// FDA onboarding sheet — explains why VaderCleaner needs Full Disk Access and links to System Settings.
+
+import SwiftUI
+
+struct PermissionOnboardingView: View {
+    @EnvironmentObject private var appState: AppState
+    @ObservedObject var viewModel: PermissionOnboardingViewModel
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "lock.shield")
+                .font(.system(size: 56))
+                .foregroundStyle(.tint)
+
+            Text("Full Disk Access Required")
+                .font(.title)
+                .fontWeight(.semibold)
+
+            Text(
+                "VaderCleaner needs Full Disk Access to scan caches, browser data, " +
+                "Mail attachments, Trash on every volume, and other protected locations. " +
+                "Without it, scans will return empty or incomplete results."
+            )
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Open System Settings", systemImage: "1.circle.fill")
+                Label("Go to Privacy & Security → Full Disk Access", systemImage: "2.circle.fill")
+                Label("Enable VaderCleaner in the list", systemImage: "3.circle.fill")
+                Label("Click Check Again to continue", systemImage: "4.circle.fill")
+            }
+            .font(.callout)
+            .padding()
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+
+            HStack(spacing: 12) {
+                Button("Continue Without Access") {
+                    viewModel.dismiss()
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button("Check Again") {
+                    appState.refresh()
+                }
+                .buttonStyle(.bordered)
+
+                Button("Open System Settings") {
+                    viewModel.openSystemSettings()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(28)
+        .frame(width: 520)
+    }
+}
+
+#Preview {
+    PermissionOnboardingView(viewModel: PermissionOnboardingViewModel())
+        .environmentObject(AppState(checker: { false }))
+}

--- a/VaderCleaner/PermissionOnboardingViewModel.swift
+++ b/VaderCleaner/PermissionOnboardingViewModel.swift
@@ -1,0 +1,32 @@
+// PermissionOnboardingViewModel.swift
+// View-model backing the FDA onboarding sheet — owns dismissal state and the System Settings deep-link.
+
+import Foundation
+import AppKit
+import Combine
+
+/// Drives `PermissionOnboardingView`. Holds the per-session dismissal flag and the URL
+/// that opens the Full Disk Access pane in System Settings.
+///
+/// `systemSettingsURL` is exposed as a static constant so tests can assert the URL
+/// string without having `openSystemSettings()` actually launch System Settings.
+final class PermissionOnboardingViewModel: ObservableObject {
+
+    /// Deep-link to System Settings → Privacy & Security → Full Disk Access.
+    static let systemSettingsURL = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+    )!
+
+    /// Set to `true` when the user chooses "Continue Without Access". Suppresses the
+    /// sheet for the remainder of the session — feature views still surface inline
+    /// FDA prompts where they need access (added in later prompts).
+    @Published var isDismissed: Bool = false
+
+    func dismiss() {
+        isDismissed = true
+    }
+
+    func openSystemSettings() {
+        NSWorkspace.shared.open(Self.systemSettingsURL)
+    }
+}

--- a/VaderCleaner/PermissionOnboardingViewModel.swift
+++ b/VaderCleaner/PermissionOnboardingViewModel.swift
@@ -10,11 +10,16 @@ import Combine
 ///
 /// `systemSettingsURL` is exposed as a static constant so tests can assert the URL
 /// string without having `openSystemSettings()` actually launch System Settings.
+@MainActor
 final class PermissionOnboardingViewModel: ObservableObject {
 
     /// Deep-link to System Settings → Privacy & Security → Full Disk Access.
+    /// Uses the macOS 13+ identifier `com.apple.Settings.PrivacyAndSecurity.extension`,
+    /// which lands directly on the Full Disk Access pane. The legacy
+    /// `com.apple.preference.security` identifier still redirects but typically
+    /// drops the user on the root Privacy pane and requires another click.
     static let systemSettingsURL = URL(
-        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+        string: "x-apple.systempreferences:com.apple.Settings.PrivacyAndSecurity.extension?Privacy_AllFiles"
     )!
 
     /// Set to `true` when the user chooses "Continue Without Access". Suppresses the

--- a/VaderCleaner/PrivacyPermissionChecker.swift
+++ b/VaderCleaner/PrivacyPermissionChecker.swift
@@ -1,0 +1,30 @@
+// PrivacyPermissionChecker.swift
+// Detects whether VaderCleaner has been granted Full Disk Access by attempting to read a TCC-gated path.
+
+import Foundation
+
+/// Probes Full Disk Access by attempting to read a file that is normally protected by TCC.
+///
+/// `FileManager.default.fileExists(atPath:)` does NOT trigger TCC and returns `true` even
+/// when access is denied — the only reliable detection is to actually open the file for
+/// reading. The default probe is `~/Library/Application Support/com.apple.TCC/TCC.db`,
+/// which exists on every macOS install and is gated by FDA. Tests pass an alternate
+/// `testPath` so that the result is deterministic regardless of host TCC state.
+enum PrivacyPermissionChecker {
+
+    /// Canonical FDA-gated path used as the default probe.
+    static var defaultTestPath: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/com.apple.TCC/TCC.db")
+    }
+
+    /// Returns `true` if the given path can be opened for reading. With the default
+    /// `testPath`, this indicates Full Disk Access has been granted to the host process.
+    static func hasFullDiskAccess(testPath: URL = defaultTestPath) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: testPath) else {
+            return false
+        }
+        try? handle.close()
+        return true
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -5,6 +5,8 @@ import SwiftUI
 
 @main
 struct VaderCleanerApp: App {
+    @StateObject private var appState = AppState()
+
     init() {
         HelperRegistration.registerIfNeeded()
     }
@@ -12,6 +14,7 @@ struct VaderCleanerApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(appState)
         }
     }
 }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -5,7 +5,12 @@ import SwiftUI
 
 @main
 struct VaderCleanerApp: App {
+    // App-scope state owned outside the WindowGroup so dismissing the FDA
+    // onboarding sheet (or any future session-wide flag) holds across all
+    // windows the user might open. A per-view @StateObject in ContentView
+    // would be re-created per WindowGroup instance.
     @StateObject private var appState = AppState()
+    @StateObject private var onboardingViewModel = PermissionOnboardingViewModel()
 
     init() {
         HelperRegistration.registerIfNeeded()
@@ -15,6 +20,7 @@ struct VaderCleanerApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
+                .environmentObject(onboardingViewModel)
         }
     }
 }

--- a/VaderCleanerTests/AppStateTests.swift
+++ b/VaderCleanerTests/AppStateTests.swift
@@ -4,6 +4,7 @@
 import XCTest
 @testable import VaderCleaner
 
+@MainActor
 final class AppStateTests: XCTestCase {
 
     func test_init_setsHasFullDiskAccess_fromInjectedChecker_whenTrue() {

--- a/VaderCleanerTests/AppStateTests.swift
+++ b/VaderCleanerTests/AppStateTests.swift
@@ -1,0 +1,36 @@
+// AppStateTests.swift
+// Tests that AppState exposes the FDA flag and refreshes it from its injected checker.
+
+import XCTest
+@testable import VaderCleaner
+
+final class AppStateTests: XCTestCase {
+
+    func test_init_setsHasFullDiskAccess_fromInjectedChecker_whenTrue() {
+        let sut = AppState(checker: { true })
+        XCTAssertTrue(sut.hasFullDiskAccess)
+    }
+
+    func test_init_setsHasFullDiskAccess_fromInjectedChecker_whenFalse() {
+        let sut = AppState(checker: { false })
+        XCTAssertFalse(sut.hasFullDiskAccess)
+    }
+
+    func test_refresh_pullsUpdatedValueFromChecker() {
+        var current = false
+        let sut = AppState(checker: { current })
+        XCTAssertFalse(sut.hasFullDiskAccess)
+        current = true
+        sut.refresh()
+        XCTAssertTrue(sut.hasFullDiskAccess)
+    }
+
+    func test_refresh_pullsUpdatedValueFromChecker_whenRevoked() {
+        var current = true
+        let sut = AppState(checker: { current })
+        XCTAssertTrue(sut.hasFullDiskAccess)
+        current = false
+        sut.refresh()
+        XCTAssertFalse(sut.hasFullDiskAccess)
+    }
+}

--- a/VaderCleanerTests/PermissionOnboardingViewModelTests.swift
+++ b/VaderCleanerTests/PermissionOnboardingViewModelTests.swift
@@ -1,0 +1,28 @@
+// PermissionOnboardingViewModelTests.swift
+// Tests that PermissionOnboardingViewModel exposes the expected dismissal state and System Settings URL.
+
+import XCTest
+@testable import VaderCleaner
+
+final class PermissionOnboardingViewModelTests: XCTestCase {
+
+    func test_isDismissed_defaultsToFalse() {
+        let sut = PermissionOnboardingViewModel()
+        XCTAssertFalse(sut.isDismissed)
+    }
+
+    func test_dismiss_setsIsDismissedToTrue() {
+        let sut = PermissionOnboardingViewModel()
+        sut.dismiss()
+        XCTAssertTrue(sut.isDismissed)
+    }
+
+    func test_systemSettingsURL_pointsToFullDiskAccessPane() {
+        // Asserts the URL constant — calling NSWorkspace.shared.open in tests would
+        // actually launch System Settings, so the test exercises the URL only.
+        XCTAssertEqual(
+            PermissionOnboardingViewModel.systemSettingsURL.absoluteString,
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+        )
+    }
+}

--- a/VaderCleanerTests/PermissionOnboardingViewModelTests.swift
+++ b/VaderCleanerTests/PermissionOnboardingViewModelTests.swift
@@ -4,6 +4,7 @@
 import XCTest
 @testable import VaderCleaner
 
+@MainActor
 final class PermissionOnboardingViewModelTests: XCTestCase {
 
     func test_isDismissed_defaultsToFalse() {
@@ -22,7 +23,7 @@ final class PermissionOnboardingViewModelTests: XCTestCase {
         // actually launch System Settings, so the test exercises the URL only.
         XCTAssertEqual(
             PermissionOnboardingViewModel.systemSettingsURL.absoluteString,
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+            "x-apple.systempreferences:com.apple.Settings.PrivacyAndSecurity.extension?Privacy_AllFiles"
         )
     }
 }

--- a/VaderCleanerTests/PrivacyPermissionCheckerTests.swift
+++ b/VaderCleanerTests/PrivacyPermissionCheckerTests.swift
@@ -1,0 +1,53 @@
+// PrivacyPermissionCheckerTests.swift
+// Tests that PrivacyPermissionChecker.hasFullDiskAccess(testPath:) probes paths via real file reads.
+
+import XCTest
+@testable import VaderCleaner
+
+final class PrivacyPermissionCheckerTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempDir { TestHelpers.tearDownTempDirectory(tempDir) }
+        tempDir = nil
+        super.tearDown()
+    }
+
+    func test_hasFullDiskAccess_returnsTrue_forReadableTempFile() throws {
+        let file = try TestHelpers.createDummyFile(named: "readable.bin", size: 16, in: tempDir)
+        XCTAssertTrue(PrivacyPermissionChecker.hasFullDiskAccess(testPath: file))
+    }
+
+    func test_hasFullDiskAccess_returnsFalse_forNonexistentPath() {
+        let missing = tempDir.appendingPathComponent("does_not_exist.bin")
+        XCTAssertFalse(PrivacyPermissionChecker.hasFullDiskAccess(testPath: missing))
+    }
+
+    func test_hasFullDiskAccess_returnsFalse_forDirectoryPath() {
+        // Real file reads fail on directories — relying on this distinguishes a granted-access
+        // directory listing (which fileExists would confirm) from an actual readable file.
+        XCTAssertFalse(PrivacyPermissionChecker.hasFullDiskAccess(testPath: tempDir))
+    }
+
+    func test_hasFullDiskAccess_defaultPath_returnsBool() {
+        // Asserting only that the default-path overload returns *some* Bool — the actual
+        // result depends on the host machine's TCC state, which would break CI either way
+        // if asserted directly.
+        let result: Bool = PrivacyPermissionChecker.hasFullDiskAccess()
+        _ = result
+    }
+
+    func test_defaultTestPath_endsWithTCCdb() {
+        // Smoke test: the canonical FDA-gated path is the TCC database.
+        XCTAssertTrue(
+            PrivacyPermissionChecker.defaultTestPath.path.hasSuffix(
+                "Library/Application Support/com.apple.TCC/TCC.db"
+            )
+        )
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -12,7 +12,7 @@
 - [x] **Prompt 1** — Xcode project + XCTest + XCUITest targets + TestHelpers
 - [x] **Prompt 2** — App shell + NavigationSection enum + sidebar navigation (11 sections)
 - [x] **Prompt 3** — Privileged XPC helper tool (VaderCleanerHelper target + HelperConnectionManager)
-- [ ] **Prompt 4** — Full Disk Access detection + onboarding sheet
+- [x] **Prompt 4** — Full Disk Access detection + onboarding sheet
 - [ ] **Prompt 5** — Menu bar extra (basic, placeholder stats)
 - [ ] **Prompt 6** — PreferencesStore + ExclusionsStore + Preferences window (4 tabs)
 - [ ] **Prompt 7** — Launch at login (SMAppService, wired to Preferences toggle)


### PR DESCRIPTION
## Summary

- Detects FDA on launch by attempting a real read of the canonical TCC.db path. `FileManager.fileExists(atPath:)` does **not** trigger TCC and would return false-positives — only opening the file via `FileHandle(forReadingFrom:)` is reliable.
- New `AppState` ObservableObject holds the cached `hasFullDiskAccess` flag; refreshes automatically on app foreground (`scenePhase == .active`).
- New `PermissionOnboardingView` sheet with numbered steps, "Open System Settings" deep-link to the FDA pane, "Check Again", and "Continue Without Access".
- Sheet is presented from `ContentView` and routes Esc / programmatic dismissal through `viewModel.dismiss()` so it stays suppressed for the session once the user opts out.

Closes #8

## Test plan

- [x] `xcodebuild test` — 38 unit + 1 UI all pass (12 new tests for Prompt 4).
- [x] `PrivacyPermissionCheckerTests` — covers readable file, missing path, directory path, default-path smoke (env-independent), and TCC.db suffix invariant.
- [x] `AppStateTests` — covers init from injected checker (true/false), `refresh()` pulling updates in both directions.
- [x] `PermissionOnboardingViewModelTests` — covers default `isDismissed`, `dismiss()` setting the flag, and the System Settings URL constant (asserted as a string — no `NSWorkspace.shared.open` side effect in tests).
- [ ] Manual: launch app on a machine without FDA → sheet appears. Click "Open System Settings" → System Settings opens to Full Disk Access. Grant access, return to app → sheet auto-dismisses on foreground.
- [ ] Manual: click "Continue Without Access" → sheet dismisses for the session and does not re-pop on foreground refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Full Disk Access permission detection now available
  * Permission onboarding screen guides users through granting access with direct System Settings link
  * Permission status automatically refreshes when app returns to foreground
  * Users can dismiss, retry, or open settings directly from onboarding screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->