### PR TITLE
System Junk scanner

### DIFF
--- a/VaderCleaner/LanguageFileLocator.swift
+++ b/VaderCleaner/LanguageFileLocator.swift
@@ -1,0 +1,129 @@
+// LanguageFileLocator.swift
+// Walks given roots looking for .lproj directories, returning each non-active locale as a .languageFiles ScanRoot.
+
+import Foundation
+import os.log
+
+/// Finds `.lproj` directories under a configurable set of scan roots and
+/// returns those whose locale is *not* in the active language list. The
+/// scanner doesn't recurse arbitrarily deep — `.lproj` only lives one level
+/// inside a bundle's `Contents/Resources/`, so a bounded walk is enough and
+/// avoids accidentally vacuuming up unrelated content.
+///
+/// Active-locale matching is by language code (the part before `-` or `_`),
+/// not by full locale name. macOS `.lproj` names are a mix of BCP-47
+/// (`en-US.lproj`), language-only (`en.lproj`), underscore-separated
+/// (`zh_CN.lproj`), and pre-ISO legacy (`English.lproj`, `Spanish.lproj`).
+/// Direct equality misses every variant; prefix matching with a small
+/// legacy allowlist gets all of them.
+struct LanguageFileLocator {
+
+    /// Root directories to walk. Caller chooses these — defaults live in
+    /// `DefaultSystemPathProvider` so this type stays unaware of macOS path
+    /// conventions and remains trivially testable from any temp directory.
+    let scanRoots: [URL]
+
+    /// Lower-cased language codes to treat as active. `.lproj` directories
+    /// whose extracted code matches anything here are filtered out of the
+    /// returned list.
+    let activeLanguageCodes: Set<String>
+
+    private static let log = Logger(
+        subsystem: "com.personal.VaderCleaner",
+        category: "LanguageFileLocator"
+    )
+
+    /// Maps legacy macOS `.lproj` names (used before ISO codes were the
+    /// norm) onto their language codes so prefix matching catches them.
+    /// Not exhaustive — these are the names still seen in older bundles
+    /// shipping today. New entries can be added as we encounter them.
+    private static let legacyLanguageNames: [String: String] = [
+        "english": "en",
+        "spanish": "es",
+        "french": "fr",
+        "german": "de",
+        "italian": "it",
+        "japanese": "ja",
+        "dutch": "nl"
+    ]
+
+    init(scanRoots: [URL], activeLanguageCodes: Set<String>) {
+        self.scanRoots = scanRoots
+        self.activeLanguageCodes = Set(activeLanguageCodes.map { $0.lowercased() })
+    }
+
+    /// Walks each scan root, surfaces every `.lproj` directory whose locale
+    /// is non-active, and returns one `ScanRoot(.languageFiles)` per match.
+    /// The walk follows package descendants because `.lproj` lives *inside*
+    /// `.app` bundles — `FileScanner`'s default `.skipsPackageDescendants`
+    /// would hide them otherwise.
+    func locate() -> [ScanRoot] {
+        var roots: [ScanRoot] = []
+        for scanRoot in scanRoots {
+            roots.append(contentsOf: lprojRoots(under: scanRoot))
+        }
+        return roots
+    }
+
+    /// Builds the `[ScanRoot]` for a single top-level directory. Pulled out
+    /// so each root is independently failure-tolerant: an unreadable
+    /// `/Library/Frameworks` doesn't prevent us from walking `/Applications`.
+    private func lprojRoots(under url: URL) -> [ScanRoot] {
+        let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { url, error in
+                Self.log.debug(
+                    "Skipping unreadable language path \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
+                )
+                return true
+            }
+        )
+        guard let enumerator else { return [] }
+
+        var roots: [ScanRoot] = []
+        for case let entry as URL in enumerator {
+            guard entry.pathExtension.caseInsensitiveCompare("lproj") == .orderedSame else {
+                continue
+            }
+            let localeName = entry.deletingPathExtension().lastPathComponent
+            guard let code = Self.languageCode(fromLocaleName: localeName) else {
+                continue
+            }
+            if activeLanguageCodes.contains(code) {
+                // Active locale — keep its `.lproj` directory.
+                continue
+            }
+            roots.append(ScanRoot(url: entry, category: .languageFiles))
+            // We tagged the whole `.lproj` as a junk root; no need to
+            // descend into its contents looking for nested `.lproj`s, and
+            // doing so would double-count files when FileScanner walks
+            // this root afterwards.
+            enumerator.skipDescendants()
+        }
+        return roots
+    }
+
+    /// Extracts the lower-cased language code from a locale name. Handles
+    /// BCP-47 (`en-US`), underscore-separated (`zh_CN`), and the legacy
+    /// English-name forms (`English`, `Spanish`). Returns `nil` for names
+    /// that don't look like a locale at all (e.g. someone created a
+    /// `Base.lproj` — keep those out of the active-match comparison so they
+    /// fall through unchanged into the result).
+    static func languageCode(fromLocaleName name: String) -> String? {
+        let lowered = name.lowercased()
+        if let mapped = legacyLanguageNames[lowered] {
+            return mapped
+        }
+        // Split on either `-` or `_` and take the first component. Both
+        // separators show up in `.lproj` names (`en-US`, `zh_CN`).
+        let scalars = lowered.split(whereSeparator: { $0 == "-" || $0 == "_" })
+        guard let first = scalars.first else { return nil }
+        // Common pseudo-locales to ignore — `Base.lproj` is bundle metadata,
+        // not a language. Returning nil keeps it from matching active codes
+        // and from being reported as junk.
+        if first == "base" { return nil }
+        return String(first)
+    }
+}

--- a/VaderCleaner/LanguageFileLocator.swift
+++ b/VaderCleaner/LanguageFileLocator.swift
@@ -65,13 +65,23 @@ struct LanguageFileLocator {
         return roots
     }
 
-    /// Cap on how deep we'll walk under any scan root looking for `.lproj`
-    /// directories. The natural locations are `Foo.app/Contents/Resources/`
-    /// (depth 3) and `Foo.framework/Resources/` (depth 2). A bound of 6
-    /// covers nested frameworks like `Foo.app/Contents/Frameworks/Bar.framework/Resources/`
-    /// (depth 5) without letting a single scan walk every binary, asset,
-    /// and `.bundle` payload under `/Applications`.
-    private static let maxLprojWalkDepth = 6
+    /// Cap on how deep we'll *descend* (into non-`.lproj` directories) when
+    /// walking a scan root. The cap is a perf bound to keep us out of
+    /// binary asset trees inside packages, not a filter on matches —
+    /// `.lproj` directories are always processed when we encounter them,
+    /// regardless of depth (see `lprojRoots(under:)`).
+    ///
+    /// Depths to plan for, measured from a top-level scan root like
+    /// `/Applications`:
+    ///   - `Foo.app/Contents/Resources/<lang>.lproj` → depth 4
+    ///   - `Foo.app/Contents/Frameworks/Bar.framework/Resources/...` → depth 6
+    ///   - `Foo.app/Contents/PlugIns/Bar.appex/Contents/Resources/...` → depth 7
+    ///   - Versioned frameworks inside extensions → depth 9–10
+    /// A cap of 10 lets the walker descend through the deepest realistic
+    /// nesting (extension-inside-app or versioned framework) without
+    /// expanding into every nested `.bundle` of subassets. Reported by
+    /// Codex on PR #28: prior cap of 6 missed `.appex` extension lprojs.
+    private static let maxLprojWalkDepth = 10
 
     /// Builds the `[ScanRoot]` for a single top-level directory. Pulled out
     /// so each root is independently failure-tolerant: an unreadable
