### PR TITLE
feat: Health Monitor UI

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var onboarding: PermissionOnboardingViewModel
+    @EnvironmentObject private var systemStats: SystemStatsService
     @Environment(\.scenePhase) private var scenePhase
     @State private var selectedSection: NavigationSection? = .smartScan
 
@@ -17,7 +18,7 @@ struct ContentView: View {
             }
             .navigationSplitViewColumnWidth(min: 200, ideal: 220)
         } detail: {
-            PlaceholderDetailView(section: selectedSection ?? .smartScan)
+            detailView(for: selectedSection ?? .smartScan)
         }
         .frame(minWidth: 900, minHeight: 600)
         .sheet(isPresented: shouldShowOnboarding) {
@@ -29,6 +30,19 @@ struct ContentView: View {
             if newPhase == .active {
                 appState.refresh()
             }
+        }
+    }
+
+    /// Routes the selected sidebar section to its detail view. Sections without
+    /// a real implementation yet fall back to `PlaceholderDetailView`; Health
+    /// Monitor (Prompt 9) is the first real wiring.
+    @ViewBuilder
+    private func detailView(for section: NavigationSection) -> some View {
+        switch section {
+        case .healthMonitor:
+            HealthMonitorView(service: systemStats)
+        default:
+            PlaceholderDetailView(section: section)
         }
     }
 
@@ -70,4 +84,5 @@ private struct PlaceholderDetailView: View {
     ContentView()
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())
+        .environmentObject(SystemStatsService(autostart: false))
 }

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -1,0 +1,250 @@
+// HealthMonitorView.swift
+// Health Monitor detail view — 5 stat cards (Battery, Disk SMART, RAM, CPU, Disk Space) plus a FileVault footer, bound to SystemStatsService via HealthMonitorViewModel.
+
+import SwiftUI
+
+/// Card-style grid showing live system health. Each card is a small fixed-shape
+/// `HealthCard` with an SF Symbol, label, primary value, optional secondary
+/// value, and a status dot driven by `HealthMonitorViewModel`'s `StatusColor`.
+///
+/// The grid uses `LazyVGrid` with `.adaptive(minimum: 260)` so the card shelf
+/// re-flows on window resize without explicit breakpoints. FileVault — being
+/// a binary security toggle rather than a continuously varying reading — sits
+/// below the grid as a single info row, matching the spec.
+struct HealthMonitorView: View {
+
+    @StateObject private var viewModel: HealthMonitorViewModel
+
+    init(service: SystemStatsService) {
+        _viewModel = StateObject(wrappedValue: HealthMonitorViewModel(service: service))
+    }
+
+    private let columns = [GridItem(.adaptive(minimum: 260), spacing: 16)]
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    batteryCard
+                    smartCard
+                    ramCard
+                    cpuCard
+                    diskCard
+                }
+                Divider()
+                fileVaultRow
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle(NavigationSection.healthMonitor.title)
+    }
+
+    // MARK: - Cards
+
+    private var batteryCard: some View {
+        HealthCard(
+            icon: "battery.100",
+            title: "Battery Health",
+            statusColor: viewModel.batteryColor
+        ) {
+            if let stats = viewModel.battery {
+                Text(HealthMonitorViewModel.batteryCapacityString(stats))
+                    .font(.title2.weight(.semibold))
+                    .accessibilityIdentifier("health.battery.capacity")
+                Text(stats.condition)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Text("\(stats.cycleCount) cycles")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("—")
+                    .font(.title2.weight(.semibold))
+                Text("No internal battery")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityIdentifier("health.card.battery")
+    }
+
+    private var smartCard: some View {
+        HealthCard(
+            icon: "internaldrive",
+            title: "Disk Health",
+            statusColor: viewModel.smartColor
+        ) {
+            Text(viewModel.smartLabel)
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("health.smart.label")
+            Text("SMART status")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityIdentifier("health.card.smart")
+    }
+
+    private var ramCard: some View {
+        HealthCard(
+            icon: "memorychip",
+            title: "RAM Pressure",
+            statusColor: viewModel.ramPressureColor
+        ) {
+            Text(viewModel.ramUsage)
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("health.ram.usage")
+            HStack(spacing: 8) {
+                PressureBadge(level: viewModel.ramPressureLevel, label: viewModel.ramPressureLabel)
+                Spacer()
+            }
+        }
+        .accessibilityIdentifier("health.card.ram")
+    }
+
+    private var cpuCard: some View {
+        HealthCard(
+            icon: "cpu",
+            title: "CPU Load",
+            statusColor: cpuStatusColor
+        ) {
+            Text(viewModel.cpuPercent)
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("health.cpu.percent")
+            ProgressView(value: viewModel.cpuRatio)
+                .progressViewStyle(.linear)
+                .tint(cpuStatusColor.color)
+        }
+        .accessibilityIdentifier("health.card.cpu")
+    }
+
+    private var diskCard: some View {
+        HealthCard(
+            icon: "externaldrive",
+            title: "Disk Space",
+            statusColor: viewModel.diskColor
+        ) {
+            Text(viewModel.diskUsage)
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("health.disk.usage")
+            ProgressView(value: viewModel.diskRatio)
+                .progressViewStyle(.linear)
+                .tint(viewModel.diskColor.color)
+        }
+        .accessibilityIdentifier("health.card.disk")
+    }
+
+    // MARK: - FileVault footer
+
+    private var fileVaultRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: viewModel.fileVaultEnabled ? "lock.shield.fill" : "lock.open")
+                .font(.title3)
+                .foregroundStyle(viewModel.fileVaultColor.color)
+            Text(viewModel.fileVaultLabel)
+                .font(.callout)
+            StatusDot(color: viewModel.fileVaultColor)
+            Spacer()
+        }
+        .padding(.horizontal, 4)
+        .accessibilityIdentifier("health.filevault")
+    }
+
+    // MARK: - Helpers
+
+    /// CPU card uses the same disk ramp (80/95) for its dot since the service
+    /// publishes a unit-interval ratio with no "pressure level" abstraction.
+    private var cpuStatusColor: StatusColor {
+        let r = viewModel.cpuRatio
+        if r < HealthMonitorViewModel.diskWarningThreshold { return .green }
+        if r < HealthMonitorViewModel.diskCriticalThreshold { return .yellow }
+        return .red
+    }
+}
+
+// MARK: - Subviews
+
+/// Reusable card wrapper. Keeps card geometry consistent across the grid so
+/// the user's eye doesn't have to retrain on each tile.
+private struct HealthCard<Content: View>: View {
+    let icon: String
+    let title: String
+    let statusColor: StatusColor
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                Spacer()
+                StatusDot(color: statusColor)
+            }
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+            content
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, minHeight: 140, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 1)
+        )
+    }
+}
+
+/// 8pt traffic-light dot used for the per-card status indicator and the
+/// FileVault footer.
+private struct StatusDot: View {
+    let color: StatusColor
+
+    var body: some View {
+        Circle()
+            .fill(color.color)
+            .frame(width: 10, height: 10)
+            .accessibilityHidden(true)
+    }
+}
+
+/// Compact pill rendering of the memory pressure level, sitting next to the
+/// raw "used / total" string on the RAM card.
+private struct PressureBadge: View {
+    let level: MemoryPressureLevel
+    let label: String
+
+    var body: some View {
+        Text(label)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(
+                Capsule().fill(HealthMonitorViewModel.pressureColor(for: level).color.opacity(0.15))
+            )
+            .foregroundStyle(HealthMonitorViewModel.pressureColor(for: level).color)
+    }
+}
+
+extension StatusColor {
+    /// Maps the SwiftUI-free `StatusColor` to a `Color` at the leaf, keeping
+    /// the view-model and its tests free of SwiftUI imports.
+    var color: Color {
+        switch self {
+        case .green: return .green
+        case .yellow: return .yellow
+        case .red: return .red
+        case .gray: return .secondary
+        }
+    }
+}
+
+#Preview {
+    HealthMonitorView(service: SystemStatsService(autostart: false))
+        .frame(width: 900, height: 600)
+}

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -106,14 +106,14 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "cpu",
             title: "CPU Load",
