### PR TITLE
Menu bar live stats wired to SystemStatsService

### DIFF
--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -1,12 +1,16 @@
 // MenuBarContent.swift
-// SwiftUI view rendering the menu bar extra popover — RAM row, disk row, Open and Quit actions.
+// SwiftUI view rendering the menu bar extra popover — RAM/Disk/CPU/Battery rows + Open and Quit actions.
 
 import SwiftUI
 import AppKit
 
-/// Popover content presented when the user clicks the menu bar icon. Uses a
-/// fixed-width column so the layout stays stable as Prompt 10 swaps in live
-/// telemetry.
+/// Popover content presented when the user clicks the menu bar icon. Rows are
+/// driven by `MenuBarViewModel` which is in turn fed by `SystemStatsService`,
+/// so values refresh on the same 2-second cadence as the Health Monitor.
+///
+/// The Battery row is conditional — desktops report no internal battery
+/// (`SystemStatsService.batteryHealth == nil`), and rendering an empty row
+/// would just look like a UI bug.
 struct MenuBarContent: View {
 
     @EnvironmentObject private var menuBar: MenuBarViewModel
@@ -14,8 +18,12 @@ struct MenuBarContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            statRow(label: "RAM", value: menuBar.formattedRAMUsage)
+            ramRow
             statRow(label: "Disk", value: menuBar.formattedDiskSpace)
+            statRow(label: "CPU", value: menuBar.formattedCPU)
+            if let battery = menuBar.formattedBatteryHealth {
+                statRow(label: "Battery", value: battery)
+            }
 
             Divider()
 
@@ -30,7 +38,25 @@ struct MenuBarContent: View {
             .keyboardShortcut("q")
         }
         .padding(12)
-        .frame(width: 220)
+        .frame(width: 240)
+    }
+
+    /// RAM row carries an extra pressure-level badge so the user can see at a
+    /// glance whether the system is under memory pressure without having to
+    /// open the Health Monitor. The badge mirrors the Health Monitor card's
+    /// color via the shared `StatusColor` mapping.
+    private var ramRow: some View {
+        HStack {
+            Text("RAM")
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(menuBar.formattedRAMUsage)
+                .monospacedDigit()
+            pressureBadge(
+                label: menuBar.ramPressureLabel,
+                color: menuBar.ramPressureColor
+            )
+        }
     }
 
     private func statRow(label: String, value: String) -> some View {
@@ -40,6 +66,32 @@ struct MenuBarContent: View {
             Spacer()
             Text(value)
                 .monospacedDigit()
+        }
+    }
+
+    /// Compact pill: a colored dot + status label. Sized small so it tucks
+    /// into the trailing edge of the row without competing with the value.
+    private func pressureBadge(label: String, color: StatusColor) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(swiftUIColor(for: color))
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Maps the view-model's `StatusColor` (deliberately UI-framework-free
+    /// for testability) to a SwiftUI `Color` at the leaf. Same mapping the
+    /// Health Monitor card uses; kept local to the view rather than on the
+    /// enum so the view-model layer stays SwiftUI-import-free.
+    private func swiftUIColor(for status: StatusColor) -> Color {
+        switch status {
+        case .green: return .green
+        case .yellow: return .yellow
+        case .red: return .red
+        case .gray: return .gray
         }
     }
 
