### PR TITLE
File scanner infrastructure

### DIFF
--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -1,0 +1,150 @@
+// FileScanner.swift
+// Recursively walks a set of root URLs and emits ScannedFile records, honoring an exclusion list and tolerating permission errors.
+
+import Foundation
+import os.log
+
+/// Pairs a directory to scan with the `ScanCategory` to tag every file under
+/// it. Lets `FileScanner` stay agnostic about which path means which kind of
+/// junk — that mapping belongs to the feature-specific scanners
+/// (`SystemJunkScanner`, etc.) layered on top.
+struct ScanRoot: Equatable {
+    let url: URL
+    let category: ScanCategory
+}
+
+/// Protocol surface so feature scanners and tests can inject a fake.
+/// Concrete implementation is `FileScanner` below.
+protocol FileScanning {
+    func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile]
+}
+
+/// Walks each root recursively and returns every regular file as a
+/// `ScannedFile` tagged with the root's category. Symlinks are skipped
+/// outright so the same physical file can never appear twice via different
+/// paths and so links pointing outside the scanned tree don't pull external
+/// content in. Permission errors on subdirectories are logged and the walk
+/// continues — a single unreadable cache directory must never abort a whole
+/// scan.
+///
+/// Non-isolated by design: the type holds no shared state and runs on
+/// whichever task it's awaited from. Prompt 26 will pass the resolved
+/// `ExclusionsStore.exclusions` snapshot through the `excluding` argument so
+/// this layer never touches a `@MainActor` store directly.
+struct FileScanner: FileScanning {
+
+    private static let log = Logger(
+        subsystem: "com.personal.VaderCleaner",
+        category: "FileScanner"
+    )
+
+    /// Resource keys we ask the enumerator to prefetch — pulling them in
+    /// bulk is materially faster than one stat() per file when scanning
+    /// large caches.
+    private static let resourceKeys: [URLResourceKey] = [
+        .isRegularFileKey,
+        .isSymbolicLinkKey,
+        .isDirectoryKey,
+        .fileSizeKey,
+        .contentAccessDateKey,
+        .contentModificationDateKey
+    ]
+
+    func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
+        let canonicalExclusions = excluding.map(Self.canonicalize)
+        var results: [ScannedFile] = []
+
+        for root in roots {
+            let rootCanonical = Self.canonicalize(root.url)
+            if Self.isExcluded(path: rootCanonical, by: canonicalExclusions) {
+                continue
+            }
+
+            // `.skipsPackageDescendants` keeps us out of .app bundles and
+            // similar packages. `.skipsHiddenFiles` is intentionally NOT
+            // set: cache and log directories on macOS routinely contain
+            // dot-prefixed files we need to count.
+            let enumerator = FileManager.default.enumerator(
+                at: root.url,
+                includingPropertiesForKeys: Self.resourceKeys,
+                options: [.skipsPackageDescendants],
+                errorHandler: { url, error in
+                    Self.log.debug(
+                        "Skipping unreadable path \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
+                    return true
+                }
+            )
+
+            guard let enumerator else { continue }
+
+            for case let url as URL in enumerator {
+                let resourceValues = try? url.resourceValues(forKeys: Set(Self.resourceKeys))
+
+                if resourceValues?.isSymbolicLink == true {
+                    // Skip symlinks unconditionally — this avoids both
+                    // double-counting (when the link's target is also under
+                    // the scanned root) and pulling in external content
+                    // (when the target is outside the root).
+                    continue
+                }
+
+                let canonicalPath = Self.canonicalize(url)
+                if Self.isExcluded(path: canonicalPath, by: canonicalExclusions) {
+                    if resourceValues?.isDirectory == true {
+                        enumerator.skipDescendants()
+                    }
+                    continue
+                }
+
+                guard resourceValues?.isRegularFile == true else { continue }
+
+                let size = Int64(resourceValues?.fileSize ?? 0)
+                let accessed = resourceValues?.contentAccessDate ?? .distantPast
+                let modified = resourceValues?.contentModificationDate ?? .distantPast
+
+                results.append(
+                    ScannedFile(
+                        url: url,
+                        size: size,
+                        lastAccessDate: accessed,
+                        lastModifiedDate: modified,
+                        category: root.category
+                    )
+                )
+            }
+        }
+
+        return results
+    }
+
+    // MARK: - Path helpers
+
+    /// Resolves symlinks and normalises `..`/`.` so exclusion comparisons are
+    /// done on canonical paths. Mirrors `ExclusionsStore.canonicalize` so a
+    /// path the user excluded matches the same canonical form a scanner sees.
+    private static func canonicalize(_ url: URL) -> String {
+        url.resolvingSymlinksInPath().path
+    }
+
+    private static func canonicalize(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+    }
+
+    /// True when `path` is exactly an excluded path or sits beneath one.
+    /// Comparison is at path-component boundaries (not raw prefix) so
+    /// excluding `/tmp/foo` does not also exclude `/tmp/foobar`. macOS's
+    /// default APFS is case-insensitive, hence the case-insensitive compare.
+    private static func isExcluded(path: String, by exclusions: [String]) -> Bool {
+        for excluded in exclusions {
+            if path.caseInsensitiveCompare(excluded) == .orderedSame {
+                return true
+            }
+            let prefix = excluded.hasSuffix("/") ? excluded : excluded + "/"
+            if path.lowercased().hasPrefix(prefix.lowercased()) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -50,14 +50,22 @@ struct FileScanner: FileScanning {
         .contentModificationDateKey
     ]
 
+    /// Pre-built `Set` form of `resourceKeys` for the per-file
+    /// `resourceValues(forKeys:)` call. Allocating it once instead of on
+    /// every iteration matters when scanning hundreds of thousands of files.
+    private static let resourceKeySet = Set(resourceKeys)
+
     func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
         let canonicalExclusions = excluding.map(Self.canonicalize)
+        let hasExclusions = !canonicalExclusions.isEmpty
         var results: [ScannedFile] = []
 
         for root in roots {
-            let rootCanonical = Self.canonicalize(root.url)
-            if Self.isExcluded(path: rootCanonical, by: canonicalExclusions) {
-                continue
+            if hasExclusions {
+                let canonicalRootPath = Self.canonicalize(root.url)
+                if Self.isExcluded(path: canonicalRootPath, by: canonicalExclusions) {
+                    continue
+                }
             }
 
             // `.skipsPackageDescendants` keeps us out of .app bundles and
@@ -70,7 +78,7 @@ struct FileScanner: FileScanning {
                 options: [.skipsPackageDescendants],
                 errorHandler: { url, error in
                     Self.log.debug(
-                        "Skipping unreadable path \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                        "Skipping unreadable path \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
                     )
                     return true
                 }
@@ -79,7 +87,7 @@ struct FileScanner: FileScanning {
             guard let enumerator else { continue }
 
             for case let url as URL in enumerator {
-                let resourceValues = try? url.resourceValues(forKeys: Set(Self.resourceKeys))
+                let resourceValues = try? url.resourceValues(forKeys: Self.resourceKeySet)
 
                 if resourceValues?.isSymbolicLink == true {
                     // Skip symlinks unconditionally — this avoids both
@@ -89,26 +97,33 @@ struct FileScanner: FileScanning {
                     continue
                 }
 
-                let canonicalPath = Self.canonicalize(url)
-                if Self.isExcluded(path: canonicalPath, by: canonicalExclusions) {
-                    if resourceValues?.isDirectory == true {
-                        enumerator.skipDescendants()
+                // Canonicalize per-file *only* when there are exclusions to
+                // compare against — the common case (no exclusions) avoids
+                // the extra symlink-resolution work entirely. We can't lift
+                // this above the loop because `FileManager.enumerator`
+                // doesn't guarantee canonical-prefixed URLs even when given
+                // a canonical root, so the comparison has to happen on a
+                // resolved path.
+                if hasExclusions {
+                    let canonicalPath = Self.canonicalize(url)
+                    if Self.isExcluded(path: canonicalPath, by: canonicalExclusions) {
+                        if resourceValues?.isDirectory == true {
+                            enumerator.skipDescendants()
+                        }
+                        continue
                     }
-                    continue
                 }
 
                 guard resourceValues?.isRegularFile == true else { continue }
 
                 let size = Int64(resourceValues?.fileSize ?? 0)
-                let accessed = resourceValues?.contentAccessDate ?? .distantPast
-                let modified = resourceValues?.contentModificationDate ?? .distantPast
 
                 results.append(
                     ScannedFile(
                         url: url,
                         size: size,
-                        lastAccessDate: accessed,
-                        lastModifiedDate: modified,
+                        lastAccessDate: resourceValues?.contentAccessDate,
+                        lastModifiedDate: resourceValues?.contentModificationDate,
                         category: root.category
                     )
                 )
@@ -127,21 +142,19 @@ struct FileScanner: FileScanning {
         url.resolvingSymlinksInPath().path
     }
 
-    private static func canonicalize(_ path: String) -> String {
-        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
-    }
-
     /// True when `path` is exactly an excluded path or sits beneath one.
     /// Comparison is at path-component boundaries (not raw prefix) so
     /// excluding `/tmp/foo` does not also exclude `/tmp/foobar`. macOS's
     /// default APFS is case-insensitive, hence the case-insensitive compare.
+    /// Uses `range(of:options:)` rather than `lowercased()` so we don't
+    /// allocate a fresh lowercased copy of every enumerated path.
     private static func isExcluded(path: String, by exclusions: [String]) -> Bool {
         for excluded in exclusions {
             if path.caseInsensitiveCompare(excluded) == .orderedSame {
                 return true
             }
             let prefix = excluded.hasSuffix("/") ? excluded : excluded + "/"
-            if path.lowercased().hasPrefix(prefix.lowercased()) {
+            if path.range(of: prefix, options: [.anchored, .caseInsensitive]) != nil {
                 return true
             }
         }

--- a/VaderCleaner/ScanCategory.swift
+++ b/VaderCleaner/ScanCategory.swift
@@ -1,0 +1,43 @@
+// ScanCategory.swift
+// Stable enum tagging every file the scanner returns so the UI and aggregator can group, label, and persist results.
+
+import Foundation
+
+/// The kind of file or directory a scanner returned. Used by `ScannedFile`,
+/// surfaced in the System Junk preview list, and persisted in scan reports —
+/// raw values are therefore stable string keys, not auto-derived from the
+/// case name.
+///
+/// New cases must be appended (never inserted), and existing raw values must
+/// not change, or stored preferences/reports from older builds will fail to
+/// decode.
+enum ScanCategory: String, CaseIterable, Codable, Hashable {
+    case systemCache
+    case userCache
+    case systemLogs
+    case userLogs
+    case languageFiles
+    case mailAttachments
+    case iosBackups
+    case trash
+    case largeFile
+    case oldFile
+
+    /// User-facing label used in the System Junk preview rows and the
+    /// Smart Scan summary cards. Kept on the enum so every caller renders
+    /// the same string.
+    var displayName: String {
+        switch self {
+        case .systemCache: return "System Caches"
+        case .userCache: return "User Caches"
+        case .systemLogs: return "System Logs"
+        case .userLogs: return "User Logs"
+        case .languageFiles: return "Language Files"
+        case .mailAttachments: return "Mail Attachments"
+        case .iosBackups: return "iOS Backups"
+        case .trash: return "Trash"
+        case .largeFile: return "Large Files"
+        case .oldFile: return "Old Files"
+        }
+    }
+}

--- a/VaderCleaner/ScanResult.swift
+++ b/VaderCleaner/ScanResult.swift
@@ -1,0 +1,54 @@
+// ScanResult.swift
+// Aggregator that groups ScannedFile records by category and reports total/per-category byte counts to the UI.
+
+import Foundation
+
+/// Read-only aggregation of a scan run. Computes total size and category
+/// groupings lazily from the `items` array. Pure data — constructing a
+/// `ScanResult` never touches disk.
+///
+/// The view layer binds to `formattedTotalSize` / `sizeByCategory` so the
+/// formatting logic lives here, not in every feature view.
+struct ScanResult: Equatable {
+
+    /// Files emitted by the scanner. Order is preserved so callers that care
+    /// (e.g. Large & Old Files sorting by size descending) can pre-sort
+    /// before constructing the result.
+    let items: [ScannedFile]
+
+    init(items: [ScannedFile]) {
+        self.items = items
+    }
+
+    /// Sum of every item's byte count. `Int64` so values up to 8 EB are
+    /// representable without overflow — well past any plausible scan target.
+    var totalSize: Int64 {
+        items.reduce(0) { $0 + $1.size }
+    }
+
+    /// Items grouped by their `ScanCategory`. Categories with no matching
+    /// items are absent from the dictionary (rather than mapped to an empty
+    /// array) so callers can iterate `keys` to learn which categories were
+    /// non-empty.
+    var itemsByCategory: [ScanCategory: [ScannedFile]] {
+        Dictionary(grouping: items, by: \.category)
+    }
+
+    /// Total byte count per category. Built from `itemsByCategory` so the two
+    /// can never disagree.
+    var sizeByCategory: [ScanCategory: Int64] {
+        itemsByCategory.mapValues { files in
+            files.reduce(0) { $0 + $1.size }
+        }
+    }
+
+    /// Human-readable total ("1.5 KB", "2.3 GB", etc.). Uses
+    /// `ByteCountFormatter`'s file-size style so labels match how Finder
+    /// reports sizes — which is what users compare scan output to.
+    var formattedTotalSize: String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = .useAll
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: totalSize)
+    }
+}

--- a/VaderCleaner/ScanResult.swift
+++ b/VaderCleaner/ScanResult.swift
@@ -3,9 +3,10 @@
 
 import Foundation
 
-/// Read-only aggregation of a scan run. Computes total size and category
-/// groupings lazily from the `items` array. Pure data — constructing a
-/// `ScanResult` never touches disk.
+/// Read-only aggregation of a scan run. Total size and category groupings are
+/// computed once during init and stored as constants — UI bindings can read
+/// them as many times as they like without re-walking `items`. Pure data:
+/// constructing a `ScanResult` never touches disk.
 ///
 /// The view layer binds to `formattedTotalSize` / `sizeByCategory` so the
 /// formatting logic lives here, not in every feature view.
@@ -16,39 +17,49 @@ struct ScanResult: Equatable {
     /// before constructing the result.
     let items: [ScannedFile]
 
-    init(items: [ScannedFile]) {
-        self.items = items
-    }
-
     /// Sum of every item's byte count. `Int64` so values up to 8 EB are
     /// representable without overflow — well past any plausible scan target.
-    var totalSize: Int64 {
-        items.reduce(0) { $0 + $1.size }
-    }
+    let totalSize: Int64
 
     /// Items grouped by their `ScanCategory`. Categories with no matching
     /// items are absent from the dictionary (rather than mapped to an empty
     /// array) so callers can iterate `keys` to learn which categories were
     /// non-empty.
-    var itemsByCategory: [ScanCategory: [ScannedFile]] {
-        Dictionary(grouping: items, by: \.category)
-    }
+    let itemsByCategory: [ScanCategory: [ScannedFile]]
 
-    /// Total byte count per category. Built from `itemsByCategory` so the two
-    /// can never disagree.
-    var sizeByCategory: [ScanCategory: Int64] {
-        itemsByCategory.mapValues { files in
-            files.reduce(0) { $0 + $1.size }
+    /// Total byte count per category. Built in lockstep with
+    /// `itemsByCategory` so the two can never disagree.
+    let sizeByCategory: [ScanCategory: Int64]
+
+    /// Shared `ByteCountFormatter`. Construction is comparatively expensive
+    /// and the formatter is stateless for our use case, so we pay that cost
+    /// once for the lifetime of the process.
+    private static let byteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = .useAll
+        formatter.countStyle = .file
+        return formatter
+    }()
+
+    init(items: [ScannedFile]) {
+        var total: Int64 = 0
+        var grouped: [ScanCategory: [ScannedFile]] = [:]
+        var sizes: [ScanCategory: Int64] = [:]
+        for item in items {
+            total += item.size
+            grouped[item.category, default: []].append(item)
+            sizes[item.category, default: 0] += item.size
         }
+        self.items = items
+        self.totalSize = total
+        self.itemsByCategory = grouped
+        self.sizeByCategory = sizes
     }
 
     /// Human-readable total ("1.5 KB", "2.3 GB", etc.). Uses
     /// `ByteCountFormatter`'s file-size style so labels match how Finder
     /// reports sizes — which is what users compare scan output to.
     var formattedTotalSize: String {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = .useAll
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: totalSize)
+        Self.byteFormatter.string(fromByteCount: totalSize)
     }
 }

--- a/VaderCleaner/ScannedFile.swift
+++ b/VaderCleaner/ScannedFile.swift
@@ -1,0 +1,18 @@
+// ScannedFile.swift
+// Value type carrying the URL, byte count, dates, and category for a single file the scanner emitted.
+
+import Foundation
+
+/// One record produced by `FileScanner` for a single regular file. Pure data —
+/// no I/O happens on this type. The `category` is assigned at scan time based
+/// on which `ScanRoot` the file lived under.
+///
+/// `Equatable` and `Hashable` are derived so test fixtures can compare results
+/// directly and view models can use `Set<ScannedFile>` for selection state.
+struct ScannedFile: Equatable, Hashable {
+    let url: URL
+    let size: Int64
+    let lastAccessDate: Date
+    let lastModifiedDate: Date
+    let category: ScanCategory
+}

--- a/VaderCleaner/ScannedFile.swift
+++ b/VaderCleaner/ScannedFile.swift
@@ -7,12 +7,18 @@ import Foundation
 /// no I/O happens on this type. The `category` is assigned at scan time based
 /// on which `ScanRoot` the file lived under.
 ///
+/// `lastAccessDate` and `lastModifiedDate` are optional: the file system can
+/// legitimately omit either when a volume doesn't track that timestamp, and
+/// substituting a sentinel like `.distantPast` would misclassify those files
+/// as ancient in the Large & Old Files scanner. `nil` means "unknown — don't
+/// classify by age."
+///
 /// `Equatable` and `Hashable` are derived so test fixtures can compare results
 /// directly and view models can use `Set<ScannedFile>` for selection state.
 struct ScannedFile: Equatable, Hashable {
     let url: URL
     let size: Int64
-    let lastAccessDate: Date
-    let lastModifiedDate: Date
+    let lastAccessDate: Date?
+    let lastModifiedDate: Date?
     let category: ScanCategory
 }

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -1,0 +1,238 @@
+// FileScannerTests.swift
+// Integration tests that drive FileScanner over real temporary directories to verify recursion, exclusions, sizes, symlinks, and error handling.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Exercises `FileScanner` against real temp directories created via
+/// `TestHelpers`. We deliberately avoid mocking `FileManager` — the whole
+/// point of this layer is to integrate with the file system, and a mock
+/// would just re-encode our own assumptions about it.
+final class FileScannerTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    // MARK: - Recursion
+
+    func test_scan_enumeratesFilesRecursively() async throws {
+        let nested = try TestHelpers.createNestedDirectories(depth: 3, in: tempRoot)
+        try TestHelpers.createDummyFiles(count: 2, size: 16, in: tempRoot)
+        try TestHelpers.createDummyFiles(count: 3, size: 32, in: nested)
+
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: []
+        )
+
+        XCTAssertEqual(files.count, 5)
+    }
+
+    func test_scan_emptyDirectoryReturnsEmpty() async throws {
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: []
+        )
+
+        XCTAssertEqual(files, [])
+    }
+
+    func test_scan_assignsCategoryFromMatchingRoot() async throws {
+        let cacheRoot = tempRoot.appendingPathComponent("cache", isDirectory: true)
+        let trashRoot = tempRoot.appendingPathComponent("trash", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: trashRoot, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 2, size: 8, in: cacheRoot)
+        try TestHelpers.createDummyFiles(count: 1, size: 8, in: trashRoot)
+
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [
+                ScanRoot(url: cacheRoot, category: .userCache),
+                ScanRoot(url: trashRoot, category: .trash)
+            ],
+            excluding: []
+        )
+
+        XCTAssertEqual(files.filter { $0.category == .userCache }.count, 2)
+        XCTAssertEqual(files.filter { $0.category == .trash }.count, 1)
+    }
+
+    // MARK: - Exclusions
+
+    func test_scan_skipsFilesUnderExcludedPath() async throws {
+        let kept = tempRoot.appendingPathComponent("kept", isDirectory: true)
+        let excluded = tempRoot.appendingPathComponent("excluded", isDirectory: true)
+        try FileManager.default.createDirectory(at: kept, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: excluded, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 2, size: 4, in: kept)
+        try TestHelpers.createDummyFiles(count: 5, size: 4, in: excluded)
+
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: [excluded]
+        )
+
+        XCTAssertEqual(files.count, 2)
+        for file in files {
+            XCTAssertFalse(
+                file.url.path.hasPrefix(excluded.path),
+                "Excluded path leaked: \(file.url.path)"
+            )
+        }
+    }
+
+    /// Exclusion match must be at path-component boundaries, not raw prefix —
+    /// otherwise excluding `/tmp/foo` would also exclude `/tmp/foobar`.
+    func test_scan_exclusionMatchesAtPathBoundary() async throws {
+        let foo = tempRoot.appendingPathComponent("foo", isDirectory: true)
+        let foobar = tempRoot.appendingPathComponent("foobar", isDirectory: true)
+        try FileManager.default.createDirectory(at: foo, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: foobar, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 1, size: 4, in: foo)
+        try TestHelpers.createDummyFiles(count: 1, size: 4, in: foobar)
+
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: [foo]
+        )
+
+        XCTAssertEqual(files.count, 1, "Only the foobar file should remain")
+        XCTAssertTrue(files[0].url.path.contains("foobar"))
+    }
+
+    // MARK: - Total size
+
+    func test_scan_resultTotalSizeMatchesFileSizes() async throws {
+        try TestHelpers.createDummyFile(named: "a.bin", size: 100, in: tempRoot)
+        try TestHelpers.createDummyFile(named: "b.bin", size: 250, in: tempRoot)
+        try TestHelpers.createDummyFile(named: "c.bin", size: 50, in: tempRoot)
+
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: []
+        )
+        let result = ScanResult(items: files)
+
+        XCTAssertEqual(result.totalSize, 400)
+    }
+
+    // MARK: - Symlinks
+
+    /// A symlink inside the scanned tree pointing to a file *outside* it must
+    /// not pull the external file into the result. Our enumerator skips
+    /// symlinks outright; this test pins that contract regardless of the
+    /// underlying mechanism (so a future switch to "follow symlinks under
+    /// root only" would still need this assertion to hold).
+    func test_scan_skipsSymlinkPointingOutsideScannedDirectory() async throws {
+        let outside = try TestHelpers.createTempDirectory()
+        defer { TestHelpers.tearDownTempDirectory(outside) }
+        let externalFile = try TestHelpers.createDummyFile(
+            named: "external.bin",
+            size: 1_000,
+            in: outside
+        )
+        try TestHelpers.createDummyFile(named: "inside.bin", size: 8, in: tempRoot)
+        let symlink = tempRoot.appendingPathComponent("link-to-outside")
+        try FileManager.default.createSymbolicLink(
+            at: symlink,
+            withDestinationURL: externalFile
+        )
+
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: []
+        )
+
+        let externalCanonical = externalFile.resolvingSymlinksInPath().path
+        for file in files {
+            XCTAssertNotEqual(
+                file.url.resolvingSymlinksInPath().path,
+                externalCanonical,
+                "Scanner followed a symlink outside the scanned root"
+            )
+        }
+        let totalSize = ScanResult(items: files).totalSize
+        XCTAssertLessThan(
+            totalSize,
+            1_000,
+            "External 1 KB file appears to have been counted via symlink"
+        )
+    }
+
+    // MARK: - Permission denied
+
+    /// The scanner must surface a clean result rather than throwing when
+    /// some children are unreadable. We approximate this by chmod-ing a
+    /// subdirectory to 0o000; the enumerator will hit EACCES on it but
+    /// should keep walking the rest of the tree.
+    func test_scan_handlesPermissionDeniedWithoutCrashing() async throws {
+        let readable = tempRoot.appendingPathComponent("readable", isDirectory: true)
+        let locked = tempRoot.appendingPathComponent("locked", isDirectory: true)
+        try FileManager.default.createDirectory(at: readable, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: locked, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 2, size: 4, in: readable)
+        try TestHelpers.createDummyFiles(count: 1, size: 4, in: locked)
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000],
+            ofItemAtPath: locked.path
+        )
+        // Restore perms in teardown order so cleanup can recurse into it.
+        addTeardownBlock {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: locked.path
+            )
+        }
+
+        let scanner = FileScanner()
+        let files: [ScannedFile]
+        do {
+            files = try await scanner.scan(
+                roots: [ScanRoot(url: tempRoot, category: .userCache)],
+                excluding: []
+            )
+        } catch {
+            XCTFail("Scanner threw on permission-denied: \(error)")
+            return
+        }
+        XCTAssertGreaterThanOrEqual(files.count, 2, "Readable subtree should still be enumerated")
+    }
+
+    // MARK: - File metadata
+
+    /// `ScannedFile.size` must match what the file system reports for the
+    /// underlying file. Dummy files in `TestHelpers` are written with a
+    /// known byte count; this pins the path through `URLResourceValues`.
+    func test_scan_recordedFileSizeMatchesActualFileSize() async throws {
+        try TestHelpers.createDummyFile(named: "exact.bin", size: 1_234, in: tempRoot)
+
+        let scanner = FileScanner()
+        let files = try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: []
+        )
+
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files.first?.size, 1_234)
+    }
+}

