### PR TITLE
feat: SystemStatsService data layer 

### DIFF
--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -210,24 +210,33 @@ final class SystemStatsService: ObservableObject {
     func start() {
         stop()
         isStopped = false
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-            // Timer callbacks fire on whichever queue scheduled them; for
-            // `Timer.scheduledTimer` that's the current run loop, which is
-            // typically `.main`. We re-enter the main actor explicitly so a
-            // future caller starting the service from a background context
-            // can't violate the actor isolation.
-            Task { @MainActor in
-                self?.refresh()
+        // Add to `.common` mode so the timer keeps firing while AppKit is in a
+        // tracking mode (menu bar popover open, scrollbar drag, etc.). With
+        // the default mode the cheap-stats publisher would freeze the moment
+        // the user clicked the menu bar icon — the very window in which the
+        // popover is showing live RAM/disk numbers.
+        let cheapTimer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                // The timer callback may already be queued by the time
+                // `stop()` invalidates the source. Without this guard the
+                // queued task can still publish one last update — which
+                // breaks the `stop()` contract and surfaces in tests as a
+                // spurious post-stop tick.
+                guard let self = self, !self.isStopped else { return }
+                self.refresh()
             }
         }
-        deviceHealthTimer = Timer.scheduledTimer(
-            withTimeInterval: Self.deviceHealthInterval,
-            repeats: true
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.refreshDeviceHealth()
+        RunLoop.main.add(cheapTimer, forMode: .common)
+        timer = cheapTimer
+
+        let healthTimer = Timer(timeInterval: Self.deviceHealthInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self = self, !self.isStopped else { return }
+                self.refreshDeviceHealth()
             }
         }
+        RunLoop.main.add(healthTimer, forMode: .common)
+        deviceHealthTimer = healthTimer
     }
 
     /// Stops all polling. Safe to call repeatedly. Used by tests to verify the
@@ -298,10 +307,16 @@ final class SystemStatsService: ObservableObject {
         var sumNice: UInt64 = 0
         for cpu in 0..<Int(numCPUs) {
             let base = Int(CPU_STATE_MAX) * cpu
-            sumUser &+= UInt64(cpuInfo[base + Int(CPU_STATE_USER)])
-            sumSystem &+= UInt64(cpuInfo[base + Int(CPU_STATE_SYSTEM)])
-            sumIdle &+= UInt64(cpuInfo[base + Int(CPU_STATE_IDLE)])
-            sumNice &+= UInt64(cpuInfo[base + Int(CPU_STATE_NICE)])
+            // The kernel returns these as `natural_t` (UInt32) but the
+            // buffer is typed as `integer_t` (Int32). A direct `UInt64(_:)`
+            // conversion of an `Int32` whose high bit is set traps at
+            // runtime — and these are monotonic counters, so the high bit
+            // *will* eventually flip on a long-uptime machine. Reinterpret
+            // the bits as unsigned first.
+            sumUser &+= UInt64(UInt32(bitPattern: cpuInfo[base + Int(CPU_STATE_USER)]))
+            sumSystem &+= UInt64(UInt32(bitPattern: cpuInfo[base + Int(CPU_STATE_SYSTEM)]))
+            sumIdle &+= UInt64(UInt32(bitPattern: cpuInfo[base + Int(CPU_STATE_IDLE)]))
+            sumNice &+= UInt64(UInt32(bitPattern: cpuInfo[base + Int(CPU_STATE_NICE)]))
         }
         totals = CPUTotals(user: sumUser, system: sumSystem, idle: sumIdle, nice: sumNice)
 
@@ -467,12 +482,24 @@ final class SystemStatsService: ObservableObject {
             // a weak reference inside the MainActor hop so a service that has
             // been deallocated or stopped before the subprocesses returned
             // doesn't try to publish stale results.
+            //
+            // Both helpers return `nil` on subprocess failure; we preserve
+            // the previously published value in that case rather than
+            // overwriting. This matters most for FileVault: a transient
+            // `fdesetup` failure must not flip the published security state
+            // from "on" to "off" and trip a downstream "FileVault disabled"
+            // notification (Prompt 11). SMART gets the same treatment for
+            // UI-flicker reasons.
             let smart = Self.readSMARTStatus()
             let fv = Self.readFileVaultEnabled()
             Task { @MainActor [weak self] in
                 guard let self = self, !self.isStopped else { return }
-                self.diskSMARTStatus = smart
-                self.fileVaultEnabled = fv
+                if let smart = smart {
+                    self.diskSMARTStatus = smart
+                }
+                if let fv = fv {
+                    self.fileVaultEnabled = fv
+                }
             }
         }
     }
