### PR TITLE
Menu bar extra (placeholder stats)

### DIFF
--- a/VaderCleaner/Info.plist
+++ b/VaderCleaner/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSPrincipalClass</key>

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -1,0 +1,59 @@
+// MenuBarContent.swift
+// SwiftUI view rendering the menu bar extra popover — RAM row, disk row, Open and Quit actions.
+
+import SwiftUI
+import AppKit
+
+/// Popover content presented when the user clicks the menu bar icon. Uses a
+/// fixed-width column so the layout stays stable as Prompt 10 swaps in live
+/// telemetry.
+struct MenuBarContent: View {
+
+    @EnvironmentObject private var menuBar: MenuBarViewModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            statRow(label: "RAM", value: menuBar.formattedRAMUsage)
+            statRow(label: "Disk", value: menuBar.formattedDiskSpace)
+
+            Divider()
+
+            Button("Open VaderCleaner") {
+                openMainWindow()
+            }
+            .keyboardShortcut("o")
+
+            Button("Quit VaderCleaner") {
+                NSApp.terminate(nil)
+            }
+            .keyboardShortcut("q")
+        }
+        .padding(12)
+        .frame(width: 220)
+    }
+
+    private func statRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .monospacedDigit()
+        }
+    }
+
+    private func openMainWindow() {
+        // `openWindow(id:)` brings the existing main window to front, or opens
+        // a new one if the user previously closed it. Following with
+        // `NSApp.activate()` moves focus to the process so the window comes to
+        // the foreground over other apps.
+        openWindow(id: VaderCleanerApp.mainWindowID)
+        NSApp.activate()
+    }
+}
+
+#Preview {
+    MenuBarContent()
+        .environmentObject(MenuBarViewModel())
+}

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -16,8 +16,12 @@ final class MenuBarViewModel: ObservableObject {
     /// Default placeholder shown until `SystemStatsService` (Prompt 10) starts
     /// publishing live values. Format mirrors what the live wiring will emit so
     /// the menu bar label width does not jump on first update.
-    static let placeholderRAM = "RAM: 0.0 GB"
-    static let placeholderDisk = "Disk: 0 GB free"
+    ///
+    /// These are value-only ("0.0 GB", "0 GB free") — the "RAM:" / "Disk:"
+    /// prefixes are owned by `MenuBarExtra`'s label and the popover row labels,
+    /// so the popover does not render the prefix twice.
+    static let placeholderRAM = "0.0 GB"
+    static let placeholderDisk = "0 GB free"
 
     @Published var formattedRAMUsage: String
     @Published var formattedDiskSpace: String

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -1,0 +1,32 @@
+// MenuBarViewModel.swift
+// View-model backing the menu bar extra — exposes formatted RAM/disk strings the popover and label render.
+
+import Foundation
+import Combine
+
+/// Drives the `MenuBarExtra` label and popover.
+///
+/// For Prompt 5 the values are static placeholders. Prompt 10 replaces the
+/// `init` defaults with a `SystemStatsService` subscription that updates these
+/// `@Published` strings every two seconds, so the popover and label re-render
+/// without further view changes.
+@MainActor
+final class MenuBarViewModel: ObservableObject {
+
+    /// Default placeholder shown until `SystemStatsService` (Prompt 10) starts
+    /// publishing live values. Format mirrors what the live wiring will emit so
+    /// the menu bar label width does not jump on first update.
+    static let placeholderRAM = "RAM: 0.0 GB"
+    static let placeholderDisk = "Disk: 0 GB free"
+
+    @Published var formattedRAMUsage: String
+    @Published var formattedDiskSpace: String
+
+    init(
+        ramUsage: String = MenuBarViewModel.placeholderRAM,
+        diskSpace: String = MenuBarViewModel.placeholderDisk
+    ) {
+        self.formattedRAMUsage = ramUsage
+        self.formattedDiskSpace = diskSpace
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -37,20 +37,30 @@ struct VaderCleanerApp: App {
                 .environmentObject(menuBarViewModel)
         } label: {
             // Compact label combining both placeholder readings — Prompt 10
-            // replaces the values, not the format.
-            Text("\(menuBarViewModel.formattedRAMUsage) | \(menuBarViewModel.formattedDiskSpace)")
+            // replaces the values, not the format. The "RAM:" / "Disk:"
+            // prefixes live here (and on the popover rows) so the view-model
+            // can stay value-only and avoid duplicated labels.
+            Text("RAM: \(menuBarViewModel.formattedRAMUsage) | Disk: \(menuBarViewModel.formattedDiskSpace)")
         }
         .menuBarExtraStyle(.window)
     }
 }
 
 /// Drives the Dock icon's lifecycle. With `LSUIElement = YES` the app launches
-/// with no Dock icon; we promote to `.regular` once the main window is up so
+/// with no Dock icon; we promote to `.regular` once a titled window is up so
 /// the user has a Dock entry, then demote back to `.accessory` when the last
 /// titled window closes so the menu bar extra can keep running headlessly.
+///
+/// Two observers cooperate to keep the policy in sync with window lifecycle:
+///   - `NSWindow.didBecomeKeyNotification` re-promotes when a titled window
+///     re-appears (e.g. user picks "Open VaderCleaner" from the menu bar after
+///     the previous window had been closed and the policy was demoted).
+///   - `NSWindow.willCloseNotification` demotes once the closing window leaves
+///     no other titled window in `NSApp.windows`.
 final class VaderCleanerAppDelegate: NSObject, NSApplicationDelegate {
 
     private var windowCloseObserver: NSObjectProtocol?
+    private var windowKeyObserver: NSObjectProtocol?
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Show the Dock icon as soon as launch begins; the SwiftUI WindowGroup
@@ -58,7 +68,7 @@ final class VaderCleanerAppDelegate: NSObject, NSApplicationDelegate {
         // early avoids the brief flicker of an icon-less Dock that would
         // happen if we deferred to the window's `onAppear`.
         NSApp.setActivationPolicy(.regular)
-        installWindowCloseObserver()
+        installWindowObservers()
     }
 
     func applicationShouldHandleReopen(
@@ -71,26 +81,51 @@ final class VaderCleanerAppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
-    private func installWindowCloseObserver() {
-        windowCloseObserver = NotificationCenter.default.addObserver(
+    private func installWindowObservers() {
+        let center = NotificationCenter.default
+
+        windowCloseObserver = center.addObserver(
             forName: NSWindow.willCloseNotification,
             object: nil,
             queue: .main
         ) { [weak self] notification in
             self?.handleWindowWillClose(notification)
         }
+
+        windowKeyObserver = center.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleWindowDidBecomeKey(notification)
+        }
+    }
+
+    private func handleWindowDidBecomeKey(_ notification: Notification) {
+        // Only titled windows count as "main app windows" — the menu bar
+        // extra's popover is borderless and would otherwise re-promote the
+        // app every time the user clicked the menu bar icon.
+        guard
+            let window = notification.object as? NSWindow,
+            window.styleMask.contains(.titled)
+        else { return }
+
+        if NSApp.activationPolicy() != .regular {
+            NSApp.setActivationPolicy(.regular)
+        }
     }
 
     private func handleWindowWillClose(_ notification: Notification) {
         let closingWindow = notification.object as? NSWindow
 
-        // The MenuBarExtra popover is a borderless utility window — only
-        // titled windows count as "main app windows" for Dock-icon purposes.
-        // We exclude the closing window itself because it is still in
-        // `NSApp.windows` at notification time.
+        // Count any other titled window — including minimized ones — as a
+        // reason to keep the Dock icon. Filtering by `isVisible` would drop
+        // the icon while a minimized window still exists, leaving that window
+        // unreachable. We exclude the closing window itself because it is
+        // still present in `NSApp.windows` at notification time.
         let hasOtherTitledWindow = NSApp.windows.contains { window in
             guard window !== closingWindow else { return false }
-            return window.isVisible && window.styleMask.contains(.titled)
+            return window.styleMask.contains(.titled)
         }
 
         if !hasOtherTitledWindow {
@@ -99,8 +134,12 @@ final class VaderCleanerAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     deinit {
+        let center = NotificationCenter.default
         if let token = windowCloseObserver {
-            NotificationCenter.default.removeObserver(token)
+            center.removeObserver(token)
+        }
+        if let token = windowKeyObserver {
+            center.removeObserver(token)
         }
     }
 }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -2,25 +2,105 @@
 // App entry point — defines the SwiftUI App lifecycle for VaderCleaner.
 
 import SwiftUI
+import AppKit
 
 @main
 struct VaderCleanerApp: App {
+
+    /// Identifier shared between the main `WindowGroup` and the menu bar's
+    /// "Open VaderCleaner" action so `openWindow(id:)` can re-focus or
+    /// re-create the window after the user has closed it.
+    static let mainWindowID = "main"
+
     // App-scope state owned outside the WindowGroup so dismissing the FDA
     // onboarding sheet (or any future session-wide flag) holds across all
     // windows the user might open. A per-view @StateObject in ContentView
     // would be re-created per WindowGroup instance.
     @StateObject private var appState = AppState()
     @StateObject private var onboardingViewModel = PermissionOnboardingViewModel()
+    @StateObject private var menuBarViewModel = MenuBarViewModel()
+    @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
         HelperRegistration.registerIfNeeded()
     }
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: Self.mainWindowID) {
             ContentView()
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)
+        }
+
+        MenuBarExtra {
+            MenuBarContent()
+                .environmentObject(menuBarViewModel)
+        } label: {
+            // Compact label combining both placeholder readings — Prompt 10
+            // replaces the values, not the format.
+            Text("\(menuBarViewModel.formattedRAMUsage) | \(menuBarViewModel.formattedDiskSpace)")
+        }
+        .menuBarExtraStyle(.window)
+    }
+}
+
+/// Drives the Dock icon's lifecycle. With `LSUIElement = YES` the app launches
+/// with no Dock icon; we promote to `.regular` once the main window is up so
+/// the user has a Dock entry, then demote back to `.accessory` when the last
+/// titled window closes so the menu bar extra can keep running headlessly.
+final class VaderCleanerAppDelegate: NSObject, NSApplicationDelegate {
+
+    private var windowCloseObserver: NSObjectProtocol?
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        // Show the Dock icon as soon as launch begins; the SwiftUI WindowGroup
+        // opens the main window immediately afterwards. Setting policy this
+        // early avoids the brief flicker of an icon-less Dock that would
+        // happen if we deferred to the window's `onAppear`.
+        NSApp.setActivationPolicy(.regular)
+        installWindowCloseObserver()
+    }
+
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows flag: Bool
+    ) -> Bool {
+        // Clicking the Dock icon while the main window is closed should
+        // restore it. Returning `true` lets AppKit forward the reopen event
+        // to SwiftUI, which re-creates the WindowGroup window.
+        return true
+    }
+
+    private func installWindowCloseObserver() {
+        windowCloseObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleWindowWillClose(notification)
+        }
+    }
+
+    private func handleWindowWillClose(_ notification: Notification) {
+        let closingWindow = notification.object as? NSWindow
+
+        // The MenuBarExtra popover is a borderless utility window — only
+        // titled windows count as "main app windows" for Dock-icon purposes.
+        // We exclude the closing window itself because it is still in
+        // `NSApp.windows` at notification time.
+        let hasOtherTitledWindow = NSApp.windows.contains { window in
+            guard window !== closingWindow else { return false }
+            return window.isVisible && window.styleMask.contains(.titled)
+        }
+
+        if !hasOtherTitledWindow {
+            NSApp.setActivationPolicy(.accessory)
+        }
+    }
+
+    deinit {
+        if let token = windowCloseObserver {
+            NotificationCenter.default.removeObserver(token)
         }
     }
 }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -7,9 +7,14 @@ import AppKit
 @main
 struct VaderCleanerApp: App {
 
-    /// Identifier shared between the main `WindowGroup` and the menu bar's
+    /// Identifier shared between the main `Window` scene and the menu bar's
     /// "Open VaderCleaner" action so `openWindow(id:)` can re-focus or
     /// re-create the window after the user has closed it.
+    ///
+    /// VaderCleaner intentionally uses a single-instance `Window` (not
+    /// `WindowGroup`): `openWindow(id:)` against a `WindowGroup` would spawn
+    /// a fresh window on every invocation, leaving the user with stacks of
+    /// duplicates each time they tapped the menu bar action.
     static let mainWindowID = "main"
 
     // App-scope state owned outside the WindowGroup so dismissing the FDA
@@ -26,7 +31,7 @@ struct VaderCleanerApp: App {
     }
 
     var body: some Scene {
-        WindowGroup(id: Self.mainWindowID) {
+        Window("VaderCleaner", id: Self.mainWindowID) {
             ContentView()
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -1,0 +1,27 @@
+// MenuBarViewModelTests.swift
+// Tests that MenuBarViewModel exposes non-empty placeholder strings the menu bar label can render.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class MenuBarViewModelTests: XCTestCase {
+
+    func test_init_setsDefaultStatValues() {
+        let sut = MenuBarViewModel()
+        // The menu bar label is built from these strings on launch — both must be
+        // populated before any real telemetry wires up in Prompt 10.
+        XCTAssertFalse(sut.formattedRAMUsage.isEmpty)
+        XCTAssertFalse(sut.formattedDiskSpace.isEmpty)
+    }
+
+    func test_formattedRAMUsage_isNonEmptyString() {
+        let sut = MenuBarViewModel()
+        XCTAssertFalse(sut.formattedRAMUsage.isEmpty)
+    }
+
+    func test_formattedDiskSpace_isNonEmptyString() {
+        let sut = MenuBarViewModel()
+        XCTAssertFalse(sut.formattedDiskSpace.isEmpty)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -53,6 +53,7 @@ targets:
         CFBundleShortVersionString: "1.0"
         CFBundleVersion: "1"
         LSMinimumSystemVersion: "$(MACOSX_DEPLOYMENT_TARGET)"
+        LSUIElement: true
         NSHumanReadableCopyright: ""
         NSPrincipalClass: NSApplication
         NSSupportsAutomaticTermination: false

--- a/todo.md
+++ b/todo.md
@@ -13,7 +13,7 @@
 - [x] **Prompt 2** — App shell + NavigationSection enum + sidebar navigation (11 sections)
 - [x] **Prompt 3** — Privileged XPC helper tool (VaderCleanerHelper target + HelperConnectionManager)
 - [x] **Prompt 4** — Full Disk Access detection + onboarding sheet
-- [ ] **Prompt 5** — Menu bar extra (basic, placeholder stats)
+- [x] **Prompt 5** — Menu bar extra (basic, placeholder stats)
 - [ ] **Prompt 6** — PreferencesStore + ExclusionsStore + Preferences window (4 tabs)
 - [ ] **Prompt 7** — Launch at login (SMAppService, wired to Preferences toggle)
 


### PR DESCRIPTION
## Summary

- New `MenuBarExtra` scene alongside the main `WindowGroup`. Label shows `RAM: X.X GB | Disk: XX GB free` placeholders today; real values wire up in Prompt 10 without further view changes.
- Popover (`menuBarExtraStyle(.window)`) renders RAM row, Disk row, divider, **Open VaderCleaner** (re-focuses or re-creates the main window via `openWindow(id:) + NSApp.activate()`), and **Quit VaderCleaner**.
- New `MenuBarViewModel` `@MainActor ObservableObject` with `@Published var formattedRAMUsage` and `formattedDiskSpace`, seeded with placeholder values that mirror the live format Prompt 10 will emit.
- `LSUIElement = YES` added to `Info.plist` (and mirrored in `project.yml` so xcodegen does not strip it). A new `NSApplicationDelegateAdaptor` promotes the activation policy to `.regular` on launch so the Dock icon shows while the main window is up, and demotes back to `.accessory` once the last titled window closes — the menu bar extra keeps running headlessly. `applicationShouldHandleReopen` returns `true` so clicking the Dock icon while the window is closed restores it.
- Main `WindowGroup` now has a stable id (`"main"`) so the popover's "Open" action can address it.

Closes #10

## Test plan

- [x] `xcodebuild test` — 41 unit + 1 UI all pass.
- [x] `MenuBarViewModelTests` — covers default placeholder values, non-empty `formattedRAMUsage`, non-empty `formattedDiskSpace` (3 new tests).
- [x] `VaderCleanerUITests.test_appLaunches` still passes with `LSUIElement=YES` and the new activation-policy code.
- [ ] Manual: launch app → menu bar icon appears with placeholder label, Dock icon shown while window is open. Close main window → Dock icon disappears, menu bar extra remains.
- [ ] Manual: from popover click **Open VaderCleaner** → main window re-opens and comes to front; Dock icon re-appears.
- [ ] Manual: from popover click **Quit VaderCleaner** → app terminates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a menu bar extra showing RAM and disk statistics (placeholder values for initial release).
  * Menu bar popover includes buttons to open the main app window and to quit the app.
  * App now runs as a menu bar utility without a standard Dock icon.

* **Tests**
  * Added unit tests verifying menu bar view model initialization and stat values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->