### PR TITLE
Notification system

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -7,8 +7,15 @@ struct ContentView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var onboarding: PermissionOnboardingViewModel
     @EnvironmentObject private var systemStats: SystemStatsService
+    @EnvironmentObject private var notificationMonitor: NotificationThresholdMonitor
     @Environment(\.scenePhase) private var scenePhase
     @State private var selectedSection: NavigationSection? = .smartScan
+    /// Latched once the notification permission prompt has been issued for the
+    /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
+    /// dismissal in the same cycle) would request authorization twice — the
+    /// system caches the answer so the second prompt is a no-op, but it's
+    /// cleaner to issue exactly one.
+    @State private var didRequestNotificationPermission = false
 
     var body: some View {
         NavigationSplitView {
@@ -31,6 +38,29 @@ struct ContentView: View {
                 appState.refresh()
             }
         }
+        // Ask for notification permission only after the FDA onboarding has
+        // settled — either the user already has Full Disk Access, or they
+        // dismissed the sheet via "Continue Without Access". Stacking the
+        // notification prompt on top of the FDA sheet would split the user's
+        // attention between two consent dialogs and make it likely they'd
+        // deny notifications without context.
+        .task { await maybeRequestNotificationPermission() }
+        .onChange(of: appState.hasFullDiskAccess) { _, _ in
+            Task { await maybeRequestNotificationPermission() }
+        }
+        .onChange(of: onboarding.isDismissed) { _, _ in
+            Task { await maybeRequestNotificationPermission() }
+        }
+    }
+
+    /// Idempotent permission-request driver. Fires the system prompt at most
+    /// once per session, and only once the FDA onboarding flow has reached a
+    /// terminal state (granted or explicitly dismissed).
+    private func maybeRequestNotificationPermission() async {
+        guard !didRequestNotificationPermission else { return }
+        guard appState.hasFullDiskAccess || onboarding.isDismissed else { return }
+        didRequestNotificationPermission = true
+        await notificationMonitor.requestPermission()
     }
 
     /// Routes the selected sidebar section to its detail view. Sections without
@@ -81,8 +111,15 @@ private struct PlaceholderDetailView: View {
 }
 
 #Preview {
-    ContentView()
+    let stats = SystemStatsService(autostart: false)
+    let prefs = PreferencesStore(defaults: UserDefaults(suiteName: "preview")!)
+    return ContentView()
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())
-        .environmentObject(SystemStatsService(autostart: false))
+        .environmentObject(stats)
+        .environmentObject(NotificationThresholdMonitor(
+            stats: stats,
+            preferences: prefs,
+            dispatcher: NotificationManager()
+        ))
 }

--- a/VaderCleaner/NotificationManager.swift
+++ b/VaderCleaner/NotificationManager.swift
@@ -1,5 +1,5 @@
 // NotificationManager.swift
-// User-facing notification dispatcher — wraps UNUserNotificationCenter and exposes pure content builders for tests.
+// User-facing notification dispatcher — wraps UNUserNotificationCenter, presents banners while foregrounded, and exposes pure content builders for tests.
 
 import Foundation
 import UserNotifications