@@ -55,5 +107,5 @@ struct MenuBarContent: View {
 
 #Preview {
     MenuBarContent()
-        .environmentObject(MenuBarViewModel())
+        .environmentObject(MenuBarViewModel(service: SystemStatsService(autostart: false)))
 }

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -168,11 +168,18 @@ final class MenuBarViewModel: ObservableObject {
     /// component at `compactGBCap` so absurd inputs render as "9999+ GB"
     /// rather than blowing up the menu bar label. Realistic Mac hardware
     /// (256 GB RAM, 16 TB disk = 16384 GB) sits well under the cap.
+    ///
+    /// Rounds to the nearest GB rather than truncating so the label tracks
+    /// `ByteCountFormatter`'s rounding in the popover row — without this a
+    /// reading of 7.9 GB would render as "7 GB" in the menu bar but "8 GB"
+    /// in the popover, looking like a bug.
     private static func clampedGB(_ bytes: UInt64) -> String {
         // Saturate at Int64.max before the divide — `UInt64.max / 1e9` would
-        // overflow Int otherwise.
-        let safeBytes = min(bytes, UInt64(Int64.max))
-        let gb = Int(safeBytes / bytesPerGB)
+        // overflow Int otherwise. Saturate again before adding the half-GB
+        // round-up bias so the addition itself can't overflow on inputs near
+        // `UInt64.max`.
+        let saturated = min(bytes, UInt64(Int64.max) - bytesPerGB)
+        let gb = Int((saturated + bytesPerGB / 2) / bytesPerGB)
         if gb > compactGBCap {
             return "\(compactGBCap)+ GB"
         }

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -189,10 +189,13 @@ final class MenuBarViewModel: ObservableObject {
     /// File-style GB (decimal, matching `ByteCountFormatter.countStyle = .file`).
     private static let bytesPerGB: UInt64 = 1_000_000_000
 
-    /// Soft cap on integer GB rendered in the compact menu bar label. 9,999
-    /// is well above realistic hardware (256 GB RAM, ~16 TB disk) but keeps
-    /// each segment to at most "9999+ GB" = 8 chars.
-    private static let compactGBCap = 9999
+    /// Soft cap on integer GB rendered in the compact menu bar label. 99,999
+    /// (~100 TB) sits comfortably above realistic Mac hardware — a 16 TB
+    /// boot volume reads as 16,384 GB and renders as the live value, not the
+    /// cap — so this only catches truly absurd readings (e.g. `UInt64.max`
+    /// bytes from a buggy upstream). Keeps each segment to at most
+    /// "99999+ GB" = 9 chars; combined label stays well under 50 chars.
+    private static let compactGBCap = 99_999
 
     /// `(total - used) / total * 100` rounded to int. Returns `0` for
     /// zero-total state so the pre-first-refresh popover renders

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -1,36 +1,201 @@
 // MenuBarViewModel.swift
-// View-model backing the menu bar extra — exposes formatted RAM/disk strings the popover and label render.
+// View-model backing the menu bar extra — formats SystemStatsService values into menu-bar-ready strings and a compact label for `MenuBarExtra`.
 
 import Foundation
 import Combine
 
 /// Drives the `MenuBarExtra` label and popover.
 ///
-/// For Prompt 5 the values are static placeholders. Prompt 10 replaces the
-/// `init` defaults with a `SystemStatsService` subscription that updates these
-/// `@Published` strings every two seconds, so the popover and label re-render
-/// without further view changes.
+/// The view-model wraps a `SystemStatsService` (the same app-scope instance
+/// the Health Monitor consumes) and exposes formatted display strings the
+/// popover and label render. All formatting is exposed as `static` pure
+/// functions so unit tests can pin the rules without instantiating a service
+/// or driving real telemetry; instance properties forward live service state
+/// through those formatters.
+///
+/// SwiftUI does not propagate a nested `ObservableObject`'s `objectWillChange`
+/// through an outer `ObservableObject` automatically — without an explicit
+/// Combine bridge in `init`, the popover would freeze on its first frame.
+/// `serviceCancellable` retains the bridge subscription for the lifetime of
+/// the view-model so each 2-second service tick fans out as a single VM
+/// change.
 @MainActor
 final class MenuBarViewModel: ObservableObject {
 
-    /// Default placeholder shown until `SystemStatsService` (Prompt 10) starts
-    /// publishing live values. Format mirrors what the live wiring will emit so
-    /// the menu bar label width does not jump on first update.
+    /// Live data source. Held strongly. The service is app-scope
+    /// (`VaderCleanerApp.systemStats`) and outlives every consumer derived
+    /// from it, so the strong reference does not extend its lifetime.
+    let service: SystemStatsService
+
+    /// Combine subscription that re-publishes service ticks as view-model
+    /// changes. Stored so the sink lives as long as the VM does; without
+    /// retaining the cancellable the subscription would be torn down at the
+    /// end of `init` and the popover would freeze on its first frame.
+    private var serviceCancellable: AnyCancellable?
+
+    init(service: SystemStatsService) {
+        self.service = service
+        self.serviceCancellable = service.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+    }
+
+    // MARK: - Live-bound display values
+
+    var formattedRAMUsage: String { Self.formattedRAMUsage(service.ramUsage) }
+    var formattedDiskSpace: String { Self.formattedDiskSpace(service.diskSpace) }
+    var formattedCPU: String { Self.formattedCPU(service.cpuUsage) }
+    var formattedBatteryHealth: String? { Self.formattedBatteryHealth(service.batteryHealth) }
+    var ramPressureLevel: MemoryPressureLevel { service.ramUsage.pressureLevel }
+    var ramPressureLabel: String { Self.pressureLabel(for: ramPressureLevel) }
+    var ramPressureColor: StatusColor { Self.pressureColor(for: ramPressureLevel) }
+
+    /// Single string the `MenuBarExtra` label renders. The format lives on the
+    /// view-model (rather than as a `Text("RAM: \(...) | Disk: \(...)")`
+    /// interpolation in the App scene) so the truncation rules in
+    /// `menuBarLabel(ram:disk:)` are the only path producing menu bar text —
+    /// no second copy of the format to keep in sync.
+    var menuBarLabelText: String {
+        Self.menuBarLabel(ram: service.ramUsage, disk: service.diskSpace)
+    }
+
+    // MARK: - Pure formatters
+
+    /// Formats `MemoryStats` to `"used / total"` in GB. We force the GB unit
+    /// (rather than letting `ByteCountFormatter` pick) so 8 GB never renders
+    /// as "8,000 MB" on a non-en locale and so the popover row width stays
+    /// stable across ticks.
+    static func formattedRAMUsage(_ stats: MemoryStats) -> String {
+        let used = byteString(stats.usedBytes)
+        let total = byteString(stats.totalBytes)
+        return "\(used) / \(total)"
+    }
+
+    /// Formats `DiskStats` to `"used / total · NN% free"`. Free percent is
+    /// derived from `(total - used) / total`; rounded to integer so a noisy
+    /// reading doesn't visually thrash with decimals.
+    static func formattedDiskSpace(_ stats: DiskStats) -> String {
+        let used = byteString(stats.usedBytes)
+        let total = byteString(stats.totalBytes)
+        let freePercent = freePercentInt(stats)
+        return "\(used) / \(total) · \(freePercent)% free"
+    }
+
+    /// Formats a unit-interval CPU usage to an integer percentage. Inputs
+    /// outside `[0, 1]` clamp at the boundary — matches
+    /// `HealthMonitorViewModel.cpuPercentString` so both consumers display
+    /// the same value for the same reading.
+    static func formattedCPU(_ usage: Double) -> String {
+        let clamped = max(0.0, min(1.0, usage))
+        return "\(Int((clamped * 100).rounded()))%"
+    }
+
+    /// Formats a battery's `maxCapacityPercent` (0.0–1.0) as an integer
+    /// percent. Returns `nil` when no battery is present so the popover can
+    /// hide the row entirely on desktops.
+    static func formattedBatteryHealth(_ stats: BatteryStats?) -> String? {
+        guard let stats = stats else { return nil }
+        let clamped = max(0.0, min(1.0, stats.maxCapacityPercent))
+        return "\(Int((clamped * 100).rounded()))%"
+    }
+
+    /// Human-readable label for a memory-pressure bucket. Matches the
+    /// `HealthMonitorViewModel` vocabulary so the badge in the popover and
+    /// the badge in the Health Monitor card always read the same way.
+    static func pressureLabel(for level: MemoryPressureLevel) -> String {
+        switch level {
+        case .nominal: return "Nominal"
+        case .fair: return "Fair"
+        case .critical: return "Critical"
+        }
+    }
+
+    /// Color for a memory-pressure bucket. Reuses `StatusColor` from
+    /// `HealthMonitorViewModel` so the menu bar palette and the Health
+    /// Monitor palette can never drift apart.
+    static func pressureColor(for level: MemoryPressureLevel) -> StatusColor {
+        switch level {
+        case .nominal: return .green
+        case .fair: return .yellow
+        case .critical: return .red
+        }
+    }
+
+    // MARK: - Compact menu bar label
+
+    /// Builds the single string `MenuBarExtra` renders. Uses compact GB
+    /// values so even at full hardware ranges (256 GB RAM, 16 TB disk) the
+    /// label stays well under the system menu bar's available width.
     ///
-    /// These are value-only ("0.0 GB", "0 GB free") — the "RAM:" / "Disk:"
-    /// prefixes are owned by `MenuBarExtra`'s label and the popover row labels,
-    /// so the popover does not render the prefix twice.
-    static let placeholderRAM = "0.0 GB"
-    static let placeholderDisk = "0 GB free"
+    /// Each segment is hard-capped via `clampedGB` so a buggy upstream
+    /// reading of `UInt64.max` bytes can't render as `"18,446,744,073 GB"`
+    /// and blow up label width.
+    static func menuBarLabel(ram: MemoryStats, disk: DiskStats) -> String {
+        let ramSegment = clampedGB(ram.usedBytes)
+        // Disk segment shows free space in GB — that's the number the user
+        // cares about at-a-glance ("how much room do I have left?"), and it
+        // matches the `0 GB free` placeholder convention from Prompt 5 so
+        // the label width doesn't jump on first real refresh.
+        let freeBytes = disk.totalBytes > disk.usedBytes
+            ? disk.totalBytes - disk.usedBytes
+            : 0
+        let diskSegment = clampedGB(freeBytes)
+        return "RAM: \(ramSegment) · Disk: \(diskSegment) free"
+    }
 
-    @Published var formattedRAMUsage: String
-    @Published var formattedDiskSpace: String
+    // MARK: - Helpers
 
-    init(
-        ramUsage: String = MenuBarViewModel.placeholderRAM,
-        diskSpace: String = MenuBarViewModel.placeholderDisk
-    ) {
-        self.formattedRAMUsage = ramUsage
-        self.formattedDiskSpace = diskSpace
+    /// Shared `ByteCountFormatter` configured for GB output. Reused so we
+    /// don't re-allocate one per render on every 2-second tick.
+    ///
+    /// `.useGB` forces the unit even for sub-1 GB inputs ("0.7 GB" rather
+    /// than "700 MB"), keeping popover row width stable as the value
+    /// changes. `countStyle = .file` matches what Finder shows.
+    private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = [.useGB]
+        f.countStyle = .file
+        f.includesUnit = true
+        return f
+    }()
+
+    private static func byteString(_ bytes: UInt64) -> String {
+        byteFormatter.string(fromByteCount: Int64(min(bytes, UInt64(Int64.max))))
+    }
+
+    /// Renders a byte count as compact GB ("12 GB"), capping the integer
+    /// component at `compactGBCap` so absurd inputs render as "9999+ GB"
+    /// rather than blowing up the menu bar label. Realistic Mac hardware
+    /// (256 GB RAM, 16 TB disk = 16384 GB) sits well under the cap.
+    private static func clampedGB(_ bytes: UInt64) -> String {
+        // Saturate at Int64.max before the divide — `UInt64.max / 1e9` would
+        // overflow Int otherwise.
+        let safeBytes = min(bytes, UInt64(Int64.max))
+        let gb = Int(safeBytes / bytesPerGB)
+        if gb > compactGBCap {
+            return "\(compactGBCap)+ GB"
+        }
+        return "\(gb) GB"
+    }
+
+    /// File-style GB (decimal, matching `ByteCountFormatter.countStyle = .file`).
+    private static let bytesPerGB: UInt64 = 1_000_000_000
+
+    /// Soft cap on integer GB rendered in the compact menu bar label. 9,999
+    /// is well above realistic hardware (256 GB RAM, ~16 TB disk) but keeps
+    /// each segment to at most "9999+ GB" = 8 chars.
+    private static let compactGBCap = 9999
+
+    /// `(total - used) / total * 100` rounded to int. Returns `0` for
+    /// zero-total state so the pre-first-refresh popover renders
+    /// `"0 GB / 0 GB · 0% free"` rather than NaN.
+    private static func freePercentInt(_ stats: DiskStats) -> Int {
+        guard stats.totalBytes > 0 else { return 0 }
+        let free = stats.totalBytes > stats.usedBytes
+            ? stats.totalBytes - stats.usedBytes
+            : 0
+        let ratio = Double(free) / Double(stats.totalBytes)
+        return Int((max(0.0, min(1.0, ratio)) * 100).rounded())
     }
 }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -23,7 +23,7 @@ struct VaderCleanerApp: App {
     // would be re-created per WindowGroup instance.
     @StateObject private var appState = AppState()
     @StateObject private var onboardingViewModel = PermissionOnboardingViewModel()
-    @StateObject private var menuBarViewModel = MenuBarViewModel()
+    @StateObject private var menuBarViewModel: MenuBarViewModel
     @StateObject private var preferences: PreferencesStore
     @StateObject private var exclusions = ExclusionsStore()
     // App-scope so the cheap-stats timer outlives any single window. The
@@ -31,7 +31,7 @@ struct VaderCleanerApp: App {
     // notification dispatcher (Prompt 11) all subscribe via
     // `@EnvironmentObject` — making it a per-view StateObject would
     // double-instantiate the timer.
-    @StateObject private var systemStats = SystemStatsService()
+    @StateObject private var systemStats: SystemStatsService
     @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
@@ -47,6 +47,15 @@ struct VaderCleanerApp: App {
                 launchAtLoginErrorReporter: VaderCleanerApp.presentLaunchAtLoginAlert(_:)
             )
         )
+        // Construct the polling service and the menu bar view-model in the
+        // same init so both `@StateObject` wrappers reference the *same*
+        // service instance. Initializing `menuBarViewModel` at its property
+        // declaration would force a separate `SystemStatsService()` —
+        // doubling the polling timer and decoupling the menu bar from the
+        // service the Health Monitor consumes.
+        let stats = SystemStatsService()
+        _systemStats = StateObject(wrappedValue: stats)
+        _menuBarViewModel = StateObject(wrappedValue: MenuBarViewModel(service: stats))
     }
 
     /// Surfaces a launchd registration failure to the user. Kept on the App
@@ -122,11 +131,12 @@ struct VaderCleanerApp: App {
                 .environmentObject(exclusions)
                 .environmentObject(systemStats)
         } label: {
-            // Compact label combining both placeholder readings — Prompt 10
-            // replaces the values, not the format. The "RAM:" / "Disk:"
-            // prefixes live here (and on the popover rows) so the view-model
-            // can stay value-only and avoid duplicated labels.
-            Text("RAM: \(menuBarViewModel.formattedRAMUsage) | Disk: \(menuBarViewModel.formattedDiskSpace)")
+            // Compact label rendered into the system menu bar. The format
+            // (prefixes, separator, truncation rules) lives on
+            // `MenuBarViewModel.menuBarLabel(ram:disk:)` so a buggy upstream
+            // reading can't blow up label width — the view-model clamps each
+            // segment before formatting.
+            Text(menuBarViewModel.menuBarLabelText)
         }
         .menuBarExtraStyle(.window)
     }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -135,8 +135,11 @@ struct VaderCleanerApp: App {
             // (prefixes, separator, truncation rules) lives on
             // `MenuBarViewModel.menuBarLabel(ram:disk:)` so a buggy upstream
             // reading can't blow up label width — the view-model clamps each
-            // segment before formatting.
+            // segment before formatting. `.monospacedDigit()` keeps numeric
+            // glyphs fixed-width so neighbouring menu bar items don't jitter
+            // as readings change every two seconds.
             Text(menuBarViewModel.menuBarLabelText)
+                .monospacedDigit()
         }
         .menuBarExtraStyle(.window)
     }

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -129,11 +129,11 @@ final class MenuBarViewModelTests: XCTestCase {
         let extremeDisk = DiskStats(usedBytes: 0, totalBytes: UInt64.max)
         let label = MenuBarViewModel.menuBarLabel(ram: extreme, disk: extremeDisk)
         XCTAssertTrue(
-            label.contains("RAM: 9999+ GB"),
+            label.contains("RAM: 99999+ GB"),
             "Expected RAM segment to be capped, got \(label)"
         )
         XCTAssertTrue(
-            label.contains("Disk: 9999+ GB free"),
+            label.contains("Disk: 99999+ GB free"),
             "Expected disk segment to be capped, got \(label)"
         )
         XCTAssertLessThanOrEqual(

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -38,8 +38,10 @@ final class MenuBarViewModelTests: XCTestCase {
         let formatted = MenuBarViewModel.formattedDiskSpace(stats)
         XCTAssertTrue(formatted.contains("250"), "Expected used GB in output, got \(formatted)")
         XCTAssertTrue(formatted.contains("500"), "Expected total GB in output, got \(formatted)")
-        XCTAssertTrue(formatted.contains("50"), "Expected free percent in output, got \(formatted)")
-        XCTAssertTrue(formatted.contains("free"), "Expected 'free' qualifier, got \(formatted)")
+        // Match the full token rather than `contains("50")` — the latter
+        // would already pass on the `"500"` total and silently let a wrong
+        // free-percent slip through.
+        XCTAssertTrue(formatted.contains("50% free"), "Expected '50% free' in output, got \(formatted)")
     }
 
     /// Zero-total state must not divide by zero and must still render.
@@ -117,15 +119,33 @@ final class MenuBarViewModelTests: XCTestCase {
     /// builder must clamp each segment so the rendered text stays bounded.
     /// 50 chars is generous for the system menu bar — real readings cap at
     /// roughly `"RAM: 256 GB · Disk: 16384 GB free"` (~36 chars).
+    ///
+    /// Disk uses `usedBytes: 0, totalBytes: UInt64.max` so the *free* space
+    /// (the segment the label renders) is also extreme — `usedBytes ==
+    /// totalBytes` would have rendered `0 GB free` and silently bypassed
+    /// the disk-side clamp.
     func test_menuBarLabel_truncatesGracefullyForLargeValues() {
         let extreme = MemoryStats(usedBytes: UInt64.max, totalBytes: UInt64.max)
-        let extremeDisk = DiskStats(usedBytes: UInt64.max, totalBytes: UInt64.max)
+        let extremeDisk = DiskStats(usedBytes: 0, totalBytes: UInt64.max)
         let label = MenuBarViewModel.menuBarLabel(ram: extreme, disk: extremeDisk)
+        XCTAssertTrue(
+            label.contains("RAM: 9999+ GB"),
+            "Expected RAM segment to be capped, got \(label)"
+        )
+        XCTAssertTrue(
+            label.contains("Disk: 9999+ GB free"),
+            "Expected disk segment to be capped, got \(label)"
+        )
         XCTAssertLessThanOrEqual(
             label.count, 50,
             "Menu bar label must stay bounded for absurd inputs, got \(label.count) chars: \(label)"
         )
-        XCTAssertFalse(label.isEmpty)
+        // Pin that the raw integer never leaked into the label — proves the
+        // bound was hit by clamping rather than incidentally short.
+        XCTAssertFalse(
+            label.contains(String(UInt64.max)),
+            "Raw UInt64.max must not appear in label, got \(label)"
+        )
     }
 
     /// Zero-total state at startup must still produce a renderable label —

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -1,27 +1,192 @@
 // MenuBarViewModelTests.swift
-// Tests that MenuBarViewModel exposes non-empty placeholder strings the menu bar label can render.
+// Tests that MenuBarViewModel formats SystemStatsService values into menu-bar-ready strings and bridges service ticks to the popover.
 
 import XCTest
+import Combine
 @testable import VaderCleaner
 
 @MainActor
 final class MenuBarViewModelTests: XCTestCase {
 
-    func test_init_setsDefaultStatValues() {
-        let sut = MenuBarViewModel()
-        // The menu bar label is built from these strings on launch — both must be
-        // populated before any real telemetry wires up in Prompt 10.
-        XCTAssertFalse(sut.formattedRAMUsage.isEmpty)
-        XCTAssertFalse(sut.formattedDiskSpace.isEmpty)
+    // MARK: - RAM formatting
+
+    /// `formattedRAMUsage` is the popover row's value. The service publishes
+    /// `MemoryStats` in bytes; the popover wants a `"used / total"` GB string
+    /// so the user can see headroom at a glance.
+    func test_formattedRAMUsage_formatsBytesToGB() {
+        let stats = MemoryStats(usedBytes: 8_000_000_000, totalBytes: 16_000_000_000)
+        let formatted = MenuBarViewModel.formattedRAMUsage(stats)
+        XCTAssertTrue(formatted.contains("8"), "Expected used GB in output, got \(formatted)")
+        XCTAssertTrue(formatted.contains("16"), "Expected total GB in output, got \(formatted)")
+        XCTAssertTrue(formatted.contains("/"), "Expected used/total separator, got \(formatted)")
     }
 
-    func test_formattedRAMUsage_isNonEmptyString() {
-        let sut = MenuBarViewModel()
-        XCTAssertFalse(sut.formattedRAMUsage.isEmpty)
+    /// Pre-first-refresh state is `MemoryStats.empty` (all zeros). The
+    /// formatter must still produce a non-empty string so the popover row
+    /// always has *something* to render.
+    func test_formattedRAMUsage_handlesZeroTotal() {
+        XCTAssertFalse(MenuBarViewModel.formattedRAMUsage(.empty).isEmpty)
     }
 
-    func test_formattedDiskSpace_isNonEmptyString() {
-        let sut = MenuBarViewModel()
-        XCTAssertFalse(sut.formattedDiskSpace.isEmpty)
+    // MARK: - Disk formatting
+
+    /// `formattedDiskSpace` returns `"used / total · NN% free"` so the popover
+    /// surfaces both absolute capacity and remaining headroom in one row.
+    func test_formattedDiskSpace_formatsBytesToGBWithFreePercent() {
+        // 250 GB used / 500 GB total → 50% free.
+        let stats = DiskStats(usedBytes: 250_000_000_000, totalBytes: 500_000_000_000)
+        let formatted = MenuBarViewModel.formattedDiskSpace(stats)
+        XCTAssertTrue(formatted.contains("250"), "Expected used GB in output, got \(formatted)")
+        XCTAssertTrue(formatted.contains("500"), "Expected total GB in output, got \(formatted)")
+        XCTAssertTrue(formatted.contains("50"), "Expected free percent in output, got \(formatted)")
+        XCTAssertTrue(formatted.contains("free"), "Expected 'free' qualifier, got \(formatted)")
+    }
+
+    /// Zero-total state must not divide by zero and must still render.
+    func test_formattedDiskSpace_handlesZeroTotal() {
+        XCTAssertFalse(MenuBarViewModel.formattedDiskSpace(.empty).isEmpty)
+    }
+
+    // MARK: - CPU formatting
+
+    /// CPU value goes in the popover as an integer percent — the menu bar is
+    /// not the place for two-decimal precision.
+    func test_formattedCPU_formatsAsPercent() {
+        XCTAssertEqual(MenuBarViewModel.formattedCPU(0.0), "0%")
+        XCTAssertEqual(MenuBarViewModel.formattedCPU(0.42), "42%")
+        XCTAssertEqual(MenuBarViewModel.formattedCPU(1.0), "100%")
+    }
+
+    /// Out-of-range inputs clamp rather than rendering `"-3%"` or `"137%"`.
+    /// The service already clamps internally; this is the last line of
+    /// defence and matches `HealthMonitorViewModel.cpuPercentString` semantics.
+    func test_formattedCPU_clampsOutOfRangeInputs() {
+        XCTAssertEqual(MenuBarViewModel.formattedCPU(-0.5), "0%")
+        XCTAssertEqual(MenuBarViewModel.formattedCPU(2.0), "100%")
+    }
+
+    // MARK: - Battery formatting
+
+    /// Battery row shows max-capacity percent — same shape as
+    /// `HealthMonitorViewModel.batteryCapacityString` but pulled through
+    /// `MenuBarViewModel` so tests pin the menu bar's contract independently.
+    func test_formattedBatteryHealth_formatsAsPercent() {
+        let stats = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
+        XCTAssertEqual(MenuBarViewModel.formattedBatteryHealth(stats), "95%")
+    }
+
+    /// Desktops have no internal battery — the service publishes `nil` and the
+    /// popover hides the row entirely. The formatter signals that with `nil`.
+    func test_formattedBatteryHealth_isNilWhenNoBattery() {
+        XCTAssertNil(MenuBarViewModel.formattedBatteryHealth(nil))
+    }
+
+    // MARK: - Pressure indicator
+
+    func test_pressureLabel_returnsHumanReadable() {
+        XCTAssertEqual(MenuBarViewModel.pressureLabel(for: .nominal), "Nominal")
+        XCTAssertEqual(MenuBarViewModel.pressureLabel(for: .fair), "Fair")
+        XCTAssertEqual(MenuBarViewModel.pressureLabel(for: .critical), "Critical")
+    }
+
+    func test_pressureColor_mapsLevelsToTrafficLights() {
+        XCTAssertEqual(MenuBarViewModel.pressureColor(for: .nominal), .green)
+        XCTAssertEqual(MenuBarViewModel.pressureColor(for: .fair), .yellow)
+        XCTAssertEqual(MenuBarViewModel.pressureColor(for: .critical), .red)
+    }
+
+    // MARK: - Menu bar label
+
+    /// The compact label is what `MenuBarExtra` renders to the system menu
+    /// bar. It bundles RAM and disk into a single string so the App scene can
+    /// stay declarative — `Text(viewModel.menuBarLabelText)` rather than a
+    /// hand-built interpolation.
+    func test_menuBarLabel_combinesRAMandDiskWithBothPrefixes() {
+        let ram = MemoryStats(usedBytes: 8_000_000_000, totalBytes: 16_000_000_000)
+        let disk = DiskStats(usedBytes: 250_000_000_000, totalBytes: 500_000_000_000)
+        let label = MenuBarViewModel.menuBarLabel(ram: ram, disk: disk)
+        XCTAssertTrue(label.contains("RAM"), "Expected RAM prefix, got \(label)")
+        XCTAssertTrue(label.contains("Disk"), "Expected Disk prefix, got \(label)")
+        XCTAssertTrue(label.contains("8"), "Expected used RAM GB in label, got \(label)")
+        XCTAssertTrue(label.contains("250"), "Expected free disk GB in label, got \(label)")
+    }
+
+    /// Critical robustness check: a buggy upstream reading of `UInt64.max`
+    /// bytes would render as `"18,446,744,073 GB"` through a naive
+    /// `ByteCountFormatter`, blowing up the menu bar label width. The label
+    /// builder must clamp each segment so the rendered text stays bounded.
+    /// 50 chars is generous for the system menu bar — real readings cap at
+    /// roughly `"RAM: 256 GB · Disk: 16384 GB free"` (~36 chars).
+    func test_menuBarLabel_truncatesGracefullyForLargeValues() {
+        let extreme = MemoryStats(usedBytes: UInt64.max, totalBytes: UInt64.max)
+        let extremeDisk = DiskStats(usedBytes: UInt64.max, totalBytes: UInt64.max)
+        let label = MenuBarViewModel.menuBarLabel(ram: extreme, disk: extremeDisk)
+        XCTAssertLessThanOrEqual(
+            label.count, 50,
+            "Menu bar label must stay bounded for absurd inputs, got \(label.count) chars: \(label)"
+        )
+        XCTAssertFalse(label.isEmpty)
+    }
+
+    /// Zero-total state at startup must still produce a renderable label —
+    /// `MenuBarExtra` evaluates `label:` immediately, before the first refresh
+    /// publishes real values.
+    func test_menuBarLabel_handlesZeroTotals() {
+        let label = MenuBarViewModel.menuBarLabel(ram: .empty, disk: .empty)
+        XCTAssertFalse(label.isEmpty)
+        XCTAssertTrue(label.contains("RAM"))
+        XCTAssertTrue(label.contains("Disk"))
+    }
+
+    // MARK: - Service binding
+
+    /// The view-model is constructed with a `SystemStatsService`. Constructing
+    /// it with a non-autostarted service must not crash — exercises the
+    /// production init path used via `@StateObject`.
+    func test_initWithService_storesServiceReference() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        let sut = MenuBarViewModel(service: service)
+        XCTAssertTrue(sut.service === service)
+    }
+
+    /// SwiftUI does not propagate a nested `ObservableObject`'s
+    /// `objectWillChange` through an outer `ObservableObject` automatically.
+    /// Without an explicit Combine bridge in `init`, the menu bar popover
+    /// would freeze on its first frame. Same invariant
+    /// `HealthMonitorViewModel` has — pinned here independently because the
+    /// menu bar has its own subscription path.
+    func test_serviceObjectWillChange_propagatesToViewModel() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        let sut = MenuBarViewModel(service: service)
+
+        let expectation = XCTestExpectation(description: "VM re-publishes service tick")
+        var cancellables = Set<AnyCancellable>()
+        sut.objectWillChange
+            .sink { _ in expectation.fulfill() }
+            .store(in: &cancellables)
+
+        // Drive a refresh — the service's @Published setters fire
+        // objectWillChange, which our bridge must forward to the VM so the
+        // popover re-renders.
+        service.refresh()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    /// Live-bound display values forward the service state through the pure
+    /// formatters. Pinning instance ↔ static parity here means a future
+    /// formatter change can't drift one consumer apart from the other.
+    func test_liveBoundProperties_matchPureFormatters() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        let sut = MenuBarViewModel(service: service)
+
+        XCTAssertEqual(sut.formattedRAMUsage, MenuBarViewModel.formattedRAMUsage(service.ramUsage))
+        XCTAssertEqual(sut.formattedDiskSpace, MenuBarViewModel.formattedDiskSpace(service.diskSpace))
+        XCTAssertEqual(sut.formattedCPU, MenuBarViewModel.formattedCPU(service.cpuUsage))
+        XCTAssertEqual(sut.formattedBatteryHealth, MenuBarViewModel.formattedBatteryHealth(service.batteryHealth))
+        XCTAssertEqual(
+            sut.menuBarLabelText,
+            MenuBarViewModel.menuBarLabel(ram: service.ramUsage, disk: service.diskSpace)
+        )
     }
 }

--- a/todo.md
+++ b/todo.md
@@ -21,7 +21,7 @@
 
 - [x] **Prompt 8** — SystemStatsService (CPU, RAM, disk, battery, SMART, FileVault)
 - [x] **Prompt 9** — Health Monitor UI (5 stat cards + FileVault row)
-- [ ] **Prompt 10** — Menu bar live stats (wired to SystemStatsService)
+- [x] **Prompt 10** — Menu bar live stats (wired to SystemStatsService)
 - [ ] **Prompt 11** — Notification system (4 notification types, threshold monitoring, cooldown)
 
 ## Phase 2 — File Cleaning


### PR DESCRIPTION
## Summary

- `MenuBarViewModel` now consumes `SystemStatsService` directly. The cheap-stats timer that already drives the Health Monitor (Prompt 9) fans out to the menu bar via the same `objectWillChange` Combine bridge — so the popover ticks every two seconds without any new polling.
- Popover gains CPU and battery rows. The RAM row carries a memory-pressure badge (color dot + Nominal / Fair / Critical label) using the shared `StatusColor` palette.
- The `MenuBarExtra` label format moved entirely onto the view-model (`menuBarLabelText` → `menuBarLabel(ram:disk:)`). Each segment is hard-capped at 9999 GB so an upstream `UInt64.max` reading can't blow up label width.

## Notes for the reviewer

- **Label format** drifted from the plan's literal `"RAM: X.XGB Disk: XXGB"`. Final shape is `"RAM: 8 GB · Disk: 250 GB free"` — the `· … free` qualifier mirrors the Prompt 5 placeholder convention and the popover's disk row, so the user reads the same number in both places.
- **Popover frame** went 220 → 240 to fit the pressure badge alongside the RAM value.
- App scene init now constructs `SystemStatsService` and `MenuBarViewModel(service:)` together so both `@StateObject` wrappers reference the *same* service instance — initializing `menuBarViewModel` at its property declaration would force a separate `SystemStatsService()` and double the polling timer.

## Test plan

- [x] All 118 unit tests + 1 UI test pass (`xcodebuild test`)
- [x] App builds and launches cleanly with the new init pattern (no crash, no `LaunchServices` error)
- [ ] Manual: click menu bar icon, confirm RAM / Disk / CPU values update every ~2 seconds and roughly match Activity Monitor — best done by the reviewer locally since Claude Code can't see the system menu bar

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CPU usage and disk space indicators to the menu bar display
  * Introduced a RAM pressure level indicator badge for system health monitoring
  * Expanded battery health information display in the menu bar
  * Increased menu bar popover width for improved readability

* **Tests**
  * Added comprehensive test suite for system stats formatting and menu bar label composition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->