-            statusColor: cpuStatusColor
+            statusColor: viewModel.cpuColor
         ) {
             Text(viewModel.cpuPercent)
                 .font(.title2.weight(.semibold))
                 .accessibilityIdentifier("health.cpu.percent")
             ProgressView(value: viewModel.cpuRatio)
                 .progressViewStyle(.linear)
-                .tint(cpuStatusColor.color)
+                .tint(viewModel.cpuColor.color)
         }
         .accessibilityIdentifier("health.card.cpu")
     }
@@ -150,16 +150,6 @@ struct HealthMonitorView: View {
         .accessibilityIdentifier("health.filevault")
     }
 
-    // MARK: - Helpers
-
-    /// CPU card uses the same disk ramp (80/95) for its dot since the service
-    /// publishes a unit-interval ratio with no "pressure level" abstraction.
-    private var cpuStatusColor: StatusColor {
-        let r = viewModel.cpuRatio
-        if r < HealthMonitorViewModel.diskWarningThreshold { return .green }
-        if r < HealthMonitorViewModel.diskCriticalThreshold { return .yellow }
-        return .red
-    }
 }
 
 // MARK: - Subviews

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -1,0 +1,229 @@
+// HealthMonitorViewModel.swift
+// View-model behind the Health Monitor — formats SystemStatsService values into card-ready display strings and traffic-light status colors.
+
+import Foundation
+import Combine
+
+/// Traffic-light state the Health Monitor cards bind to.
+///
+/// We deliberately don't use `SwiftUI.Color` here so the view-model — and its
+/// tests — stay free of SwiftUI imports. The view layer maps `StatusColor` →
+/// `Color` once at the leaf. The same enum will back the menu bar (Prompt 10)
+/// and notification dispatcher (Prompt 11) palette.
+enum StatusColor: Equatable {
+    case green
+    case yellow
+    case red
+    case gray
+}
+
+/// Drives the Health Monitor feature view.
+///
+/// The view-model is intentionally thin: it holds a reference to
+/// `SystemStatsService` (the live polling source) and exposes computed
+/// properties that render the published service state into card-ready strings
+/// and `StatusColor` values.
+///
+/// All formatting and color-mapping logic is exposed as `static` pure
+/// functions so unit tests can pin the rules without instantiating a service
+/// or driving real CPU/RAM/disk telemetry. Instance properties simply forward
+/// the live service state through those formatters.
+@MainActor
+final class HealthMonitorViewModel: ObservableObject {
+
+    /// Live data source. Marked `unowned` (via the strong reference held in
+    /// the consuming view's `@EnvironmentObject` chain) — the service is
+    /// app-scope (`VaderCleanerApp.systemStats`) and outlives every view-model
+    /// derived from it.
+    let service: SystemStatsService
+
+    init(service: SystemStatsService) {
+        self.service = service
+    }
+
+    // MARK: - Live-bound display values
+
+    var cpuPercent: String { Self.cpuPercentString(service.cpuUsage) }
+    var cpuRatio: Double { Self.cpuRatio(service.cpuUsage) }
+
+    var ramUsage: String { Self.ramUsageString(service.ramUsage) }
+    var ramPressureLevel: MemoryPressureLevel { service.ramUsage.pressureLevel }
+    var ramPressureLabel: String { Self.pressureLabel(for: ramPressureLevel) }
+    var ramPressureColor: StatusColor { Self.pressureColor(for: ramPressureLevel) }
+
+    var diskUsage: String { Self.diskSpaceString(service.diskSpace) }
+    var diskRatio: Double { Self.diskUsageRatio(service.diskSpace) }
+    var diskColor: StatusColor { Self.diskColor(for: service.diskSpace) }
+
+    var battery: BatteryStats? { service.batteryHealth }
+    var batteryColor: StatusColor { Self.batteryColor(for: battery) }
+    var batteryCapacity: String? { battery.map(Self.batteryCapacityString) }
+    var batteryCondition: String? { battery?.condition }
+    var batteryCycleCount: Int? { battery?.cycleCount }
+
+    var smartStatus: SMARTStatus { service.diskSMARTStatus }
+    var smartLabel: String { Self.smartLabel(for: smartStatus) }
+    var smartColor: StatusColor { Self.smartColor(for: smartStatus) }
+
+    var fileVaultEnabled: Bool { service.fileVaultEnabled }
+    var fileVaultLabel: String { Self.fileVaultLabel(enabled: fileVaultEnabled) }
+    var fileVaultColor: StatusColor { Self.fileVaultColor(enabled: fileVaultEnabled) }
+
+    // MARK: - Pure formatters / color rules
+
+    /// Formats a unit-interval CPU usage to an integer percentage. Inputs
+    /// outside `[0, 1]` clamp at the boundary — the service is expected to
+    /// clamp first, but the formatter is the last line of defence and is
+    /// reused by the menu bar (Prompt 10) and Smart Scan (Prompt 25).
+    static func cpuPercentString(_ usage: Double) -> String {
+        let clamped = cpuRatio(usage)
+        return "\(Int((clamped * 100).rounded()))%"
+    }
+
+    /// Returns `usage` clamped to `[0, 1]`. Drives the CPU progress bar.
+    static func cpuRatio(_ usage: Double) -> Double {
+        max(0.0, min(1.0, usage))
+    }
+
+    /// Formats RAM byte counts as `"used / total"` in GB. We force the GB unit
+    /// (rather than letting `ByteCountFormatter` pick) so 8 GB never renders
+    /// as "8,000 MB" on a non-en locale and so the card width stays stable.
+    static func ramUsageString(_ stats: MemoryStats) -> String {
+        let used = byteString(stats.usedBytes)
+        let total = byteString(stats.totalBytes)
+        return "\(used) / \(total)"
+    }
+
+    /// Formats disk byte counts identically to RAM — see `ramUsageString` for
+    /// rationale on locking the unit.
+    static func diskSpaceString(_ stats: DiskStats) -> String {
+        let used = byteString(stats.usedBytes)
+        let total = byteString(stats.totalBytes)
+        return "\(used) / \(total)"
+    }
+
+    /// `usedBytes / totalBytes` clamped to `[0, 1]`. Returns `0` for zero-byte
+    /// totals (pre-first-refresh) so the % bar stays empty rather than NaN.
+    static func diskUsageRatio(_ stats: DiskStats) -> Double {
+        guard stats.totalBytes > 0 else { return 0.0 }
+        let raw = Double(stats.usedBytes) / Double(stats.totalBytes)
+        return max(0.0, min(1.0, raw))
+    }
+
+    /// Disk fullness color. Below 80% green, 80–95% yellow, above red.
+    /// Boundaries are inclusive at the lower bound (a disk exactly at 80%
+    /// flips to yellow), matching `MemoryPressureLevel`'s convention.
+    static func diskColor(for stats: DiskStats) -> StatusColor {
+        let ratio = diskUsageRatio(stats)
+        if ratio < diskWarningThreshold { return .green }
+        if ratio < diskCriticalThreshold { return .yellow }
+        return .red
+    }
+
+    /// Threshold at which the disk card flips from green to yellow.
+    static let diskWarningThreshold = 0.80
+
+    /// Threshold at which the disk card flips from yellow to red.
+    static let diskCriticalThreshold = 0.95
+
+    /// Color for a memory-pressure bucket. Mirrors the disk ramp but reads
+    /// off `MemoryPressureLevel` (whose thresholds are pinned in
+    /// `SystemStatsService`).
+    static func pressureColor(for level: MemoryPressureLevel) -> StatusColor {
+        switch level {
+        case .nominal: return .green
+        case .fair: return .yellow
+        case .critical: return .red
+        }
+    }
+
+    /// Human-readable label for a memory-pressure bucket.
+    static func pressureLabel(for level: MemoryPressureLevel) -> String {
+        switch level {
+        case .nominal: return "Nominal"
+        case .fair: return "Fair"
+        case .critical: return "Critical"
+        }
+    }
+
+    /// Battery health color from `BatteryStats.condition`. The IOKit key
+    /// flipped from `BatteryHealth` to `BatteryHealthCondition` across macOS
+    /// versions, so we accept both vocabularies. `nil` means no internal
+    /// battery (Mac mini / Studio / Pro) → gray.
+    static func batteryColor(for stats: BatteryStats?) -> StatusColor {
+        guard let stats = stats else { return .gray }
+        switch stats.condition {
+        case "Good", "Normal":
+            return .green
+        case "Service Battery", "Service Recommended", "Replace Soon", "Replace Now", "Permanent Failure":
+            return .red
+        default:
+            // "Fair", "Poor", "Unknown" or anything unrecognised → yellow.
+            // Unknown leans toward yellow rather than gray because the battery
+            // *exists* (we have a non-nil `BatteryStats`); the state is just
+            // ambiguous, which is itself worth surfacing.
+            return .yellow
+        }
+    }
+
+    /// Formats `maxCapacityPercent` (0.0–1.0) as an integer percentage.
+    static func batteryCapacityString(_ stats: BatteryStats) -> String {
+        let clamped = max(0.0, min(1.0, stats.maxCapacityPercent))
+        return "\(Int((clamped * 100).rounded()))%"
+    }
+
+    /// SMART status color. Only `.failing` warrants red — the user needs to
+    /// be backing up. `.unknown` is gray (no opinion) rather than yellow
+    /// because an Apple Silicon internal disk reporting "Verified" is the
+    /// common case and a USB enclosure declining to report SMART is not a
+    /// problem the user can act on.
+    static func smartColor(for status: SMARTStatus) -> StatusColor {
+        switch status {
+        case .good: return .green
+        case .failing: return .red
+        case .unknown: return .gray
+        }
+    }
+
+    /// Human-readable SMART label.
+    static func smartLabel(for status: SMARTStatus) -> String {
+        switch status {
+        case .good: return "Good"
+        case .failing: return "Failing"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    /// FileVault footer text. The "On" / "Off" wording mirrors the
+    /// `fdesetup status` vocabulary the service parses.
+    static func fileVaultLabel(enabled: Bool) -> String {
+        enabled ? "FileVault: On" : "FileVault: Off"
+    }
+
+    /// FileVault color. Off is yellow rather than red because disabling
+    /// FileVault is a deliberate user choice, not a failure mode — the dot
+    /// flags it for visibility without alarmism.
+    static func fileVaultColor(enabled: Bool) -> StatusColor {
+        enabled ? .green : .yellow
+    }
+
+    // MARK: - Helpers
+
+    /// Shared `ByteCountFormatter` configured for GB output. Reused so we
+    /// don't re-allocate one per card on every 2-second tick.
+    ///
+    /// `.useGB` forces the unit even for sub-1 GB inputs ("0.7 GB" rather
+    /// than "700 MB"), which keeps the card layout stable as the value
+    /// changes. `countStyle = .file` matches what Finder shows.
+    private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = [.useGB]
+        f.countStyle = .file
+        f.includesUnit = true
+        return f
+    }()
+
+    private static func byteString(_ bytes: UInt64) -> String {
+        byteFormatter.string(fromByteCount: Int64(min(bytes, UInt64(Int64.max))))
+    }
+}

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -31,20 +31,37 @@ enum StatusColor: Equatable {
 @MainActor
 final class HealthMonitorViewModel: ObservableObject {
 
-    /// Live data source. Marked `unowned` (via the strong reference held in
-    /// the consuming view's `@EnvironmentObject` chain) — the service is
-    /// app-scope (`VaderCleanerApp.systemStats`) and outlives every view-model
-    /// derived from it.
+    /// Live data source. Held strongly. The service itself is app-scope
+    /// (`VaderCleanerApp.systemStats`) and outlives every view-model derived
+    /// from it, so the strong reference does not extend its lifetime.
     let service: SystemStatsService
 
+    /// Holds the Combine subscription that re-publishes service ticks as
+    /// view-model changes. Stored so the sink lives as long as the VM does;
+    /// without retaining the cancellable the subscription would be torn down
+    /// at the end of `init` and the view would freeze on its first frame.
+    private var serviceCancellable: AnyCancellable?
+
+    /// `HealthMonitorViewModel` exposes only computed properties — none of
+    /// them are `@Published` themselves. SwiftUI does **not** automatically
+    /// propagate a nested `ObservableObject`'s `objectWillChange` through an
+    /// outer `ObservableObject`, so a `@StateObject` on the view bound to
+    /// this VM would never observe the service's 2-second polling ticks.
+    /// We bridge the two manually here so every service refresh fans out to
+    /// the view as a single VM change.
     init(service: SystemStatsService) {
         self.service = service
+        self.serviceCancellable = service.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
     }
 
     // MARK: - Live-bound display values
 
     var cpuPercent: String { Self.cpuPercentString(service.cpuUsage) }
     var cpuRatio: Double { Self.cpuRatio(service.cpuUsage) }
+    var cpuColor: StatusColor { Self.cpuColor(for: service.cpuUsage) }
 
     var ramUsage: String { Self.ramUsageString(service.ramUsage) }
     var ramPressureLevel: MemoryPressureLevel { service.ramUsage.pressureLevel }
@@ -121,10 +138,32 @@ final class HealthMonitorViewModel: ObservableObject {
     }
 
     /// Threshold at which the disk card flips from green to yellow.
+    /// Disk fullness is a near-permanent state — anything ≥ 80% warrants
+    /// surfacing in the UI because reclaiming space is slow user work.
     static let diskWarningThreshold = 0.80
 
     /// Threshold at which the disk card flips from yellow to red.
     static let diskCriticalThreshold = 0.95
+
+    /// Threshold at which the CPU card flips from green to yellow. Kept
+    /// separate from `diskWarningThreshold` (even though the initial values
+    /// match) because CPU and disk thresholds tune independently — a
+    /// compile-host machine pegging CPU at 95% is normal, while a disk at
+    /// 95% full is not.
+    static let cpuWarningThreshold = 0.80
+
+    /// Threshold at which the CPU card flips from yellow to red.
+    static let cpuCriticalThreshold = 0.95
+
+    /// CPU load color from a unit-interval ratio. Same shape as
+    /// `diskColor(for:)`; thresholds are independent so the two metrics can
+    /// evolve apart.
+    static func cpuColor(for usage: Double) -> StatusColor {
+        let ratio = cpuRatio(usage)
+        if ratio < cpuWarningThreshold { return .green }
+        if ratio < cpuCriticalThreshold { return .yellow }
+        return .red
+    }
 
     /// Color for a memory-pressure bucket. Mirrors the disk ramp but reads
     /// off `MemoryPressureLevel` (whose thresholds are pinned in

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -2,6 +2,7 @@
 // Tests that HealthMonitorViewModel formats SystemStatsService values into display strings and status colors the Health Monitor cards bind to.
 
 import XCTest
+import Combine
 @testable import VaderCleaner
 
 @MainActor
@@ -113,6 +114,43 @@ final class HealthMonitorViewModelTests: XCTestCase {
         XCTAssertEqual(HealthMonitorViewModel.diskColor(for: dire), .red)
     }
 
+    /// Pin the inclusive/exclusive semantics at the bucket edges. A
+    /// future refactor flipping `<` to `<=` (or vice versa) would silently
+    /// shift the boundary cases — the interior cases above would still pass
+    /// while the boundary readings flipped colors. These two assertions
+    /// catch that.
+    func test_diskColor_atExactThresholds() {
+        // 0.80 exactly: still flips to yellow because comparison is `<`.
+        let atWarning = DiskStats(usedBytes: 800, totalBytes: 1000)
+        XCTAssertEqual(HealthMonitorViewModel.diskColor(for: atWarning), .yellow)
+
+        // 0.95 exactly: still flips to red because comparison is `<`.
+        let atCritical = DiskStats(usedBytes: 950, totalBytes: 1000)
+        XCTAssertEqual(HealthMonitorViewModel.diskColor(for: atCritical), .red)
+    }
+
+    // MARK: - CPU color
+
+    /// CPU color uses the same shape as disk color but with independently
+    /// tunable thresholds. Pin both the bucket interiors and the exact
+    /// boundaries.
+    func test_cpuColor_escalatesWithUsage() {
+        XCTAssertEqual(HealthMonitorViewModel.cpuColor(for: 0.20), .green)
+        XCTAssertEqual(HealthMonitorViewModel.cpuColor(for: 0.85), .yellow)
+        XCTAssertEqual(HealthMonitorViewModel.cpuColor(for: 0.97), .red)
+        // Boundaries: same `<` semantics as disk.
+        XCTAssertEqual(HealthMonitorViewModel.cpuColor(for: HealthMonitorViewModel.cpuWarningThreshold), .yellow)
+        XCTAssertEqual(HealthMonitorViewModel.cpuColor(for: HealthMonitorViewModel.cpuCriticalThreshold), .red)
+    }
+
+    /// Out-of-range inputs clamp before the threshold check — a `1.5`
+    /// reading from a buggy upstream must render red, not crash and not
+    /// fall through to the default green branch.
+    func test_cpuColor_clampsOutOfRangeInputs() {
+        XCTAssertEqual(HealthMonitorViewModel.cpuColor(for: -0.3), .green)
+        XCTAssertEqual(HealthMonitorViewModel.cpuColor(for: 1.5), .red)
+    }
+
     // MARK: - Battery color + formatting
 
     /// `"Good"` and `"Normal"` are the two condition strings IOKit returns for
@@ -203,5 +241,29 @@ final class HealthMonitorViewModelTests: XCTestCase {
         let service = SystemStatsService(interval: 2.0, autostart: false)
         let sut = HealthMonitorViewModel(service: service)
         XCTAssertTrue(sut.service === service)
+    }
+
+    /// Critical end-to-end invariant: when the underlying service publishes
+    /// a tick, the view-model must re-publish so views bound via
+    /// `@StateObject` re-evaluate their computed properties. SwiftUI does
+    /// not propagate a nested `ObservableObject`'s changes through an outer
+    /// `ObservableObject` automatically — without an explicit Combine
+    /// bridge in `init`, the Health Monitor would freeze on its first
+    /// frame. This test pins the bridge.
+    func test_serviceObjectWillChange_propagatesToViewModel() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        let sut = HealthMonitorViewModel(service: service)
+
+        let expectation = XCTestExpectation(description: "VM re-publishes service tick")
+        var cancellables = Set<AnyCancellable>()
+        sut.objectWillChange
+            .sink { _ in expectation.fulfill() }
+            .store(in: &cancellables)
+
+        // Drive a refresh — the service's @Published setters fire
+        // objectWillChange, which our bridge must forward to the VM.
+        service.refresh()
+
+        wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -1,0 +1,207 @@
+// HealthMonitorViewModelTests.swift
+// Tests that HealthMonitorViewModel formats SystemStatsService values into display strings and status colors the Health Monitor cards bind to.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class HealthMonitorViewModelTests: XCTestCase {
+
+    // MARK: - CPU formatting
+
+    /// `cpuPercentString` is the value rendered in the CPU Load card. The
+    /// service publishes a unit-interval `Double`; the card needs an integer
+    /// percentage so a noisy reading doesn't visually thrash with decimals.
+    func test_cpuPercentString_formatsZeroToOneDouble() {
+        XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(0.0), "0%")
+        XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(0.5), "50%")
+        XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(1.0), "100%")
+    }
+
+    /// Inputs outside `[0, 1]` must clamp rather than render `"-3%"` or
+    /// `"137%"`. The service already clamps internally, but the formatter is
+    /// the last line of defence — the menu bar (Prompt 10) and Smart Scan
+    /// (Prompt 25) reuse it.
+    func test_cpuPercentString_clampsOutOfRangeInputs() {
+        XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(-0.2), "0%")
+        XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(1.5), "100%")
+    }
+
+    /// `cpuRatio` is what the card's progress bar binds to. Same clamp.
+    func test_cpuRatio_clampsToUnitInterval() {
+        XCTAssertEqual(HealthMonitorViewModel.cpuRatio(-0.5), 0.0)
+        XCTAssertEqual(HealthMonitorViewModel.cpuRatio(0.5), 0.5)
+        XCTAssertEqual(HealthMonitorViewModel.cpuRatio(1.5), 1.0)
+    }
+
+    // MARK: - RAM formatting
+
+    /// `ramUsageString` formats `MemoryStats` to `"used / total"` in GB. We
+    /// pin the GB unit explicitly (not "let the system pick") so 8 GB doesn't
+    /// render as "8,000 MB" on a localised machine.
+    func test_ramUsageString_formatsBytesToGB() {
+        // 8 GB used / 16 GB total in decimal bytes (ByteCountFormatter default)
+        let stats = MemoryStats(usedBytes: 8_000_000_000, totalBytes: 16_000_000_000)
+        let formatted = HealthMonitorViewModel.ramUsageString(stats)
+        XCTAssertTrue(formatted.contains("8"), "Expected used GB in output, got \(formatted)")
+        XCTAssertTrue(formatted.contains("16"), "Expected total GB in output, got \(formatted)")
+        XCTAssertTrue(
+            formatted.contains("/") || formatted.contains("of"),
+            "Expected used/total separator, got \(formatted)"
+        )
+    }
+
+    /// Zero-byte total is the pre-first-refresh state. The formatter must
+    /// render something — not crash and not return empty — so the card can
+    /// always show a value.
+    func test_ramUsageString_handlesZeroTotal() {
+        let stats = MemoryStats.empty
+        let formatted = HealthMonitorViewModel.ramUsageString(stats)
+        XCTAssertFalse(formatted.isEmpty)
+    }
+
+    /// The pressure-level badge color binds to `MemoryPressureLevel`. The
+    /// thresholds are pinned in `SystemStatsServiceTests`; here we just pin
+    /// the color mapping.
+    func test_pressureColor_mapsLevelsToTrafficLights() {
+        XCTAssertEqual(HealthMonitorViewModel.pressureColor(for: .nominal), .green)
+        XCTAssertEqual(HealthMonitorViewModel.pressureColor(for: .fair), .yellow)
+        XCTAssertEqual(HealthMonitorViewModel.pressureColor(for: .critical), .red)
+    }
+
+    func test_pressureLabel_isHumanReadable() {
+        XCTAssertEqual(HealthMonitorViewModel.pressureLabel(for: .nominal), "Nominal")
+        XCTAssertEqual(HealthMonitorViewModel.pressureLabel(for: .fair), "Fair")
+        XCTAssertEqual(HealthMonitorViewModel.pressureLabel(for: .critical), "Critical")
+    }
+
+    // MARK: - Disk space formatting
+
+    /// `diskSpaceString` formats `DiskStats` to `"used / total"` in GB.
+    func test_diskSpaceString_formatsBytesToGB() {
+        // 256 GB used / 500 GB total
+        let stats = DiskStats(usedBytes: 256_000_000_000, totalBytes: 500_000_000_000)
+        let formatted = HealthMonitorViewModel.diskSpaceString(stats)
+        XCTAssertTrue(formatted.contains("256"), "Expected used GB in output, got \(formatted)")
+        XCTAssertTrue(formatted.contains("500"), "Expected total GB in output, got \(formatted)")
+    }
+
+    /// `diskUsageRatio` drives the % used bar. Same clamp behaviour as CPU.
+    func test_diskUsageRatio_returnsUsedOverTotal() {
+        let stats = DiskStats(usedBytes: 250, totalBytes: 1000)
+        XCTAssertEqual(HealthMonitorViewModel.diskUsageRatio(stats), 0.25, accuracy: 0.0001)
+    }
+
+    /// Zero-total disk is implausible in practice but possible during the
+    /// pre-first-refresh window — must not divide by zero.
+    func test_diskUsageRatio_zeroTotalReturnsZero() {
+        let stats = DiskStats.empty
+        XCTAssertEqual(HealthMonitorViewModel.diskUsageRatio(stats), 0.0)
+    }
+
+    /// Disk space color escalates as the disk fills — green below 80%,
+    /// yellow 80–95%, red above. Boundaries pinned here so a future refactor
+    /// flipping `<` to `<=` is caught.
+    func test_diskColor_escalatesWithUsage() {
+        let comfortable = DiskStats(usedBytes: 500, totalBytes: 1000)
+        XCTAssertEqual(HealthMonitorViewModel.diskColor(for: comfortable), .green)
+
+        let getting = DiskStats(usedBytes: 850, totalBytes: 1000)
+        XCTAssertEqual(HealthMonitorViewModel.diskColor(for: getting), .yellow)
+
+        let dire = DiskStats(usedBytes: 970, totalBytes: 1000)
+        XCTAssertEqual(HealthMonitorViewModel.diskColor(for: dire), .red)
+    }
+
+    // MARK: - Battery color + formatting
+
+    /// `"Good"` and `"Normal"` are the two condition strings IOKit returns for
+    /// a healthy battery (the key flipped from `BatteryHealth` to
+    /// `BatteryHealthCondition` across macOS releases). Both must produce
+    /// green so a perfectly healthy battery doesn't render yellow on older
+    /// macOS.
+    func test_batteryColor_isGreenForGoodCondition() {
+        let good = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: good), .green)
+
+        let normal = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Normal")
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: normal), .green)
+    }
+
+    /// Apple's documented "needs service" condition strings — `"Service
+    /// Battery"` (older macOS) and `"Service Recommended"` (newer) — are
+    /// the two states that warrant a red dot on the card.
+    func test_batteryColor_isRedForServiceCondition() {
+        let service = BatteryStats(cycleCount: 1200, maxCapacityPercent: 0.65, condition: "Service Battery")
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: service), .red)
+
+        let serviceRecommended = BatteryStats(cycleCount: 1500, maxCapacityPercent: 0.60, condition: "Service Recommended")
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: serviceRecommended), .red)
+    }
+
+    /// Anything else (`"Fair"`, `"Poor"`, `"Unknown"`) is yellow — it's not
+    /// pristine but doesn't warrant the alarm of red.
+    func test_batteryColor_isYellowForOtherKnownConditions() {
+        let fair = BatteryStats(cycleCount: 800, maxCapacityPercent: 0.82, condition: "Fair")
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: fair), .yellow)
+    }
+
+    /// Desktops have no internal battery — the service publishes `nil`. The
+    /// card displays a neutral "—" + gray dot instead of being absent.
+    func test_batteryColor_isGrayWhenNoBattery() {
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: nil), .gray)
+    }
+
+    /// `batteryCapacityString` formats the unit-interval capacity as a
+    /// percentage. `0.95` → `"95%"`.
+    func test_batteryCapacityString_formatsAsPercent() {
+        let stats = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
+        XCTAssertEqual(HealthMonitorViewModel.batteryCapacityString(stats), "95%")
+    }
+
+    // MARK: - SMART color
+
+    /// `.failing` is the only state that warrants a red dot — the user should
+    /// be backing up immediately.
+    func test_smartColor_isRedForFailing() {
+        XCTAssertEqual(HealthMonitorViewModel.smartColor(for: .failing), .red)
+    }
+
+    /// `.good` (diskutil's `"Verified"`) is the green case. `.unknown` is
+    /// gray — common on Apple Silicon where `diskutil` reports "Verified" but
+    /// some external NVMe enclosures decline to.
+    func test_smartColor_isGreenForGoodAndGrayForUnknown() {
+        XCTAssertEqual(HealthMonitorViewModel.smartColor(for: .good), .green)
+        XCTAssertEqual(HealthMonitorViewModel.smartColor(for: .unknown), .gray)
+    }
+
+    /// Human-readable label rendered on the SMART card.
+    func test_smartLabel_isHumanReadable() {
+        XCTAssertEqual(HealthMonitorViewModel.smartLabel(for: .good), "Good")
+        XCTAssertEqual(HealthMonitorViewModel.smartLabel(for: .failing), "Failing")
+        XCTAssertEqual(HealthMonitorViewModel.smartLabel(for: .unknown), "Unknown")
+    }
+
+    // MARK: - FileVault footer
+
+    func test_fileVaultLabel_reflectsEnabledState() {
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(enabled: true), "FileVault: On")
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(enabled: false), "FileVault: Off")
+    }
+
+    func test_fileVaultColor_isGreenWhenEnabled() {
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(enabled: true), .green)
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(enabled: false), .yellow)
+    }
+
+    // MARK: - Service binding
+
+    /// The view-model wraps a `SystemStatsService`. Constructing the VM with
+    /// a real (non-autostarted) service must not crash — exercises the init
+    /// path used in production via `@StateObject`.
+    func test_initWithService_storesServiceReference() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        let sut = HealthMonitorViewModel(service: service)
+        XCTAssertTrue(sut.service === service)
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -20,7 +20,7 @@
 ## Phase 1 — System Stats & Health Monitor
 
 - [x] **Prompt 8** — SystemStatsService (CPU, RAM, disk, battery, SMART, FileVault)
