### PR TITLE
feat: System Junk UI + deletion

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @EnvironmentObject private var onboarding: PermissionOnboardingViewModel
     @EnvironmentObject private var systemStats: SystemStatsService
     @EnvironmentObject private var notificationMonitor: NotificationThresholdMonitor
+    @EnvironmentObject private var exclusions: ExclusionsStore
     @Environment(\.scenePhase) private var scenePhase
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Latched once the notification permission prompt has been issued for the
@@ -71,6 +72,8 @@ struct ContentView: View {
         switch section {
         case .healthMonitor:
             HealthMonitorView(service: systemStats)
+        case .systemJunk:
+            SystemJunkView(viewModel: SystemJunkViewModel.live(exclusions: exclusions))
         default:
             PlaceholderDetailView(section: section)
         }
@@ -122,4 +125,5 @@ private struct PlaceholderDetailView: View {
             preferences: prefs,
             dispatcher: NotificationManager()
         ))
+        .environmentObject(ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!))
 }

--- a/VaderCleaner/SystemJunkDeleter.swift
+++ b/VaderCleaner/SystemJunkDeleter.swift
@@ -7,10 +7,20 @@ import os.log
 /// Deletes the files emitted by a System Junk scan, returning the total bytes
 /// successfully freed. The split between `FileManager.removeItem` and the
 /// privileged helper's `deleteFiles(_:reply:)` is decided per-file from the
-/// path prefix — anything under `/Library`, `/private/var`, or `/Volumes/*/.Trashes`
-/// goes to the helper because those locations are not writable in-process even
-/// with Full Disk Access. Everything else (the user's `~/Library`, `~/.Trash`,
-/// `~/Library/Mail Downloads`, `~/Library/Application Support/MobileSync/Backup`)
+/// path. Routed through the helper:
+///
+///   - `/Library/...` and `/private/var/...` (system caches, logs, /var/folders)
+///   - `/System/...` (kept routed even though SSV blocks it, so accidental
+///     selections fail loudly via the helper rather than silently in-process)
+///   - `/Applications/...` (system-installed `.app` bundles are usually owned
+///     by `root:wheel` and not user-writable, so language-file deletion under
+///     them would silently fail in-process)
+///   - `/Volumes/<name>/.Trashes/<uid>/...` — per-user trash on mounted local
+///     volumes; everything else under `/Volumes/...` is left in-process
+///     because mounted external drives are typically user-writable.
+///
+/// Everything else (the user's `~/Library`, `~/.Trash`, `~/Library/Mail Downloads`,
+/// `~/Library/Application Support/MobileSync/Backup`, and `~/Applications`)
 /// is removed in-process.
 ///
 /// Errors on individual files are logged and skipped — a single locked log