@@ -26,19 +26,65 @@ protocol NotificationDispatching: AnyObject {
 /// scheduling a real notification request — `UNUserNotificationCenter.add`
 /// requires an authorized notification entitlement and a running app, neither
 /// of which a unit test bundle reliably has.
+///
+/// ## Foreground presentation
+///
+/// `UNUserNotificationCenter` suppresses banners while the owning app is
+/// frontmost unless a delegate opts in via
+/// `userNotificationCenter(_:willPresent:withCompletionHandler:)`. Setting
+/// `self` as the delegate and returning `[.banner, .sound]` keeps low-disk /
+/// high-RAM alerts visible even while the user has the Health Monitor open —
+/// which is precisely when those alerts are most actionable.
 @MainActor
-final class NotificationManager: NotificationDispatching {
+final class NotificationManager: NSObject, NotificationDispatching, UNUserNotificationCenterDelegate {
+
+    /// Closure that performs the underlying `requestAuthorization` call.
+    /// Production wires this through `UNUserNotificationCenter`. Tests inject
+    /// a no-op so the test bundle never hits the real permission system —
+    /// which would block in CI on a clean machine.
+    typealias AuthorizationRequester = @MainActor () async throws -> Bool
 
     private let center: UNUserNotificationCenter
+    private let authorizationRequester: AuthorizationRequester
     private let log = OSLog(subsystem: "com.personal.VaderCleaner",
                             category: "NotificationManager")
 
-    /// `UNUserNotificationCenter.current()` is a singleton tied to the host
-    /// app's bundle identifier; it is always the right instance in production.
-    /// Exposed for parity with other ObservableObjects' init signatures, but
-    /// production callers use the default.
-    init(center: UNUserNotificationCenter = .current()) {
+    /// Single shared formatter for byte → string conversion in the
+    /// large-files notification body. `ByteCountFormatter` allocates internal
+    /// state on each construction; reusing one instance avoids unnecessary
+    /// churn even though the per-kind cooldown already throttles fire rate.
+    private static let byteCountFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter
+    }()
+
+    /// - Parameters:
+    ///   - center: `UNUserNotificationCenter.current()` is the right
+    ///     production instance; tests can pass a different instance only
+    ///     incidentally — the meaningful seam is `authorizationRequester`.
+    ///   - authorizationRequester: Override for the underlying authorization
+    ///     call. Defaults to invoking
+    ///     `center.requestAuthorization(options: [.alert, .sound])`. Tests
+    ///     pass a closure that returns immediately so `requestPermission`
+    ///     never blocks waiting for user input.
+    init(
+        center: UNUserNotificationCenter = .current(),
+        authorizationRequester: AuthorizationRequester? = nil
+    ) {
         self.center = center
+        // Capture `center` in the default requester closure so the seam still
+        // routes through the supplied center instance when no override is
+        // provided.
+        self.authorizationRequester = authorizationRequester ?? { [center] in
+            try await center.requestAuthorization(options: [.alert, .sound])
+        }
+        super.init()
+        // The delegate property is `weak`, so the manager has to live for the
+        // notifications to keep presenting. In production the App holds it as
+        // a stored property; in tests the manager is held by the test method
+        // and the post-test deallocation cleans up the weak ref harmlessly.
+        center.delegate = self
     }
 
     // MARK: - Permission
@@ -50,11 +96,29 @@ final class NotificationManager: NotificationDispatching {
     /// silently no-ops when authorization is missing, which is fine.
     func requestPermission() async {
         do {
-            _ = try await center.requestAuthorization(options: [.alert, .sound])
+            _ = try await authorizationRequester()
         } catch {
             os_log("requestAuthorization failed: %{public}@",
                    log: log, type: .error, error.localizedDescription)
         }
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// Tells the system to present the banner + sound even while VaderCleaner
+    /// is the active app. Without this hook the user never sees an in-app
+    /// banner for low-disk / high-RAM alerts — the most common moment to act
+    /// on those alerts is precisely when the app is frontmost.
+    ///
+    /// Marked `nonisolated` because UNUserNotificationCenter delegate methods
+    /// may be invoked from any thread. The body touches no instance state and
+    /// just calls the completion handler synchronously, which is safe.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
     }
 
     // MARK: - Dispatch entry points
@@ -128,10 +192,7 @@ final class NotificationManager: NotificationDispatching {
     static func makeLargeFilesFoundContent(count: Int, totalSize: Int64) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = "Large Files Found"
-        let formattedSize = ByteCountFormatter.string(
-            fromByteCount: totalSize,
-            countStyle: .file
-        )
+        let formattedSize = byteCountFormatter.string(fromByteCount: totalSize)
         content.body = "Found \(count) large or old files totaling \(formattedSize)."
         content.sound = .default
         return content

--- a/VaderCleaner/NotificationManager.swift
+++ b/VaderCleaner/NotificationManager.swift
@@ -1,0 +1,139 @@
+// NotificationManager.swift
+// User-facing notification dispatcher — wraps UNUserNotificationCenter and exposes pure content builders for tests.
+
+import Foundation
+import UserNotifications
+import os.log
+
+/// Abstracts the four notification dispatch entry points plus the
+/// permission-request flow so the threshold monitor (and any future feature
+/// module) can be unit-tested with a stub instead of touching the real
+/// `UNUserNotificationCenter`.
+@MainActor
+protocol NotificationDispatching: AnyObject {
+    func requestPermission() async
+    func sendLowDiskNotification(freePercent: Double)
+    func sendHighRAMNotification(pressureLevel: String)
+    func sendMalwareDetectedNotification(threatName: String)
+    func sendLargeFilesFoundNotification(count: Int, totalSize: Int64)
+}
+
+/// Production `NotificationDispatching` backed by
+/// `UNUserNotificationCenter.current()`.
+///
+/// The four `send…` methods funnel through `make…Content(…)` static helpers so
+/// the content shape (title, body, sound) can be unit-tested without
+/// scheduling a real notification request — `UNUserNotificationCenter.add`
+/// requires an authorized notification entitlement and a running app, neither
+/// of which a unit test bundle reliably has.
+@MainActor
+final class NotificationManager: NotificationDispatching {
+
+    private let center: UNUserNotificationCenter
+    private let log = OSLog(subsystem: "com.personal.VaderCleaner",
+                            category: "NotificationManager")
+
+    /// `UNUserNotificationCenter.current()` is a singleton tied to the host
+    /// app's bundle identifier; it is always the right instance in production.
+    /// Exposed for parity with other ObservableObjects' init signatures, but
+    /// production callers use the default.
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    // MARK: - Permission
+
+    /// Asks the user (once, then cached by the system) for permission to
+    /// display alerts and play sounds. Errors are logged and swallowed: a
+    /// transient denial during launch must not crash the app, and the threshold
+    /// monitor will still try to dispatch — `UNUserNotificationCenter.add`
+    /// silently no-ops when authorization is missing, which is fine.
+    func requestPermission() async {
+        do {
+            _ = try await center.requestAuthorization(options: [.alert, .sound])
+        } catch {
+            os_log("requestAuthorization failed: %{public}@",
+                   log: log, type: .error, error.localizedDescription)
+        }
+    }
+
+    // MARK: - Dispatch entry points
+
+    func sendLowDiskNotification(freePercent: Double) {
+        deliver(content: Self.makeLowDiskContent(freePercent: freePercent))
+    }
+
+    func sendHighRAMNotification(pressureLevel: String) {
+        deliver(content: Self.makeHighRAMContent(pressureLevel: pressureLevel))
+    }
+
+    func sendMalwareDetectedNotification(threatName: String) {
+        deliver(content: Self.makeMalwareDetectedContent(threatName: threatName))
+    }
+
+    func sendLargeFilesFoundNotification(count: Int, totalSize: Int64) {
+        deliver(content: Self.makeLargeFilesFoundContent(count: count,
+                                                         totalSize: totalSize))
+    }
+
+    /// Schedules `content` for immediate delivery. A unique request identifier
+    /// per call avoids collapsing into a still-displayed banner from a previous
+    /// firing — the monitor's per-kind cooldown already prevents spam, and
+    /// users expect each post-cooldown alert to be a fresh banner rather than
+    /// a silent merge.
+    private func deliver(content: UNNotificationContent) {
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        center.add(request) { [log] error in
+            if let error = error {
+                os_log("UNUserNotificationCenter.add failed: %{public}@",
+                       log: log, type: .error, error.localizedDescription)
+            }
+        }
+    }
+
+    // MARK: - Content builders (pure — unit-test surface)
+
+    static func makeLowDiskContent(freePercent: Double) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Low Disk Space"
+        // Round to whole percent so the banner reads cleanly. The threshold
+        // setting is itself an integer-feeling slider in Preferences, so a
+        // sub-percent reading would look out of place next to it.
+        let rounded = Int(freePercent.rounded())
+        content.body = "Only \(rounded)% of disk space is free. Consider cleaning system junk."
+        content.sound = .default
+        return content
+    }
+
+    static func makeHighRAMContent(pressureLevel: String) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "High Memory Pressure"
+        content.body = "Memory pressure is \(pressureLevel). Closing some apps may help."
+        content.sound = .default
+        return content
+    }
+
+    static func makeMalwareDetectedContent(threatName: String) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Malware Detected"
+        content.body = "VaderCleaner found \(threatName). Open the Malware Removal section to review."
+        content.sound = .default
+        return content
+    }
+
+    static func makeLargeFilesFoundContent(count: Int, totalSize: Int64) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Large Files Found"
+        let formattedSize = ByteCountFormatter.string(
+            fromByteCount: totalSize,
+            countStyle: .file
+        )
+        content.body = "Found \(count) large or old files totaling \(formattedSize)."
+        content.sound = .default
+        return content
+    }
+}

--- a/VaderCleaner/NotificationThresholdMonitor.swift
+++ b/VaderCleaner/NotificationThresholdMonitor.swift
@@ -167,14 +167,25 @@ final class NotificationThresholdMonitor: ObservableObject {
         lastFired[.largeFiles] = now()
     }
 
+    // MARK: - Permission passthrough
+
+    /// Forwards to the dispatcher's `requestPermission()`. Exposed on the
+    /// monitor so callers (the App / ContentView) can drive permission requests
+    /// through the same instance they receive via `@EnvironmentObject` without
+    /// also injecting the underlying `NotificationManager`.
+    func requestPermission() async {
+        await dispatcher.requestPermission()
+    }
+
     // MARK: - Cooldown helper
 
     /// Returns true if `kind` has either never fired or fired at least
-    /// `cooldown` seconds ago. The boundary is exclusive — a sample exactly
-    /// `cooldown` seconds after the previous firing is treated as elapsed,
-    /// matching test expectations (301 s after, not 300 s).
+    /// `cooldown` seconds ago. The boundary is inclusive: a sample exactly
+    /// `cooldown` seconds after the previous firing is treated as elapsed, so
+    /// a 5-minute cooldown means "next allowed firing is at last + 5 minutes,"
+    /// matching what most users would intuit from the spec wording.
     private func isCooldownElapsed(_ kind: Kind) -> Bool {
         guard let last = lastFired[kind] else { return true }
-        return now().timeIntervalSince(last) > cooldown
+        return now().timeIntervalSince(last) >= cooldown
     }
 }

