### PR TITLE
feat: launch at login via SMAppService

### DIFF
--- a/VaderCleaner/LoginItemManager.swift
+++ b/VaderCleaner/LoginItemManager.swift
@@ -48,10 +48,13 @@ enum LoginItemManager {
             os_log("Registered as login item (status=%{public}@)",
                    log: log, type: .info, String(describing: service.status))
         } else {
-            // Anything other than `.enabled` means there is nothing to undo.
-            // Includes `.notRegistered`, `.notFound`, `.requiresApproval`.
-            guard service.status == .enabled else {
-                os_log("Not enabled; skipping unregister()", log: log, type: .debug)
+            // `.requiresApproval` means launchd has the entry but the user
+            // hasn't yet approved it in System Settings — it is still
+            // registered, so calling unregister() must succeed for the
+            // off-toggle to actually take effect. Only `.notRegistered` /
+            // `.notFound` represent "nothing to undo".
+            guard service.status == .enabled || service.status == .requiresApproval else {
+                os_log("Not registered; skipping unregister()", log: log, type: .debug)
                 return
             }
             try service.unregister()

--- a/VaderCleaner/LoginItemManager.swift
+++ b/VaderCleaner/LoginItemManager.swift
@@ -1,0 +1,62 @@
+// LoginItemManager.swift
+// Thin wrapper around SMAppService.mainApp for the launch-at-login preference.
+
+import Foundation
+import ServiceManagement
+import os.log
+
+/// Toggles VaderCleaner's "launch at login" registration.
+///
+/// `SMAppService.mainApp` registers the host bundle with launchd so the system
+/// starts the app at user login — replacing the deprecated
+/// `SMLoginItemSetEnabled` API on macOS 13+. The wrapper exists for two
+/// reasons:
+///   - Idempotence: `register()` and `unregister()` throw if the service is
+///     already in the requested state, which would surface on every preference
+///     toggle as a spurious error. We short-circuit when `status` already
+///     matches.
+///   - A single seam to log against, so the menu bar / Settings flows can call
+///     in without each duplicating error reporting.
+enum LoginItemManager {
+
+    private static let log = OSLog(
+        subsystem: "com.personal.VaderCleaner",
+        category: "LoginItemManager"
+    )
+
+    /// `true` when launchd reports the main app as an active login item.
+    /// Reads the live status, so flipping the toggle in System Settings →
+    /// Login Items is reflected immediately on the next read.
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    /// Registers (or unregisters) the host app with launchd. No-op when the
+    /// requested state already matches `service.status`, so this is safe to
+    /// call from a `didSet` that fires on every preference write.
+    static func setEnabled(_ enabled: Bool) throws {
+        let service = SMAppService.mainApp
+
+        if enabled {
+            // `.enabled` means launchd already has us registered. Calling
+            // register() again would throw `kSMErrorAlreadyRegistered`.
+            guard service.status != .enabled else {
+                os_log("Already enabled; skipping register()", log: log, type: .debug)
+                return
+            }
+            try service.register()
+            os_log("Registered as login item (status=%{public}@)",
+                   log: log, type: .info, String(describing: service.status))
+        } else {
+            // Anything other than `.enabled` means there is nothing to undo.
+            // Includes `.notRegistered`, `.notFound`, `.requiresApproval`.
+            guard service.status == .enabled else {
+                os_log("Not enabled; skipping unregister()", log: log, type: .debug)
+                return
+            }
+            try service.unregister()
+            os_log("Unregistered as login item (status=%{public}@)",
+                   log: log, type: .info, String(describing: service.status))
+        }
+    }
+}

--- a/VaderCleaner/LoginItemManager.swift
+++ b/VaderCleaner/LoginItemManager.swift
@@ -38,10 +38,14 @@ enum LoginItemManager {
         let service = SMAppService.mainApp
 
         if enabled {
-            // `.enabled` means launchd already has us registered. Calling
-            // register() again would throw `kSMErrorAlreadyRegistered`.
-            guard service.status != .enabled else {
-                os_log("Already enabled; skipping register()", log: log, type: .debug)
+            // Both `.enabled` and `.requiresApproval` mean launchd already has
+            // us registered (`.requiresApproval` is "registered, awaiting user
+            // approval in System Settings"). Calling `register()` in either
+            // state throws `kSMErrorAlreadyRegistered`, so we treat them
+            // symmetrically — mirroring the disable path's guard below.
+            guard service.status != .enabled,
+                  service.status != .requiresApproval else {
+                os_log("Already registered; skipping register()", log: log, type: .debug)
                 return
             }
             try service.register()

--- a/VaderCleaner/PreferencesStore.swift
+++ b/VaderCleaner/PreferencesStore.swift
@@ -12,12 +12,23 @@ import Combine
 /// instead of touching `.standard`. Production code uses the default `.standard`
 /// argument and never sees the seam.
 ///
-/// Side effects that depend on these values (the actual SMAppService registration
-/// in Prompt 7, the menu bar hide/show in Prompt 10, notification dispatch in
-/// Prompt 11) are added by later prompts. This store stays a pure model so tests
-/// can run without scheduling any system-level work.
+/// Side effects that depend on these values are wired in via small handler
+/// closures injected at construction. Production wiring happens in
+/// `VaderCleanerApp` (e.g. `launchAtLoginHandler` calls `LoginItemManager`);
+/// unit tests omit the handlers so mutating a published property never
+/// triggers a system call. Menu-bar hide/show (Prompt 10) and notification
+/// dispatch (Prompt 11) follow the same pattern when added.
 @MainActor
 final class PreferencesStore: ObservableObject {
+
+    /// Side-effect contract for the `launchAtLogin` toggle. Production passes
+    /// `LoginItemManager.setEnabled`; tests pass `nil` so writing to
+    /// `launchAtLogin` is a pure model mutation.
+    typealias LaunchAtLoginHandler = @MainActor (Bool) throws -> Void
+
+    /// Reported when applying the launch-at-login change to launchd fails. The
+    /// app layer surfaces this via `NSAlert`; the model stays UI-free.
+    typealias LaunchAtLoginErrorReporter = @MainActor (Error) -> Void
 
     // MARK: - Storage keys
 
@@ -83,7 +94,10 @@ final class PreferencesStore: ObservableObject {
     }
 
     @Published var launchAtLogin: Bool {
-        didSet { defaults.set(launchAtLogin, forKey: Key.launchAtLogin) }
+        didSet {
+            defaults.set(launchAtLogin, forKey: Key.launchAtLogin)
+            applyLaunchAtLogin()
+        }
     }
 
     @Published var showMenuBar: Bool {
@@ -93,9 +107,17 @@ final class PreferencesStore: ObservableObject {
     // MARK: - Init
 
     private let defaults: UserDefaults
+    private let launchAtLoginHandler: LaunchAtLoginHandler?
+    private let launchAtLoginErrorReporter: LaunchAtLoginErrorReporter?
 
-    init(defaults: UserDefaults = .standard) {
+    init(
+        defaults: UserDefaults = .standard,
+        launchAtLoginHandler: LaunchAtLoginHandler? = nil,
+        launchAtLoginErrorReporter: LaunchAtLoginErrorReporter? = nil
+    ) {
         self.defaults = defaults
+        self.launchAtLoginHandler = launchAtLoginHandler
+        self.launchAtLoginErrorReporter = launchAtLoginErrorReporter
 
         // Initialise the @Published wrappers directly with `_property =
         // Published(initialValue:)` instead of `self.property = …`. Going
@@ -143,5 +165,28 @@ final class PreferencesStore: ObservableObject {
             initialValue: (defaults.object(forKey: Key.showMenuBar) as? Bool)
                 ?? Self.defaultShowMenuBar
         )
+
+        // Reconcile the persisted preference with launchd's actual state once
+        // the @Published wrappers are populated. The handler's presence is the
+        // signal that we're in production wiring (tests pass nil); skipping in
+        // tests keeps unit tests from mutating the host's login items.
+        if launchAtLoginHandler != nil {
+            applyLaunchAtLogin()
+        }
+    }
+
+    // MARK: - Side effects
+
+    /// Pushes the current `launchAtLogin` value through the injected handler
+    /// (in production, `LoginItemManager.setEnabled`). Errors are forwarded to
+    /// the optional reporter so the App layer can surface an alert without
+    /// coupling the model to AppKit.
+    private func applyLaunchAtLogin() {
+        guard let handler = launchAtLoginHandler else { return }
+        do {
+            try handler(launchAtLogin)
+        } catch {
+            launchAtLoginErrorReporter?(error)
+        }
     }
 }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -24,12 +24,50 @@ struct VaderCleanerApp: App {
     @StateObject private var appState = AppState()
     @StateObject private var onboardingViewModel = PermissionOnboardingViewModel()
     @StateObject private var menuBarViewModel = MenuBarViewModel()
-    @StateObject private var preferences = PreferencesStore()
+    @StateObject private var preferences: PreferencesStore
     @StateObject private var exclusions = ExclusionsStore()
     @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
         HelperRegistration.registerIfNeeded()
+        // Construct the store with production side-effect handlers. The init
+        // also reconciles the persisted preference with `SMAppService` so a
+        // user who toggled "Login Items" in System Settings while VaderCleaner
+        // was quit gets pushed back into a consistent state on the next
+        // launch.
+        _preferences = StateObject(
+            wrappedValue: PreferencesStore(
+                launchAtLoginHandler: { try LoginItemManager.setEnabled($0) },
+                launchAtLoginErrorReporter: VaderCleanerApp.presentLaunchAtLoginAlert(_:)
+            )
+        )
+    }
+
+    /// Surfaces a launchd registration failure to the user. Kept on the App
+    /// type (rather than inside the store) so the model layer remains free of
+    /// AppKit references and continues to be unit-testable without `NSAlert`.
+    ///
+    /// The alert is dispatched asynchronously because the very first call site
+    /// is `PreferencesStore.init` running inside `VaderCleanerApp.init()` —
+    /// before `NSApp` has finished launching. Presenting a modal there would
+    /// race the run loop and could deadlock startup. The async hop guarantees
+    /// the alert lands after the app is up.
+    @MainActor
+    private static func presentLaunchAtLoginAlert(_ error: Error) {
+        let description = error.localizedDescription
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = "Couldn't update Launch at Login"
+            alert.informativeText = """
+            VaderCleaner couldn't update its Launch at Login setting. \
+            You can manage this manually from System Settings → General → Login Items.
+
+            Details: \(description)
+            """
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        }
     }
 
     var body: some Scene {

--- a/VaderCleanerTests/LoginItemManagerTests.swift
+++ b/VaderCleanerTests/LoginItemManagerTests.swift
@@ -17,24 +17,37 @@ import ServiceManagement
 /// can't poison each other.
 final class LoginItemManagerTests: XCTestCase {
 
-    private var initialEnabled: Bool!
+    /// Captures the full `SMAppService.Status`, not just `isEnabled`, because
+    /// `isEnabled` collapses `.requiresApproval` to `false`. If the host
+    /// machine started in `.requiresApproval` (a pending-approval entry the
+    /// user has already opted into via System Settings), restoring from a
+    /// `Bool` would call `setEnabled(false)` and silently unregister it.
+    private var initialStatus: SMAppService.Status!
 
     override func setUp() {
         super.setUp()
-        initialEnabled = LoginItemManager.isEnabled
+        initialStatus = SMAppService.mainApp.status
     }
 
     override func tearDown() {
-        // Best-effort restore; if the restore itself throws (e.g. the bundle
-        // signature changed mid-run) we log via XCTFail rather than masking the
-        // failure, but still continue teardown so subsequent tests aren't
-        // blocked.
+        // Best-effort restore. Both `.enabled` and `.requiresApproval` are
+        // "registered" states from launchd's perspective; the user's approval
+        // toggle in System Settings is independent of our register() call, so
+        // re-registering is the closest we can get to the original — the
+        // post-restore status will be whichever of the two the system
+        // reports. `.notRegistered` / `.notFound` / any future case fall
+        // through to unregister, which is also idempotent for those states.
         do {
-            try LoginItemManager.setEnabled(initialEnabled)
+            switch initialStatus {
+            case .enabled, .requiresApproval:
+                try LoginItemManager.setEnabled(true)
+            default:
+                try LoginItemManager.setEnabled(false)
+            }
         } catch {
             XCTFail("Failed to restore initial login-item state: \(error)")
         }
-        initialEnabled = nil
+        initialStatus = nil
         super.tearDown()
     }
 

--- a/VaderCleanerTests/LoginItemManagerTests.swift
+++ b/VaderCleanerTests/LoginItemManagerTests.swift
@@ -47,11 +47,14 @@ final class LoginItemManagerTests: XCTestCase {
     }
 
     func test_isEnabled_returnsBool() {
-        // The signature already constrains this at compile time; the assertion
-        // exists to catch a future change to e.g. an optional or throwing
-        // accessor that would silently weaken callers.
+        // The annotated assignment is the actual compile-time guard — if a
+        // future refactor weakens the accessor (e.g. to `Bool?` or a throwing
+        // form), this line stops compiling. The runtime assertion confirms
+        // the accessor is referentially stable across two consecutive reads,
+        // which would catch a regression that turned `isEnabled` into a
+        // call with side effects.
         let value: Bool = LoginItemManager.isEnabled
-        XCTAssertTrue(value || !value)
+        XCTAssertEqual(value, LoginItemManager.isEnabled)
     }
 
     /// Pins the round-trip: enabling then disabling must leave the host in a

--- a/VaderCleanerTests/LoginItemManagerTests.swift
+++ b/VaderCleanerTests/LoginItemManagerTests.swift
@@ -53,4 +53,19 @@ final class LoginItemManagerTests: XCTestCase {
         let value: Bool = LoginItemManager.isEnabled
         XCTAssertTrue(value || !value)
     }
+
+    /// Pins the round-trip: enabling then disabling must leave the host in a
+    /// not-enabled state. This is the regression guard for the
+    /// `.requiresApproval` bug — the previous `setEnabled(false)` skipped
+    /// `unregister()` whenever `service.status` was anything other than
+    /// `.enabled`, which left a `.requiresApproval` entry behind. We can't
+    /// deterministically synthesize `.requiresApproval` from a unit test, but
+    /// asserting `!isEnabled` after the cycle catches any future regression
+    /// where the off-toggle silently no-ops on the dev machine's landing
+    /// state.
+    func test_setEnabled_roundTrip_endsDisabled() throws {
+        try LoginItemManager.setEnabled(true)
+        try LoginItemManager.setEnabled(false)
+        XCTAssertFalse(LoginItemManager.isEnabled)
+    }
 }

--- a/VaderCleanerTests/LoginItemManagerTests.swift
+++ b/VaderCleanerTests/LoginItemManagerTests.swift
@@ -1,0 +1,56 @@
+// LoginItemManagerTests.swift
+// Tests that LoginItemManager wraps SMAppService.mainApp without throwing for the basic on/off/query operations.
+
+import XCTest
+import ServiceManagement
+@testable import VaderCleaner
+
+/// `LoginItemManager` wraps `SMAppService.mainApp`, which talks to the live
+/// launchd registration database. The test host (VaderCleaner.app inside
+/// DerivedData, ad-hoc signed) is registered the same way the shipping app is,
+/// so calling `register()`/`unregister()` here actually mutates state on the
+/// developer's machine.
+///
+/// We capture the pre-test status in `setUp` and restore it in `tearDown` so
+/// running these tests can never leave the host with a stray login-item entry
+/// the developer didn't ask for, and the relative ordering of the three tests
+/// can't poison each other.
+final class LoginItemManagerTests: XCTestCase {
+
+    private var initialEnabled: Bool!
+
+    override func setUp() {
+        super.setUp()
+        initialEnabled = LoginItemManager.isEnabled
+    }
+
+    override func tearDown() {
+        // Best-effort restore; if the restore itself throws (e.g. the bundle
+        // signature changed mid-run) we log via XCTFail rather than masking the
+        // failure, but still continue teardown so subsequent tests aren't
+        // blocked.
+        do {
+            try LoginItemManager.setEnabled(initialEnabled)
+        } catch {
+            XCTFail("Failed to restore initial login-item state: \(error)")
+        }
+        initialEnabled = nil
+        super.tearDown()
+    }
+
+    func test_setEnabledTrue_doesNotThrow() {
+        XCTAssertNoThrow(try LoginItemManager.setEnabled(true))
+    }
+
+    func test_setEnabledFalse_doesNotThrow() {
+        XCTAssertNoThrow(try LoginItemManager.setEnabled(false))
+    }
+
+    func test_isEnabled_returnsBool() {
+        // The signature already constrains this at compile time; the assertion
+        // exists to catch a future change to e.g. an optional or throwing
+        // accessor that would silently weaken callers.
+        let value: Bool = LoginItemManager.isEnabled
+        XCTAssertTrue(value || !value)
+    }
+}

--- a/VaderCleanerTests/PreferencesStoreTests.swift
+++ b/VaderCleanerTests/PreferencesStoreTests.swift
@@ -81,4 +81,75 @@ final class PreferencesStoreTests: XCTestCase {
         XCTAssertFalse(reader.launchAtLogin)
         XCTAssertFalse(reader.showMenuBar)
     }
+
+    // MARK: - Launch-at-login wiring
+
+    func test_didSet_invokesLaunchAtLoginHandler() {
+        // Each handler invocation appends the value it received so we can
+        // assert on both the initial reconcile and the user-driven toggle.
+        var received: [Bool] = []
+        let sut = PreferencesStore(
+            defaults: defaults,
+            launchAtLoginHandler: { received.append($0) }
+        )
+
+        // The reconcile in init runs before the test mutates anything, so we
+        // clear the captured values to focus the assertion on the didSet.
+        received.removeAll()
+
+        sut.launchAtLogin = false
+
+        XCTAssertEqual(received, [false])
+    }
+
+    func test_handlerThrows_invokesErrorReporter() {
+        struct StubError: Error, Equatable {}
+        var reported: [StubError] = []
+        let sut = PreferencesStore(
+            defaults: defaults,
+            launchAtLoginHandler: { _ in throw StubError() },
+            launchAtLoginErrorReporter: { error in
+                if let stub = error as? StubError {
+                    reported.append(stub)
+                }
+            }
+        )
+
+        // The init reconcile already throws once because the handler always
+        // throws. Reset, then exercise the didSet path explicitly so the
+        // assertion covers the user-driven toggle, not the reconcile path.
+        reported.removeAll()
+        sut.launchAtLogin = !sut.launchAtLogin
+
+        XCTAssertEqual(reported, [StubError()])
+    }
+
+    func test_init_reconcilesLaunchAtLogin_whenHandlerProvided() {
+        // Persist a non-default value first so we can assert that the
+        // reconcile pushes the *persisted* state, not the spec default.
+        defaults.set(false, forKey: "preferences.launchAtLogin")
+
+        var received: [Bool] = []
+        _ = PreferencesStore(
+            defaults: defaults,
+            launchAtLoginHandler: { received.append($0) }
+        )
+
+        XCTAssertEqual(received, [false])
+    }
+
+    func test_init_skipsReconcile_whenHandlerNil() {
+        // Belt-and-braces: the existing tests rely on the nil-handler default
+        // staying side-effect-free. This test pins that contract so a future
+        // change can't regress unit tests into touching launchd.
+        defaults.set(true, forKey: "preferences.launchAtLogin")
+
+        var didSetCalled = false
+        _ = PreferencesStore(defaults: defaults)
+
+        // No handler means nothing observable to assert against directly; the
+        // implicit assertion is that constructing the store does not crash or
+        // attempt any side effect. The flag below documents the intent.
+        XCTAssertFalse(didSetCalled)
+    }
 }

--- a/VaderCleanerTests/PreferencesStoreTests.swift
+++ b/VaderCleanerTests/PreferencesStoreTests.swift
@@ -139,17 +139,28 @@ final class PreferencesStoreTests: XCTestCase {
     }
 
     func test_init_skipsReconcile_whenHandlerNil() {
-        // Belt-and-braces: the existing tests rely on the nil-handler default
-        // staying side-effect-free. This test pins that contract so a future
-        // change can't regress unit tests into touching launchd.
+        // Pins the nil-handler contract that all the other PreferencesStore
+        // tests depend on: constructing the store with no handler must not
+        // attempt any side effect, even when the persisted preference would
+        // otherwise drive a reconcile call.
+        //
+        // We can't directly assert that "no handler was called" — there is no
+        // handler to observe. Instead we assert through the *reporter*: if
+        // the implementation ever started feeding the persisted value into
+        // some other side-effect path that bypassed the nil handler, we'd
+        // expect it to also surface errors through the reporter. With both
+        // hooks nil, neither path can fire, and the only thing left to
+        // verify is that init returns without crashing — which the test
+        // implicitly covers by reaching the end.
         defaults.set(true, forKey: "preferences.launchAtLogin")
 
-        var didSetCalled = false
-        _ = PreferencesStore(defaults: defaults)
+        var reporterCalled = false
+        _ = PreferencesStore(
+            defaults: defaults,
+            launchAtLoginHandler: nil,
+            launchAtLoginErrorReporter: { _ in reporterCalled = true }
+        )
 
-        // No handler means nothing observable to assert against directly; the
-        // implicit assertion is that constructing the store does not crash or
-        // attempt any side effect. The flag below documents the intent.
-        XCTAssertFalse(didSetCalled)
+        XCTAssertFalse(reporterCalled)
     }
 }

--- a/todo.md
+++ b/todo.md
@@ -15,7 +15,7 @@
 - [x] **Prompt 4** — Full Disk Access detection + onboarding sheet
 - [x] **Prompt 5** — Menu bar extra (basic, placeholder stats)
 - [x] **Prompt 6** — PreferencesStore + ExclusionsStore + Preferences window (4 tabs)
-- [ ] **Prompt 7** — Launch at login (SMAppService, wired to Preferences toggle)
+- [x] **Prompt 7** — Launch at login (SMAppService, wired to Preferences toggle)
 
 ## Phase 1 — System Stats & Health Monitor
 


### PR DESCRIPTION
Closes #14.

## Summary
- New `LoginItemManager` enum wraps `SMAppService.mainApp` with idempotent `setEnabled(_:)` and `isEnabled` accessors, plus `os_log` instrumentation matching `HelperRegistration.swift`.
- `PreferencesStore.launchAtLogin` now invokes an injected handler in `didSet` and fires it once on `init` to reconcile the persisted preference with launchd.
- `VaderCleanerApp` wires the production handler (`LoginItemManager.setEnabled`) and an error reporter that surfaces failures via `NSAlert`. The alert is dispatched async so it can't deadlock startup if the very first reconcile throws before `NSApp` is ready.

## Design notes
- The handler/reporter are optional and default to `nil`. Existing `PreferencesStoreTests` keep their pure-model behavior, and the new tests pin both the wiring and the "nil = no side effects" contract.
- Reconcile direction: the persisted preference is treated as the source of truth and pushed down to launchd. If a user disables Login Items via System Settings while VaderCleaner is quit, the next launch re-enables. Defensible (matches the toggle's UI semantics) but called out for review.

## Test plan
- [x] `xcodebuild test` — 63 unit tests + 1 UI test pass locally.
- [x] New tests:
  - `LoginItemManagerTests` (3) — `setEnabled(true/false)` does not throw, `isEnabled` returns a `Bool`. `tearDown` restores the host's pre-test state.
  - `PreferencesStoreTests` (4 new) — `didSet` invokes the handler; thrown errors flow to the reporter; `init` reconciles when the handler is non-nil; nil handler stays side-effect free.
- [ ] Manual smoke: toggle the Startup tab in Settings, confirm `System Settings → General → Login Items` reflects the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Launch at Login" support and a preferences toggle to control it.
  * App now surfaces a warning alert if enabling/disabling launch-at-login fails.

* **Chores**
  * Preferences now use injected handlers to apply launch-at-login changes safely.

* **Tests**
  * Added unit tests covering launch-at-login behavior and error reporting.

* **Documentation**
  * Updated TODO status for the launch-at-login item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->