@@ -19,25 +29,39 @@ import os.log
 /// total it did not deliver.
 struct SystemJunkDeleter {
 
-    /// Path prefixes that must be deleted via the privileged helper. Stored
-    /// without trailing slashes so a `hasPrefix` check matches both the
-    /// directory itself and any descendant.
+    /// Closure that yields a fresh helper proxy bound to the supplied
+    /// per-call XPC error handler, or `nil` if the helper is unreachable.
+    /// We accept the error handler at provider time (rather than letting
+    /// `HelperConnectionManager` keep a single global one) so each
+    /// `deleteViaHelper(...)` await can be resumed by whichever of the
+    /// reply block or the connection-level error handler fires first.
+    typealias HelperProvider = (@escaping (Error) -> Void) -> VaderCleanerHelperProtocol?
+
+    /// Plain prefix matches that mean "must go through the helper". Stored
+    /// with trailing slashes so the check matches descendants but not paths
+    /// that merely start with the same characters (`/Libraryfoo` ≠ `/Library/`).
     private static let helperOnlyPrefixes: [String] = [
         "/Library/",
         "/private/var/",
         "/System/",
-        "/Volumes/"
+        "/Applications/"
     ]
+
+    /// Substring that, when paired with `/Volumes/` rooting, marks per-volume
+    /// `.Trashes/<uid>/...` paths as helper-only. Plain `/Volumes/X/foo` is
+    /// left in-process because mounted external drives are typically writable
+    /// by the user and don't need privilege escalation.
+    private static let volumesTrashesNeedle = "/.Trashes/"
 
     private let log = Logger(subsystem: "com.personal.VaderCleaner",
                              category: "SystemJunkDeleter")
 
     private let fileManager: FileManager
-    private let helperProvider: () -> VaderCleanerHelperProtocol?
+    private let helperProvider: HelperProvider
 
     init(
         fileManager: FileManager = .default,
-        helperProvider: @escaping () -> VaderCleanerHelperProtocol? = SystemJunkDeleter.defaultHelperProvider
+        helperProvider: @escaping HelperProvider = SystemJunkDeleter.defaultHelperProvider
     ) {
         self.fileManager = fileManager
         self.helperProvider = helperProvider
@@ -66,52 +90,66 @@ struct SystemJunkDeleter {
         return bytesFreed
     }
 
-    /// Splits `files` into `(needsHelper, userDomain)` based on path prefix.
+    /// Splits `files` into `(needsHelper, userDomain)` based on the routing
+    /// rule in `requiresHelper(path:)`.
     private func partition(_ files: [ScannedFile]) -> ([ScannedFile], [ScannedFile]) {
-        var helper: [ScannedFile] = []
-        var user: [ScannedFile] = []
-        for file in files {
+        files.reduce(into: ([ScannedFile](), [ScannedFile]())) { acc, file in
             if Self.requiresHelper(path: file.url.path) {
-                helper.append(file)
+                acc.0.append(file)
             } else {
-                user.append(file)
+                acc.1.append(file)
             }
         }
-        return (helper, user)
     }
 
-    /// True when the path must go through the privileged helper. Public so
-    /// `SystemJunkDeleterTests` can pin the routing without instantiating
-    /// the deleter.
+    /// True when `path` must go through the privileged helper. Public so
+    /// `SystemJunkDeleterTests` can pin the routing rule without needing
+    /// to instantiate the deleter or fake the helper.
     static func requiresHelper(path: String) -> Bool {
-        for prefix in helperOnlyPrefixes {
-            if path.hasPrefix(prefix) { return true }
+        if helperOnlyPrefixes.contains(where: { path.hasPrefix($0) }) {
+            return true
+        }
+        if path.hasPrefix("/Volumes/") && path.contains(volumesTrashesNeedle) {
+            return true
         }
         return false
     }
 
     /// Attempts a single batched helper call. The XPC interface uses the
-    /// classic reply-block style so we bridge through
-    /// `withCheckedContinuation`. On any error from the proxy we treat the
-    /// whole batch as failed and return `0` — the helper has a best-effort
-    /// contract (it deletes what it can and returns the first error), but
-    /// because the protocol does not surface a per-path success vector, we
-    /// do not credit byte counts in the failure case.
+    /// classic reply-block style so we bridge through `withCheckedContinuation`.
+    ///
+    /// `NSXPCConnection` may, in failure cases, fire the connection-level
+    /// error handler **instead of** the per-call reply block — leaving an
+    /// unresolved continuation forever and freezing the cleaning UI on the
+    /// spinner. To prevent that, we install both: the helper proxy is built
+    /// with a per-call error handler and the reply block is registered as
+    /// usual. Whichever path resumes first wins, the other becomes a no-op
+    /// thanks to `Resumer.resume(with:)`'s once-only guarantee.
+    ///
+    /// On any error from either path we treat the whole batch as failed and
+    /// return `0` — the helper has a best-effort contract (it deletes what
+    /// it can and returns the first error), but because the protocol does
+    /// not surface a per-path success vector, we do not credit byte counts
+    /// in the failure case.
     private func deleteViaHelper(files: [ScannedFile]) async -> Int64 {
         let paths = files.map { $0.url.path }
         let totalBytes = files.reduce(Int64(0)) { $0 + $1.size }
 
         let error: Error? = await withCheckedContinuation { continuation in
-            guard let helper = helperProvider() else {
-                continuation.resume(returning: NSError(
+            let resumer = Resumer(continuation: continuation)
+            let helper = helperProvider { connectionError in
+                resumer.resume(with: connectionError)
+            }
+            guard let helper else {
+                resumer.resume(with: NSError(
                     domain: "com.personal.VaderCleaner.SystemJunkDeleter",
                     code: -1,
                     userInfo: [NSLocalizedDescriptionKey: "Helper unavailable"]
                 ))
                 return
             }
-            helper.deleteFiles(paths) { error in
-                continuation.resume(returning: error)
+            helper.deleteFiles(paths) { replyError in
+                resumer.resume(with: replyError)
             }
         }
 
@@ -123,14 +161,45 @@ struct SystemJunkDeleter {
     }
 
     /// Default helper provider — returns the proxy from
-    /// `HelperConnectionManager.shared`. Logs and returns nil on connection
-    /// errors (e.g. helper not registered in dev), letting the caller treat
-    /// system-domain deletes as failed without crashing.
-    static let defaultHelperProvider: () -> VaderCleanerHelperProtocol? = {
+    /// `HelperConnectionManager.shared` bound to the per-call error handler.
+    /// Logs the connection error in addition to forwarding it (so the failure
+    /// is visible in Console even when the awaiting call has already
+    /// resumed).
+    static let defaultHelperProvider: HelperProvider = { errorHandler in
         let log = Logger(subsystem: "com.personal.VaderCleaner",
                          category: "SystemJunkDeleter.HelperProvider")
         return HelperConnectionManager.shared.helper { error in
             log.error("Helper connection error: \(error.localizedDescription, privacy: .public)")
+            errorHandler(error)
         }
+    }
+}
+
+// MARK: - Once-only continuation resume
+
+/// Wraps a `CheckedContinuation` so that exactly one of the multiple paths
+/// that may complete it (XPC reply block, XPC error handler, "helper
+/// unavailable" early return) actually resumes — subsequent attempts are
+/// silently dropped. `CheckedContinuation` traps on a second resume, which
+/// would otherwise crash the app the first time the helper connection
+/// dropped mid-call.
+///
+/// A class because it must be referenced by multiple closures and mutated
+/// from whichever fires first. The `NSLock` covers the "two callbacks land
+/// on different threads at the same time" race.
+private final class Resumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: error)
     }
 }

--- a/VaderCleaner/SystemJunkDeleter.swift
+++ b/VaderCleaner/SystemJunkDeleter.swift
@@ -1,0 +1,136 @@
+// SystemJunkDeleter.swift
+// Routes ScannedFile deletion between FileManager (user-domain paths) and the privileged XPC helper (system-domain paths) and reports the bytes actually freed.
+
+import Foundation
+import os.log
+
+/// Deletes the files emitted by a System Junk scan, returning the total bytes
+/// successfully freed. The split between `FileManager.removeItem` and the
+/// privileged helper's `deleteFiles(_:reply:)` is decided per-file from the
+/// path prefix — anything under `/Library`, `/private/var`, or `/Volumes/*/.Trashes`
+/// goes to the helper because those locations are not writable in-process even
+/// with Full Disk Access. Everything else (the user's `~/Library`, `~/.Trash`,
+/// `~/Library/Mail Downloads`, `~/Library/Application Support/MobileSync/Backup`)
+/// is removed in-process.
+///
+/// Errors on individual files are logged and skipped — a single locked log
+/// file must never abort the whole clean. The returned `bytesFreed` reflects
+/// only the files we actually removed, so the UI never claims a freed-space
+/// total it did not deliver.
+struct SystemJunkDeleter {
+
+    /// Path prefixes that must be deleted via the privileged helper. Stored
+    /// without trailing slashes so a `hasPrefix` check matches both the
+    /// directory itself and any descendant.
+    private static let helperOnlyPrefixes: [String] = [
+        "/Library/",
+        "/private/var/",
+        "/System/",
+        "/Volumes/"
+    ]
+
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "SystemJunkDeleter")
+
+    private let fileManager: FileManager
+    private let helperProvider: () -> VaderCleanerHelperProtocol?
+
+    init(
+        fileManager: FileManager = .default,
+        helperProvider: @escaping () -> VaderCleanerHelperProtocol? = SystemJunkDeleter.defaultHelperProvider
+    ) {
+        self.fileManager = fileManager
+        self.helperProvider = helperProvider
+    }
+
+    /// Deletes every file in `files` and returns the sum of byte sizes for
+    /// the ones that were successfully removed.
+    func delete(_ files: [ScannedFile]) async throws -> Int64 {
+        let (helperFiles, userFiles) = partition(files)
+
+        var bytesFreed: Int64 = 0
+        for file in userFiles {
+            do {
+                try fileManager.removeItem(at: file.url)
+                bytesFreed += file.size
+            } catch {
+                log.debug("Skipping unremovable user file \(file.url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        if !helperFiles.isEmpty {
+            let succeeded = await deleteViaHelper(files: helperFiles)
+            bytesFreed += succeeded
+        }
+
+        return bytesFreed
+    }
+
+    /// Splits `files` into `(needsHelper, userDomain)` based on path prefix.
+    private func partition(_ files: [ScannedFile]) -> ([ScannedFile], [ScannedFile]) {
+        var helper: [ScannedFile] = []
+        var user: [ScannedFile] = []
+        for file in files {
+            if Self.requiresHelper(path: file.url.path) {
+                helper.append(file)
+            } else {
+                user.append(file)
+            }
+        }
+        return (helper, user)
+    }
+
+    /// True when the path must go through the privileged helper. Public so
+    /// `SystemJunkDeleterTests` can pin the routing without instantiating
+    /// the deleter.
+    static func requiresHelper(path: String) -> Bool {
+        for prefix in helperOnlyPrefixes {
+            if path.hasPrefix(prefix) { return true }
+        }
+        return false
+    }
+
+    /// Attempts a single batched helper call. The XPC interface uses the
+    /// classic reply-block style so we bridge through
+    /// `withCheckedContinuation`. On any error from the proxy we treat the
+    /// whole batch as failed and return `0` — the helper has a best-effort
+    /// contract (it deletes what it can and returns the first error), but
+    /// because the protocol does not surface a per-path success vector, we
+    /// do not credit byte counts in the failure case.
+    private func deleteViaHelper(files: [ScannedFile]) async -> Int64 {
+        let paths = files.map { $0.url.path }
+        let totalBytes = files.reduce(Int64(0)) { $0 + $1.size }
+
+        let error: Error? = await withCheckedContinuation { continuation in
+            guard let helper = helperProvider() else {
+                continuation.resume(returning: NSError(
+                    domain: "com.personal.VaderCleaner.SystemJunkDeleter",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Helper unavailable"]
+                ))
+                return
+            }
+            helper.deleteFiles(paths) { error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        if let error {
+            log.error("Helper deletion failed for \(paths.count, privacy: .public) paths: \(error.localizedDescription, privacy: .public)")
+            return 0
+        }
+        return totalBytes
+    }
+
+    /// Default helper provider — returns the proxy from
+    /// `HelperConnectionManager.shared`. Logs and returns nil on connection
+    /// errors (e.g. helper not registered in dev), letting the caller treat
+    /// system-domain deletes as failed without crashing.
+    static let defaultHelperProvider: () -> VaderCleanerHelperProtocol? = {
+        let log = Logger(subsystem: "com.personal.VaderCleaner",
+                         category: "SystemJunkDeleter.HelperProvider")
+        return HelperConnectionManager.shared.helper { error in
+            log.error("Helper connection error: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -1,0 +1,233 @@
+// SystemJunkView.swift
+// System Junk feature view — renders the idle/scanning/preview/cleaning/complete states from SystemJunkViewModel and binds the per-category checkboxes and Clean / Re-scan / Scan Again actions.
+
+import SwiftUI
+
+/// Detail view shown when the user selects "System Junk" in the sidebar.
+/// Each phase of `SystemJunkViewModel.Phase` maps to a dedicated subview:
+///   - `.idle` — centered Scan call-to-action.
+///   - `.scanning` — progress spinner.
+///   - `.preview` — list of categories with checkboxes plus Clean/Re-scan.
+///   - `.cleaning` — progress spinner.
+///   - `.complete` — "X.X freed" summary plus Scan Again.
+///   - `.failed` — message plus Try Again.
+///
+/// Accessibility identifiers are namespaced under `system-junk.*` so UI tests
+/// can drive the flow without relying on label localisation.
+struct SystemJunkView: View {
+
+    @StateObject private var viewModel: SystemJunkViewModel
+
+    init(viewModel: SystemJunkViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.phase {
+            case .idle:
+                idleState
+            case .scanning:
+                progressState(label: "Scanning…", identifier: "system-junk.scanning")
+            case .preview(let result):
+                previewState(result: result)
+            case .cleaning:
+                progressState(label: "Cleaning…", identifier: "system-junk.cleaning")
+            case .complete(let bytes):
+                completeState(bytesFreed: bytes)
+            case .failed(let message):
+                failedState(message: message)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle(NavigationSection.systemJunk.title)
+    }
+
+    // MARK: - States
+
+    private var idleState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "trash")
+                .font(.system(size: 56))
+                .foregroundStyle(.secondary)
+            Text("System Junk")
+                .font(.title2.weight(.semibold))
+            Text("Scan caches, logs, mail attachments, iOS backups, trash, and stale language files.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+            Button("Scan") {
+                Task { await viewModel.scan() }
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("system-junk.scan")
+        }
+        .padding()
+    }
+
+    private func progressState(label: String, identifier: String) -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func previewState(result: ScanResult) -> some View {
+        VStack(spacing: 0) {
+            previewList(result: result)
+            Divider()
+            previewFooter
+        }
+    }
+
+    private func previewList(result: ScanResult) -> some View {
+        let categories = ScanCategory.allCases.filter { result.itemsByCategory[$0] != nil }
+        return List {
+            ForEach(categories, id: \.self) { category in
+                CategoryRow(
+                    category: category,
+                    itemCount: result.itemsByCategory[category]?.count ?? 0,
+                    sizeBytes: result.sizeByCategory[category] ?? 0,
+                    isChecked: Binding(
+                        get: { viewModel.isChecked(category) },
+                        set: { _ in viewModel.toggle(category) }
+                    )
+                )
+                .accessibilityIdentifier("system-junk.row.\(category.rawValue)")
+            }
+        }
+    }
+
+    private var previewFooter: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Total selected")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(viewModel.formattedTotalSelectedSize)
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("system-junk.totalSelected")
+            }
+            Spacer()
+            Button("Re-scan") {
+                viewModel.scanAgain()
+            }
+            .accessibilityIdentifier("system-junk.rescan")
+            Button("Clean") {
+                Task { await viewModel.clean() }
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.totalSelectedSize == 0)
+            .accessibilityIdentifier("system-junk.clean")
+        }
+        .padding(16)
+    }
+
+    private func completeState(bytesFreed: Int64) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text(SystemJunkView.byteFormatter.string(fromByteCount: bytesFreed) + " freed")
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("system-junk.bytesFreed")
+            Button("Scan Again") {
+                viewModel.scanAgain()
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("system-junk.scanAgain")
+        }
+        .padding()
+    }
+
+    private func failedState(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text("Couldn't complete the scan")
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+                .accessibilityIdentifier("system-junk.errorMessage")
+            Button("Try Again") {
+                viewModel.scanAgain()
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("system-junk.tryAgain")
+        }
+        .padding()
+    }
+
+    // MARK: - Formatter
+
+    /// Shared `ByteCountFormatter` for the "freed" summary on the complete
+    /// state. Kept on the view so the formatter allocation does not happen
+    /// inside the view body's expression evaluator on every redraw.
+    private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+}
+
+// MARK: - Subviews
+
+/// Single row in the preview list. Bound to a checkbox `Toggle` whose
+/// `Binding` drives `SystemJunkViewModel.toggle(_:)` on changes.
+private struct CategoryRow: View {
+    let category: ScanCategory
+    let itemCount: Int
+    let sizeBytes: Int64
+    @Binding var isChecked: Bool
+
+    private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: $isChecked)
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+            VStack(alignment: .leading, spacing: 2) {
+                Text(category.displayName)
+                    .font(.body.weight(.medium))
+                Text("\(itemCount) item\(itemCount == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text(Self.byteFormatter.string(fromByteCount: sizeBytes))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview("Idle") {
+    SystemJunkView(viewModel: SystemJunkViewModel(
+        scanner: { ScanResult(items: []) },
+        deleter: { _ in 0 }
+    ))
+    .frame(width: 700, height: 480)
+}

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -35,8 +35,8 @@ struct SystemJunkView: View {
                 progressState(label: "Cleaning…", identifier: "system-junk.cleaning")
             case .complete(let bytes):
                 completeState(bytesFreed: bytes)
-            case .failed(let message):
-                failedState(message: message)
+            case .failed(let stage, let message):
+                failedState(stage: stage, message: message)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -150,12 +150,12 @@ struct SystemJunkView: View {
         .padding()
     }
 
-    private func failedState(message: String) -> some View {
+    private func failedState(stage: SystemJunkViewModel.FailureStage, message: String) -> some View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 56))
                 .foregroundStyle(.orange)
-            Text("Couldn't complete the scan")
+            Text(stage == .scanning ? "Couldn't complete the scan" : "Couldn't finish cleaning")
                 .font(.title2.weight(.semibold))
             Text(message)
                 .font(.callout)
@@ -176,9 +176,11 @@ struct SystemJunkView: View {
     // MARK: - Formatter
 
     /// Shared `ByteCountFormatter` for the "freed" summary on the complete
-    /// state. Kept on the view so the formatter allocation does not happen
-    /// inside the view body's expression evaluator on every redraw.
-    private static let byteFormatter: ByteCountFormatter = {
+    /// state and every per-category row. `fileprivate` (not `private`) so
+    /// the `CategoryRow` subview below can reuse the same instance instead
+    /// of allocating its own. Kept as a static so the allocation does not
+    /// happen inside the view body's expression evaluator on every redraw.
+    fileprivate static let byteFormatter: ByteCountFormatter = {
         let f = ByteCountFormatter()
         f.allowedUnits = .useAll
         f.countStyle = .file
@@ -196,13 +198,6 @@ private struct CategoryRow: View {
     let sizeBytes: Int64
     @Binding var isChecked: Bool
 
-    private static let byteFormatter: ByteCountFormatter = {
-        let f = ByteCountFormatter()
-        f.allowedUnits = .useAll
-        f.countStyle = .file
-        return f
-    }()
-
     var body: some View {
         HStack(spacing: 12) {
             Toggle("", isOn: $isChecked)
@@ -216,7 +211,7 @@ private struct CategoryRow: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            Text(Self.byteFormatter.string(fromByteCount: sizeBytes))
+            Text(SystemJunkView.byteFormatter.string(fromByteCount: sizeBytes))
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(.secondary)
         }

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -23,6 +23,14 @@ import os.log
 @MainActor
 final class SystemJunkViewModel: ObservableObject {
 
+    /// Which step of the flow generated a `.failed` phase, so the view can
+    /// pick the right heading. `clean()` failure must not surface as
+    /// "Couldn't complete the scan" — the scan succeeded; deletion blew up.
+    enum FailureStage: Equatable {
+        case scanning
+        case cleaning
+    }
+
     /// Discrete phases the System Junk view binds to. Equatable so tests can
     /// pin exact transitions and SwiftUI's `Equatable`-aware diffing avoids
     /// redundant re-renders when an incoming value is unchanged.
@@ -32,7 +40,7 @@ final class SystemJunkViewModel: ObservableObject {
         case preview(ScanResult)
         case cleaning
         case complete(bytesFreed: Int64)
-        case failed(message: String)
+        case failed(stage: FailureStage, message: String)
     }
 
     /// Closure type for the scan source. Async + throwing so production can
@@ -106,7 +114,7 @@ final class SystemJunkViewModel: ObservableObject {
             log.error("System Junk scan failed: \(String(describing: error), privacy: .public)")
             self.latestResult = nil
             self.checkedCategories = []
-            self.phase = .failed(message: error.localizedDescription)
+            self.phase = .failed(stage: .scanning, message: error.localizedDescription)
         }
     }
 
@@ -123,7 +131,7 @@ final class SystemJunkViewModel: ObservableObject {
             self.phase = .complete(bytesFreed: bytes)
         } catch {
             log.error("System Junk clean failed: \(String(describing: error), privacy: .public)")
-            self.phase = .failed(message: error.localizedDescription)
+            self.phase = .failed(stage: .cleaning, message: error.localizedDescription)
         }
     }
 
@@ -173,12 +181,13 @@ extension SystemJunkViewModel {
     static func live(exclusions: ExclusionsStore) -> SystemJunkViewModel {
         SystemJunkViewModel(
             scanner: { [weak exclusions] in
-                // Snapshot exclusions on the main actor at scan time so a
-                // freshly-added Preferences entry takes effect on the very
-                // next run, then walk the file tree off the main actor.
-                let excluded: [URL] = await MainActor.run {
-                    (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
-                }
+                // Both `scan()` (the caller) and this closure inherit the
+                // enclosing `@MainActor` isolation, so the `exclusions`
+                // snapshot can be read directly without an explicit
+                // `MainActor.run` hop. The actual file walk happens inside
+                // `SystemJunkScanner.scan(excluding:)`, which is async and
+                // yields the main actor at its first internal `await`.
+                let excluded = (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
                 return try await SystemJunkScanner().scan(excluding: excluded)
             },
             deleter: { files in

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -1,0 +1,189 @@
+// SystemJunkViewModel.swift
+// State machine and selection logic behind the System Junk feature view — drives idle/scanning/preview/cleaning/complete transitions and routes the user's category selection through an injected deleter.
+
+import Foundation
+import os.log
+
+/// Drives the System Junk feature view (scan → preview → clean → done).
+///
+/// The view-model owns four pieces of state:
+///   - `phase`: the current step in the state machine, bound to the view's
+///     switch on rendered content.
+///   - `checkedCategories`: the user's per-category opt-in/out. Defaults to
+///     every category present in the latest scan result on each successful
+///     `scan()`, so users never have to "select all" before cleaning.
+///   - `result`: the most recent `ScanResult`. Held alongside `phase` so
+///     toggling a checkbox can recompute `totalSelectedSize` without re-
+///     scanning, and so `clean()` can pick the right items to delete.
+///   - `errorMessage`: the surfaced description for the `.failed` phase.
+///
+/// All collaborators are injected as closures so unit tests can drive every
+/// transition without touching the real filesystem or the privileged XPC
+/// helper. Production wiring lives in `SystemJunkViewModel.live(...)` below.
+@MainActor
+final class SystemJunkViewModel: ObservableObject {
+
+    /// Discrete phases the System Junk view binds to. Equatable so tests can
+    /// pin exact transitions and SwiftUI's `Equatable`-aware diffing avoids
+    /// redundant re-renders when an incoming value is unchanged.
+    enum Phase: Equatable {
+        case idle
+        case scanning
+        case preview(ScanResult)
+        case cleaning
+        case complete(bytesFreed: Int64)
+        case failed(message: String)
+    }
+
+    /// Closure type for the scan source. Async + throwing so production can
+    /// wrap `SystemJunkScanner.scan(excluding:)` and tests can supply an
+    /// in-memory `ScanResult` (or throw to exercise the failure path).
+    /// Kept non-Sendable: every invocation flows through `@MainActor scan()`,
+    /// so the closure body inherits main-actor isolation and there is nothing
+    /// to gain by widening the contract.
+    typealias Scanner = () async throws -> ScanResult
+
+    /// Closure type for the deletion sink. Returns the number of bytes that
+    /// were actually freed (not the byte sum of the input) so partial-failure
+    /// cases — e.g. the helper deletes nine of ten paths — are reported
+    /// accurately to the user.
+    typealias Deleter = ([ScannedFile]) async throws -> Int64
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var checkedCategories: Set<ScanCategory> = []
+
+    private let scanner: Scanner
+    private let deleter: Deleter
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "SystemJunkViewModel")
+
+    /// Cached most-recent scan result. Held so checkbox toggles can recompute
+    /// `totalSelectedSize` cheaply, and so `clean()` knows which items to
+    /// hand to the deleter.
+    private var latestResult: ScanResult?
+
+    init(scanner: @escaping Scanner, deleter: @escaping Deleter) {
+        self.scanner = scanner
+        self.deleter = deleter
+    }
+
+    // MARK: - Public surface
+
+    /// Sum of bytes for every file in a currently-checked category. Computed
+    /// from `latestResult.sizeByCategory` (built once when the result lands)
+    /// rather than walking `items` per query, so a hot toggle doesn't burn
+    /// CPU on hundreds of thousands of file records.
+    var totalSelectedSize: Int64 {
+        guard let sizes = latestResult?.sizeByCategory else { return 0 }
+        return checkedCategories.reduce(into: Int64(0)) { acc, category in
+            acc += sizes[category] ?? 0
+        }
+    }
+
+    /// Convenience for the view layer — formatting once on the VM keeps the
+    /// "human-readable size" rule in one place across cards and totals.
+    var formattedTotalSelectedSize: String {
+        Self.byteFormatter.string(fromByteCount: totalSelectedSize)
+    }
+
+    /// Whether `category` is currently checked. The view binds each row's
+    /// `Toggle` to `Binding(get:set:)` over `isChecked` + `toggle`.
+    func isChecked(_ category: ScanCategory) -> Bool {
+        checkedCategories.contains(category)
+    }
+
+    /// Run the injected scanner and land in `.preview` (or `.failed`).
+    /// Marks every category present in the result as checked so the user is
+    /// at "select all" by default.
+    func scan() async {
+        phase = .scanning
+        do {
+            let result = try await scanner()
+            self.latestResult = result
+            self.checkedCategories = Set(result.itemsByCategory.keys)
+            self.phase = .preview(result)
+        } catch {
+            log.error("System Junk scan failed: \(String(describing: error), privacy: .public)")
+            self.latestResult = nil
+            self.checkedCategories = []
+            self.phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    /// Hand the injected deleter every file in a checked category and land
+    /// in `.complete(bytesFreed:)`. A no-op when no category is checked.
+    func clean() async {
+        guard let result = latestResult, !checkedCategories.isEmpty else { return }
+        let toDelete = result.items.filter { checkedCategories.contains($0.category) }
+        guard !toDelete.isEmpty else { return }
+
+        phase = .cleaning
+        do {
+            let bytes = try await deleter(toDelete)
+            self.phase = .complete(bytesFreed: bytes)
+        } catch {
+            log.error("System Junk clean failed: \(String(describing: error), privacy: .public)")
+            self.phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    /// Flip the checkbox state for `category`. Idempotent in the sense that
+    /// two calls in a row return the VM to its prior selection, by design.
+    func toggle(_ category: ScanCategory) {
+        if checkedCategories.contains(category) {
+            checkedCategories.remove(category)
+        } else {
+            checkedCategories.insert(category)
+        }
+    }
+
+    /// Reset the VM to `.idle`, dropping the cached result and selection so
+    /// the next scan starts from a clean slate. Called from the "Scan Again"
+    /// button on the complete state and the "Re-scan" button on preview.
+    func scanAgain() {
+        latestResult = nil
+        checkedCategories = []
+        phase = .idle
+    }
+
+    // MARK: - Formatters
+
+    /// Shared `ByteCountFormatter` for the human-readable total. Constructed
+    /// once because the formatter allocates measurable internal state per
+    /// instance and `formattedTotalSelectedSize` is read on every keystroke /
+    /// toggle while the preview list is on screen.
+    private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+}
+
+// MARK: - Production wiring
+
+extension SystemJunkViewModel {
+
+    /// Build a view-model wired to the real `SystemJunkScanner` and a deleter
+    /// that splits files between `FileManager` (user-domain) and the
+    /// privileged XPC helper (`/Library/Caches`, `/Library/Logs`, mounted-
+    /// volume trashes). The exclusions snapshot is captured per scan so a
+    /// freshly-added Preferences exclusion takes effect on the very next run.
+    @MainActor
+    static func live(exclusions: ExclusionsStore) -> SystemJunkViewModel {
+        SystemJunkViewModel(
+            scanner: { [weak exclusions] in
+                // Snapshot exclusions on the main actor at scan time so a
+                // freshly-added Preferences entry takes effect on the very
+                // next run, then walk the file tree off the main actor.
+                let excluded: [URL] = await MainActor.run {
+                    (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
+                }
+                return try await SystemJunkScanner().scan(excluding: excluded)
+            },
+            deleter: { files in
+                try await SystemJunkDeleter().delete(files)
+            }
+        )
+    }
+}

--- a/VaderCleanerTests/SystemJunkDeleterTests.swift
+++ b/VaderCleanerTests/SystemJunkDeleterTests.swift
@@ -24,10 +24,11 @@ final class SystemJunkDeleterTests: XCTestCase {
 
     // MARK: - Path routing
 
-    /// Anything under `/Library`, `/private/var`, `/System`, or `/Volumes`
-    /// must be flagged as helper-only; anything else stays in-process. The
-    /// rule lives on a static for testability — callers should not have to
-    /// instantiate the deleter just to ask the question.
+    /// Anything under `/Library`, `/private/var`, `/System`, or `/Applications`,
+    /// plus per-volume `.Trashes/<uid>/...` under `/Volumes/...`, must be
+    /// flagged as helper-only. The rule lives on a static for testability —
+    /// callers should not have to instantiate the deleter just to ask the
+    /// question.
     func test_requiresHelper_recognisesSystemPrefixes() {
         XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Library/Caches/foo"))
         XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Library/Logs/bar.log"))
@@ -36,13 +37,28 @@ final class SystemJunkDeleterTests: XCTestCase {
         XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Volumes/External/.Trashes/501/file"))
     }
 
+    /// `/Applications` is owned by `root:wheel` on a default macOS install
+    /// and most system-installed `.app` bundles inside it are not writable
+    /// by the user process, so language-file pruning under them must go
+    /// through the helper. Reported by Codex review on PR #30.
+    func test_requiresHelper_routesSystemInstalledAppsThroughHelper() {
+        XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Applications/Safari.app/Contents/Resources/nl.lproj/Localizable.strings"))
+        XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Applications/Some.app/Contents/Resources/de.lproj/InfoPlist.strings"))
+    }
+
     /// User-domain paths must never be routed through the helper — that would
     /// make the privileged tool do work the app could safely do itself, and
     /// would reject in dev environments where the helper isn't registered.
+    /// Includes a regression case for the previous "every `/Volumes/...` is
+    /// helper-only" behaviour: a plain file on a mounted external drive is
+    /// user-writable and stays in-process. Reported by CodeRabbit review on
+    /// PR #30.
     func test_requiresHelper_rejectsUserDomainPaths() {
         XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/Users/alice/Library/Caches/x"))
         XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/Users/alice/.Trash/file"))
+        XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/Users/alice/Applications/MyApp.app/Contents/Resources/de.lproj/x"))
         XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/tmp/whatever"))
+        XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/Volumes/External/Movies/clip.mov"))
     }
 
     // MARK: - User-domain deletion
@@ -58,7 +74,7 @@ final class SystemJunkDeleterTests: XCTestCase {
             ScannedFile(url: $0, size: 100, lastAccessDate: nil, lastModifiedDate: nil, category: .userCache)
         }
 
-        let deleter = SystemJunkDeleter(helperProvider: { nil })
+        let deleter = SystemJunkDeleter(helperProvider: { _ in nil })
         let bytesFreed = try await deleter.delete(files)
 
         XCTAssertEqual(bytesFreed, 300)
@@ -84,7 +100,7 @@ final class SystemJunkDeleterTests: XCTestCase {
             ScannedFile(url: absentURL,  size: 9_999, lastAccessDate: nil, lastModifiedDate: nil, category: .userCache)
         ]
 
-        let deleter = SystemJunkDeleter(helperProvider: { nil })
+        let deleter = SystemJunkDeleter(helperProvider: { _ in nil })
         let bytesFreed = try await deleter.delete(files)
 
         XCTAssertEqual(bytesFreed, 50, "Only the file that actually existed should contribute to bytesFreed")
@@ -110,7 +126,7 @@ final class SystemJunkDeleterTests: XCTestCase {
         ]
 
         let fakeHelper = FakeHelper(replyError: nil)
-        let deleter = SystemJunkDeleter(helperProvider: { fakeHelper })
+        let deleter = SystemJunkDeleter(helperProvider: { _ in fakeHelper })
         let bytesFreed = try await deleter.delete(files)
 
         XCTAssertEqual(bytesFreed, 350, "Both user (100) and helper-credited system (250) bytes count")
@@ -132,10 +148,41 @@ final class SystemJunkDeleterTests: XCTestCase {
         ]
 
         let fakeHelper = FakeHelper(replyError: NSError(domain: "test", code: 1))
-        let deleter = SystemJunkDeleter(helperProvider: { fakeHelper })
+        let deleter = SystemJunkDeleter(helperProvider: { _ in fakeHelper })
         let bytesFreed = try await deleter.delete(files)
 
         XCTAssertEqual(bytesFreed, 50, "Only user-domain bytes should be credited when the helper batch failed")
+    }
+
+    /// Regression test for the XPC continuation hang reported on PR #30:
+    /// when the privileged helper fires its connection-level error handler
+    /// **instead of** invoking the per-call reply block (the way
+    /// `NSXPCConnection` reports interrupted/invalidated connections),
+    /// `delete()` must still resolve — not leave `clean()` stuck on the
+    /// `.cleaning` spinner forever. We simulate that by dropping the reply
+    /// block on the floor and using the per-call error handler that the
+    /// new `helperProvider` signature exposes.
+    func test_delete_resumesWhenHelperConnectionErrorFiresInsteadOfReply() async throws {
+        let systemURL = URL(fileURLWithPath: "/Library/Caches/com.bogus.test/file.bin")
+        let files = [
+            ScannedFile(url: systemURL, size: 999, lastAccessDate: nil, lastModifiedDate: nil, category: .systemCache)
+        ]
+
+        // Deleter that never replies — only the error handler fires. Without
+        // the per-call error sink, `withCheckedContinuation` would never
+        // resume and this test would time out under XCTest's default cap.
+        let droppingHelper = DroppingReplyHelper()
+        let deleter = SystemJunkDeleter(helperProvider: { errorHandler in
+            // Simulate XPC delivering a connection-level error.
+            errorHandler(NSError(domain: "test.xpc", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Connection invalidated"
+            ]))
+            return droppingHelper
+        })
+
+        let bytesFreed = try await deleter.delete(files)
+
+        XCTAssertEqual(bytesFreed, 0, "Connection error must resolve as failure, not hang")
     }
 
     /// When the helper is unavailable (typical dev environment without ad-hoc
@@ -152,7 +199,7 @@ final class SystemJunkDeleterTests: XCTestCase {
             ScannedFile(url: systemURL, size: 999, lastAccessDate: nil, lastModifiedDate: nil, category: .systemCache)
         ]
 
-        let deleter = SystemJunkDeleter(helperProvider: { nil })
+        let deleter = SystemJunkDeleter(helperProvider: { _ in nil })
         let bytesFreed = try await deleter.delete(files)
 
         XCTAssertEqual(bytesFreed, 75)
@@ -182,4 +229,18 @@ private final class FakeHelper: NSObject, VaderCleanerHelperProtocol {
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+}
+
+/// Helper stand-in that intentionally drops the reply block on the floor —
+/// models the real `NSXPCConnection` failure mode where the connection-level
+/// error handler fires instead of the per-call reply. The test confirms the
+/// awaiting `delete()` resolves anyway, via the per-call error sink.
+private final class DroppingReplyHelper: NSObject, VaderCleanerHelperProtocol {
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
+        // Intentionally no `reply(...)`.
+    }
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {}
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
 }

--- a/VaderCleanerTests/SystemJunkDeleterTests.swift
+++ b/VaderCleanerTests/SystemJunkDeleterTests.swift
@@ -1,0 +1,185 @@
+// SystemJunkDeleterTests.swift
+// Pins SystemJunkDeleter's user/system path routing rule and exercises the user-domain delete path against a temp directory; helper-domain calls are routed through an injected fake helper so no privileged XPC connection is required.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class SystemJunkDeleterTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    // MARK: - Path routing
+
+    /// Anything under `/Library`, `/private/var`, `/System`, or `/Volumes`
+    /// must be flagged as helper-only; anything else stays in-process. The
+    /// rule lives on a static for testability — callers should not have to
+    /// instantiate the deleter just to ask the question.
+    func test_requiresHelper_recognisesSystemPrefixes() {
+        XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Library/Caches/foo"))
+        XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Library/Logs/bar.log"))
+        XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/private/var/folders/abc"))
+        XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/System/Library/Caches/x"))
+        XCTAssertTrue(SystemJunkDeleter.requiresHelper(path: "/Volumes/External/.Trashes/501/file"))
+    }
+
+    /// User-domain paths must never be routed through the helper — that would
+    /// make the privileged tool do work the app could safely do itself, and
+    /// would reject in dev environments where the helper isn't registered.
+    func test_requiresHelper_rejectsUserDomainPaths() {
+        XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/Users/alice/Library/Caches/x"))
+        XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/Users/alice/.Trash/file"))
+        XCTAssertFalse(SystemJunkDeleter.requiresHelper(path: "/tmp/whatever"))
+    }
+
+    // MARK: - User-domain deletion
+
+    /// Files under the temp root (a user-writable location) must go through
+    /// `FileManager.removeItem` and contribute their byte count to the
+    /// returned freed-bytes total.
+    func test_delete_userDomainFiles_removesAndReportsBytesFreed() async throws {
+        let dir = tempRoot.appendingPathComponent("user-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let urls = try TestHelpers.createDummyFiles(count: 3, size: 100, in: dir)
+        let files = urls.map {
+            ScannedFile(url: $0, size: 100, lastAccessDate: nil, lastModifiedDate: nil, category: .userCache)
+        }
+
+        let deleter = SystemJunkDeleter(helperProvider: { nil })
+        let bytesFreed = try await deleter.delete(files)
+
+        XCTAssertEqual(bytesFreed, 300)
+        for url in urls {
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: url.path),
+                "Expected \(url.path) to be removed"
+            )
+        }
+    }
+
+    /// A nonexistent user-domain file must not abort the rest of the batch —
+    /// a single locked or already-deleted log file is the most common
+    /// failure mode and must not block the rest of the clean. The freed
+    /// total reflects only the files that actually succeeded.
+    func test_delete_skipsNonexistentUserFiles() async throws {
+        let dir = tempRoot.appendingPathComponent("user-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let presentURL = try TestHelpers.createDummyFile(named: "real.bin", size: 50, in: dir)
+        let absentURL = dir.appendingPathComponent("missing.bin")
+        let files = [
+            ScannedFile(url: presentURL, size: 50, lastAccessDate: nil, lastModifiedDate: nil, category: .userCache),
+            ScannedFile(url: absentURL,  size: 9_999, lastAccessDate: nil, lastModifiedDate: nil, category: .userCache)
+        ]
+
+        let deleter = SystemJunkDeleter(helperProvider: { nil })
+        let bytesFreed = try await deleter.delete(files)
+
+        XCTAssertEqual(bytesFreed, 50, "Only the file that actually existed should contribute to bytesFreed")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: presentURL.path))
+    }
+
+    // MARK: - Helper-domain deletion (routing only)
+
+    /// When a system-path file is in the batch, the helper proxy must be
+    /// asked to delete it. We don't run a real privileged helper here —
+    /// instead, an injected `FakeHelper` records the paths it received so
+    /// the test can assert the routing decision without launching XPC.
+    func test_delete_systemPathRoutesThroughHelperAndCountsBytesOnSuccess() async throws {
+        let userDir = tempRoot.appendingPathComponent("user-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: userDir, withIntermediateDirectories: true)
+        let userURL = try TestHelpers.createDummyFile(named: "u.bin", size: 100, in: userDir)
+        // System-path fixture URL — the file does not have to exist on disk;
+        // the fake helper will accept any path it is handed.
+        let systemURL = URL(fileURLWithPath: "/Library/Caches/com.bogus.test/file.bin")
+        let files = [
+            ScannedFile(url: userURL,   size: 100, lastAccessDate: nil, lastModifiedDate: nil, category: .userCache),
+            ScannedFile(url: systemURL, size: 250, lastAccessDate: nil, lastModifiedDate: nil, category: .systemCache)
+        ]
+
+        let fakeHelper = FakeHelper(replyError: nil)
+        let deleter = SystemJunkDeleter(helperProvider: { fakeHelper })
+        let bytesFreed = try await deleter.delete(files)
+
+        XCTAssertEqual(bytesFreed, 350, "Both user (100) and helper-credited system (250) bytes count")
+        XCTAssertEqual(fakeHelper.receivedPaths, [systemURL.path])
+    }
+
+    /// If the helper reports an error, the system-path bytes must NOT be
+    /// credited to the freed total — the protocol cannot tell us which
+    /// paths succeeded, so we cannot honestly claim partial progress.
+    /// User-domain bytes still count because we deleted those in-process.
+    func test_delete_systemPathErrorDoesNotCreditBytes() async throws {
+        let userDir = tempRoot.appendingPathComponent("user-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: userDir, withIntermediateDirectories: true)
+        let userURL = try TestHelpers.createDummyFile(named: "u.bin", size: 50, in: userDir)
+        let systemURL = URL(fileURLWithPath: "/Library/Caches/com.bogus.test/missing.bin")
+        let files = [
+            ScannedFile(url: userURL,   size: 50,  lastAccessDate: nil, lastModifiedDate: nil, category: .userCache),
+            ScannedFile(url: systemURL, size: 999, lastAccessDate: nil, lastModifiedDate: nil, category: .systemCache)
+        ]
+
+        let fakeHelper = FakeHelper(replyError: NSError(domain: "test", code: 1))
+        let deleter = SystemJunkDeleter(helperProvider: { fakeHelper })
+        let bytesFreed = try await deleter.delete(files)
+
+        XCTAssertEqual(bytesFreed, 50, "Only user-domain bytes should be credited when the helper batch failed")
+    }
+
+    /// When the helper is unavailable (typical dev environment without ad-hoc
+    /// signing), system-path deletion must not credit bytes — but the user-
+    /// domain side of the batch must still go through. This is the most
+    /// common case during local development.
+    func test_delete_unavailableHelperFallsBackToUserOnlyDelete() async throws {
+        let userDir = tempRoot.appendingPathComponent("user-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: userDir, withIntermediateDirectories: true)
+        let userURL = try TestHelpers.createDummyFile(named: "u.bin", size: 75, in: userDir)
+        let systemURL = URL(fileURLWithPath: "/Library/Caches/com.bogus.test/x.bin")
+        let files = [
+            ScannedFile(url: userURL,   size: 75,  lastAccessDate: nil, lastModifiedDate: nil, category: .userCache),
+            ScannedFile(url: systemURL, size: 999, lastAccessDate: nil, lastModifiedDate: nil, category: .systemCache)
+        ]
+
+        let deleter = SystemJunkDeleter(helperProvider: { nil })
+        let bytesFreed = try await deleter.delete(files)
+
+        XCTAssertEqual(bytesFreed, 75)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: userURL.path))
+    }
+}
+
+// MARK: - Test doubles
+
+/// Minimal `VaderCleanerHelperProtocol` stand-in — captures the paths it was
+/// asked to delete and replies with the supplied error (or nil for success).
+/// Inherits from `NSObject` because the underlying protocol is `@objc`.
+private final class FakeHelper: NSObject, VaderCleanerHelperProtocol {
+    private let replyError: Error?
+    private(set) var receivedPaths: [String] = []
+
+    init(replyError: Error?) {
+        self.replyError = replyError
+    }
+
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
+        receivedPaths = paths
+        reply(replyError)
+    }
+
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+}

--- a/VaderCleanerTests/SystemJunkViewModelTests.swift
+++ b/VaderCleanerTests/SystemJunkViewModelTests.swift
@@ -1,0 +1,265 @@
+// SystemJunkViewModelTests.swift
+// Tests the SystemJunkViewModel state machine, selection logic, and clean dispatch — driving each transition (idle → scanning → preview → cleaning → complete) through injected fake scanner and deleter closures so no real filesystem or XPC helper is touched.
+
+import XCTest
+import Combine
+@testable import VaderCleaner
+
+@MainActor
+final class SystemJunkViewModelTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    /// The view-model must arrive in `.idle` so the System Junk view renders
+    /// its "Scan" CTA on first appearance, not a momentary preview/cleaning
+    /// flash from a stale cached state.
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertTrue(vm.checkedCategories.isEmpty)
+        XCTAssertEqual(vm.totalSelectedSize, 0)
+    }
+
+    // MARK: - Scan transitions
+
+    /// `scan()` must advance through `.scanning` and land on `.preview` once
+    /// the injected scanner closure resolves. We capture every emitted phase
+    /// from `$phase.sink` to assert the transient `.scanning` value really
+    /// appeared — without that subscription the test could pass even if the
+    /// VM jumped straight from `.idle` to `.preview`.
+    func test_scan_transitionsIdleToScanningToPreview() async {
+        let result = makeResult(
+            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)]),
+            (.userLogs,  [makeFile(name: "b", size: 200, category: .userLogs)])
+        )
+        let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
+
+        var phases: [SystemJunkViewModel.Phase] = []
+        let cancellable = vm.$phase.sink { phases.append($0) }
+
+        await vm.scan()
+        cancellable.cancel()
+
+        XCTAssertEqual(phases.first, .idle, "Expected initial .idle to be replayed by sink")
+        XCTAssertTrue(phases.contains(.scanning), "Expected to observe .scanning during scan()")
+        XCTAssertEqual(phases.last, .preview(result))
+    }
+
+    /// All categories present in the scan result must be checked by default —
+    /// the user opts out of categories rather than opting in, matching the
+    /// expectation set in the plan and how cleaner UIs typically work.
+    func test_scan_marksEveryCategoryCheckedByDefault() async {
+        let result = makeResult(
+            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)]),
+            (.systemLogs, [makeFile(name: "b", size: 200, category: .systemLogs)]),
+            (.trash, [makeFile(name: "c", size: 300, category: .trash)])
+        )
+        let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
+
+        await vm.scan()
+
+        XCTAssertEqual(vm.checkedCategories, [.userCache, .systemLogs, .trash])
+        XCTAssertEqual(vm.totalSelectedSize, 600)
+    }
+
+    /// A scanner that throws must surface a `.failed` phase rather than leave
+    /// the view-model stuck in `.scanning` — otherwise the spinner would never
+    /// resolve and the user has no way back.
+    func test_scan_failureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let vm = makeViewModel(
+            scanner: { throw BoomError() },
+            deleter: noopDeleter
+        )
+
+        await vm.scan()
+
+        if case .failed = vm.phase {
+            // expected
+        } else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Selection
+
+    /// Toggling a category off must drop both the membership and its bytes
+    /// from `totalSelectedSize`. Toggling it back on must restore the total —
+    /// the selection state is purely additive, with no side-effects on the
+    /// underlying scan result.
+    func test_toggle_updatesCheckedCategoriesAndTotalSelectedSize() async {
+        let result = makeResult(
+            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)]),
+            (.userLogs,  [makeFile(name: "b", size: 250, category: .userLogs)])
+        )
+        let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
+        await vm.scan()
+        XCTAssertEqual(vm.totalSelectedSize, 350)
+
+        vm.toggle(.userCache)
+        XCTAssertFalse(vm.checkedCategories.contains(.userCache))
+        XCTAssertEqual(vm.totalSelectedSize, 250)
+
+        vm.toggle(.userCache)
+        XCTAssertTrue(vm.checkedCategories.contains(.userCache))
+        XCTAssertEqual(vm.totalSelectedSize, 350)
+    }
+
+    // MARK: - Clean
+
+    /// `clean()` must hand the deleter only the files whose category is
+    /// currently checked. An unchecked category's files must not be passed
+    /// through — we cannot rely on the deleter to filter, the view-model owns
+    /// the contract.
+    func test_clean_invokesDeleterOnlyForCheckedCategories() async {
+        let userFile = makeFile(name: "a", size: 100, category: .userCache)
+        let logFile  = makeFile(name: "b", size: 250, category: .userLogs)
+        let result = makeResult(
+            (.userCache, [userFile]),
+            (.userLogs,  [logFile])
+        )
+        let recorded = ActorBox<[ScannedFile]>([])
+        let vm = makeViewModel(
+            scanner: { result },
+            deleter: { files in
+                await recorded.set(files)
+                return files.reduce(Int64(0)) { $0 + $1.size }
+            }
+        )
+
+        await vm.scan()
+        vm.toggle(.userLogs)  // uncheck user logs
+        await vm.clean()
+
+        let received = await recorded.value
+        XCTAssertEqual(received, [userFile], "Deleter must receive only files in checked categories")
+    }
+
+    /// After a successful clean, the phase becomes `.complete(bytesFreed)` so
+    /// the view can render the success summary and offer "Scan Again". Bytes
+    /// freed comes from the deleter so partial-failure cases (helper deletes
+    /// 9 of 10 files) report accurate values rather than the full selection.
+    func test_clean_transitionsToCompleteWithBytesFreed() async {
+        let result = makeResult(
+            (.userCache, [makeFile(name: "a", size: 1_024, category: .userCache)])
+        )
+        let vm = makeViewModel(
+            scanner: { result },
+            deleter: { _ in 1_024 }
+        )
+
+        await vm.scan()
+        await vm.clean()
+
+        XCTAssertEqual(vm.phase, .complete(bytesFreed: 1_024))
+    }
+
+    /// A throwing deleter must surface `.failed` rather than leaving the user
+    /// stuck on the cleaning spinner. We don't claim "X bytes freed" if the
+    /// underlying delete blew up — better to show an error and let the user
+    /// retry.
+    func test_clean_failureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let result = makeResult(
+            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)])
+        )
+        let vm = makeViewModel(
+            scanner: { result },
+            deleter: { _ in throw BoomError() }
+        )
+
+        await vm.scan()
+        await vm.clean()
+
+        if case .failed = vm.phase {
+            // expected
+        } else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    /// `clean()` is a no-op when nothing is checked — the View disables the
+    /// button in this state, but the VM contract must hold even if a hot-key
+    /// path or future caller bypasses the disabled state.
+    func test_clean_withNoSelectionDoesNotInvokeDeleter() async {
+        let result = makeResult(
+            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)])
+        )
+        let invoked = ActorBox(false)
+        let vm = makeViewModel(
+            scanner: { result },
+            deleter: { _ in
+                await invoked.set(true)
+                return 0
+            }
+        )
+
+        await vm.scan()
+        vm.toggle(.userCache)  // now nothing is checked
+        await vm.clean()
+
+        let didInvoke = await invoked.value
+        XCTAssertFalse(didInvoke, "Deleter must not be called when no category is checked")
+    }
+
+    // MARK: - Scan again
+
+    /// `scanAgain()` returns the view-model to `.idle` so the user is back at
+    /// the Scan CTA — selection state is dropped because the previous result
+    /// is no longer valid.
+    func test_scanAgain_returnsToIdle() async {
+        let result = makeResult(
+            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)])
+        )
+        let vm = makeViewModel(
+            scanner: { result },
+            deleter: { _ in 100 }
+        )
+        await vm.scan()
+        await vm.clean()
+        XCTAssertEqual(vm.phase, .complete(bytesFreed: 100))
+
+        vm.scanAgain()
+
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertTrue(vm.checkedCategories.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        scanner: @escaping () async throws -> ScanResult = { ScanResult(items: []) },
+        deleter: @escaping ([ScannedFile]) async throws -> Int64 = { _ in 0 }
+    ) -> SystemJunkViewModel {
+        SystemJunkViewModel(scanner: scanner, deleter: deleter)
+    }
+
+    private func makeResult(_ groups: (ScanCategory, [ScannedFile])...) -> ScanResult {
+        let items = groups.flatMap { $0.1 }
+        return ScanResult(items: items)
+    }
+
+    private func makeFile(name: String, size: Int64, category: ScanCategory) -> ScannedFile {
+        ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/sjv-tests/\(category.rawValue)/\(name)"),
+            size: size,
+            lastAccessDate: nil,
+            lastModifiedDate: nil,
+            category: category
+        )
+    }
+
+    /// Default no-op deleter for tests that don't exercise the clean path.
+    private let noopDeleter: ([ScannedFile]) async throws -> Int64 = { _ in 0 }
+}
+
+/// Small actor wrapper that lets test deleter closures record values without
+/// data-race warnings under Swift's strict concurrency checks. The deleter
+/// closure is `@Sendable`, so it cannot capture a `@MainActor` test fixture's
+/// stored properties directly — funnelling values through an actor is the
+/// simplest race-free alternative.
+private actor ActorBox<Value: Sendable> {
+    private(set) var value: Value
+    init(_ initial: Value) { self.value = initial }
+    func set(_ newValue: Value) { value = newValue }
+}

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -1,0 +1,70 @@
+// SystemJunkUITests.swift
+// End-to-end UI tests for the System Junk feature — navigates to the section, taps Scan, and waits for the preview list to appear so the wiring between sidebar selection, view-model, and view is exercised against the real app process.
+
+import XCTest
+
+/// We deliberately do not tap "Clean" in this test. The view-model unit tests
+/// cover the deletion contract exhaustively against an injected fake deleter;
+/// here, hitting the real `Clean` button would remove files from the user's
+/// `~/Library/Caches` (and similar) on the machine running the test, which is
+/// not something a UI test should ever do as a side effect.
+final class SystemJunkUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    /// Sidebar → System Junk → Scan must reveal the preview UI. We accept any
+    /// of the preview-state identifiers (the totalSelected label, the Clean
+    /// button, or the Re-scan button) as evidence that the preview rendered,
+    /// so the test does not depend on the scan returning at least one result —
+    /// an empty Caches directory on a freshly imaged CI host must not flake.
+    func test_navigateToSystemJunk_andScan_revealsPreview() throws {
+        // The Full Disk Access onboarding sheet may be in the way. Dismiss it
+        // through "Continue Without Access" if present so the sidebar is
+        // reachable. The button label comes from `PermissionOnboardingView`.
+        dismissOnboardingIfNeeded()
+
+        // The sidebar is a single-selection List; clicking the row whose
+        // label text matches the section title selects it.
+        let sidebarRow = app.outlines.staticTexts["System Junk"].firstMatch
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
+                      "Expected System Junk row in sidebar")
+        sidebarRow.click()
+
+        // Idle state should expose the Scan button by accessibility identifier.
+        let scanButton = app.buttons["system-junk.scan"]
+        XCTAssertTrue(scanButton.waitForExistence(timeout: 5),
+                      "Expected Scan button in System Junk idle state")
+        scanButton.click()
+
+        // The scan completes once we land on either the preview footer
+        // (Total selected label / Clean button) or — if no junk files were
+        // found — the empty preview list still rendered.
+        let totalSelected = app.staticTexts["system-junk.totalSelected"]
+        let cleanButton = app.buttons["system-junk.clean"]
+
+        let appeared = totalSelected.waitForExistence(timeout: 30)
+            || cleanButton.waitForExistence(timeout: 1)
+        XCTAssertTrue(appeared,
+                      "Expected to land on the preview state after a Scan")
+    }
+
+    // MARK: - Helpers
+
+    private func dismissOnboardingIfNeeded() {
+        let continueWithout = app.buttons["Continue Without Access"]
+        if continueWithout.waitForExistence(timeout: 2) {
+            continueWithout.click()
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -28,7 +28,7 @@
 
 - [x] **Prompt 12** — File scanner infrastructure (FileScanner, ScanCategory, ScanResult)
 - [x] **Prompt 13** — System Junk scanner (all 8 categories)
-- [ ] **Prompt 14** — System Junk UI + deletion (scan → preview → clean flow)
+- [x] **Prompt 14** — System Junk UI + deletion (scan → preview → clean flow)
 - [ ] **Prompt 15** — Large & Old Files scanner + UI
 - [ ] **Prompt 16** — Space Lens disk scanner (DiskNode tree + DiskScanner)
 - [ ] **Prompt 17** — Space Lens treemap UI (squarified treemap + drill-down)


### PR DESCRIPTION
## Summary
- `SystemJunkViewModel` drives the full state machine — idle → scanning → preview → cleaning → complete (plus a `.failed` fallback) — with per-category checkbox selection and dependency-injected scanner / deleter closures so tests cover every transition without touching the real filesystem or XPC helper.
- `SystemJunkDeleter` routes deletion: user-domain paths go through `FileManager.removeItem`, `/Library`, `/private/var`, `/System`, and `/Volumes` paths go through the privileged helper. Returns bytes actually freed, not the byte sum of the input, so the UI never claims space it didn't deliver.
- `SystemJunkView` replaces the placeholder for `NavigationSection.systemJunk` with idle / scanning / preview (per-category checkboxes + Total selected + Clean / Re-scan) / cleaning / complete / failed states. All states expose `system-junk.*` accessibility identifiers for UI tests.

Closes #29.

## Test plan
- [x] `xcodebuild ... -only-testing:VaderCleanerTests test` — 196 tests pass (10 new in `SystemJunkViewModelTests`, 7 new in `SystemJunkDeleterTests`).
- [x] `SystemJunkUITests.test_navigateToSystemJunk_andScan_revealsPreview` — sidebar selection → Scan → preview flow against the real app process. The "Clean" button is intentionally not tapped from the UI test (would mutate the test machine's user caches); deletion is covered exhaustively in unit tests.
- [x] `xcodebuild build` — release build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced System Junk cleanup with category-level scan, selection, preview, and formatted freed-space summary
  * System Junk view integrated into the app UI (accessible from the sidebar)

* **Tests**
  * Added comprehensive unit and UI tests covering scanning, deletion flows, helper routing, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->