@@ -480,10 +507,12 @@ final class SystemStatsService: ObservableObject {
     /// Runs `/usr/sbin/diskutil info -plist /` and parses `SMARTStatus` from
     /// the resulting property list. `"Verified"` is the value Apple Silicon
     /// internal NVMe disks report; older Intel SATA disks report `"Verified"`
-    /// or `"Failing"`. Anything else, or any subprocess failure, reduces to
-    /// `.unknown` — the UI layer treats `.unknown` as "no opinion" rather
-    /// than alarming the user.
-    nonisolated private static func readSMARTStatus() -> SMARTStatus {
+    /// or `"Failing"`. A successful read with any other value (or a missing
+    /// key) returns `.unknown` — that's diskutil genuinely saying "no
+    /// opinion." A subprocess failure returns `nil` so the caller can
+    /// preserve the previously published status rather than flicker the
+    /// Health Monitor between a known state and `.unknown`.
+    nonisolated private static func readSMARTStatus() -> SMARTStatus? {
         let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "SystemStatsService")
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
@@ -495,11 +524,11 @@ final class SystemStatsService: ObservableObject {
 
         do {
             try process.run()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let data = (try pipe.fileHandleForReading.readToEnd()) ?? Data()
             process.waitUntilExit()
             guard process.terminationStatus == 0 else {
                 os_log("diskutil exited %d", log: log, type: .error, process.terminationStatus)
-                return .unknown
+                return nil
             }
             guard let plist = try PropertyListSerialization.propertyList(
                 from: data,
@@ -520,16 +549,22 @@ final class SystemStatsService: ObservableObject {
         } catch {
             os_log("diskutil invocation failed: %{public}@",
                    log: log, type: .error, error.localizedDescription)
-            return .unknown
+            return nil
         }
     }
 
-    /// Runs `/usr/bin/fdesetup status` and parses the first line of stdout.
-    /// `fdesetup` prints `"FileVault is On."` or `"FileVault is Off."` on the
-    /// first line; we look for the literal `" On."` substring so future
-    /// trailing notes (the encryption-progress percentage during the initial
-    /// encryption phase, for example) don't trip us up.
-    nonisolated private static func readFileVaultEnabled() -> Bool {
+    /// Runs `/usr/bin/fdesetup status` and parses stdout for the literal
+    /// `"FileVault is On."` substring (the fragment is robust to the
+    /// trailing encryption-progress percentage that fdesetup appends during
+    /// the initial encryption phase).
+    ///
+    /// Returns `nil` on subprocess failure (non-zero exit, undecodable
+    /// output, run failure). The caller treats `nil` as "no new information"
+    /// and preserves the previously published value — overwriting a real
+    /// "on" with `false` on a transient failure would falsely indicate
+    /// FileVault is disabled and could trip the security-state notification
+    /// in Prompt 11.
+    nonisolated private static func readFileVaultEnabled() -> Bool? {
         let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "SystemStatsService")
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/fdesetup")
@@ -540,17 +575,17 @@ final class SystemStatsService: ObservableObject {
 
         do {
             try process.run()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let data = (try pipe.fileHandleForReading.readToEnd()) ?? Data()
             process.waitUntilExit()
             guard process.terminationStatus == 0,
                   let output = String(data: data, encoding: .utf8) else {
-                return false
+                return nil
             }
             return output.contains("FileVault is On.")
         } catch {
             os_log("fdesetup invocation failed: %{public}@",
                    log: log, type: .error, error.localizedDescription)
-            return false
+            return nil
         }
     }
 }

--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -553,17 +553,22 @@ final class SystemStatsService: ObservableObject {
         }
     }
 
-    /// Runs `/usr/bin/fdesetup status` and parses stdout for the literal
-    /// `"FileVault is On."` substring (the fragment is robust to the
-    /// trailing encryption-progress percentage that fdesetup appends during
-    /// the initial encryption phase).
+    /// Runs `/usr/bin/fdesetup status` and parses stdout for an
+    /// `"FileVault is On"` / `"FileVault is Off"` substring.
     ///
-    /// Returns `nil` on subprocess failure (non-zero exit, undecodable
-    /// output, run failure). The caller treats `nil` as "no new information"
-    /// and preserves the previously published value — overwriting a real
-    /// "on" with `false` on a transient failure would falsely indicate
-    /// FileVault is disabled and could trip the security-state notification
+    /// Termination status is intentionally **not** gated on. `fdesetup`
+    /// exits with status `2` for "FileVault is On but Busy" — i.e.
+    /// encryption or decryption is in progress — while still printing the
+    /// expected "On" line on stdout. Treating that as a hard failure would
+    /// preserve the previously published value (which defaults to `false`),
+    /// so during a multi-hour encryption phase the app would report
+    /// FileVault as disabled and could trip the security-state notification
     /// in Prompt 11.
+    ///
+    /// Returns `nil` only on a genuine read failure: the process couldn't
+    /// be launched, stdout couldn't be decoded as UTF-8, or stdout
+    /// contained neither expected phrase. Callers treat `nil` as "no new
+    /// information" and preserve the previously published value.
     nonisolated private static func readFileVaultEnabled() -> Bool? {
         let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "SystemStatsService")
         let process = Process()
@@ -577,11 +582,18 @@ final class SystemStatsService: ObservableObject {
             try process.run()
             let data = (try pipe.fileHandleForReading.readToEnd()) ?? Data()
             process.waitUntilExit()
-            guard process.terminationStatus == 0,
-                  let output = String(data: data, encoding: .utf8) else {
+            guard let output = String(data: data, encoding: .utf8) else {
                 return nil
             }
-            return output.contains("FileVault is On.")
+            if output.contains("FileVault is On") {
+                return true
+            }
+            if output.contains("FileVault is Off") {
+                return false
+            }
+            os_log("fdesetup output not recognized (exit=%d): %{public}@",
+                   log: log, type: .error, process.terminationStatus, output)
+            return nil
         } catch {
             os_log("fdesetup invocation failed: %{public}@",
                    log: log, type: .error, error.localizedDescription)

--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -1,0 +1,556 @@
+// SystemStatsService.swift
+// Polling data layer behind the Health Monitor — reads CPU, RAM, disk, battery, SMART, and FileVault state from mach/IOKit/diskutil.
+
+import Foundation
+import Combine
+import Darwin
+import IOKit
+import IOKit.ps
+import os.log
+
+// MARK: - Value types
+
+/// Three coarse buckets the Health Monitor binds color state to. Derived from
+/// `usedBytes / totalBytes`; the boundaries live on `MemoryPressureLevel`
+/// itself so any new caller (notifications in Prompt 11, the menu bar in
+/// Prompt 10) reads the same thresholds the UI does.
+enum MemoryPressureLevel: Equatable {
+    case nominal
+    case fair
+    case critical
+
+    /// Threshold at which the bucket flips from `.nominal` to `.fair`.
+    /// Centralised so future tuning is one edit — all callers and tests
+    /// reference the same constant.
+    static let fairThreshold = 0.70
+
+    /// Threshold at which the bucket flips from `.fair` to `.critical`.
+    static let criticalThreshold = 0.85
+
+    /// Bucket selection from a unit-interval ratio. Inputs outside `[0, 1]`
+    /// are clamped at the boundaries — a transient zero-byte total during
+    /// startup must not crash, and an arithmetic overflow upstream must
+    /// degrade gracefully rather than mis-report.
+    init(usedRatio: Double) {
+        let clamped = max(0.0, min(1.0, usedRatio))
+        if clamped < Self.fairThreshold {
+            self = .nominal
+        } else if clamped < Self.criticalThreshold {
+            self = .fair
+        } else {
+            self = .critical
+        }
+    }
+}
+
+/// Snapshot of system memory in bytes plus a derived `pressureLevel`.
+///
+/// `pressureLevel` is computed on read rather than stored so a manual
+/// `MemoryStats(usedBytes:totalBytes:)` in tests stays a one-liner — and so
+/// the bucket can never disagree with the byte counts that produced it.
+struct MemoryStats: Equatable {
+    let usedBytes: UInt64
+    let totalBytes: UInt64
+
+    /// Derived pressure level from `usedBytes / totalBytes`. Returns
+    /// `.nominal` when `totalBytes == 0` so a transient pre-first-refresh
+    /// state doesn't crash on the divide.
+    var pressureLevel: MemoryPressureLevel {
+        guard totalBytes > 0 else { return .nominal }
+        return MemoryPressureLevel(usedRatio: Double(usedBytes) / Double(totalBytes))
+    }
+
+    /// All-zeros placeholder used as the published default before the first
+    /// refresh has run.
+    static let empty = MemoryStats(usedBytes: 0, totalBytes: 0)
+}
+
+/// Snapshot of root-volume disk usage in bytes. Used + free does not always
+/// equal total on APFS (containers, snapshots, purgeable space), so we store
+/// `usedBytes` and `totalBytes` and let callers derive `freeBytes` if they
+/// need it — but the spec test pins `usedBytes <= totalBytes`, so we round
+/// `usedBytes` to `min(usedBytes, totalBytes)` at read time.
+struct DiskStats: Equatable {
+    let usedBytes: UInt64
+    let totalBytes: UInt64
+
+    static let empty = DiskStats(usedBytes: 0, totalBytes: 0)
+}
+
+/// Battery health snapshot from `AppleSmartBattery` IOKit registry. Returned
+/// as `nil` from `SystemStatsService.batteryHealth` on machines without an
+/// internal battery (Mac mini, Mac Studio, Mac Pro).
+struct BatteryStats: Equatable {
+    /// Number of full charge cycles the battery has logged.
+    let cycleCount: Int
+
+    /// Maximum capacity as a fraction of design capacity (0.0–1.0). 1.0 means
+    /// "as good as new"; ~0.80 is Apple's typical service threshold.
+    let maxCapacityPercent: Double
+
+    /// Localized condition string from IOKit (`"Normal"`, `"Service Battery"`,
+    /// etc.). Treated opaquely by the model; the UI just renders it.
+    let condition: String
+}
+
+/// SMART status of the boot disk. `.good` corresponds to diskutil's
+/// `"Verified"`, `.failing` to `"Failing"`. `.unknown` covers everything
+/// else — most relevantly, the case where `diskutil info -plist /` fails or
+/// returns no `SMARTStatus` key.
+enum SMARTStatus: Equatable {
+    case good
+    case failing
+    case unknown
+}
+
+// MARK: - SystemStatsService
+
+/// Publishes live system-health readings on a polling timer.
+///
+/// All `@Published` properties are read by the Health Monitor (Prompt 9), the
+/// menu bar (Prompt 10), and the threshold-based notification dispatcher
+/// (Prompt 11). The service intentionally exposes raw value types — no
+/// formatting, no thresholds beyond `MemoryPressureLevel` — so each consumer
+/// can format / threshold differently without coupling.
+///
+/// ## Cadence
+///
+/// One 2-second main-thread timer fans the cheap stats out:
+///   - `cpuUsage` (`host_processor_info`)
+///   - `ramUsage` (`host_statistics64`)
+///   - `diskSpace` (`FileManager.attributesOfFileSystem`)
+///   - `batteryHealth` (`AppleSmartBattery` IOKit registry — synchronous,
+///     microseconds)
+///
+/// Subprocess-driven readings (`diskSMARTStatus`, `fileVaultEnabled`) take
+/// tens of milliseconds because `diskutil` and `fdesetup` fork + exec. Running
+/// them on the same 2-second main-thread tick would jank the UI as soon as
+/// anything subscribes. They run on a background `DispatchQueue` and refresh
+/// at startup plus once every five minutes — both values are near-static, so
+/// sub-second cadence buys nothing.
+///
+/// ## Testability
+///
+/// `interval` and `autostart` are injectable. Production calls
+/// `SystemStatsService()`; unit tests pass `autostart: false` and call
+/// `refresh()` directly to exercise invariants without burning a real timer.
+@MainActor
+final class SystemStatsService: ObservableObject {
+
+    // MARK: Published readings
+
+    @Published private(set) var cpuUsage: Double = 0
+    @Published private(set) var ramUsage: MemoryStats = .empty
+    @Published private(set) var diskSpace: DiskStats = .empty
+    @Published private(set) var batteryHealth: BatteryStats?
+    @Published private(set) var diskSMARTStatus: SMARTStatus = .unknown
+    @Published private(set) var fileVaultEnabled: Bool = false
+
+    // MARK: Configuration
+
+    /// Tick rate of the cheap-stats timer.
+    private let interval: TimeInterval
+
+    /// Slow timer cadence for SMART + FileVault. Five minutes is a compromise:
+    /// the values are near-static, but a manual change (toggling FileVault,
+    /// hot-swapping a drive) should reflect within a reasonable window without
+    /// requiring an explicit refresh action.
+    private static let deviceHealthInterval: TimeInterval = 300
+
+    // MARK: State
+
+    private var timer: Timer?
+    private var deviceHealthTimer: Timer?
+    /// Tracks whether `stop()` has been called more recently than `start()`.
+    /// In-flight background subprocess work (SMART, FileVault) hops back to
+    /// the main actor *after* potentially tens of milliseconds; if `stop()`
+    /// landed in that window, we must not publish the stale result. The flag
+    /// gates only the timer-driven and async-hop paths — the synchronous
+    /// `refresh()` is still callable directly so unit tests with
+    /// `autostart: false` keep working.
+    private var isStopped = false
+    private let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "SystemStatsService")
+
+    /// Background queue for `Process` invocations. Serial so two ticks can't
+    /// race a `diskutil` and an `fdesetup` against each other and confuse
+    /// stdout interleaving in any future shared parser.
+    private let backgroundQueue = DispatchQueue(label: "com.personal.VaderCleaner.SystemStatsService.background")
+
+    /// Previous CPU tick totals for delta computation. `host_processor_info`
+    /// reports cumulative ticks since boot, so usage is `(busy_now -
+    /// busy_then) / (total_now - total_then)`. Nil before the first sample;
+    /// the first `refresh()` seeds it and publishes `cpuUsage = 0`.
+    private var previousCPUTotals: CPUTotals?
+
+    // MARK: Init / lifecycle
+
+    init(interval: TimeInterval = 2.0, autostart: Bool = true) {
+        self.interval = interval
+        if autostart {
+            start()
+            // Kick off the slow path immediately so SMART + FileVault are
+            // populated by the time the Health Monitor first renders. The
+            // timer below schedules subsequent refreshes.
+            refreshDeviceHealth()
+        }
+    }
+
+    deinit {
+        // Timers retain their target via the closure capture, but invalidating
+        // here is still polite — the run loop will drop them on the next
+        // iteration. Without the explicit invalidate, a service that outlives
+        // its expected scope (e.g. a leaked test instance) would keep firing.
+        timer?.invalidate()
+        deviceHealthTimer?.invalidate()
+    }
+
+    /// Begins periodic refreshes. Idempotent — calling `start()` on an
+    /// already-running service tears down the previous timers first so the
+    /// caller can change `interval` semantics without leaking.
+    func start() {
+        stop()
+        isStopped = false
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            // Timer callbacks fire on whichever queue scheduled them; for
+            // `Timer.scheduledTimer` that's the current run loop, which is
+            // typically `.main`. We re-enter the main actor explicitly so a
+            // future caller starting the service from a background context
+            // can't violate the actor isolation.
+            Task { @MainActor in
+                self?.refresh()
+            }
+        }
+        deviceHealthTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.deviceHealthInterval,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshDeviceHealth()
+            }
+        }
+    }
+
+    /// Stops all polling. Safe to call repeatedly. Used by tests to verify the
+    /// service goes quiet on demand and by the App during teardown.
+    func stop() {
+        isStopped = true
+        timer?.invalidate()
+        timer = nil
+        deviceHealthTimer?.invalidate()
+        deviceHealthTimer = nil
+    }
+
+    // MARK: Cheap stats — refresh
+
+    /// Reads all cheap stats and republishes. Synchronous; safe to call from
+    /// the main thread.
+    func refresh() {
+        cpuUsage = readCPUUsage()
+        ramUsage = readMemoryStats()
+        diskSpace = readDiskStats()
+        batteryHealth = readBatteryStats()
+    }
+
+    // MARK: CPU
+
+    private struct CPUTotals {
+        let user: UInt64
+        let system: UInt64
+        let idle: UInt64
+        let nice: UInt64
+
+        var busy: UInt64 { user &+ system &+ nice }
+        var total: UInt64 { busy &+ idle }
+    }
+
+    /// Sums per-CPU tick counters via `host_processor_info(PROCESSOR_CPU_LOAD_INFO)`,
+    /// then returns the delta against the previous sample. The first call
+    /// seeds the baseline and returns `0` because there is nothing to subtract
+    /// against. Subsequent calls return `(busy_delta) / (total_delta)`.
+    private func readCPUUsage() -> Double {
+        var cpuInfo: processor_info_array_t!
+        var numCPUs: natural_t = 0
+        var numCPUInfo: mach_msg_type_number_t = 0
+
+        let result = host_processor_info(
+            mach_host_self(),
+            PROCESSOR_CPU_LOAD_INFO,
+            &numCPUs,
+            &cpuInfo,
+            &numCPUInfo
+        )
+        guard result == KERN_SUCCESS, let cpuInfo = cpuInfo else {
+            os_log("host_processor_info failed (code=%d)", log: log, type: .error, result)
+            return cpuUsage // keep the previously published value rather than spike to 0
+        }
+        // `host_processor_info` allocates the buffer in our task; we own it.
+        // Forgetting the deallocate here would leak a small chunk of vm on
+        // every two-second tick — measurable as RSS creep over hours.
+        defer {
+            let size = vm_size_t(numCPUInfo) * vm_size_t(MemoryLayout<integer_t>.stride)
+            vm_deallocate(mach_task_self_, vm_address_t(bitPattern: cpuInfo), size)
+        }
+
+        var totals = CPUTotals(user: 0, system: 0, idle: 0, nice: 0)
+        var sumUser: UInt64 = 0
+        var sumSystem: UInt64 = 0
+        var sumIdle: UInt64 = 0
+        var sumNice: UInt64 = 0
+        for cpu in 0..<Int(numCPUs) {
+            let base = Int(CPU_STATE_MAX) * cpu
+            sumUser &+= UInt64(cpuInfo[base + Int(CPU_STATE_USER)])
+            sumSystem &+= UInt64(cpuInfo[base + Int(CPU_STATE_SYSTEM)])
+            sumIdle &+= UInt64(cpuInfo[base + Int(CPU_STATE_IDLE)])
+            sumNice &+= UInt64(cpuInfo[base + Int(CPU_STATE_NICE)])
+        }
+        totals = CPUTotals(user: sumUser, system: sumSystem, idle: sumIdle, nice: sumNice)
+
+        guard let previous = previousCPUTotals else {
+            // First read — seed the baseline and report no usage. The next
+            // tick will produce a real number.
+            previousCPUTotals = totals
+            return 0.0
+        }
+
+        let busyDelta = totals.busy &- previous.busy
+        let totalDelta = totals.total &- previous.total
+        previousCPUTotals = totals
+
+        guard totalDelta > 0 else {
+            // Two reads inside the same scheduling quantum — no ticks elapsed.
+            // Returning the previously published value avoids a spurious zero.
+            return cpuUsage
+        }
+        let usage = Double(busyDelta) / Double(totalDelta)
+        // Clamp defensively — kernel arithmetic is well-behaved but we never
+        // want to publish a value the test invariants reject.
+        return max(0.0, min(1.0, usage))
+    }
+
+    // MARK: Memory
+
+    /// Reads physical memory totals via `host_statistics64(HOST_VM_INFO64)` for
+    /// per-region page counts and `host_info(HOST_BASIC_INFO)` for the
+    /// physical maximum. "Used" is `active + wired + compressor`, which is
+    /// what Activity Monitor's "Memory Used" reports.
+    private func readMemoryStats() -> MemoryStats {
+        var vmStats = vm_statistics64_data_t()
+        var vmCount = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        let vmResult = withUnsafeMutablePointer(to: &vmStats) { statsPtr in
+            statsPtr.withMemoryRebound(to: integer_t.self, capacity: Int(vmCount)) { intPtr in
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, intPtr, &vmCount)
+            }
+        }
+        guard vmResult == KERN_SUCCESS else {
+            os_log("host_statistics64 failed (code=%d)", log: log, type: .error, vmResult)
+            return ramUsage // keep last good value
+        }
+
+        let pageSize = UInt64(vm_kernel_page_size)
+        let active = UInt64(vmStats.active_count)
+        let wired = UInt64(vmStats.wire_count)
+        let compressed = UInt64(vmStats.compressor_page_count)
+        let usedPages = active &+ wired &+ compressed
+        let usedBytes = usedPages &* pageSize
+
+        var hostInfo = host_basic_info_data_t()
+        var hostCount = mach_msg_type_number_t(
+            MemoryLayout<host_basic_info_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        let hostResult = withUnsafeMutablePointer(to: &hostInfo) { infoPtr in
+            infoPtr.withMemoryRebound(to: integer_t.self, capacity: Int(hostCount)) { intPtr in
+                host_info(mach_host_self(), HOST_BASIC_INFO, intPtr, &hostCount)
+            }
+        }
+        guard hostResult == KERN_SUCCESS else {
+            os_log("host_info failed (code=%d)", log: log, type: .error, hostResult)
+            return ramUsage
+        }
+        // `max_mem` is a 64-bit field on host_basic_info; `memory_size` is the
+        // 32-bit legacy alias and overflows above 4 GB. Use `max_mem`.
+        let totalBytes = UInt64(hostInfo.max_mem)
+
+        // Cap usedBytes at totalBytes — `active + wired + compressor` can
+        // briefly exceed `max_mem` during transient kernel accounting. Capping
+        // preserves the test invariant `usedBytes <= totalBytes` and
+        // matches what a UI should display anyway.
+        let cappedUsed = min(usedBytes, totalBytes)
+        return MemoryStats(usedBytes: cappedUsed, totalBytes: totalBytes)
+    }
+
+    // MARK: Disk
+
+    /// Reads root-volume capacity via `FileManager.attributesOfFileSystem`.
+    /// `/` is the boot volume on every macOS configuration we support.
+    private func readDiskStats() -> DiskStats {
+        do {
+            let attrs = try FileManager.default.attributesOfFileSystem(forPath: "/")
+            // The system-* keys are documented as `NSNumber` (UInt64-backed).
+            // Using `NSNumber.uint64Value` rather than `Int` avoids the
+            // signed/unsigned trap on volumes >= 8 EiB (theoretical, but
+            // costs nothing).
+            let total = (attrs[.systemSize] as? NSNumber)?.uint64Value ?? 0
+            let free = (attrs[.systemFreeSize] as? NSNumber)?.uint64Value ?? 0
+            let used = total > free ? total - free : 0
+            return DiskStats(usedBytes: used, totalBytes: total)
+        } catch {
+            os_log("FileManager.attributesOfFileSystem failed: %{public}@",
+                   log: log, type: .error, error.localizedDescription)
+            return diskSpace // keep last good
+        }
+    }
+
+    // MARK: Battery
+
+    /// Reads battery health from the `AppleSmartBattery` IORegistry entry.
+    /// Returns `nil` on machines with no internal battery (the matching call
+    /// fails silently with `IO_OBJECT_NULL`). The keys read here are stable
+    /// across at least the last decade of macOS releases — Apple uses the
+    /// same registry for `system_profiler SPPowerDataType`.
+    private func readBatteryStats() -> BatteryStats? {
+        let matching = IOServiceMatching("AppleSmartBattery")
+        let service = IOServiceGetMatchingService(kIOMainPortDefault, matching)
+        guard service != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(service) }
+
+        let cycle = (copyProperty(service: service, key: "CycleCount") as? NSNumber)?.intValue ?? 0
+        let maxCap = (copyProperty(service: service, key: "AppleRawMaxCapacity") as? NSNumber)?.doubleValue
+            ?? (copyProperty(service: service, key: "MaxCapacity") as? NSNumber)?.doubleValue
+            ?? 0
+        let designCap = (copyProperty(service: service, key: "DesignCapacity") as? NSNumber)?.doubleValue
+            ?? 0
+        // Some hardware reports `BatteryHealth` ("Good"/"Fair"/"Poor") under a
+        // few different keys depending on macOS version. Try the modern key
+        // first, then fall back. An empty string would fail the test invariant
+        // (`condition.isEmpty == false`) so we substitute `"Unknown"` on
+        // outright misses.
+        let condition = (copyProperty(service: service, key: "BatteryHealthCondition") as? String)
+            ?? (copyProperty(service: service, key: "BatteryHealth") as? String)
+            ?? "Unknown"
+
+        let healthFraction = designCap > 0 ? min(1.0, maxCap / designCap) : 0.0
+        return BatteryStats(
+            cycleCount: cycle,
+            maxCapacityPercent: healthFraction,
+            condition: condition.isEmpty ? "Unknown" : condition
+        )
+    }
+
+    /// Thin wrapper around `IORegistryEntryCreateCFProperty` that returns the
+    /// CF object as `Any?`. Centralised so each property read above is one
+    /// line and we don't repeat the bridging dance.
+    private func copyProperty(service: io_service_t, key: String) -> Any? {
+        guard let unmanaged = IORegistryEntryCreateCFProperty(
+            service,
+            key as CFString,
+            kCFAllocatorDefault,
+            0
+        ) else {
+            return nil
+        }
+        return unmanaged.takeRetainedValue() as Any
+    }
+
+    // MARK: Device health (SMART, FileVault) — slow path
+
+    /// Refreshes SMART and FileVault state by shelling out to `diskutil` and
+    /// `fdesetup` on a background queue, then publishing back on the main
+    /// actor. Safe to call from any context. Errors fall back to `.unknown`
+    /// and `false` so a transient failure doesn't flicker existing UI between
+    /// stale and zero values.
+    func refreshDeviceHealth() {
+        backgroundQueue.async {
+            // Static methods read SMART and FileVault from subprocesses; no
+            // `self` capture is required on the background hop. We re-acquire
+            // a weak reference inside the MainActor hop so a service that has
+            // been deallocated or stopped before the subprocesses returned
+            // doesn't try to publish stale results.
+            let smart = Self.readSMARTStatus()
+            let fv = Self.readFileVaultEnabled()
+            Task { @MainActor [weak self] in
+                guard let self = self, !self.isStopped else { return }
+                self.diskSMARTStatus = smart
+                self.fileVaultEnabled = fv
+            }
+        }
+    }
+
+    /// Runs `/usr/sbin/diskutil info -plist /` and parses `SMARTStatus` from
+    /// the resulting property list. `"Verified"` is the value Apple Silicon
+    /// internal NVMe disks report; older Intel SATA disks report `"Verified"`
+    /// or `"Failing"`. Anything else, or any subprocess failure, reduces to
+    /// `.unknown` — the UI layer treats `.unknown` as "no opinion" rather
+    /// than alarming the user.
+    nonisolated private static func readSMARTStatus() -> SMARTStatus {
+        let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "SystemStatsService")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+        process.arguments = ["info", "-plist", "/"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        // Discard stderr so a noisy warning doesn't spam Console.app from us.
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else {
+                os_log("diskutil exited %d", log: log, type: .error, process.terminationStatus)
+                return .unknown
+            }
+            guard let plist = try PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            ) as? [String: Any],
+                  let status = plist["SMARTStatus"] as? String else {
+                return .unknown
+            }
+            switch status {
+            case "Verified":
+                return .good
+            case "Failing":
+                return .failing
+            default:
+                return .unknown
+            }
+        } catch {
+            os_log("diskutil invocation failed: %{public}@",
+                   log: log, type: .error, error.localizedDescription)
+            return .unknown
+        }
+    }
+
+    /// Runs `/usr/bin/fdesetup status` and parses the first line of stdout.
+    /// `fdesetup` prints `"FileVault is On."` or `"FileVault is Off."` on the
+    /// first line; we look for the literal `" On."` substring so future
+    /// trailing notes (the encryption-progress percentage during the initial
+    /// encryption phase, for example) don't trip us up.
+    nonisolated private static func readFileVaultEnabled() -> Bool {
+        let log = OSLog(subsystem: "com.personal.VaderCleaner", category: "SystemStatsService")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/fdesetup")
+        process.arguments = ["status"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0,
+                  let output = String(data: data, encoding: .utf8) else {
+                return false
+            }
+            return output.contains("FileVault is On.")
+        } catch {
+            os_log("fdesetup invocation failed: %{public}@",
+                   log: log, type: .error, error.localizedDescription)
+            return false
+        }
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -26,6 +26,12 @@ struct VaderCleanerApp: App {
     @StateObject private var menuBarViewModel = MenuBarViewModel()
     @StateObject private var preferences: PreferencesStore
     @StateObject private var exclusions = ExclusionsStore()
+    // App-scope so the cheap-stats timer outlives any single window. The
+    // Health Monitor view (Prompt 9), the menu bar (Prompt 10), and the
+    // notification dispatcher (Prompt 11) all subscribe via
+    // `@EnvironmentObject` — making it a per-view StateObject would
+    // double-instantiate the timer.
+    @StateObject private var systemStats = SystemStatsService()
     @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
@@ -77,6 +83,7 @@ struct VaderCleanerApp: App {
                 .environmentObject(onboardingViewModel)
                 .environmentObject(preferences)
                 .environmentObject(exclusions)
+                .environmentObject(systemStats)
         }
 
         // Each SwiftUI scene gets its own environment, so PreferencesView gets
@@ -113,6 +120,7 @@ struct VaderCleanerApp: App {
                 .environmentObject(menuBarViewModel)
                 .environmentObject(preferences)
                 .environmentObject(exclusions)
+                .environmentObject(systemStats)
         } label: {
             // Compact label combining both placeholder readings — Prompt 10
             // replaces the values, not the format. The "RAM:" / "Disk:"

--- a/VaderCleanerTests/SystemStatsServiceTests.swift
+++ b/VaderCleanerTests/SystemStatsServiceTests.swift
@@ -121,16 +121,21 @@ final class SystemStatsServiceTests: XCTestCase {
 
     /// "Updates stats on a timer" — the spec test from plan.md. We don't mock
     /// `Timer` itself; instead we configure a tiny interval, subscribe to the
-    /// `objectWillChange` publisher, and verify it fires within a deadline.
-    /// That proves the timer fans publishes out without coupling the test to
-    /// any internal scheduling abstraction.
+    /// `objectWillChange` publisher *before* starting, and verify it fires
+    /// within a deadline. That proves the timer fans publishes out without
+    /// coupling the test to any internal scheduling abstraction.
+    ///
+    /// The service is built with `autostart: false` and started manually
+    /// after the sink is attached. Otherwise the auto-fired
+    /// `refreshDeviceHealth()` from the init can satisfy this expectation
+    /// via its background subprocess path even when the cheap-stats timer is
+    /// broken — making the test pass spuriously.
     func test_timer_publishesUpdates_whenStarted() {
-        let service = SystemStatsService(interval: 0.05, autostart: true)
+        let service = SystemStatsService(interval: 0.05, autostart: false)
         let didPublish = expectation(description: "service publishes on timer tick")
 
-        var cancellable: AnyCancellable?
         var fired = false
-        cancellable = service.objectWillChange.sink {
+        let cancellable: AnyCancellable = service.objectWillChange.sink {
             // First publish wins; subsequent ticks would over-fulfil the
             // expectation otherwise (which XCTest treats as a failure).
             guard !fired else { return }
@@ -138,14 +143,18 @@ final class SystemStatsServiceTests: XCTestCase {
             didPublish.fulfill()
         }
 
+        service.start()
         wait(for: [didPublish], timeout: 2.0)
-        cancellable?.cancel()
+        cancellable.cancel()
         service.stop()
     }
 
     func test_stop_haltsFurtherUpdates() {
-        let service = SystemStatsService(interval: 0.05, autostart: true)
-        // Let one tick land so the baseline is established.
+        let service = SystemStatsService(interval: 0.05, autostart: false)
+        // Let one tick land so the baseline is established. Sink-then-start
+        // ordering guarantees the first publish we observe is timer-driven,
+        // not the slow-path device-health refresh that the autostart init
+        // would otherwise kick off.
         let firstTick = expectation(description: "first tick")
         var firstFired = false
         var cancellable: AnyCancellable? = service.objectWillChange.sink {
@@ -153,6 +162,7 @@ final class SystemStatsServiceTests: XCTestCase {
             firstFired = true
             firstTick.fulfill()
         }
+        service.start()
         wait(for: [firstTick], timeout: 2.0)
         cancellable?.cancel()
 

--- a/VaderCleanerTests/SystemStatsServiceTests.swift
+++ b/VaderCleanerTests/SystemStatsServiceTests.swift
@@ -1,0 +1,178 @@
+// SystemStatsServiceTests.swift
+// Tests that the system-stats data layer reports plausible values and that its polling timer fans them out.
+
+import XCTest
+import Combine
+@testable import VaderCleaner
+
+/// Exercises `SystemStatsService` and its supporting value types.
+///
+/// The service reads live numbers from mach / IOKit / `FileManager` against
+/// the host running the test, so assertions are framed as **invariants** —
+/// "is this a plausible value?" — rather than fixed expectations. The CI box
+/// is the developer's laptop, which means we can't drive memory into a
+/// `.critical` pressure state or unplug the battery; what we can do is pin the
+/// shape of the output (ranges, non-negativity, ordering) and verify the timer
+/// fans publishes out as expected.
+@MainActor
+final class SystemStatsServiceTests: XCTestCase {
+
+    // MARK: - MemoryPressureLevel
+
+    /// `MemoryPressureLevel` is the public surface every Health Monitor color
+    /// state binds to, so the four representative ratios (well below the low
+    /// threshold, just above it, just above the high threshold, and a saturated
+    /// near-1.0) lock the bucket boundaries the UI depends on.
+    func test_memoryPressureLevel_thresholds() {
+        XCTAssertEqual(MemoryPressureLevel(usedRatio: 0.30), .nominal)
+        XCTAssertEqual(MemoryPressureLevel(usedRatio: 0.80), .fair)
+        XCTAssertEqual(MemoryPressureLevel(usedRatio: 0.90), .critical)
+        XCTAssertEqual(MemoryPressureLevel(usedRatio: 0.99), .critical)
+    }
+
+    /// Pin the inclusive/exclusive semantics at the bucket edges. A future
+    /// refactor flipping `<` to `<=` would silently shift the boundary cases —
+    /// these assertions catch that.
+    func test_memoryPressureLevel_boundariesAreLowerInclusive() {
+        // 0.70 is exactly the fair threshold: the `<` comparison flips to fair.
+        XCTAssertEqual(MemoryPressureLevel(usedRatio: 0.70), .fair)
+        // 0.85 is exactly the critical threshold: the `<` comparison flips to critical.
+        XCTAssertEqual(MemoryPressureLevel(usedRatio: 0.85), .critical)
+    }
+
+    /// `MemoryStats.pressureLevel` must derive from `usedBytes / totalBytes` and
+    /// match the same buckets — the property is what the UI binds to, not the
+    /// raw enum initializer.
+    func test_memoryStats_pressureLevel_derivedFromRatio() {
+        let nominal = MemoryStats(usedBytes: 30, totalBytes: 100)
+        let fair = MemoryStats(usedBytes: 75, totalBytes: 100)
+        let critical = MemoryStats(usedBytes: 90, totalBytes: 100)
+        XCTAssertEqual(nominal.pressureLevel, .nominal)
+        XCTAssertEqual(fair.pressureLevel, .fair)
+        XCTAssertEqual(critical.pressureLevel, .critical)
+    }
+
+    /// A zero-byte total can occur transiently before the first refresh
+    /// populates `ramUsage`. We must not crash on the divide.
+    func test_memoryStats_pressureLevel_zeroTotalIsNominal() {
+        let stats = MemoryStats(usedBytes: 0, totalBytes: 0)
+        XCTAssertEqual(stats.pressureLevel, .nominal)
+    }
+
+    // MARK: - SystemStatsService — cheap stats
+
+    func test_cpuUsage_isInUnitInterval() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        // First refresh seeds the baseline (returns 0); second refresh produces
+        // a real delta. Both must lie in [0, 1].
+        service.refresh()
+        XCTAssertGreaterThanOrEqual(service.cpuUsage, 0.0)
+        XCTAssertLessThanOrEqual(service.cpuUsage, 1.0)
+        service.refresh()
+        XCTAssertGreaterThanOrEqual(service.cpuUsage, 0.0)
+        XCTAssertLessThanOrEqual(service.cpuUsage, 1.0)
+    }
+
+    func test_ramUsage_hasPlausibleByteCounts() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        service.refresh()
+        XCTAssertGreaterThan(service.ramUsage.totalBytes, 0)
+        XCTAssertGreaterThan(service.ramUsage.usedBytes, 0)
+        XCTAssertLessThanOrEqual(service.ramUsage.usedBytes, service.ramUsage.totalBytes)
+    }
+
+    /// The pressureLevel discriminator is what the UI keys color off of, so we
+    /// pin its inhabitancy in the live read — even though we can't force the
+    /// host into `.critical` from a unit test.
+    func test_ramUsage_pressureLevel_isOneOfThreeCases() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        service.refresh()
+        let level = service.ramUsage.pressureLevel
+        XCTAssertTrue(
+            [.nominal, .fair, .critical].contains(level),
+            "Unexpected MemoryPressureLevel: \(level)"
+        )
+    }
+
+    func test_diskSpace_hasPlausibleByteCounts() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        service.refresh()
+        XCTAssertGreaterThan(service.diskSpace.totalBytes, 0)
+        XCTAssertGreaterThan(service.diskSpace.usedBytes, 0)
+        XCTAssertLessThanOrEqual(service.diskSpace.usedBytes, service.diskSpace.totalBytes)
+    }
+
+    /// Battery may be `nil` on a desktop or absent on a Mac mini. When present,
+    /// cycleCount is non-negative and the condition string is not empty. This
+    /// is the "either nil or plausible" invariant — tests can't force the
+    /// nil branch on a laptop runner.
+    func test_batteryHealth_eitherNilOrPlausible() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        service.refresh()
+        if let battery = service.batteryHealth {
+            XCTAssertGreaterThanOrEqual(battery.cycleCount, 0)
+            XCTAssertGreaterThanOrEqual(battery.maxCapacityPercent, 0.0)
+            XCTAssertFalse(battery.condition.isEmpty)
+        }
+        // Else: no battery present, which is a valid state — nothing to assert.
+    }
+
+    // MARK: - Timer wiring
+
+    /// "Updates stats on a timer" — the spec test from plan.md. We don't mock
+    /// `Timer` itself; instead we configure a tiny interval, subscribe to the
+    /// `objectWillChange` publisher, and verify it fires within a deadline.
+    /// That proves the timer fans publishes out without coupling the test to
+    /// any internal scheduling abstraction.
+    func test_timer_publishesUpdates_whenStarted() {
+        let service = SystemStatsService(interval: 0.05, autostart: true)
+        let didPublish = expectation(description: "service publishes on timer tick")
+
+        var cancellable: AnyCancellable?
+        var fired = false
+        cancellable = service.objectWillChange.sink {
+            // First publish wins; subsequent ticks would over-fulfil the
+            // expectation otherwise (which XCTest treats as a failure).
+            guard !fired else { return }
+            fired = true
+            didPublish.fulfill()
+        }
+
+        wait(for: [didPublish], timeout: 2.0)
+        cancellable?.cancel()
+        service.stop()
+    }
+
+    func test_stop_haltsFurtherUpdates() {
+        let service = SystemStatsService(interval: 0.05, autostart: true)
+        // Let one tick land so the baseline is established.
+        let firstTick = expectation(description: "first tick")
+        var firstFired = false
+        var cancellable: AnyCancellable? = service.objectWillChange.sink {
+            guard !firstFired else { return }
+            firstFired = true
+            firstTick.fulfill()
+        }
+        wait(for: [firstTick], timeout: 2.0)
+        cancellable?.cancel()
+
+        service.stop()
+
+        // After stop(), no further objectWillChange should fire within the
+        // window. We use a manual counter rather than an inverted
+        // XCTestExpectation because the timer can otherwise emit several
+        // events before XCTest unwinds the wait, over-fulfilling the
+        // expectation and tripping its internal assertion.
+        var ticksAfterStop = 0
+        cancellable = service.objectWillChange.sink {
+            ticksAfterStop += 1
+        }
+        let settle = expectation(description: "settle window")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            settle.fulfill()
+        }
+        wait(for: [settle], timeout: 1.0)
+        cancellable?.cancel()
+        XCTAssertEqual(ticksAfterStop, 0, "Service emitted \(ticksAfterStop) updates after stop()")
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -19,7 +19,7 @@
 
 ## Phase 1 — System Stats & Health Monitor
 
-- [ ] **Prompt 8** — SystemStatsService (CPU, RAM, disk, battery, SMART, FileVault)
+- [x] **Prompt 8** — SystemStatsService (CPU, RAM, disk, battery, SMART, FileVault)
 - [ ] **Prompt 9** — Health Monitor UI (5 stat cards + FileVault row)
 - [ ] **Prompt 10** — Menu bar live stats (wired to SystemStatsService)
 - [ ] **Prompt 11** — Notification system (4 notification types, threshold monitoring, cooldown)


### PR DESCRIPTION
## Summary

Implements **Prompt 8** from `plan.md` — the system-stats data layer that the Health Monitor (Prompt 9), menu bar live stats (Prompt 10), and threshold-based notifications (Prompt 11) will subscribe to. No UI work in this PR.

- `SystemStatsService` ObservableObject with a 2-second main-thread timer for cheap stats (CPU, RAM, disk, battery) and a 5-minute background cadence for subprocess-driven stats (SMART via `diskutil`, FileVault via `fdesetup`)
- Value types: `MemoryStats` (derived `pressureLevel`), `MemoryPressureLevel` (`.nominal`/`.fair`/`.critical` at 0.70/0.85), `DiskStats`, `BatteryStats`, `SMARTStatus`
- Injected as `@StateObject` in `VaderCleanerApp` and exposed via `.environmentObject`
- 11 new unit tests; full suite is 79 tests, all green

### Cadence — deviation from the literal plan

The plan says "2-second polling timer." Cheap mach/IOKit stats run every 2s; SMART and FileVault read via `Process` and take tens of milliseconds, so they run on a background queue at 5-minute cadence (plus once at startup). Both values are near-static — sub-second cadence buys nothing and would jank the UI. Rationale captured in the file header and on issue #16.

### Sharp edges addressed

- **CPU first sample returns 0.** `host_processor_info` is cumulative; usage is a delta against the previous sample. First `refresh()` seeds the baseline, publishes 0.0.
- **`vm_deallocate` the CPU info buffer** every tick to avoid leaking on each call.
- **Battery test accepts both `nil` and a valid `BatteryStats`.** Test runner is the developer's laptop — we can't force the desktop branch.
- **SMART parsing uses `PropertyListSerialization`** of `diskutil info -plist /`, not stdout regex.
- **`@MainActor`** on the service. `stop()` flips an `isStopped` flag the async-hop guards check, so in-flight subprocess results land safely after a teardown.

Closes #16

## Test plan

- [x] `xcodebuild test` — 79 unit tests pass
- [x] All `SystemStatsServiceTests` (10) pass
- [x] Existing tests unaffected (no regressions)
- [ ] Smoke test on launch: verify `systemStats` is published into the env and a future Health Monitor view can subscribe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live system monitoring now tracks CPU usage, RAM, disk space, and battery status in real-time.
  * Device health checks added for SMART status and FileVault encryption monitoring.
  * Real-time system statistics are accessible in both the main window and menu bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->