--- a/VaderCleanerTests/ScanCategoryTests.swift
+++ b/VaderCleanerTests/ScanCategoryTests.swift
@@ -1,0 +1,52 @@
+// ScanCategoryTests.swift
+// Tests that every ScanCategory case has a non-empty display name and stable raw value for persistence.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Pins the public surface of `ScanCategory`.
+///
+/// Categories are persisted (e.g. as raw values in user preferences) and
+/// surfaced in the UI by `displayName`. A future refactor that drops a case
+/// or renames a raw value would silently break stored state — these tests
+/// catch that.
+final class ScanCategoryTests: XCTestCase {
+
+    /// `allCases` is the source of truth for the System Junk preview list and
+    /// the Large & Old Files scanner's category set. Pinning the count means
+    /// any future case addition is a deliberate test update, not a silent
+    /// expansion that breaks downstream UI assumptions.
+    func test_allCases_containsAllExpectedCategories() {
+        XCTAssertEqual(ScanCategory.allCases.count, 10)
+        XCTAssertTrue(ScanCategory.allCases.contains(.systemCache))
+        XCTAssertTrue(ScanCategory.allCases.contains(.userCache))
+        XCTAssertTrue(ScanCategory.allCases.contains(.systemLogs))
+        XCTAssertTrue(ScanCategory.allCases.contains(.userLogs))
+        XCTAssertTrue(ScanCategory.allCases.contains(.languageFiles))
+        XCTAssertTrue(ScanCategory.allCases.contains(.mailAttachments))
+        XCTAssertTrue(ScanCategory.allCases.contains(.iosBackups))
+        XCTAssertTrue(ScanCategory.allCases.contains(.trash))
+        XCTAssertTrue(ScanCategory.allCases.contains(.largeFile))
+        XCTAssertTrue(ScanCategory.allCases.contains(.oldFile))
+    }
+
+    /// Every case must produce a non-empty user-facing label so the UI never
+    /// renders a blank row.
+    func test_displayName_nonEmptyForEveryCase() {
+        for category in ScanCategory.allCases {
+            XCTAssertFalse(
+                category.displayName.isEmpty,
+                "Display name was empty for \(category)"
+            )
+        }
+    }
+
+    /// Raw values back persistence (preferences, JSON-encoded scan reports).
+    /// Pinning them here guarantees a rename is accompanied by a test update.
+    func test_rawValues_areStable() {
+        XCTAssertEqual(ScanCategory.systemCache.rawValue, "systemCache")
+        XCTAssertEqual(ScanCategory.userCache.rawValue, "userCache")
+        XCTAssertEqual(ScanCategory.trash.rawValue, "trash")
+        XCTAssertEqual(ScanCategory.largeFile.rawValue, "largeFile")
+    }
+}