--- a/VaderCleaner/NotificationThresholdMonitor.swift
+++ b/VaderCleaner/NotificationThresholdMonitor.swift
@@ -54,6 +54,16 @@ final class NotificationThresholdMonitor: ObservableObject {
     /// reading after launch always dispatches.
     private var lastFired: [Kind: Date] = [:]
 
+    /// Flips to `true` once `requestPermission()` has resolved (the user
+    /// either accepted or denied the system prompt). Until then, threshold
+    /// readings are observed but do **not** dispatch and do **not** stamp
+    /// the cooldown table — `UNUserNotificationCenter` silently drops
+    /// `add(_:)` calls placed before authorization has been requested, so
+    /// stamping a 5-minute cooldown against a notification that never
+    /// surfaced would suppress the next genuine alert immediately after
+    /// the user grants permission.
+    private var hasResolvedPermission: Bool
+
     /// Combine subscriptions from `SystemStatsService.$diskSpace` /
     /// `$ramUsage`. Held in `cancellables` so they tear down with `self`.
     private var cancellables: Set<AnyCancellable> = []
@@ -74,18 +84,27 @@ final class NotificationThresholdMonitor: ObservableObject {
     ///   - now: Clock provider. Defaults to `Date.init` in production; tests
     ///     pass a closure that reads from a mutable virtual time so cooldown
     ///     tests don't sleep.
+    ///   - assumesPermissionResolved: When `true`, the monitor begins in the
+    ///     post-permission state and dispatches immediately on the first
+    ///     eligible reading. Production defaults to `false` so a threshold
+    ///     reading that arrives during the FDA onboarding window (before
+    ///     ContentView has called `requestPermission()`) is silently
+    ///     observed without burning its cooldown. Tests that want to exercise
+    ///     dispatch synchronously pass `true`.
     init(
         stats: SystemStatsService,
         preferences: PreferencesStore,
         dispatcher: NotificationDispatching,
         cooldown: TimeInterval = 5 * 60,
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> Date = Date.init,
+        assumesPermissionResolved: Bool = false
     ) {
         self.stats = stats
         self.preferences = preferences
         self.dispatcher = dispatcher
         self.cooldown = cooldown
         self.now = now
+        self.hasResolvedPermission = assumesPermissionResolved
 
         // Drop the first emission from each publisher because `@Published`
         // sends the initial value immediately on subscription. That initial
@@ -107,13 +126,15 @@ final class NotificationThresholdMonitor: ObservableObject {
     // MARK: - Threshold evaluation (public for testability)
 
     /// Evaluates a disk-space reading and dispatches a low-disk notification
-    /// if all three conditions hold:
-    ///   1. The user has `notifyLowDisk` enabled.
-    ///   2. Free percentage is strictly below `diskSpaceThresholdPercent`.
-    ///   3. The low-disk cooldown has elapsed since the last firing.
+    /// if all four conditions hold:
+    ///   1. Permission has been resolved (see `hasResolvedPermission`).
+    ///   2. The user has `notifyLowDisk` enabled.
+    ///   3. Free percentage is strictly below `diskSpaceThresholdPercent`.
+    ///   4. The low-disk cooldown has elapsed since the last firing.
     /// `totalBytes == 0` short-circuits to no-op — that is the pre-first-
     /// refresh placeholder and would otherwise compute a 0% free reading.
     func evaluate(disk: DiskStats) {
+        guard hasResolvedPermission else { return }
         guard preferences.notifyLowDisk else { return }
         guard disk.totalBytes > 0 else { return }
 
@@ -135,6 +156,7 @@ final class NotificationThresholdMonitor: ObservableObject {
     /// "do something now" alert. Cooldown gates re-firing the same way as
     /// disk.
     func evaluate(ram: MemoryStats) {
+        guard hasResolvedPermission else { return }
         guard preferences.notifyHighRAM else { return }
         guard ram.pressureLevel == .critical else { return }
         guard isCooldownElapsed(.highRAM) else { return }
@@ -149,6 +171,7 @@ final class NotificationThresholdMonitor: ObservableObject {
     /// Stub-wired here so the cooldown + toggle gate is in place before the
     /// scanner module exists.
     func triggerMalwareDetected(threatName: String) {
+        guard hasResolvedPermission else { return }
         guard preferences.notifyMalwareFound else { return }
         guard isCooldownElapsed(.malware) else { return }
 
@@ -160,6 +183,7 @@ final class NotificationThresholdMonitor: ObservableObject {
     /// completes. Stub-wired here so the cooldown + toggle gate is consistent
     /// with the other notification paths.
     func triggerLargeFilesFound(count: Int, totalSize: Int64) {
+        guard hasResolvedPermission else { return }
         guard preferences.notifyLargeFilesFound else { return }
         guard isCooldownElapsed(.largeFiles) else { return }
 
@@ -169,12 +193,15 @@ final class NotificationThresholdMonitor: ObservableObject {
 
     // MARK: - Permission passthrough
 
-    /// Forwards to the dispatcher's `requestPermission()`. Exposed on the
-    /// monitor so callers (the App / ContentView) can drive permission requests
-    /// through the same instance they receive via `@EnvironmentObject` without
-    /// also injecting the underlying `NotificationManager`.
+    /// Forwards to the dispatcher's `requestPermission()` and flips the
+    /// internal gate so subsequent threshold readings can dispatch. The flag
+    /// flips regardless of whether the user accepted or denied — once the
+    /// system prompt has been answered, `UNUserNotificationCenter.add` will
+    /// either deliver or silently drop, but in neither case is there value in
+    /// continuing to suppress at the monitor layer.
     func requestPermission() async {
         await dispatcher.requestPermission()
+        hasResolvedPermission = true
     }
 
     // MARK: - Cooldown helper

--- a/VaderCleaner/NotificationThresholdMonitor.swift
+++ b/VaderCleaner/NotificationThresholdMonitor.swift
@@ -1,0 +1,180 @@
+// NotificationThresholdMonitor.swift
+// Bridges SystemStatsService readings + PreferencesStore toggles to NotificationDispatching, with a per-kind cooldown to prevent spam.
+
+import Foundation
+import Combine
+
+/// Watches `SystemStatsService` and dispatches threshold-based notifications
+/// (low disk, high RAM) through a `NotificationDispatching` instance, gated by
+/// the user's `PreferencesStore` toggles and a per-kind cooldown.
+///
+/// Malware and large-files notifications are pushed by feature modules via the
+/// `triggerMalwareDetected` / `triggerLargeFilesFound` hooks rather than
+/// derived from a polling reading. They use the same toggle + cooldown gate so
+/// every notification path goes through one chokepoint and the spam-prevention
+/// behavior cannot drift between callers.
+///
+/// ## Cooldown
+///
+/// A 5-minute (300 s) per-kind cooldown means a user who is genuinely at
+/// 5% free disk space gets at most one banner every five minutes — enough to
+/// remind, not enough to harass. The cooldown table is keyed by `Kind` so each
+/// notification type has its own clock; a ringing low-disk alert does not
+/// suppress a fresh malware alert from the same scan.
+///
+/// ## Testability
+///
+/// The clock is injected (`now: () -> Date`) so tests can advance virtual time
+/// across the cooldown boundary without sleeping. The dispatcher is protocol-
+/// backed so tests can record calls without scheduling real notifications.
+@MainActor
+final class NotificationThresholdMonitor: ObservableObject {
+
+    /// Notification kinds that share the cooldown table. Adding a new kind
+    /// here requires updating the toggle gate in the `evaluate…` / `trigger…`
+    /// path that produces it; the compiler's exhaustiveness check on switches
+    /// over `Kind` keeps that honest.
+    private enum Kind: Hashable {
+        case lowDisk
+        case highRAM
+        case malware
+        case largeFiles
+    }
+
+    // MARK: - Dependencies
+
+    private let stats: SystemStatsService
+    private let preferences: PreferencesStore
+    private let dispatcher: NotificationDispatching
+    private let cooldown: TimeInterval
+    private let now: () -> Date
+
+    /// Last dispatch timestamp per `Kind`. A missing entry means "never fired",
+    /// which the cooldown check treats as "elapsed" so the first eligible
+    /// reading after launch always dispatches.
+    private var lastFired: [Kind: Date] = [:]
+
+    /// Combine subscriptions from `SystemStatsService.$diskSpace` /
+    /// `$ramUsage`. Held in `cancellables` so they tear down with `self`.
+    private var cancellables: Set<AnyCancellable> = []
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - stats: Source of disk/RAM readings. The monitor subscribes to
+    ///     `$diskSpace` and `$ramUsage` and forwards each new value to the
+    ///     `evaluate(disk:)` / `evaluate(ram:)` paths below.
+    ///   - preferences: Backing store for the four notification toggles and
+    ///     `diskSpaceThresholdPercent`.
+    ///   - dispatcher: Notification sink. Production passes
+    ///     `NotificationManager()`; tests pass a recording stub.
+    ///   - cooldown: Per-kind minimum interval between successive dispatches.
+    ///     Defaults to 5 minutes per the spec; tests can pass a smaller value
+    ///     if they prefer to advance the virtual clock by less.
+    ///   - now: Clock provider. Defaults to `Date.init` in production; tests
+    ///     pass a closure that reads from a mutable virtual time so cooldown
+    ///     tests don't sleep.
+    init(
+        stats: SystemStatsService,
+        preferences: PreferencesStore,
+        dispatcher: NotificationDispatching,
+        cooldown: TimeInterval = 5 * 60,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.stats = stats
+        self.preferences = preferences
+        self.dispatcher = dispatcher
+        self.cooldown = cooldown
+        self.now = now
+
+        // Drop the first emission from each publisher because `@Published`
+        // sends the initial value immediately on subscription. That initial
+        // value is `DiskStats.empty` / `MemoryStats.empty` — both at zero —
+        // which would falsely register as "0% free, fire low-disk!" the
+        // moment the monitor is constructed. After the first real `refresh()`
+        // the publishers emit honest readings.
+        stats.$diskSpace
+            .dropFirst()
+            .sink { [weak self] disk in self?.evaluate(disk: disk) }
+            .store(in: &cancellables)
+
+        stats.$ramUsage
+            .dropFirst()
+            .sink { [weak self] ram in self?.evaluate(ram: ram) }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Threshold evaluation (public for testability)
+
+    /// Evaluates a disk-space reading and dispatches a low-disk notification
+    /// if all three conditions hold:
+    ///   1. The user has `notifyLowDisk` enabled.
+    ///   2. Free percentage is strictly below `diskSpaceThresholdPercent`.
+    ///   3. The low-disk cooldown has elapsed since the last firing.
+    /// `totalBytes == 0` short-circuits to no-op — that is the pre-first-
+    /// refresh placeholder and would otherwise compute a 0% free reading.
+    func evaluate(disk: DiskStats) {
+        guard preferences.notifyLowDisk else { return }
+        guard disk.totalBytes > 0 else { return }
+
+        let freeBytes = disk.totalBytes > disk.usedBytes
+            ? disk.totalBytes - disk.usedBytes
+            : 0
+        let freePercent = Double(freeBytes) / Double(disk.totalBytes) * 100.0
+
+        guard freePercent < preferences.diskSpaceThresholdPercent else { return }
+        guard isCooldownElapsed(.lowDisk) else { return }
+
+        dispatcher.sendLowDiskNotification(freePercent: freePercent)
+        lastFired[.lowDisk] = now()
+    }
+
+    /// Evaluates a memory-pressure reading and dispatches a high-RAM
+    /// notification only when pressure is `.critical`. `.fair` is intentionally
+    /// not surfaced — it's a soft yellow state in the Health Monitor, not a
+    /// "do something now" alert. Cooldown gates re-firing the same way as
+    /// disk.
+    func evaluate(ram: MemoryStats) {
+        guard preferences.notifyHighRAM else { return }
+        guard ram.pressureLevel == .critical else { return }
+        guard isCooldownElapsed(.highRAM) else { return }
+
+        dispatcher.sendHighRAMNotification(pressureLevel: "Critical")
+        lastFired[.highRAM] = now()
+    }
+
+    // MARK: - Trigger hooks for feature modules
+
+    /// Called by the malware scanner (Prompt 24) when a threat is detected.
+    /// Stub-wired here so the cooldown + toggle gate is in place before the
+    /// scanner module exists.
+    func triggerMalwareDetected(threatName: String) {
+        guard preferences.notifyMalwareFound else { return }
+        guard isCooldownElapsed(.malware) else { return }
+
+        dispatcher.sendMalwareDetectedNotification(threatName: threatName)
+        lastFired[.malware] = now()
+    }
+
+    /// Called by the Large & Old Files feature (Prompt 15) once a scan
+    /// completes. Stub-wired here so the cooldown + toggle gate is consistent
+    /// with the other notification paths.
+    func triggerLargeFilesFound(count: Int, totalSize: Int64) {
+        guard preferences.notifyLargeFilesFound else { return }
+        guard isCooldownElapsed(.largeFiles) else { return }
+
+        dispatcher.sendLargeFilesFoundNotification(count: count, totalSize: totalSize)
+        lastFired[.largeFiles] = now()
+    }
+
+    // MARK: - Cooldown helper
+
+    /// Returns true if `kind` has either never fired or fired at least
+    /// `cooldown` seconds ago. The boundary is exclusive — a sample exactly
+    /// `cooldown` seconds after the previous firing is treated as elapsed,
+    /// matching test expectations (301 s after, not 300 s).
+    private func isCooldownElapsed(_ kind: Kind) -> Bool {
+        guard let last = lastFired[kind] else { return true }
+        return now().timeIntervalSince(last) > cooldown
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -32,6 +32,17 @@ struct VaderCleanerApp: App {
     // `@EnvironmentObject` — making it a per-view StateObject would
     // double-instantiate the timer.
     @StateObject private var systemStats: SystemStatsService
+    // App-scope: subscribes to `systemStats` and pushes notifications via
+    // `NotificationManager`. Held here so the Combine subscriptions live as
+    // long as the app and so the per-kind cooldown table survives across
+    // window open/close cycles.
+    @StateObject private var notificationMonitor: NotificationThresholdMonitor
+    /// Reference held outside the monitor so the permission-request flow
+    /// (triggered after the FDA onboarding sheet dismisses, see ContentView)
+    /// can call into the same dispatcher the monitor is forwarding to.
+    /// `NotificationManager` is a reference type so the monitor and this
+    /// property share one instance.
+    private let notificationManager: NotificationManager
     @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
@@ -41,12 +52,11 @@ struct VaderCleanerApp: App {
         // user who toggled "Login Items" in System Settings while VaderCleaner
         // was quit gets pushed back into a consistent state on the next
         // launch.
-        _preferences = StateObject(
-            wrappedValue: PreferencesStore(
-                launchAtLoginHandler: { try LoginItemManager.setEnabled($0) },
-                launchAtLoginErrorReporter: VaderCleanerApp.presentLaunchAtLoginAlert(_:)
-            )
+        let prefs = PreferencesStore(
+            launchAtLoginHandler: { try LoginItemManager.setEnabled($0) },
+            launchAtLoginErrorReporter: VaderCleanerApp.presentLaunchAtLoginAlert(_:)
         )
+        _preferences = StateObject(wrappedValue: prefs)
         // Construct the polling service and the menu bar view-model in the
         // same init so both `@StateObject` wrappers reference the *same*
         // service instance. Initializing `menuBarViewModel` at its property
@@ -56,6 +66,21 @@ struct VaderCleanerApp: App {
         let stats = SystemStatsService()
         _systemStats = StateObject(wrappedValue: stats)
         _menuBarViewModel = StateObject(wrappedValue: MenuBarViewModel(service: stats))
+        // Wire the notification monitor to the same stats + preferences
+        // instances the rest of the app sees. The manager is a stored property
+        // (not a StateObject) because it has no observable state — it just
+        // forwards to UNUserNotificationCenter. Sharing one manager between
+        // the monitor and the App's `requestPermission` call site keeps every
+        // notification path going through one chokepoint.
+        let manager = NotificationManager()
+        notificationManager = manager
+        _notificationMonitor = StateObject(
+            wrappedValue: NotificationThresholdMonitor(
+                stats: stats,
+                preferences: prefs,
+                dispatcher: manager
+            )
+        )
     }
 
     /// Surfaces a launchd registration failure to the user. Kept on the App
@@ -93,6 +118,16 @@ struct VaderCleanerApp: App {
                 .environmentObject(preferences)
                 .environmentObject(exclusions)
                 .environmentObject(systemStats)
+                .environmentObject(notificationMonitor)
+                .task {
+                    // Ask for permission once per app launch. The system caches
+                    // the answer after the first prompt, so subsequent launches
+                    // resolve immediately without re-prompting the user. Done
+                    // from `.task` rather than `init` so it runs on the main
+                    // actor after the scene is set up — `requestAuthorization`
+                    // hangs if it fires before NSApp finishes launching.
+                    await notificationManager.requestPermission()
+                }
         }
 
         // Each SwiftUI scene gets its own environment, so PreferencesView gets

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -37,12 +37,6 @@ struct VaderCleanerApp: App {
     // long as the app and so the per-kind cooldown table survives across
     // window open/close cycles.
     @StateObject private var notificationMonitor: NotificationThresholdMonitor
-    /// Reference held outside the monitor so the permission-request flow
-    /// (triggered after the FDA onboarding sheet dismisses, see ContentView)
-    /// can call into the same dispatcher the monitor is forwarding to.
-    /// `NotificationManager` is a reference type so the monitor and this
-    /// property share one instance.
-    private let notificationManager: NotificationManager
     @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
@@ -67,18 +61,16 @@ struct VaderCleanerApp: App {
         _systemStats = StateObject(wrappedValue: stats)
         _menuBarViewModel = StateObject(wrappedValue: MenuBarViewModel(service: stats))
         // Wire the notification monitor to the same stats + preferences
-        // instances the rest of the app sees. The manager is a stored property
-        // (not a StateObject) because it has no observable state — it just
-        // forwards to UNUserNotificationCenter. Sharing one manager between
-        // the monitor and the App's `requestPermission` call site keeps every
-        // notification path going through one chokepoint.
-        let manager = NotificationManager()
-        notificationManager = manager
+        // instances the rest of the app sees. The monitor holds the manager
+        // strongly via `dispatcher`, and ContentView drives the permission
+        // request through `monitor.requestPermission()` after the FDA
+        // onboarding sheet has settled — so we don't need a separate App-
+        // level reference to the manager.
         _notificationMonitor = StateObject(
             wrappedValue: NotificationThresholdMonitor(
                 stats: stats,
                 preferences: prefs,
-                dispatcher: manager
+                dispatcher: NotificationManager()
             )
         )
     }
@@ -119,15 +111,6 @@ struct VaderCleanerApp: App {
                 .environmentObject(exclusions)
                 .environmentObject(systemStats)
                 .environmentObject(notificationMonitor)
-                .task {
-                    // Ask for permission once per app launch. The system caches
-                    // the answer after the first prompt, so subsequent launches
-                    // resolve immediately without re-prompting the user. Done
-                    // from `.task` rather than `init` so it runs on the main
-                    // actor after the scene is set up — `requestAuthorization`
-                    // hangs if it fires before NSApp finishes launching.
-                    await notificationManager.requestPermission()
-                }
         }
 
         // Each SwiftUI scene gets its own environment, so PreferencesView gets

--- a/VaderCleanerTests/NotificationManagerTests.swift
+++ b/VaderCleanerTests/NotificationManagerTests.swift
@@ -11,16 +11,23 @@ final class NotificationManagerTests: XCTestCase {
     // MARK: - requestPermission
 
     /// Smoke test: `requestPermission()` must complete without throwing and
-    /// without hanging. The unit-test bundle is loaded into the host app, so
-    /// `UNUserNotificationCenter.current()` resolves to the app's center —
-    /// `requestAuthorization` returns the cached state immediately when
-    /// authorization has already been answered, and prompts the user otherwise.
-    /// Either way, the call must not throw or block past the test timeout.
+    /// without hanging. The injected requester closure stands in for
+    /// `UNUserNotificationCenter.requestAuthorization`, which on a clean CI
+    /// machine could otherwise block waiting for a user decision and time out
+    /// the suite.
     func test_requestPermission_completesWithoutError() async {
-        let manager = NotificationManager()
+        let manager = NotificationManager(authorizationRequester: { true })
         await manager.requestPermission()
         // No assertion needed: completing the await without crashing satisfies
         // the contract. The XCTest timeout catches a hang.
+    }
+
+    /// A throwing requester must be swallowed, not propagated — the spec says
+    /// a transient denial during launch must not crash the app.
+    func test_requestPermission_swallowsErrors() async {
+        struct StubError: Error {}
+        let manager = NotificationManager(authorizationRequester: { throw StubError() })
+        await manager.requestPermission()
     }
 
     // MARK: - Content shape
@@ -61,5 +68,62 @@ final class NotificationManagerTests: XCTestCase {
         // ByteCountFormatter produces "1.5 GB" or "1,5 GB" depending on locale;
         // assert the GB unit so the test isn't locale-fragile.
         XCTAssertTrue(content.body.contains("GB") || content.body.contains("MB"))
+    }
+
+    // MARK: - Foreground presentation delegate
+
+    /// Without this delegate hook, `UNUserNotificationCenter` suppresses
+    /// banners while the app is foregrounded — exactly when the user is most
+    /// likely to act on a low-disk or high-RAM alert. The completion handler
+    /// must request both `.banner` and `.sound`.
+    func test_willPresent_returnsBannerAndSound() {
+        let manager = NotificationManager(authorizationRequester: { true })
+        let center = UNUserNotificationCenter.current()
+        // Build a `UNNotification` indirectly by invoking the delegate method
+        // with a synthesized request — we only care that the completion is
+        // called with the right options. The notification argument is unused
+        // by our implementation, so passing a dummy is fine.
+        let exp = expectation(description: "completion handler invoked")
+        var received: UNNotificationPresentationOptions = []
+        // The delegate method is `nonisolated` so calling it off the main
+        // actor is permitted, but we're already on @MainActor here in the
+        // test. Either is fine.
+        manager.userNotificationCenter(
+            center,
+            willPresent: Self.makeDummyNotification(),
+            withCompletionHandler: { options in
+                received = options
+                exp.fulfill()
+            }
+        )
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(received.contains(.banner))
+        XCTAssertTrue(received.contains(.sound))
+    }
+
+    /// `UNNotification` has no public initializer; building one from a coded
+    /// archive of a `UNNotificationRequest` is the standard workaround for
+    /// tests that need to feed the delegate API. Failing to decode falls back
+    /// to `XCTFail` so a future SDK change surfaces clearly.
+    private static func makeDummyNotification() -> UNNotification {
+        let request = UNNotificationRequest(
+            identifier: "test",
+            content: UNMutableNotificationContent(),
+            trigger: nil
+        )
+        let archiver = NSKeyedArchiver(requiringSecureCoding: false)
+        archiver.encode(request, forKey: "request")
+        archiver.encode(Date(), forKey: "date")
+        archiver.finishEncoding()
+        guard let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: archiver.encodedData) else {
+            XCTFail("Failed to construct NSKeyedUnarchiver")
+            fatalError("unreachable")
+        }
+        unarchiver.requiresSecureCoding = false
+        guard let notification = UNNotification(coder: unarchiver) else {
+            XCTFail("UNNotification(coder:) returned nil — Apple SDK contract change")
+            fatalError("unreachable")
+        }
+        return notification
     }
 }

--- a/VaderCleanerTests/NotificationManagerTests.swift
+++ b/VaderCleanerTests/NotificationManagerTests.swift
@@ -1,0 +1,65 @@
+// NotificationManagerTests.swift
+// Tests that NotificationManager constructs correctly-shaped notification content and that requestPermission returns.
+
+import XCTest
+import UserNotifications
+@testable import VaderCleaner
+
+@MainActor
+final class NotificationManagerTests: XCTestCase {
+
+    // MARK: - requestPermission
+
+    /// Smoke test: `requestPermission()` must complete without throwing and
+    /// without hanging. The unit-test bundle is loaded into the host app, so
+    /// `UNUserNotificationCenter.current()` resolves to the app's center —
+    /// `requestAuthorization` returns the cached state immediately when
+    /// authorization has already been answered, and prompts the user otherwise.
+    /// Either way, the call must not throw or block past the test timeout.
+    func test_requestPermission_completesWithoutError() async {
+        let manager = NotificationManager()
+        await manager.requestPermission()
+        // No assertion needed: completing the await without crashing satisfies
+        // the contract. The XCTest timeout catches a hang.
+    }
+
+    // MARK: - Content shape
+
+    /// The malware notification must surface the threat name in the body so the
+    /// banner is actionable at a glance, and a recognisable title so the user
+    /// can identify the alert from the macOS Notification Center summary.
+    func test_malwareDetected_buildsContentWithThreatName() {
+        let content = NotificationManager.makeMalwareDetectedContent(threatName: "Eicar-Test-Signature")
+        XCTAssertTrue(content.title.contains("Malware"))
+        XCTAssertTrue(content.body.contains("Eicar-Test-Signature"))
+    }
+
+    /// Low-disk notification embeds the free percentage so the user sees the
+    /// severity without opening the app. The percentage is rounded to whole
+    /// percent for readability.
+    func test_lowDisk_buildsContentWithPercent() {
+        let content = NotificationManager.makeLowDiskContent(freePercent: 7.4)
+        XCTAssertTrue(content.title.lowercased().contains("disk"))
+        XCTAssertTrue(content.body.contains("7%") || content.body.contains("7.4"))
+    }
+
+    /// High-RAM notification surfaces the pressure level string verbatim so a
+    /// future tweak to `MemoryPressureLevel` labels (e.g. "Fair" → "Warning")
+    /// doesn't require touching the manager.
+    func test_highRAM_buildsContentWithPressureLevel() {
+        let content = NotificationManager.makeHighRAMContent(pressureLevel: "Critical")
+        XCTAssertTrue(content.title.lowercased().contains("memory") ||
+                      content.title.lowercased().contains("ram"))
+        XCTAssertTrue(content.body.contains("Critical"))
+    }
+
+    /// Large-files notification surfaces both the count and a human-readable
+    /// total size — the pair is what makes the banner worth tapping.
+    func test_largeFilesFound_buildsContentWithCountAndSize() {
+        let content = NotificationManager.makeLargeFilesFoundContent(count: 42, totalSize: 1_500_000_000)
+        XCTAssertTrue(content.body.contains("42"))
+        // ByteCountFormatter produces "1.5 GB" or "1,5 GB" depending on locale;
+        // assert the GB unit so the test isn't locale-fragile.
+        XCTAssertTrue(content.body.contains("GB") || content.body.contains("MB"))
+    }
+}

--- a/VaderCleanerTests/NotificationThresholdMonitorTests.swift
+++ b/VaderCleanerTests/NotificationThresholdMonitorTests.swift
@@ -1,0 +1,266 @@
+// NotificationThresholdMonitorTests.swift
+// Tests that the threshold monitor dispatches notifications only when toggles allow it and respects the per-kind cooldown.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Records `NotificationDispatching` calls in order for test assertions. Each
+/// test gets a fresh stub so call counts and recorded payloads do not leak.
+@MainActor
+final class StubNotificationDispatcher: NotificationDispatching {
+
+    enum Call: Equatable {
+        case requestPermission
+        case lowDisk(freePercent: Double)
+        case highRAM(pressureLevel: String)
+        case malware(threatName: String)
+        case largeFiles(count: Int, totalSize: Int64)
+    }
+
+    private(set) var calls: [Call] = []
+
+    func requestPermission() async { calls.append(.requestPermission) }
+    func sendLowDiskNotification(freePercent: Double) {
+        calls.append(.lowDisk(freePercent: freePercent))
+    }
+    func sendHighRAMNotification(pressureLevel: String) {
+        calls.append(.highRAM(pressureLevel: pressureLevel))
+    }
+    func sendMalwareDetectedNotification(threatName: String) {
+        calls.append(.malware(threatName: threatName))
+    }
+    func sendLargeFilesFoundNotification(count: Int, totalSize: Int64) {
+        calls.append(.largeFiles(count: count, totalSize: totalSize))
+    }
+}
+
+@MainActor
+final class NotificationThresholdMonitorTests: XCTestCase {
+
+    // MARK: - Test scaffolding
+
+    private var preferences: PreferencesStore!
+    private var stats: SystemStatsService!
+    private var dispatcher: StubNotificationDispatcher!
+    /// Mutable virtual clock so tests can advance time across the cooldown
+    /// boundary without sleeping.
+    private var virtualNow: Date = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() {
+        super.setUp()
+        let suite = "VaderCleanerTests.NotificationThresholdMonitor.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        preferences = PreferencesStore(defaults: defaults)
+        // autostart: false so no real timer fires during the test — every
+        // evaluation goes through `evaluate(disk:)` / `evaluate(ram:)` directly.
+        stats = SystemStatsService(interval: 60, autostart: false)
+        dispatcher = StubNotificationDispatcher()
+        virtualNow = Date(timeIntervalSince1970: 1_700_000_000)
+    }
+
+    override func tearDown() {
+        preferences = nil
+        stats = nil
+        dispatcher = nil
+        super.tearDown()
+    }
+
+    /// Fresh monitor pinned to the test's virtual clock. Tests that need to
+    /// advance time mutate `virtualNow` between calls.
+    private func makeMonitor() -> NotificationThresholdMonitor {
+        NotificationThresholdMonitor(
+            stats: stats,
+            preferences: preferences,
+            dispatcher: dispatcher,
+            cooldown: 5 * 60,
+            now: { [unowned self] in self.virtualNow }
+        )
+    }
+
+    /// Builds a `DiskStats` with the requested free percentage. `total` is held
+    /// constant at 1 TB so the math is easy to read in test bodies.
+    private func disk(freePercent: Double) -> DiskStats {
+        let total: UInt64 = 1_000_000_000_000
+        let free = UInt64(Double(total) * (freePercent / 100.0))
+        let used = total - free
+        return DiskStats(usedBytes: used, totalBytes: total)
+    }
+
+    /// Builds a `MemoryStats` whose `pressureLevel` matches the supplied bucket.
+    /// The constructor takes raw bytes; deriving them from a target ratio keeps
+    /// tests honest about which bucket they're exercising.
+    private func memory(forLevel level: MemoryPressureLevel) -> MemoryStats {
+        let total: UInt64 = 16_000_000_000
+        let ratio: Double
+        switch level {
+        case .nominal: ratio = 0.30
+        case .fair: ratio = 0.75
+        case .critical: ratio = 0.90
+        }
+        return MemoryStats(usedBytes: UInt64(Double(total) * ratio), totalBytes: total)
+    }
+
+    // MARK: - Low-disk dispatch
+
+    func test_lowDisk_firesWhenFreePercentBelowThresholdAndToggleOn() {
+        preferences.notifyLowDisk = true
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = makeMonitor()
+
+        monitor.evaluate(disk: disk(freePercent: 8.0))
+
+        XCTAssertEqual(dispatcher.calls.count, 1)
+        if case .lowDisk(let freePercent)? = dispatcher.calls.first {
+            // Free percent passed through unchanged so the notification can
+            // format it however it wants.
+            XCTAssertEqual(freePercent, 8.0, accuracy: 0.01)
+        } else {
+            XCTFail("Expected a .lowDisk call, got \(dispatcher.calls)")
+        }
+    }
+
+    func test_lowDisk_doesNotFireWhenToggleOff() {
+        preferences.notifyLowDisk = false
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = makeMonitor()
+
+        monitor.evaluate(disk: disk(freePercent: 5.0))
+
+        XCTAssertTrue(dispatcher.calls.isEmpty,
+                      "Notification must respect the user's preference toggle")
+    }
+
+    func test_lowDisk_doesNotFireAboveThreshold() {
+        preferences.notifyLowDisk = true
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = makeMonitor()
+
+        monitor.evaluate(disk: disk(freePercent: 15.0))
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_lowDisk_doesNotReFireWithinCooldown() {
+        preferences.notifyLowDisk = true
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = makeMonitor()
+
+        // First crossing fires.
+        monitor.evaluate(disk: disk(freePercent: 8.0))
+        // 4:59 later — still under the 5-minute cooldown.
+        virtualNow = virtualNow.addingTimeInterval(299)
+        monitor.evaluate(disk: disk(freePercent: 6.0))
+
+        XCTAssertEqual(dispatcher.calls.count, 1,
+                       "Second sample inside the cooldown must not re-trigger")
+    }
+
+    func test_lowDisk_reFiresAfterCooldownElapses() {
+        preferences.notifyLowDisk = true
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = makeMonitor()
+
+        monitor.evaluate(disk: disk(freePercent: 8.0))
+        // Step past the 5-minute boundary.
+        virtualNow = virtualNow.addingTimeInterval(301)
+        monitor.evaluate(disk: disk(freePercent: 6.0))
+
+        XCTAssertEqual(dispatcher.calls.count, 2)
+    }
+
+    // MARK: - High-RAM dispatch
+
+    func test_highRAM_firesOnCritical() {
+        preferences.notifyHighRAM = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(ram: memory(forLevel: .critical))
+
+        XCTAssertEqual(dispatcher.calls.count, 1)
+        if case .highRAM(let level)? = dispatcher.calls.first {
+            XCTAssertFalse(level.isEmpty)
+        } else {
+            XCTFail("Expected a .highRAM call, got \(dispatcher.calls)")
+        }
+    }
+
+    func test_highRAM_doesNotFireOnFairOrNominal() {
+        preferences.notifyHighRAM = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(ram: memory(forLevel: .nominal))
+        monitor.evaluate(ram: memory(forLevel: .fair))
+
+        XCTAssertTrue(dispatcher.calls.isEmpty,
+                      "Only critical pressure should trigger the notification")
+    }
+
+    func test_highRAM_doesNotFireWhenToggleOff() {
+        preferences.notifyHighRAM = false
+        let monitor = makeMonitor()
+
+        monitor.evaluate(ram: memory(forLevel: .critical))
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_highRAM_doesNotReFireWithinCooldown() {
+        preferences.notifyHighRAM = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(ram: memory(forLevel: .critical))
+        virtualNow = virtualNow.addingTimeInterval(60)
+        monitor.evaluate(ram: memory(forLevel: .critical))
+
+        XCTAssertEqual(dispatcher.calls.count, 1)
+    }
+
+    // MARK: - Cooldowns are independent per kind
+
+    func test_cooldownsAreIndependentPerKind() {
+        preferences.notifyLowDisk = true
+        preferences.notifyHighRAM = true
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = makeMonitor()
+
+        monitor.evaluate(disk: disk(freePercent: 5.0))
+        // Still inside the disk cooldown, but RAM has its own clock.
+        monitor.evaluate(ram: memory(forLevel: .critical))
+
+        XCTAssertEqual(dispatcher.calls.count, 2,
+                       "Disk and RAM cooldowns must not share state")
+    }
+
+    // MARK: - Malware + large-files trigger paths
+
+    func test_malware_firesWhenToggleOnAndCooldownElapsed() {
+        preferences.notifyMalwareFound = true
+        let monitor = makeMonitor()
+
+        monitor.triggerMalwareDetected(threatName: "Eicar-Test-Signature")
+
+        XCTAssertEqual(dispatcher.calls,
+                       [.malware(threatName: "Eicar-Test-Signature")])
+    }
+
+    func test_malware_doesNotFireWhenToggleOff() {
+        preferences.notifyMalwareFound = false
+        let monitor = makeMonitor()
+
+        monitor.triggerMalwareDetected(threatName: "X")
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_largeFiles_firesAndRespectsCooldown() {
+        preferences.notifyLargeFilesFound = true
+        let monitor = makeMonitor()
+
+        monitor.triggerLargeFilesFound(count: 5, totalSize: 1_000_000_000)
+        // Inside cooldown — no second call.
+        virtualNow = virtualNow.addingTimeInterval(60)
+        monitor.triggerLargeFilesFound(count: 7, totalSize: 2_000_000_000)
+
+        XCTAssertEqual(dispatcher.calls.count, 1)
+    }
+}

--- a/VaderCleanerTests/NotificationThresholdMonitorTests.swift
+++ b/VaderCleanerTests/NotificationThresholdMonitorTests.swift
@@ -67,13 +67,19 @@ final class NotificationThresholdMonitorTests: XCTestCase {
 
     /// Fresh monitor pinned to the test's virtual clock. Tests that need to
     /// advance time mutate `virtualNow` between calls.
+    ///
+    /// `assumesPermissionResolved: true` keeps the existing dispatch tests
+    /// synchronous — they don't care about the permission gate, only the
+    /// toggle / threshold / cooldown logic. Tests that *do* care about the
+    /// gate construct their own monitor with the default (`false`).
     private func makeMonitor() -> NotificationThresholdMonitor {
         NotificationThresholdMonitor(
             stats: stats,
             preferences: preferences,
             dispatcher: dispatcher,
             cooldown: 5 * 60,
-            now: { [unowned self] in self.virtualNow }
+            now: { [unowned self] in self.virtualNow },
+            assumesPermissionResolved: true
         )
     }
 
@@ -250,6 +256,76 @@ final class NotificationThresholdMonitorTests: XCTestCase {
         monitor.triggerMalwareDetected(threatName: "X")
 
         XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    // MARK: - Permission gate
+
+    /// A threshold reading observed before `requestPermission()` has resolved
+    /// must not dispatch and must not stamp the cooldown. Stamping a 5-minute
+    /// cooldown against a notification the system would silently drop would
+    /// suppress the next eligible alert immediately after the user grants
+    /// permission.
+    func test_doesNotDispatchBeforePermissionResolved() {
+        preferences.notifyLowDisk = true
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = NotificationThresholdMonitor(
+            stats: stats,
+            preferences: preferences,
+            dispatcher: dispatcher,
+            cooldown: 5 * 60,
+            now: { [unowned self] in self.virtualNow }
+            // assumesPermissionResolved defaults to false
+        )
+
+        monitor.evaluate(disk: disk(freePercent: 5.0))
+        monitor.evaluate(ram: memory(forLevel: .critical))
+        monitor.triggerMalwareDetected(threatName: "X")
+        monitor.triggerLargeFilesFound(count: 1, totalSize: 1)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty,
+                      "No notifications should fire before requestPermission resolves")
+    }
+
+    /// After `requestPermission()` resolves, the same reading that was
+    /// suppressed earlier must dispatch — and the cooldown table must still
+    /// be empty so the post-grant alert fires immediately rather than waiting
+    /// out a stale stamp.
+    func test_dispatchesImmediatelyAfterPermissionResolves() async {
+        preferences.notifyLowDisk = true
+        preferences.notifyHighRAM = true
+        preferences.diskSpaceThresholdPercent = 10.0
+        let monitor = NotificationThresholdMonitor(
+            stats: stats,
+            preferences: preferences,
+            dispatcher: dispatcher,
+            cooldown: 5 * 60,
+            now: { [unowned self] in self.virtualNow }
+        )
+
+        // Pre-resolution: gate suppresses everything.
+        monitor.evaluate(disk: disk(freePercent: 5.0))
+        XCTAssertTrue(dispatcher.calls.filter { !isPermissionRequest($0) }.isEmpty)
+
+        // Resolve.
+        await monitor.requestPermission()
+
+        // Post-resolution: dispatch fires.
+        monitor.evaluate(disk: disk(freePercent: 5.0))
+
+        let dispatches = dispatcher.calls.filter { !isPermissionRequest($0) }
+        XCTAssertEqual(dispatches.count, 1, "Post-grant low-disk alert should fire on the next reading")
+        if case .lowDisk(let pct) = dispatches.first {
+            XCTAssertEqual(pct, 5.0, accuracy: 0.01)
+        } else {
+            XCTFail("Expected a .lowDisk dispatch, got \(dispatches)")
+        }
+    }
+
+    /// Filters out the bookkeeping `.requestPermission` entries so the
+    /// gate tests can assert only on actual notification dispatches.
+    private func isPermissionRequest(_ call: StubNotificationDispatcher.Call) -> Bool {
+        if case .requestPermission = call { return true }
+        return false
     }
 
     func test_largeFiles_firesAndRespectsCooldown() {

--- a/todo.md
+++ b/todo.md
@@ -22,7 +22,7 @@
 - [x] **Prompt 8** — SystemStatsService (CPU, RAM, disk, battery, SMART, FileVault)
 - [x] **Prompt 9** — Health Monitor UI (5 stat cards + FileVault row)
 - [x] **Prompt 10** — Menu bar live stats (wired to SystemStatsService)
-- [ ] **Prompt 11** — Notification system (4 notification types, threshold monitoring, cooldown)
+- [x] **Prompt 11** — Notification system (4 notification types, threshold monitoring, cooldown)
 
 ## Phase 2 — File Cleaning
 


### PR DESCRIPTION
## Summary
- `NotificationManager` wraps `UNUserNotificationCenter` and exposes pure `make…Content(…)` static helpers, so the title/body shape is unit-tested without scheduling real notifications.
- `NotificationThresholdMonitor` subscribes to `SystemStatsService.$diskSpace` and `$ramUsage`, gates dispatch on `PreferencesStore` toggles, and enforces a 5-minute per-kind cooldown via an injectable clock.
- Wired into `VaderCleanerApp`: shared `SystemStatsService` + `PreferencesStore` instances feed the monitor; permission requested once via the main scene's `.task`.

Closes #24

## Test plan
- [x] `xcodebuild test` — 136 unit tests + 1 UI test pass
- [x] `NotificationManagerTests` (5) — content builders + permission smoke test
- [x] `NotificationThresholdMonitorTests` (13) — toggle gating, threshold edges, cooldown, malware/large-files trigger paths
- [ ] Manual verification on a real Mac: launch, accept notification permission, force a low-disk reading, observe banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized notification system that alerts users about critical system events: low disk space, high RAM usage, malware detection, and large files found.
  * Notifications respect user preferences and include intelligent per-event cooldown logic to prevent alert fatigue.

* **Tests**
  * Added comprehensive test coverage for the notification system, including edge cases and cooldown behavior.

* **Chores**
  * Updated project status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->