@@ -94,31 +104,31 @@ struct LanguageFileLocator {
 
         var roots: [ScanRoot] = []
         for case let entry as URL in enumerator {
-            // Depth bound: stop descending once we're past where `.lproj`
-            // realistically lives. `.skipDescendants()` returns the walker
-            // to the next sibling rather than aborting the whole scan.
-            if enumerator.level > Self.maxLprojWalkDepth {
+            // Match on `.lproj` first — *before* the depth cap. The cap is
+            // a perf bound on descent into non-matching subtrees; it must
+            // not also prune valid matches at the same depth (e.g. an
+            // `.appex` extension's `.lproj` at depth 7).
+            if entry.pathExtension.caseInsensitiveCompare("lproj") == .orderedSame {
+                let localeName = entry.deletingPathExtension().lastPathComponent
+                if let code = Self.languageCode(fromLocaleName: localeName),
+                   !activeLanguageCodes.contains(code) {
+                    roots.append(ScanRoot(url: entry, category: .languageFiles))
+                }
+                // Always skip the contents of an `.lproj`. For a non-active
+                // match we tagged the whole directory as the junk root, so
+                // descending would double-count when FileScanner walks it
+                // later. For an active or skipped (`Base`/unmapped legacy)
+                // match we don't expect nested `.lproj`s and don't want to
+                // pay the descent cost either.
                 enumerator.skipDescendants()
                 continue
             }
 
-            guard entry.pathExtension.caseInsensitiveCompare("lproj") == .orderedSame else {
-                continue
+            // Non-`.lproj` directory at or past the cap: stop descending
+            // further down this branch but keep walking siblings.
+            if enumerator.level > Self.maxLprojWalkDepth {
+                enumerator.skipDescendants()
             }
-            let localeName = entry.deletingPathExtension().lastPathComponent
-            guard let code = Self.languageCode(fromLocaleName: localeName) else {
-                continue
-            }
-            if activeLanguageCodes.contains(code) {
-                // Active locale — keep its `.lproj` directory.
-                continue
-            }
-            roots.append(ScanRoot(url: entry, category: .languageFiles))
-            // We tagged the whole `.lproj` as a junk root; no need to
-            // descend into its contents looking for nested `.lproj`s, and
-            // doing so would double-count files when FileScanner walks
-            // this root afterwards.
-            enumerator.skipDescendants()
         }
         return roots
     }

--- a/VaderCleaner/LanguageFileLocator.swift
+++ b/VaderCleaner/LanguageFileLocator.swift
@@ -65,9 +65,19 @@ struct LanguageFileLocator {
         return roots
     }
 
+    /// Cap on how deep we'll walk under any scan root looking for `.lproj`
+    /// directories. The natural locations are `Foo.app/Contents/Resources/`
+    /// (depth 3) and `Foo.framework/Resources/` (depth 2). A bound of 6
+    /// covers nested frameworks like `Foo.app/Contents/Frameworks/Bar.framework/Resources/`
+    /// (depth 5) without letting a single scan walk every binary, asset,
+    /// and `.bundle` payload under `/Applications`.
+    private static let maxLprojWalkDepth = 6
+
     /// Builds the `[ScanRoot]` for a single top-level directory. Pulled out
     /// so each root is independently failure-tolerant: an unreadable
     /// `/Library/Frameworks` doesn't prevent us from walking `/Applications`.
+    /// The walk is depth-bounded — see `maxLprojWalkDepth` — to keep `.app`
+    /// bundles from making this O(every-file-under-/Applications).
     private func lprojRoots(under url: URL) -> [ScanRoot] {
         let enumerator = FileManager.default.enumerator(
             at: url,
@@ -84,6 +94,14 @@ struct LanguageFileLocator {
 
         var roots: [ScanRoot] = []
         for case let entry as URL in enumerator {
+            // Depth bound: stop descending once we're past where `.lproj`
+            // realistically lives. `.skipDescendants()` returns the walker
+            // to the next sibling rather than aborting the whole scan.
+            if enumerator.level > Self.maxLprojWalkDepth {
+                enumerator.skipDescendants()
+                continue
+            }
+
             guard entry.pathExtension.caseInsensitiveCompare("lproj") == .orderedSame else {
                 continue
             }
@@ -107,10 +125,19 @@ struct LanguageFileLocator {
 
     /// Extracts the lower-cased language code from a locale name. Handles
     /// BCP-47 (`en-US`), underscore-separated (`zh_CN`), and the legacy
-    /// English-name forms (`English`, `Spanish`). Returns `nil` for names
-    /// that don't look like a locale at all (e.g. someone created a
-    /// `Base.lproj` — keep those out of the active-match comparison so they
-    /// fall through unchanged into the result).
+    /// English-name forms (`English`, `Spanish`) listed in
+    /// `legacyLanguageNames`. Returns `nil` when the name should be skipped
+    /// entirely — callers (`lprojRoots(under:)`) drop nil-coded entries
+    /// from the result, so neither `Base.lproj` nor unmapped legacy names
+    /// like `Portuguese` are ever reported as junk.
+    ///
+    /// Conservative skip rule for unmapped legacy names: a single-token
+    /// name (no `-` or `_`) longer than 3 characters that isn't in the
+    /// allowlist is skipped. ISO 639-1/-2 codes are 2–3 chars, so this
+    /// preserves `nl`/`eng` while rejecting `Portuguese`/`Norwegian`.
+    /// Without this, `Portuguese.lproj` returned `"portuguese"` — never a
+    /// match for active BCP-47 `pt`, so the user's *active* locale
+    /// resources got reported as junk. Reported by Codex review on PR #28.
     static func languageCode(fromLocaleName name: String) -> String? {
         let lowered = name.lowercased()
         if let mapped = legacyLanguageNames[lowered] {
@@ -118,12 +145,20 @@ struct LanguageFileLocator {
         }
         // Split on either `-` or `_` and take the first component. Both
         // separators show up in `.lproj` names (`en-US`, `zh_CN`).
-        let scalars = lowered.split(whereSeparator: { $0 == "-" || $0 == "_" })
-        guard let first = scalars.first else { return nil }
-        // Common pseudo-locales to ignore — `Base.lproj` is bundle metadata,
-        // not a language. Returning nil keeps it from matching active codes
-        // and from being reported as junk.
+        let parts = lowered.split(whereSeparator: { $0 == "-" || $0 == "_" })
+        guard let first = parts.first.map(String.init) else { return nil }
+        // Pseudo-locale ignored explicitly — `Base.lproj` is bundle
+        // metadata, not a language.
         if first == "base" { return nil }
-        return String(first)
+        // Single-token name longer than an ISO code is almost certainly a
+        // legacy English-style name we don't have an allowlist entry for
+        // (e.g. `Portuguese`, `Norwegian`). Returning nil here means the
+        // caller drops the entry — safer than emitting a code that will
+        // never match an active locale and risking deletion of the user's
+        // active resources.
+        if parts.count == 1 && first.count > 3 {
+            return nil
+        }
+        return first
     }
 }

--- a/VaderCleaner/SystemJunkScanner.swift
+++ b/VaderCleaner/SystemJunkScanner.swift
@@ -1,0 +1,45 @@
+// SystemJunkScanner.swift
+// Orchestrator that asks SystemPathProviding for category-tagged roots, runs FileScanner over them, and packages the output as a ScanResult.
+
+import Foundation
+
+/// Top-level entry point for the System Junk feature. Composes a
+/// `SystemPathProviding` (which knows where macOS keeps caches, logs,
+/// trash, iOS backups, mail attachments, and stale `.lproj` bundles) with a
+/// `FileScanning` (which does the actual recursive walk) and returns a
+/// `ScanResult` keyed by `ScanCategory`.
+///
+/// The scanner itself owns no path knowledge — that lives entirely in the
+/// path provider — so tests inject a stub that returns roots under a temp
+/// directory and exercise every code path without touching real system
+/// locations.
+///
+/// Privileged-helper-driven enumeration of `/Library/Caches` and
+/// `/Library/Logs` is deferred to Prompt 14 where it pairs with deletion.
+/// With Full Disk Access (granted via Prompt 4) the in-process walk reads
+/// these paths today; `FileScanner`'s permission-error tolerance handles
+/// any locked descendants.
+struct SystemJunkScanner {
+
+    private let fileScanner: FileScanning
+    private let pathProvider: SystemPathProviding
+
+    init(
+        fileScanner: FileScanning = FileScanner(),
+        pathProvider: SystemPathProviding = DefaultSystemPathProvider()
+    ) {
+        self.fileScanner = fileScanner
+        self.pathProvider = pathProvider
+    }
+
+    /// Runs the scan and returns aggregated results. `excluding` is forwarded
+    /// straight to `FileScanner` — the path-component-aware match semantics
+    /// (covered in `FileScannerTests`) apply unchanged here, so a user who
+    /// excluded `~/Library/Caches/com.apple.Safari` will see Safari's caches
+    /// disappear from every category their parent path falls under.
+    func scan(excluding: [URL]) async throws -> ScanResult {
+        let roots = pathProvider.roots()
+        let files = try await fileScanner.scan(roots: roots, excluding: excluding)
+        return ScanResult(items: files)
+    }
+}

--- a/VaderCleaner/SystemPathProviding.swift
+++ b/VaderCleaner/SystemPathProviding.swift
@@ -1,0 +1,127 @@
+// SystemPathProviding.swift
+// Resolves the macOS filesystem locations that contribute to a System Junk scan, returning a list of ScanRoot pairs that FileScanner can consume.
+
+import Foundation
+
+/// Test seam between `SystemJunkScanner` and the real macOS path layout.
+/// Implementations return the concrete `[ScanRoot]` to feed into a scan.
+/// Tests inject a stub returning paths under a temp directory, which is why
+/// the production `DefaultSystemPathProvider` lives behind the same protocol
+/// instead of being a free function on the scanner.
+protocol SystemPathProviding {
+    func roots() -> [ScanRoot]
+}
+
+/// Production implementation that resolves real macOS junk paths plus
+/// non-active language `.lproj` directories. Constructed once per scan —
+/// volume enumeration and `.lproj` walking happen at call time so a newly
+/// mounted volume or freshly installed app shows up on the next run.
+struct DefaultSystemPathProvider: SystemPathProviding {
+
+    private let fileManager: FileManager
+    private let homeDirectory: URL
+    private let languageFileLocator: LanguageFileLocator
+
+    /// Roots searched for `.lproj` bundles. Deviation from the plan, which
+    /// names `/Library` and `/System/Library`: `/System/Library` lives on the
+    /// read-only Signed System Volume and its `.lproj` files cannot be
+    /// deleted, so reporting them as "junk" misleads the user. We restrict
+    /// to user-installed locations: `/Applications` for app bundles plus
+    /// `/Library/Application Support` and `/Library/Frameworks` for
+    /// third-party resources.
+    private static let defaultLanguageScanRoots: [URL] = [
+        URL(fileURLWithPath: "/Applications", isDirectory: true),
+        URL(fileURLWithPath: "/Library/Application Support", isDirectory: true),
+        URL(fileURLWithPath: "/Library/Frameworks", isDirectory: true)
+    ]
+
+    init(
+        fileManager: FileManager = .default,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        languageFileLocator: LanguageFileLocator? = nil
+    ) {
+        self.fileManager = fileManager
+        self.homeDirectory = homeDirectory
+        self.languageFileLocator = languageFileLocator
+            ?? LanguageFileLocator(
+                scanRoots: Self.defaultLanguageScanRoots,
+                activeLanguageCodes: Self.activePreferredLanguageCodes()
+            )
+    }
+
+    func roots() -> [ScanRoot] {
+        var roots: [ScanRoot] = []
+
+        // User-domain paths — readable in-process, no helper needed.
+        let userLibrary = homeDirectory.appendingPathComponent("Library", isDirectory: true)
+        roots.append(ScanRoot(url: userLibrary.appendingPathComponent("Caches", isDirectory: true), category: .userCache))
+        roots.append(ScanRoot(url: userLibrary.appendingPathComponent("Logs", isDirectory: true), category: .userLogs))
+        roots.append(ScanRoot(url: userLibrary.appendingPathComponent("Mail Downloads", isDirectory: true), category: .mailAttachments))
+        roots.append(ScanRoot(
+            url: userLibrary
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("MobileSync", isDirectory: true)
+                .appendingPathComponent("Backup", isDirectory: true),
+            category: .iosBackups
+        ))
+
+        // System-domain paths — readable when Full Disk Access is granted.
+        // Privileged enumeration via the helper is deferred to Prompt 14
+        // where it pairs with helper-driven deletion; FileScanner's
+        // permission-error tolerance keeps the in-process walk safe.
+        roots.append(ScanRoot(url: URL(fileURLWithPath: "/Library/Caches", isDirectory: true), category: .systemCache))
+        roots.append(ScanRoot(url: URL(fileURLWithPath: "/Library/Logs", isDirectory: true), category: .systemLogs))
+
+        // Trash — home plus every mounted volume's per-user trash directory.
+        roots.append(ScanRoot(url: homeDirectory.appendingPathComponent(".Trash", isDirectory: true), category: .trash))
+        roots.append(contentsOf: volumeTrashRoots())
+
+        // Language files — non-active `.lproj` directories under
+        // `defaultLanguageScanRoots`, each emitted as its own ScanRoot so
+        // `FileScanner` tags every file inside as `.languageFiles`.
+        roots.append(contentsOf: languageFileLocator.locate())
+
+        return roots
+    }
+
+    /// Per-user Trash directories for every mounted, removable volume.
+    /// macOS stores them at `/Volumes/<name>/.Trashes/<uid>`. We skip the
+    /// boot volume (its trash is `~/.Trash`, already added above) and any
+    /// volume that doesn't expose a per-user trash subdirectory yet —
+    /// FileScanner would still tolerate the missing path, but emitting a
+    /// non-existent root produces noise in logs.
+    private func volumeTrashRoots() -> [ScanRoot] {
+        let uid = String(getuid())
+        let volumes: [URL]
+        do {
+            volumes = try fileManager.contentsOfDirectory(
+                at: URL(fileURLWithPath: "/Volumes", isDirectory: true),
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            return []
+        }
+        return volumes.compactMap { volume in
+            let trash = volume
+                .appendingPathComponent(".Trashes", isDirectory: true)
+                .appendingPathComponent(uid, isDirectory: true)
+            return fileManager.fileExists(atPath: trash.path)
+                ? ScanRoot(url: trash, category: .trash)
+                : nil
+        }
+    }
+
+    /// Lower-cased BCP-47 language codes the user has configured as
+    /// preferred. Used by `LanguageFileLocator` to filter active locales out
+    /// of the scan. We take only the first component of each preferred
+    /// language (`en-US` → `en`) because macOS will fall back from the
+    /// regional variant to the base language code at runtime.
+    private static func activePreferredLanguageCodes() -> Set<String> {
+        Set(
+            Locale.preferredLanguages.compactMap { tag in
+                LanguageFileLocator.languageCode(fromLocaleName: tag)
+            }
+        )
+    }
+}

--- a/VaderCleaner/SystemPathProviding.swift
+++ b/VaderCleaner/SystemPathProviding.swift
@@ -84,32 +84,52 @@ struct DefaultSystemPathProvider: SystemPathProviding {
         return roots
     }
 
-    /// Per-user Trash directories for every mounted, removable volume.
-    /// macOS stores them at `/Volumes/<name>/.Trashes/<uid>`. We skip the
-    /// boot volume (its trash is `~/.Trash`, already added above) and any
-    /// volume that doesn't expose a per-user trash subdirectory yet —
-    /// FileScanner would still tolerate the missing path, but emitting a
-    /// non-existent root produces noise in logs.
+    /// Per-user Trash directories for every mounted, *local* volume except
+    /// the boot volume. macOS stores them at `/Volumes/<name>/.Trashes/<uid>`.
+    ///
+    /// Three filters apply, each pinned by review feedback on PR #28:
+    /// - **Boot volume skip** — its trash is `~/.Trash`, already added above.
+    ///   Reported by CodeRabbit; the previous comment promised this skip but
+    ///   never implemented it, so a `/Volumes/Macintosh HD/.Trashes/<uid>`
+    ///   firmlink could double-count via path aliasing.
+    /// - **Local-only** — network shares (SMB/AFP) can be wildly slow to
+    ///   enumerate and shouldn't contribute to a *system* junk scan.
+    ///   Reported by Gemini.
+    /// - **Trash exists** — we drop volumes with no per-user trash yet so
+    ///   we don't emit empty roots that just create log noise downstream.
     private func volumeTrashRoots() -> [ScanRoot] {
         let uid = String(getuid())
+        let bootVolumeURL = (try? URL(fileURLWithPath: "/")
+            .resourceValues(forKeys: [.volumeURLKey])
+            .volume)?.standardizedFileURL
+        let resourceKeys: [URLResourceKey] = [.volumeIsLocalKey, .volumeURLKey]
         let volumes: [URL]
         do {
             volumes = try fileManager.contentsOfDirectory(
                 at: URL(fileURLWithPath: "/Volumes", isDirectory: true),
-                includingPropertiesForKeys: [.isDirectoryKey],
+                includingPropertiesForKeys: resourceKeys,
                 options: [.skipsHiddenFiles]
             )
         } catch {
             return []
         }
-        return volumes.compactMap { volume in
+        var roots: [ScanRoot] = []
+        for volume in volumes {
+            let values = try? volume.resourceValues(forKeys: Set(resourceKeys))
+            guard values?.volumeIsLocal == true else { continue }
+            if let bootVolumeURL,
+               let volumeURL = values?.volume?.standardizedFileURL,
+               volumeURL == bootVolumeURL {
+                continue
+            }
             let trash = volume
                 .appendingPathComponent(".Trashes", isDirectory: true)
                 .appendingPathComponent(uid, isDirectory: true)
-            return fileManager.fileExists(atPath: trash.path)
-                ? ScanRoot(url: trash, category: .trash)
-                : nil
+            if fileManager.fileExists(atPath: trash.path) {
+                roots.append(ScanRoot(url: trash, category: .trash))
+            }
         }
+        return roots
     }
 
     /// Lower-cased BCP-47 language codes the user has configured as

--- a/VaderCleaner/SystemPathProviding.swift
+++ b/VaderCleaner/SystemPathProviding.swift
@@ -22,19 +22,6 @@ struct DefaultSystemPathProvider: SystemPathProviding {
     private let homeDirectory: URL
     private let languageFileLocator: LanguageFileLocator
 
-    /// Roots searched for `.lproj` bundles. Deviation from the plan, which
-    /// names `/Library` and `/System/Library`: `/System/Library` lives on the
-    /// read-only Signed System Volume and its `.lproj` files cannot be
-    /// deleted, so reporting them as "junk" misleads the user. We restrict
-    /// to user-installed locations: `/Applications` for app bundles plus
-    /// `/Library/Application Support` and `/Library/Frameworks` for
-    /// third-party resources.
-    private static let defaultLanguageScanRoots: [URL] = [
-        URL(fileURLWithPath: "/Applications", isDirectory: true),
-        URL(fileURLWithPath: "/Library/Application Support", isDirectory: true),
-        URL(fileURLWithPath: "/Library/Frameworks", isDirectory: true)
-    ]
-
     init(
         fileManager: FileManager = .default,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
@@ -44,9 +31,27 @@ struct DefaultSystemPathProvider: SystemPathProviding {
         self.homeDirectory = homeDirectory
         self.languageFileLocator = languageFileLocator
             ?? LanguageFileLocator(
-                scanRoots: Self.defaultLanguageScanRoots,
+                scanRoots: Self.defaultLanguageScanRoots(homeDirectory: homeDirectory),
                 activeLanguageCodes: Self.activePreferredLanguageCodes()
             )
+    }
+
+    /// Roots searched for `.lproj` bundles. Deviation from the plan, which
+    /// names `/Library` and `/System/Library`: `/System/Library` lives on the
+    /// read-only Signed System Volume and its `.lproj` files cannot be
+    /// deleted, so reporting them as "junk" misleads the user. We restrict
+    /// to user-installed locations: `/Applications` (system-wide installs)
+    /// and `~/Applications` (per-user installs — Codex review on PR #28
+    /// flagged that omitting this missed the entire language-files
+    /// category for non-admin app installs), plus `/Library/Application Support`
+    /// and `/Library/Frameworks` for third-party resources.
+    static func defaultLanguageScanRoots(homeDirectory: URL) -> [URL] {
+        [
+            URL(fileURLWithPath: "/Applications", isDirectory: true),
+            homeDirectory.appendingPathComponent("Applications", isDirectory: true),
+            URL(fileURLWithPath: "/Library/Application Support", isDirectory: true),
+            URL(fileURLWithPath: "/Library/Frameworks", isDirectory: true)
+        ]
     }
 
     func roots() -> [ScanRoot] {
@@ -132,16 +137,29 @@ struct DefaultSystemPathProvider: SystemPathProviding {
         return roots
     }
 
-    /// Lower-cased BCP-47 language codes the user has configured as
-    /// preferred. Used by `LanguageFileLocator` to filter active locales out
-    /// of the scan. We take only the first component of each preferred
+    /// Lower-cased language codes treated as active during a system-junk
+    /// scan. Used by `LanguageFileLocator` to filter active locales out of
+    /// the result. We take only the first component of each preferred
     /// language (`en-US` → `en`) because macOS will fall back from the
     /// regional variant to the base language code at runtime.
-    private static func activePreferredLanguageCodes() -> Set<String> {
-        Set(
+    ///
+    /// Always includes `"en"` regardless of `Locale.preferredLanguages`.
+    /// Most macOS bundles use English as their `CFBundleDevelopmentRegion`
+    /// fallback — when a string is missing for the user's preferred locale,
+    /// the loader looks up the development region next. Removing
+    /// `en.lproj` (or `English.lproj`) from a non-English user's machine
+    /// can leave apps with missing UI strings. Reading each bundle's
+    /// development region for a per-bundle answer is more accurate but
+    /// costly; defaulting to "always preserve English" matches what other
+    /// macOS cleaners do and is the safe default. Reported by Codex review
+    /// on PR #28.
+    static func activePreferredLanguageCodes() -> Set<String> {
+        var codes = Set(
             Locale.preferredLanguages.compactMap { tag in
                 LanguageFileLocator.languageCode(fromLocaleName: tag)
             }
         )
+        codes.insert("en")
+        return codes
     }
 }

--- a/VaderCleanerTests/DefaultSystemPathProviderTests.swift
+++ b/VaderCleanerTests/DefaultSystemPathProviderTests.swift
@@ -1,0 +1,95 @@
+// DefaultSystemPathProviderTests.swift
+// Pins the default-wiring decisions in DefaultSystemPathProvider — English fallback preservation and the language scan roots — that govern what a real System Junk scan produces on a user's machine.
+
+import XCTest
+@testable import VaderCleaner
+
+/// `DefaultSystemPathProvider`'s `roots()` walks the real macOS filesystem
+/// and is therefore not driven directly here — the test seam for that is
+/// `StubSystemPathProvider` in `SystemJunkScannerTests`. What this file
+/// covers is the *defaults*: how `DefaultSystemPathProvider` builds its
+/// language-file locator. Both decisions (always-active English, the
+/// `~/Applications` root) were called out by Codex review on PR #28.
+final class DefaultSystemPathProviderTests: XCTestCase {
+
+    // MARK: - English fallback preservation
+
+    /// English must always be in the active set even if the user's
+    /// preferred languages don't include it. macOS bundles fall back to
+    /// `CFBundleDevelopmentRegion` (typically `en`) for strings missing in
+    /// the user's locale, so removing `en.lproj` or `English.lproj` for a
+    /// non-English user can leave apps with blank UI text.
+    func test_activePreferredLanguageCodes_alwaysIncludesEnglish() {
+        let codes = DefaultSystemPathProvider.activePreferredLanguageCodes()
+
+        XCTAssertTrue(
+            codes.contains("en"),
+            "English fallback must always be preserved regardless of Locale.preferredLanguages"
+        )
+    }
+
+    /// Whatever the user's actual preferred languages are at test time,
+    /// they must still be honoured — the always-active English must be
+    /// additive, not a replacement.
+    func test_activePreferredLanguageCodes_includesUserPreferredLanguages() {
+        let codes = DefaultSystemPathProvider.activePreferredLanguageCodes()
+
+        let expected = Set(
+            Locale.preferredLanguages.compactMap { tag in
+                LanguageFileLocator.languageCode(fromLocaleName: tag)
+            }
+        )
+        for code in expected {
+            XCTAssertTrue(
+                codes.contains(code),
+                "Preferred language '\(code)' must remain active"
+            )
+        }
+    }
+
+    // MARK: - Language scan roots
+
+    /// `~/Applications` must be in the default scan roots so per-user app
+    /// installs (apps the user dropped under their home directory rather
+    /// than `/Applications`) get walked for non-active `.lproj` files.
+    /// Without it the entire language-files category for those bundles
+    /// went unreported.
+    func test_defaultLanguageScanRoots_includesUserApplications() {
+        let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+
+        let roots = DefaultSystemPathProvider.defaultLanguageScanRoots(homeDirectory: home)
+
+        let expected = home.appendingPathComponent("Applications", isDirectory: true)
+        XCTAssertTrue(
+            roots.contains(expected),
+            "Default language roots must include ~/Applications for per-user installs"
+        )
+    }
+
+    /// System-wide installs and the third-party resource trees must still
+    /// be present — adding `~/Applications` is additive, not a replacement.
+    func test_defaultLanguageScanRoots_includesSystemWideRoots() {
+        let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+
+        let roots = DefaultSystemPathProvider.defaultLanguageScanRoots(homeDirectory: home)
+
+        XCTAssertTrue(roots.contains(URL(fileURLWithPath: "/Applications", isDirectory: true)))
+        XCTAssertTrue(roots.contains(URL(fileURLWithPath: "/Library/Application Support", isDirectory: true)))
+        XCTAssertTrue(roots.contains(URL(fileURLWithPath: "/Library/Frameworks", isDirectory: true)))
+    }
+
+    /// `/System/Library` must NOT appear — files there live on the
+    /// read-only Signed System Volume and reporting them as junk would
+    /// mislead the user since they can never be deleted. Pinning this so
+    /// nobody re-adds it absent-mindedly.
+    func test_defaultLanguageScanRoots_excludesSystemLibrary() {
+        let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+
+        let roots = DefaultSystemPathProvider.defaultLanguageScanRoots(homeDirectory: home)
+
+        XCTAssertFalse(
+            roots.contains(URL(fileURLWithPath: "/System/Library", isDirectory: true)),
+            "Read-only system volume must stay out of the language-file scan roots"
+        )
+    }
+}

--- a/VaderCleanerTests/LanguageFileLocatorTests.swift
+++ b/VaderCleanerTests/LanguageFileLocatorTests.swift
@@ -128,6 +128,56 @@ final class LanguageFileLocatorTests: XCTestCase {
         XCTAssertTrue(lprojPaths.contains(ptBR.path))
     }
 
+    /// `Base.lproj` is bundle metadata, not a language. The locator must
+    /// drop it from the result regardless of which active codes are passed,
+    /// or every bundle's main NIBs would surface as junk on every scan.
+    func test_locate_skipsBaseLproj() throws {
+        let resources = try makeAppResources(named: "BaseHolder.app")
+        let base = try makeLproj("Base", in: resources)
+        try TestHelpers.createDummyFile(named: "MainMenu.nib", size: 100, in: base)
+
+        let locator = LanguageFileLocator(
+            scanRoots: [tempRoot],
+            activeLanguageCodes: ["en"]
+        )
+
+        let lprojRoots = locator.locate()
+        let lprojPaths = Set(lprojRoots.map(\.url.path))
+
+        XCTAssertFalse(lprojPaths.contains(base.path), "Base.lproj is bundle metadata and must never be reported as junk")
+    }
+
+    /// Legacy English-style names not in the allowlist (e.g. `Portuguese`,
+    /// `Norwegian`) used to slip through and return their lower-cased name
+    /// as the "language code" — which never matches an active BCP-47 code
+    /// like `pt`, so the user's *active* locale resources got reported as
+    /// junk. Conservative rule: an unmapped single-token name longer than
+    /// 3 chars is skipped entirely. Reported by Codex review on PR #28.
+    func test_locate_unmappedLegacyNamesAreSkipped() throws {
+        let resources = try makeAppResources(named: "Legacy.app")
+        let portuguese = try makeLproj("Portuguese", in: resources)
+        let norwegian = try makeLproj("Norwegian", in: resources)
+        try TestHelpers.createDummyFile(named: "x", size: 1, in: portuguese)
+        try TestHelpers.createDummyFile(named: "x", size: 1, in: norwegian)
+
+        let locator = LanguageFileLocator(
+            scanRoots: [tempRoot],
+            activeLanguageCodes: ["pt"]
+        )
+
+        let lprojRoots = locator.locate()
+        let lprojPaths = Set(lprojRoots.map(\.url.path))
+
+        XCTAssertFalse(
+            lprojPaths.contains(portuguese.path),
+            "Unmapped legacy 'Portuguese' must not be reported as junk while 'pt' is active"
+        )
+        XCTAssertFalse(
+            lprojPaths.contains(norwegian.path),
+            "Unmapped legacy names should be skipped rather than misclassified"
+        )
+    }
+
     /// `.lproj` directories nested inside `.app` packages must still be found
     /// even though `FileScanner` skips package descendants — the locator does
     /// its own walk specifically because `.lproj` lives under `.app/Contents`.

--- a/VaderCleanerTests/LanguageFileLocatorTests.swift
+++ b/VaderCleanerTests/LanguageFileLocatorTests.swift
@@ -1,0 +1,168 @@
+// LanguageFileLocatorTests.swift
+// Verifies LanguageFileLocator finds .lproj directories under given roots and filters them by active locale (BCP-47 prefix match plus a small legacy-name allowlist).
+
+import XCTest
+@testable import VaderCleaner
+
+/// Drives `LanguageFileLocator` over temp directory trees that mimic
+/// real macOS `.lproj` layouts (`/Applications/Foo.app/Contents/Resources/<lang>.lproj`)
+/// and confirms that active locales are filtered out while non-active ones
+/// surface as `ScanRoot` entries tagged `.languageFiles`.
+final class LanguageFileLocatorTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // `FileManager.enumerator(at:)` returns realpath-canonical URLs
+        // (`/private/var/...`) while `temporaryDirectory` returns the
+        // unresolved form (`/var/...`). `resolvingSymlinksInPath` doesn't
+        // peek through the `/var → /private/var` mount-style symlink, so we
+        // call `realpath(3)` directly to get the same form the enumerator
+        // emits. Without this, every "lproj path is in result" assertion
+        // hits a `/private/var` vs `/var` false negative.
+        tempRoot = try canonicalize(TestHelpers.createTempDirectory())
+    }
+
+    private func canonicalize(_ url: URL) throws -> URL {
+        var buffer = [Int8](repeating: 0, count: Int(PATH_MAX))
+        guard realpath(url.path, &buffer) != nil else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "realpath failed for \(url.path)"]
+            )
+        }
+        return URL(fileURLWithPath: String(cString: buffer), isDirectory: true)
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    // MARK: - Filtering
+
+    /// Active locales (`en-US`, `en`) must not appear in the output. Other
+    /// languages do, with each `.lproj` returned as its own `ScanRoot` so
+    /// `FileScanner` can tag every file inside as `.languageFiles`.
+    func test_locate_returnsNonActiveLprojDirsOnly() throws {
+        let resources = try makeAppResources(named: "Foo.app")
+        let en = try makeLproj("en", in: resources)
+        let enUS = try makeLproj("en-US", in: resources)
+        let nl = try makeLproj("nl", in: resources)
+        let de = try makeLproj("de", in: resources)
+        try TestHelpers.createDummyFile(named: "Localizable.strings", size: 8, in: en)
+        try TestHelpers.createDummyFile(named: "Localizable.strings", size: 8, in: enUS)
+        try TestHelpers.createDummyFile(named: "Localizable.strings", size: 8, in: nl)
+        try TestHelpers.createDummyFile(named: "Localizable.strings", size: 8, in: de)
+
+        let locator = LanguageFileLocator(
+            scanRoots: [tempRoot],
+            activeLanguageCodes: ["en"]
+        )
+
+        let lprojRoots = locator.locate()
+        let lprojPaths = Set(lprojRoots.map(\.url.path))
+
+        XCTAssertFalse(lprojPaths.contains(en.path), "Active language 'en' should be filtered out")
+        XCTAssertFalse(lprojPaths.contains(enUS.path), "BCP-47 'en-US' must match prefix 'en' and be filtered")
+        XCTAssertTrue(lprojPaths.contains(nl.path))
+        XCTAssertTrue(lprojPaths.contains(de.path))
+        for root in lprojRoots {
+            XCTAssertEqual(root.category, .languageFiles)
+        }
+    }
+
+    /// Legacy `.lproj` names like `English.lproj` and `Spanish.lproj` predate
+    /// ISO codes and still ship in some bundles. The allowlist maps them to
+    /// language codes so `English.lproj` is treated as `en` for active-locale
+    /// matching.
+    func test_locate_legacyLanguageNamesMapToCodes() throws {
+        let resources = try makeAppResources(named: "Bar.app")
+        let english = try makeLproj("English", in: resources)
+        let spanish = try makeLproj("Spanish", in: resources)
+        let french = try makeLproj("French", in: resources)
+        try TestHelpers.createDummyFile(named: "MainMenu.nib", size: 100, in: english)
+        try TestHelpers.createDummyFile(named: "MainMenu.nib", size: 100, in: spanish)
+        try TestHelpers.createDummyFile(named: "MainMenu.nib", size: 100, in: french)
+
+        let locator = LanguageFileLocator(
+            scanRoots: [tempRoot],
+            activeLanguageCodes: ["en"]
+        )
+
+        let lprojRoots = locator.locate()
+        let lprojPaths = Set(lprojRoots.map(\.url.path))
+
+        XCTAssertFalse(lprojPaths.contains(english.path), "Legacy 'English.lproj' must be treated as active")
+        XCTAssertTrue(lprojPaths.contains(spanish.path))
+        XCTAssertTrue(lprojPaths.contains(french.path))
+    }
+
+    /// Underscore-separated locale names (`zh_CN`, `pt_BR`) appear in some
+    /// bundles. Prefix matching must split on either `-` or `_` so an active
+    /// `zh` filters them out.
+    func test_locate_underscoreSeparatedLocalesPrefixMatch() throws {
+        let resources = try makeAppResources(named: "Baz.app")
+        let zhCN = try makeLproj("zh_CN", in: resources)
+        let zhTW = try makeLproj("zh_TW", in: resources)
+        let ptBR = try makeLproj("pt_BR", in: resources)
+        try TestHelpers.createDummyFile(named: "x.strings", size: 4, in: zhCN)
+        try TestHelpers.createDummyFile(named: "x.strings", size: 4, in: zhTW)
+        try TestHelpers.createDummyFile(named: "x.strings", size: 4, in: ptBR)
+
+        let locator = LanguageFileLocator(
+            scanRoots: [tempRoot],
+            activeLanguageCodes: ["zh"]
+        )
+
+        let lprojRoots = locator.locate()
+        let lprojPaths = Set(lprojRoots.map(\.url.path))
+
+        XCTAssertFalse(lprojPaths.contains(zhCN.path))
+        XCTAssertFalse(lprojPaths.contains(zhTW.path))
+        XCTAssertTrue(lprojPaths.contains(ptBR.path))
+    }
+
+    /// `.lproj` directories nested inside `.app` packages must still be found
+    /// even though `FileScanner` skips package descendants — the locator does
+    /// its own walk specifically because `.lproj` lives under `.app/Contents`.
+    func test_locate_findsLprojInsideAppBundles() throws {
+        let resources = try makeAppResources(named: "Nested.app")
+        let nl = try makeLproj("nl", in: resources)
+        try TestHelpers.createDummyFile(named: "x", size: 1, in: nl)
+
+        let locator = LanguageFileLocator(
+            scanRoots: [tempRoot],
+            activeLanguageCodes: ["en"]
+        )
+
+        let lprojRoots = locator.locate()
+
+        XCTAssertEqual(lprojRoots.count, 1)
+        XCTAssertEqual(lprojRoots.first?.url.path, nl.path)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds `<tempRoot>/<appName>/Contents/Resources` so tests can drop
+    /// `.lproj` directories where macOS actually puts them.
+    private func makeAppResources(named appName: String) throws -> URL {
+        let resources = tempRoot
+            .appendingPathComponent(appName, isDirectory: true)
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+        return resources
+    }
+
+    private func makeLproj(_ language: String, in resources: URL) throws -> URL {
+        let lproj = resources.appendingPathComponent("\(language).lproj", isDirectory: true)
+        try FileManager.default.createDirectory(at: lproj, withIntermediateDirectories: true)
+        return lproj
+    }
+}

--- a/VaderCleanerTests/LanguageFileLocatorTests.swift
+++ b/VaderCleanerTests/LanguageFileLocatorTests.swift
@@ -178,6 +178,36 @@ final class LanguageFileLocatorTests: XCTestCase {
         )
     }
 
+    /// App extensions live at `Foo.app/Contents/PlugIns/Bar.appex/Contents/Resources/<lang>.lproj`,
+    /// which is depth 7 from a top-level scan root. An overly-tight depth
+    /// cap on the walker would prune the whole subtree before reaching the
+    /// `.lproj`, so localized extension resources never made it into the
+    /// junk list. Reported by Codex review on PR #28.
+    func test_locate_findsLprojInsideNestedAppExtensions() throws {
+        let resources = tempRoot
+            .appendingPathComponent("Host.app", isDirectory: true)
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("PlugIns", isDirectory: true)
+            .appendingPathComponent("Widget.appex", isDirectory: true)
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+        let nl = try makeLproj("nl", in: resources)
+        try TestHelpers.createDummyFile(named: "Localizable.strings", size: 8, in: nl)
+
+        let locator = LanguageFileLocator(
+            scanRoots: [tempRoot],
+            activeLanguageCodes: ["en"]
+        )
+
+        let lprojPaths = Set(locator.locate().map(\.url.path))
+
+        XCTAssertTrue(
+            lprojPaths.contains(nl.path),
+            "App-extension .lproj at depth 7 must still surface"
+        )
+    }
+
     /// `.lproj` directories nested inside `.app` packages must still be found
     /// even though `FileScanner` skips package descendants — the locator does
     /// its own walk specifically because `.lproj` lives under `.app/Contents`.

--- a/VaderCleanerTests/SystemJunkScannerTests.swift
+++ b/VaderCleanerTests/SystemJunkScannerTests.swift
@@ -1,0 +1,224 @@
+// SystemJunkScannerTests.swift
+// Integration tests that drive SystemJunkScanner against temp directories via an injected SystemPathProviding stub, covering all eight junk categories plus exclusions and grouping.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Verifies `SystemJunkScanner` end-to-end. We never touch the real macOS
+/// system paths — a `StubSystemPathProvider` returns roots under a temp
+/// directory so each test is hermetic and deterministic, regardless of what's
+/// in `/Library/Caches` on the test machine.
+final class SystemJunkScannerTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    // MARK: - Per-category coverage
+
+    func test_scan_findsUserCacheFiles() async throws {
+        let userCaches = try makeRoot("user-caches")
+        try TestHelpers.createDummyFiles(count: 3, size: 16, in: userCaches)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: userCaches, category: .userCache)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.userCache]?.count, 3)
+        XCTAssertEqual(result.totalSize, 48)
+    }
+
+    func test_scan_findsSystemCacheFiles() async throws {
+        let systemCaches = try makeRoot("system-caches")
+        try TestHelpers.createDummyFiles(count: 2, size: 64, in: systemCaches)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: systemCaches, category: .systemCache)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.systemCache]?.count, 2)
+    }
+
+    func test_scan_findsSystemLogFiles() async throws {
+        let systemLogs = try makeRoot("system-logs")
+        try TestHelpers.createDummyFile(named: "kernel.log", size: 1_024, in: systemLogs)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: systemLogs, category: .systemLogs)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.systemLogs]?.count, 1)
+        XCTAssertEqual(result.itemsByCategory[.systemLogs]?.first?.size, 1_024)
+    }
+
+    func test_scan_findsMailAttachments() async throws {
+        let mail = try makeRoot("mail-downloads")
+        try TestHelpers.createDummyFiles(count: 4, size: 8, in: mail)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: mail, category: .mailAttachments)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.mailAttachments]?.count, 4)
+    }
+
+    func test_scan_findsIOSBackups() async throws {
+        let backups = try makeRoot("ios-backups")
+        let backupSubdir = try TestHelpers.createNestedDirectories(depth: 2, in: backups)
+        try TestHelpers.createDummyFile(named: "Manifest.plist", size: 200, in: backupSubdir)
+        try TestHelpers.createDummyFile(named: "Info.plist", size: 100, in: backupSubdir)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: backups, category: .iosBackups)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.iosBackups]?.count, 2)
+        XCTAssertEqual(result.sizeByCategory[.iosBackups], 300)
+    }
+
+    func test_scan_findsTrashOnHomeAndMountedVolumes() async throws {
+        let homeTrash = try makeRoot("home-trash")
+        let volumeTrash = try makeRoot("volume-trash")
+        try TestHelpers.createDummyFiles(count: 1, size: 32, in: homeTrash)
+        try TestHelpers.createDummyFiles(count: 2, size: 32, in: volumeTrash)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: homeTrash, category: .trash),
+                ScanRoot(url: volumeTrash, category: .trash)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.trash]?.count, 3)
+        XCTAssertEqual(result.sizeByCategory[.trash], 96)
+    }
+
+    func test_scan_findsLanguageFiles() async throws {
+        let lprojRoot = try makeRoot("nl.lproj")
+        try TestHelpers.createDummyFiles(count: 5, size: 4, in: lprojRoot)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: lprojRoot, category: .languageFiles)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.languageFiles]?.count, 5)
+    }
+
+    // MARK: - Exclusions
+
+    /// Every file under the exclusion path must be omitted from the result,
+    /// regardless of which category root it lived under. SystemJunkScanner
+    /// forwards `excluding:` straight to `FileScanning`, so this is really an
+    /// integration check that the wiring is in place — `FileScanner` itself
+    /// owns the matching semantics (covered in `FileScannerTests`).
+    func test_scan_respectsExclusions() async throws {
+        let userCaches = try makeRoot("user-caches")
+        let kept = userCaches.appendingPathComponent("kept", isDirectory: true)
+        let excluded = userCaches.appendingPathComponent("excluded", isDirectory: true)
+        try FileManager.default.createDirectory(at: kept, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: excluded, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 2, size: 4, in: kept)
+        try TestHelpers.createDummyFiles(count: 4, size: 4, in: excluded)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: userCaches, category: .userCache)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [excluded])
+
+        XCTAssertEqual(result.itemsByCategory[.userCache]?.count, 2)
+        for file in result.items {
+            XCTAssertFalse(
+                file.url.path.hasPrefix(excluded.path),
+                "Excluded path leaked: \(file.url.path)"
+            )
+        }
+    }
+
+    // MARK: - Aggregation
+
+    /// `ScanResult.itemsByCategory` must group files by the category they were
+    /// tagged with — no cross-contamination, no missing buckets, and absent
+    /// categories must not appear (rather than mapping to an empty array).
+    func test_scan_resultGroupsByCategory() async throws {
+        let userCaches = try makeRoot("user-caches")
+        let systemLogs = try makeRoot("system-logs")
+        let trash = try makeRoot("trash")
+        try TestHelpers.createDummyFiles(count: 2, size: 4, in: userCaches)
+        try TestHelpers.createDummyFiles(count: 3, size: 4, in: systemLogs)
+        try TestHelpers.createDummyFiles(count: 1, size: 4, in: trash)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: userCaches, category: .userCache),
+                ScanRoot(url: systemLogs, category: .systemLogs),
+                ScanRoot(url: trash, category: .trash)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.userCache]?.count, 2)
+        XCTAssertEqual(result.itemsByCategory[.systemLogs]?.count, 3)
+        XCTAssertEqual(result.itemsByCategory[.trash]?.count, 1)
+        XCTAssertNil(
+            result.itemsByCategory[.iosBackups],
+            "Empty categories must not appear in the dictionary"
+        )
+        XCTAssertNil(
+            result.itemsByCategory[.mailAttachments],
+            "Empty categories must not appear in the dictionary"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a uniquely named subdirectory under `tempRoot` so each scan
+    /// root in a test has its own isolated tree.
+    private func makeRoot(_ name: String) throws -> URL {
+        let url = tempRoot.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}
+
+// MARK: - Stub
+
+/// Returns a fixed list of `ScanRoot` values supplied at construction time,
+/// bypassing any real filesystem layout. Lets tests drive `SystemJunkScanner`
+/// over temp directories deterministically.
+private struct StubSystemPathProvider: SystemPathProviding {
+    private let stubbedRoots: [ScanRoot]
+    init(roots: [ScanRoot]) { self.stubbedRoots = roots }
+    func roots() -> [ScanRoot] { stubbedRoots }
+}

--- a/VaderCleanerTests/SystemJunkScannerTests.swift
+++ b/VaderCleanerTests/SystemJunkScannerTests.swift
@@ -56,6 +56,22 @@ final class SystemJunkScannerTests: XCTestCase {
         XCTAssertEqual(result.itemsByCategory[.systemCache]?.count, 2)
     }
 
+    func test_scan_findsUserLogFiles() async throws {
+        let userLogs = try makeRoot("user-logs")
+        try TestHelpers.createDummyFile(named: "app.log", size: 256, in: userLogs)
+        try TestHelpers.createDummyFile(named: "app.1.log", size: 256, in: userLogs)
+        let scanner = SystemJunkScanner(
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: userLogs, category: .userLogs)
+            ])
+        )
+
+        let result = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(result.itemsByCategory[.userLogs]?.count, 2)
+        XCTAssertEqual(result.sizeByCategory[.userLogs], 512)
+    }
+
     func test_scan_findsSystemLogFiles() async throws {
         let systemLogs = try makeRoot("system-logs")
         try TestHelpers.createDummyFile(named: "kernel.log", size: 1_024, in: systemLogs)

--- a/todo.md
+++ b/todo.md
@@ -27,7 +27,7 @@
 ## Phase 2 — File Cleaning
 
 - [x] **Prompt 12** — File scanner infrastructure (FileScanner, ScanCategory, ScanResult)
-- [ ] **Prompt 13** — System Junk scanner (all 8 categories)
+- [x] **Prompt 13** — System Junk scanner (all 8 categories)
 - [ ] **Prompt 14** — System Junk UI + deletion (scan → preview → clean flow)
 - [ ] **Prompt 15** — Large & Old Files scanner + UI
 - [ ] **Prompt 16** — Space Lens disk scanner (DiskNode tree + DiskScanner)


### PR DESCRIPTION
## Summary

- Adds `SystemJunkScanner`, `SystemPathProviding` (+ `DefaultSystemPathProvider`), and `LanguageFileLocator` — the orchestration + path-resolution layer on top of the file walker shipped in #26.
- Covers all eight junk categories from the spec: user caches, system caches, user logs, system logs, mail attachments, iOS backups, trash (home + mounted volumes), and non-active language `.lproj` bundles.
- 13 new tests (9 scanner integration + 4 locator). Full suite: **170 unit tests, all passing**.

Closes #27

## Architecture

```
SystemJunkScanner
    ├─ SystemPathProviding   (test seam — what to scan)
    │   └─ DefaultSystemPathProvider
    │       └─ LanguageFileLocator    (.lproj filtering)
    └─ FileScanning           (how to walk — already in #26)
```

`SystemJunkScanner` is a thin orchestrator. The scanner itself owns no path knowledge — `SystemPathProviding` does — so tests inject a `StubSystemPathProvider` returning roots under a temp directory and exercise every code path without touching real macOS locations.

## Scope deviations from the plan

Both documented in source comments so they don't get lost in PR archaeology.

**1. `/System/Library` is excluded from the language-file walk.** Plan says `.lproj` directories under `/Library` and `/System/Library`. `/System/Library` lives on the read-only Signed System Volume (macOS 11+) — files there can't be deleted, and a default scan that walks it would be unusable in practice (every Apple framework, every component). Reporting "junk" you can never clean misleads the user. Default roots are `/Applications`, `/Library/Application Support`, and `/Library/Frameworks` instead.

**2. Privileged-helper-driven enumeration of `/Library/Caches` and `/Library/Logs` is deferred to Prompt 14.** With Full Disk Access (Prompt 4) the in-process walk reads these paths today. `FileScanner` already tolerates per-subdir permission errors per #26. Prompt 14 will touch the helper protocol anyway for deletion — bundling read+delete keeps both prompts cohesive and avoids a partial XPC surface mid-stream. The `DefaultSystemPathProvider` includes `/Library/Caches` and `/Library/Logs` as ordinary `ScanRoot`s for now.

## Locale matching

`.lproj` names are a mix of forms: `en-US.lproj`, `en.lproj`, `zh_CN.lproj`, `Spanish.lproj`, `Base.lproj`. Direct equality with `Locale.preferredLanguages` (which gives BCP-47 like `en-US`) catches none of them reliably.

The matching rule:
1. Lower-case the locale name.
2. Look it up in a small legacy-name allowlist (`English` → `en`, `Spanish` → `es`, …).
3. Otherwise split on `-` or `_` and take the first component.
4. `Base.lproj` returns `nil` (not a language at all).

`activeLanguageCodes` is built from `Locale.preferredLanguages` reduced to the same first-component form, so a user with `en-US, fr-CA` set is treated as having `en` and `fr` active.

## Files

**New**:
- `VaderCleaner/SystemJunkScanner.swift`
- `VaderCleaner/SystemPathProviding.swift`
- `VaderCleaner/LanguageFileLocator.swift`
- `VaderCleanerTests/SystemJunkScannerTests.swift`
- `VaderCleanerTests/LanguageFileLocatorTests.swift`

**Untouched**: `Shared/HelperProtocol.swift`, `VaderCleanerHelper/main.swift` (privileged read deferred to Prompt 14, see deviation #2).

## Test plan
- [x] `xcodebuild ... test` — 170 unit tests + 1 UI test pass
- [x] Each plan-mandated test case covered (user caches, system logs, language files, iOS backups, trash on home + volumes, exclusions, ScanCategory grouping)
- [x] Locale matching tests cover BCP-47 (`en-US`), language-only (`en`), underscore (`zh_CN`), and legacy (`English`, `Spanish`)
- [x] No regressions in existing Phase 0/1/2 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded junk scanning to detect and manage language files across user, system, and volume-specific storage locations for comprehensive cleanup.

* **Tests**
  * Added comprehensive test suites to validate junk scanning workflows and language file discovery across multiple system domains.

* **Chores**
  * Updated project progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->