--- a/VaderCleanerTests/ScanResultTests.swift
+++ b/VaderCleanerTests/ScanResultTests.swift
@@ -1,0 +1,88 @@
+// ScanResultTests.swift
+// Tests that ScanResult aggregates ScannedFile records by category and reports a correct total size.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Exercises the pure aggregation layer that sits between scanners and the
+/// UI. Constructed from a fixed set of `ScannedFile` records so these tests
+/// never touch disk — the file system traversal is covered by
+/// `FileScannerTests`.
+final class ScanResultTests: XCTestCase {
+
+    private func makeFile(
+        path: String = "/tmp/file",
+        size: Int64,
+        category: ScanCategory
+    ) -> ScannedFile {
+        ScannedFile(
+            url: URL(fileURLWithPath: path),
+            size: size,
+            lastAccessDate: Date(timeIntervalSince1970: 0),
+            lastModifiedDate: Date(timeIntervalSince1970: 0),
+            category: category
+        )
+    }
+
+    // MARK: - Total size
+
+    func test_totalSize_sumsAllItemSizes() {
+        let files = [
+            makeFile(size: 100, category: .userCache),
+            makeFile(size: 250, category: .systemCache),
+            makeFile(size: 50, category: .trash)
+        ]
+        let result = ScanResult(items: files)
+
+        XCTAssertEqual(result.totalSize, 400)
+    }
+
+    func test_totalSize_isZeroForEmptyResult() {
+        let result = ScanResult(items: [])
+        XCTAssertEqual(result.totalSize, 0)
+    }
+
+    // MARK: - Grouping
+
+    func test_itemsByCategory_groupsRecordsBySharedCategory() {
+        let files = [
+            makeFile(path: "/tmp/a", size: 1, category: .userCache),
+            makeFile(path: "/tmp/b", size: 2, category: .userCache),
+            makeFile(path: "/tmp/c", size: 3, category: .trash)
+        ]
+        let result = ScanResult(items: files)
+
+        XCTAssertEqual(result.itemsByCategory[.userCache]?.count, 2)
+        XCTAssertEqual(result.itemsByCategory[.trash]?.count, 1)
+        XCTAssertNil(result.itemsByCategory[.systemCache])
+    }
+
+    func test_sizeByCategory_sumsWithinEachCategory() {
+        let files = [
+            makeFile(path: "/tmp/a", size: 100, category: .userCache),
+            makeFile(path: "/tmp/b", size: 200, category: .userCache),
+            makeFile(path: "/tmp/c", size: 50, category: .trash)
+        ]
+        let result = ScanResult(items: files)
+
+        XCTAssertEqual(result.sizeByCategory[.userCache], 300)
+        XCTAssertEqual(result.sizeByCategory[.trash], 50)
+    }
+
+    // MARK: - Formatted total size
+
+    /// `formattedTotalSize` should round-trip through `ByteCountFormatter`
+    /// (file-size style) so the UI never has to format byte counts itself.
+    /// Non-empty + containing "KB" for a kilobyte-scale value is enough to
+    /// pin the contract without coupling to locale-specific punctuation.
+    func test_formattedTotalSize_usesByteCountFormatterFileStyle() {
+        let files = [makeFile(size: 1_500, category: .userCache)]
+        let result = ScanResult(items: files)
+
+        XCTAssertFalse(result.formattedTotalSize.isEmpty)
+        XCTAssertTrue(
+            result.formattedTotalSize.contains("KB"),
+            "Expected KB suffix in '\(result.formattedTotalSize)'"
+        )
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -26,7 +26,7 @@
 
 ## Phase 2 — File Cleaning
 
-- [ ] **Prompt 12** — File scanner infrastructure (FileScanner, ScanCategory, ScanResult)
+- [x] **Prompt 12** — File scanner infrastructure (FileScanner, ScanCategory, ScanResult)
 - [ ] **Prompt 13** — System Junk scanner (all 8 categories)
 - [ ] **Prompt 14** — System Junk UI + deletion (scan → preview → clean flow)
 - [ ] **Prompt 15** — Large & Old Files scanner + UI


### PR DESCRIPTION
## Summary
- Adds the shared file-walking + aggregation layer (`FileScanner`, `ScanCategory`, `ScannedFile`, `ScanResult`) that System Junk, Large & Old Files, and the rest of Phase 2 build on.
- 17 new tests cover recursion, exclusions, per-root category tagging, symlink skipping, permission-denied tolerance, and aggregation. Full suite: 157 unit tests + 1 UI test, all passing.

## Design notes
**1. Spec deviation — `ScanRoot` instead of `paths: [URL]`.** The plan specifies `func scan(paths: [URL], excluding: [URL]) -> [ScannedFile]` *and* `ScannedFile.category: ScanCategory`. A plain `[URL]` input has no source for that category. The cleanest resolution is to pair url + category at the input via a `ScanRoot` value type, so each file is tagged with the category of the root it lived under. Feature scanners (Prompt 13) construct one `ScanRoot` per directory they care about and feed them all to a single `scan(...)` call.

**2. Symlinks are skipped unconditionally.** The spec says "skips symlinks that point outside the scanned directory." We skip *all* symlinks — stricter, but it satisfies the requirement and avoids double-counting when a symlink points back inside the scanned tree. A test pins this contract.

**3. Exclusion match is path-component-aware.** `/tmp/foo` excludes `/tmp/foo/anything` but not `/tmp/foobar`. Comparison is case-insensitive and on canonical (symlink-resolved) paths, mirroring `ExclusionsStore.canonicalize` so a path the user excluded matches the same string a scanner sees.

**4. Non-isolated.** `FileScanner` is a plain `struct` with no actor isolation — it's safe to await from any task. Prompt 26 will pass `ExclusionsStore.exclusions` (a `@MainActor`-resolved snapshot) through the `excluding` parameter, keeping the boundary clean.

## Test plan
- [x] `xcodebuild ... test` — 157 unit tests + 1 UI test pass
- [x] New test files cover all six requirements from the prompt: recursion, exclusions, total size aggregation, ScanResult grouping, symlink skipping, permission-denied tolerance
- [x] No regressions in existing Phase 0/1 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File scanning identifies files across categories (system/user caches, logs, language files, mail attachments, iOS backups, trash, large/old files).
  * Scan results show total storage with per-category breakdowns and human-readable sizes.

* **Improvements**
  * More reliable scanning: handles symlinks, unreadable paths, and permission issues more gracefully.

* **Tests**
  * Added integration and unit tests covering scanning, grouping, sizing, and formatting.

* **Chores**
  * Updated project TODO status for File Cleaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->