-- [ ] **Prompt 9** — Health Monitor UI (5 stat cards + FileVault row)
+- [x] **Prompt 9** — Health Monitor UI (5 stat cards + FileVault row)
 - [ ] **Prompt 10** — Menu bar live stats (wired to SystemStatsService)
 - [ ] **Prompt 11** — Notification system (4 notification types, threshold monitoring, cooldown)
 


### PR DESCRIPTION
## Summary

- Implements **Prompt 9** from `plan.md` — the Health Monitor feature view, the first real consumer of `SystemStatsService` (Prompt 8).
- New `HealthMonitorViewModel` exposes static pure formatters + a SwiftUI-free `StatusColor` enum so the formatting / traffic-light rules are testable without standing up a real service.
- New `HealthMonitorView` renders 5 cards (Battery, Disk SMART, RAM Pressure, CPU Load, Disk Space) in a `LazyVGrid` plus a FileVault info row beneath a `Divider`.
- `ContentView` routes `NavigationSection.healthMonitor` to the real view; other sections still render the placeholder until their prompts land.

Closes #18

## Test plan

- [x] `xcodebuild test` — all 101 unit tests pass (22 new in `HealthMonitorViewModelTests`)
- [x] `xcodebuild -only-testing:VaderCleanerUITests test` — UI test still passes
- [ ] Manual: launch app → click "Health Monitor" sidebar → verify 5 cards + FileVault row render with live values
- [ ] Manual: window resize → verify card grid re-flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health Monitor screen added to the app, showing five live system-health cards (Battery, CPU Load, RAM Pressure, Disk Space, SMART) plus FileVault status, with color-coded indicators and user-friendly formatted values; accessible from the app's detail/navigation area.
* **Tests**
  * Added comprehensive tests covering formatting, thresholds, color mappings, and service-driven updates for the Health Monitor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->