### PR TITLE
feat: Large & Old Files scanner + UI (Prompt 15)

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -74,6 +74,8 @@ struct ContentView: View {
             HealthMonitorView(service: systemStats)
         case .systemJunk:
             SystemJunkView(viewModel: SystemJunkViewModel.live(exclusions: exclusions))
+        case .largeOldFiles:
+            LargeOldFilesView(viewModel: LargeOldFilesViewModel.live(exclusions: exclusions))
         default:
             PlaceholderDetailView(section: section)
         }

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -1,0 +1,94 @@
+// LargeOldFilesScanner.swift
+// Walks the user-files roots via FileScanner, then filters and re-tags each ScannedFile as .largeFile (size > 50 MB) or .oldFile (not accessed in 6+ months); files matching neither are dropped.
+
+import Foundation
+
+/// Top-level entry point for the Large & Old Files feature. Composes a
+/// `UserFilesPathProviding` (which knows where the user keeps their personal
+/// files) with a `FileScanning` (which does the recursive walk) and post-
+/// processes the output to keep only files matching at least one criterion.
+///
+/// Two-pass design — walk-then-classify — instead of teaching `FileScanner`
+/// about size/age predicates: keeps `FileScanner` a generic walker, lets the
+/// thresholds be injected per-test, and means the same `FileScanner` instance
+/// can be shared with `SystemJunkScanner` without either one growing
+/// feature-specific knobs.
+struct LargeOldFilesScanner {
+
+    /// Files larger than this byte count are tagged `.largeFile`. 50 MB is
+    /// the threshold called for in plan.md — high enough that it surfaces
+    /// genuine forgotten media, low enough that it catches multi-megabyte
+    /// installer disk images.
+    static let sizeThresholdBytes: Int64 = 50 * 1024 * 1024
+
+    /// Files whose `lastAccessDate` is more than 6 months in the past are
+    /// tagged `.oldFile`. Expressed in seconds (`60 * 60 * 24 * 30 * 6`) so
+    /// the constant is unit-clear at the call site.
+    static let ageThresholdSeconds: TimeInterval = 60 * 60 * 24 * 30 * 6
+
+    private let fileScanner: FileScanning
+    private let pathProvider: UserFilesPathProviding
+    private let now: () -> Date
+
+    init(
+        fileScanner: FileScanning = FileScanner(),
+        pathProvider: UserFilesPathProviding = DefaultUserFilesPathProvider(),
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.fileScanner = fileScanner
+        self.pathProvider = pathProvider
+        self.now = now
+    }
+
+    /// Runs the scan and returns the matching files. `excluding` is forwarded
+    /// straight to the underlying `FileScanning` — the path-component-aware
+    /// match semantics covered in `FileScannerTests` apply unchanged.
+    ///
+    /// Walks every root with a placeholder `.largeFile` category tag (the
+    /// `ScanRoot` API requires one), then re-tags each file based on the
+    /// per-file size and age check. The tiebreak when both apply is
+    /// `.largeFile` — see `classify(_:cutoff:)`.
+    func scan(excluding: [URL]) async throws -> [ScannedFile] {
+        let roots = pathProvider.roots().map {
+            // The placeholder category never reaches the caller — every file
+            // is re-tagged below — so the value picked here is irrelevant.
+            // We pass `.largeFile` for readability rather than introducing a
+            // synthetic "unclassified" case to the public `ScanCategory` enum.
+            ScanRoot(url: $0, category: .largeFile)
+        }
+        let everything = try await fileScanner.scan(roots: roots, excluding: excluding)
+        let cutoff = now().addingTimeInterval(-Self.ageThresholdSeconds)
+        return everything.compactMap { Self.classify($0, cutoff: cutoff) }
+    }
+
+    /// Returns the input file with its category re-tagged when it qualifies,
+    /// or `nil` when neither criterion matches.
+    ///
+    /// **Tiebreak**: when a file is both large *and* old, we report it as
+    /// `.largeFile`. Size is a deterministic file-system property; access
+    /// dates can be unreliable on `noatime`-mounted volumes or after a
+    /// restore. Reporting the more reliable signal first matches what users
+    /// expect from "show me the biggest forgotten files" — they look at size
+    /// before they look at age.
+    ///
+    /// Files with `lastAccessDate == nil` cannot be classified by age (per
+    /// the `ScannedFile` doc comment, `nil` means "unknown — don't classify
+    /// by age"), so they only enter the result set if they pass the size
+    /// threshold. This avoids a stale-volume backup folder showing every
+    /// 4-byte file as "ancient" just because its access date is missing.
+    private static func classify(_ file: ScannedFile, cutoff: Date) -> ScannedFile? {
+        let isLarge = file.size > sizeThresholdBytes
+        let isOld: Bool = {
+            guard let lastAccess = file.lastAccessDate else { return false }
+            return lastAccess < cutoff
+        }()
+        guard isLarge || isOld else { return nil }
+        return ScannedFile(
+            url: file.url,
+            size: file.size,
+            lastAccessDate: file.lastAccessDate,
+            lastModifiedDate: file.lastModifiedDate,
+            category: isLarge ? .largeFile : .oldFile
+        )
+    }
+}

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -80,7 +80,13 @@ struct LargeOldFilesScanner {
         let isLarge = file.size > sizeThresholdBytes
         let isOld: Bool = {
             guard let lastAccess = file.lastAccessDate else { return false }
-            return lastAccess < cutoff
+            // Inclusive: a file accessed exactly at the 6-month cutoff is
+            // already "not accessed within the past six months", so it
+            // belongs in the old-files bucket. Strict `<` would leave a
+            // one-second sliver where the boundary case is invisible to
+            // the user — without inclusive comparison the result depends
+            // on file-system timestamp resolution.
+            return lastAccess <= cutoff
         }()
         guard isLarge || isOld else { return nil }
         return ScannedFile(

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -53,15 +53,29 @@ struct LargeOldFilesView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle(NavigationSection.largeOldFiles.title)
-        .alert(item: $pendingDeletion) { deletion in
-            Alert(
-                title: Text("Delete \(deletion.count) item\(deletion.count == 1 ? "" : "s")?"),
-                message: Text("\(deletion.formattedSize) will be moved out of these locations. This cannot be undone."),
-                primaryButton: .destructive(Text("Delete")) {
-                    Task { await viewModel.delete(urls: deletion.urls) }
-                },
-                secondaryButton: .cancel()
-            )
+        // The classic `Alert(title:message:primaryButton:secondaryButton:)`
+        // initializer was deprecated in macOS 12 in favor of the role-aware
+        // `.alert(_:isPresented:presenting:actions:message:)` modifier. We
+        // bridge the optional `pendingDeletion` payload through a derived
+        // `Bool` binding because the new modifier separates "show me" and
+        // "what to show" — clearing the binding still also clears the
+        // payload so the next request rebuilds the alert from scratch.
+        .alert(
+            deletionAlertTitle,
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { presented in
+                    if !presented { pendingDeletion = nil }
+                }
+            ),
+            presenting: pendingDeletion
+        ) { deletion in
+            Button("Delete", role: .destructive) {
+                Task { await viewModel.delete(urls: deletion.urls) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: { deletion in
+            Text("\(deletion.formattedSize) will be moved out of these locations. This cannot be undone.")
         }
         .onChange(of: viewModel.phase) { _, newPhase in
             handlePhaseChange(newPhase)
@@ -314,6 +328,17 @@ struct LargeOldFilesView: View {
         return Self.dateFormatter.string(from: date)
     }
 
+    /// Title for the destructive-action alert. Computed from
+    /// `pendingDeletion` because the modern `.alert(_:isPresented:...)`
+    /// modifier wants a static title at modifier-call time, but the count
+    /// is dynamic. Re-evaluating per render is cheap and the alert is only
+    /// rendered while `pendingDeletion` is non-nil, so the fallback `0`
+    /// branch is unreachable in practice.
+    private var deletionAlertTitle: String {
+        let count = pendingDeletion?.count ?? 0
+        return "Delete \(count) item\(count == 1 ? "" : "s")?"
+    }
+
     fileprivate static let byteFormatter: ByteCountFormatter = {
         let f = ByteCountFormatter()
         f.allowedUnits = .useAll
@@ -331,10 +356,13 @@ struct LargeOldFilesView: View {
 
 // MARK: - Pending deletion
 
-/// View-local payload describing what's about to be deleted, used by the
-/// `Alert(item:)` modifier. `Identifiable` because `Alert(item:)` requires
-/// it; `id` is a fresh UUID per construction so the same selection re-
-/// triggers a new alert if needed.
+/// View-local payload describing what's about to be deleted, surfaced
+/// to the destructive-action alert via the `presenting:` parameter of
+/// `.alert(_:isPresented:presenting:actions:message:)`. `Identifiable`
+/// is no longer required by the modifier we use, but we keep the fresh-
+/// UUID `id` because `Alert.actions(_:)` re-renders per identity change
+/// and a fresh UUID guarantees a fresh closure capture for each pending
+/// request.
 private struct PendingDeletion: Identifiable {
     let id = UUID()
     let urls: [URL]

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -1,0 +1,367 @@
+// LargeOldFilesView.swift
+// Large & Old Files feature view — renders the idle/scanning/results/empty/failed states from LargeOldFilesViewModel, the sortable Table with per-row checkboxes, and the Delete-Selected confirmation alert.
+
+import SwiftUI
+import AppKit
+
+/// Detail view shown when the user selects "Large & Old Files" in the
+/// sidebar. Each phase of `LargeOldFilesViewModel.Phase` maps to a dedicated
+/// subview:
+///   - `.idle`     — centered Scan call-to-action.
+///   - `.scanning` — progress spinner.
+///   - `.results`  — sortable table with per-row checkboxes plus the footer.
+///   - `.empty`    — "Nothing matched" copy with Scan Again.
+///   - `.failed`   — message plus Try Again.
+///
+/// Accessibility identifiers are namespaced under `large-old.*` so future UI
+/// tests can drive the flow without relying on label localisation.
+struct LargeOldFilesView: View {
+
+    @StateObject private var viewModel: LargeOldFilesViewModel
+    @EnvironmentObject private var notificationMonitor: NotificationThresholdMonitor
+
+    /// Drives the "Are you sure?" alert before destructive actions. Held on
+    /// the view rather than the VM so the confirmation copy can reference
+    /// the *current* selection without forcing the VM to know about UI
+    /// formatting.
+    @State private var pendingDeletion: PendingDeletion?
+
+    /// Latches once per scan so we don't fire the
+    /// `triggerLargeFilesFound` hook on every re-render of the same
+    /// `.results` phase. Reset on `.scan()` and `.scanAgain()` paths via
+    /// the `.onChange` handler below.
+    @State private var notifiedForCurrentScan = false
+
+    init(viewModel: LargeOldFilesViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.phase {
+            case .idle:
+                idleState
+            case .scanning:
+                progressState(label: "Scanning…", identifier: "large-old.scanning")
+            case .results(let files):
+                resultsState(files: files)
+            case .empty:
+                emptyState
+            case .failed(let stage, let message):
+                failedState(stage: stage, message: message)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle(NavigationSection.largeOldFiles.title)
+        .alert(item: $pendingDeletion) { deletion in
+            Alert(
+                title: Text("Delete \(deletion.count) item\(deletion.count == 1 ? "" : "s")?"),
+                message: Text("\(deletion.formattedSize) will be moved out of these locations. This cannot be undone."),
+                primaryButton: .destructive(Text("Delete")) {
+                    Task { await viewModel.delete(urls: deletion.urls) }
+                },
+                secondaryButton: .cancel()
+            )
+        }
+        .onChange(of: viewModel.phase) { _, newPhase in
+            handlePhaseChange(newPhase)
+        }
+    }
+
+    // MARK: - States
+
+    private var idleState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 56))
+                .foregroundStyle(.secondary)
+            Text("Large & Old Files")
+                .font(.title2.weight(.semibold))
+            Text("Scan your home folder for files larger than 50 MB or not accessed in the past six months.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+            Button("Scan") {
+                Task { await viewModel.scan() }
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("large-old.scan")
+        }
+        .padding()
+    }
+
+    private func progressState(label: String, identifier: String) -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func resultsState(files: [ScannedFile]) -> some View {
+        // We bind the table to `viewModel.displayedFiles` rather than the
+        // `files` payload off the phase so re-sorting and deletes flow
+        // through one stable source of truth.
+        VStack(spacing: 0) {
+            resultsTable
+            Divider()
+            resultsFooter
+        }
+    }
+
+    private var resultsTable: some View {
+        Table(viewModel.displayedFiles) {
+            TableColumn("") { file in
+                Toggle("", isOn: Binding(
+                    get: { viewModel.isSelected(file) },
+                    set: { _ in viewModel.toggleSelection(file) }
+                ))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+                .accessibilityIdentifier("large-old.row.\(file.url.path).checkbox")
+            }
+            .width(28)
+
+            TableColumn("Name") { file in
+                HStack(spacing: 6) {
+                    Image(nsImage: NSWorkspace.shared.icon(forFile: file.url.path))
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                    Text(file.url.lastPathComponent)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .contextMenu { rowContextMenu(for: file) }
+            }
+
+            TableColumn("Size") { file in
+                Text(Self.byteFormatter.string(fromByteCount: file.size))
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 70, ideal: 90, max: 120)
+
+            TableColumn("Last Accessed") { file in
+                Text(formattedAccessDate(file.lastAccessDate))
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 110, ideal: 140, max: 180)
+
+            TableColumn("Path") { file in
+                Text(file.url.deletingLastPathComponent().path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .help(file.url.path)
+            }
+        }
+        .accessibilityIdentifier("large-old.table")
+        .toolbar { sortToolbar }
+    }
+
+    private var sortToolbar: some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            Picker("Sort by", selection: $viewModel.sortOrder) {
+                Text("Largest first").tag(LargeOldFilesViewModel.SortOrder.sizeDescending)
+                Text("Smallest first").tag(LargeOldFilesViewModel.SortOrder.sizeAscending)
+                Text("Oldest first").tag(LargeOldFilesViewModel.SortOrder.dateAscending)
+                Text("Newest first").tag(LargeOldFilesViewModel.SortOrder.dateDescending)
+                Text("Name (A–Z)").tag(LargeOldFilesViewModel.SortOrder.nameAscending)
+            }
+            .pickerStyle(.menu)
+            .accessibilityIdentifier("large-old.sort")
+        }
+    }
+
+    private var resultsFooter: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Total selected")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(Self.byteFormatter.string(fromByteCount: viewModel.totalSelectedSize))
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("large-old.totalSelected")
+            }
+            Spacer()
+            Button("Re-scan") {
+                Task { await viewModel.scan() }
+            }
+            .accessibilityIdentifier("large-old.rescan")
+            Button("Delete Selected") {
+                requestDeletionForSelection()
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.selectedURLs.isEmpty)
+            .accessibilityIdentifier("large-old.delete")
+        }
+        .padding(16)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text("Nothing to clean up")
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("large-old.emptyTitle")
+            Text("No files larger than 50 MB or untouched for the past six months were found in your home folder.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+            Button("Scan Again") {
+                viewModel.scanAgain()
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("large-old.scanAgain")
+        }
+        .padding()
+    }
+
+    private func failedState(stage: LargeOldFilesViewModel.FailureStage, message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(stage == .scanning ? "Couldn't complete the scan" : "Couldn't finish deleting")
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("large-old.errorMessage")
+            Button("Try Again") {
+                viewModel.scanAgain()
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("large-old.tryAgain")
+        }
+        .padding()
+    }
+
+    // MARK: - Context menu
+
+    @ViewBuilder
+    private func rowContextMenu(for file: ScannedFile) -> some View {
+        Button("Show in Finder") {
+            NSWorkspace.shared.activateFileViewerSelecting([file.url])
+        }
+        Divider()
+        Button("Delete", role: .destructive) {
+            requestDeletionForSingle(file)
+        }
+    }
+
+    // MARK: - Delete confirmation
+
+    private func requestDeletionForSelection() {
+        let selected = viewModel.displayedFiles.filter { viewModel.isSelected($0) }
+        guard !selected.isEmpty else { return }
+        pendingDeletion = PendingDeletion(
+            urls: selected.map(\.url),
+            totalBytes: selected.reduce(Int64(0)) { $0 + $1.size }
+        )
+    }
+
+    private func requestDeletionForSingle(_ file: ScannedFile) {
+        // Right-click "Delete" targets only the single right-clicked row,
+        // not the broader selection — that matches Finder's behavior and
+        // avoids the user accidentally nuking unrelated checked rows.
+        pendingDeletion = PendingDeletion(
+            urls: [file.url],
+            totalBytes: file.size
+        )
+    }
+
+    /// Run a phase change through the notification dispatcher exactly once
+    /// per scan, when a `.results` lands non-empty. The cooldown gate on
+    /// `NotificationThresholdMonitor` still applies — multiple scans in
+    /// quick succession won't spam the user.
+    private func handlePhaseChange(_ newPhase: LargeOldFilesViewModel.Phase) {
+        switch newPhase {
+        case .scanning, .idle:
+            notifiedForCurrentScan = false
+        case .results(let files) where !notifiedForCurrentScan && !files.isEmpty:
+            notifiedForCurrentScan = true
+            let total = files.reduce(Int64(0)) { $0 + $1.size }
+            notificationMonitor.triggerLargeFilesFound(count: files.count, totalSize: total)
+        default:
+            break
+        }
+    }
+
+    // MARK: - Formatting
+
+    /// Renders an access date the way Finder labels its "Last opened" column —
+    /// medium-style date, no time, abbreviated for table density.
+    private func formattedAccessDate(_ date: Date?) -> String {
+        guard let date else { return "—" }
+        return Self.dateFormatter.string(from: date)
+    }
+
+    fileprivate static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .none
+        return f
+    }()
+}
+
+// MARK: - Pending deletion
+
+/// View-local payload describing what's about to be deleted, used by the
+/// `Alert(item:)` modifier. `Identifiable` because `Alert(item:)` requires
+/// it; `id` is a fresh UUID per construction so the same selection re-
+/// triggers a new alert if needed.
+private struct PendingDeletion: Identifiable {
+    let id = UUID()
+    let urls: [URL]
+    let totalBytes: Int64
+
+    var count: Int { urls.count }
+
+    var formattedSize: String {
+        LargeOldFilesView.byteFormatter.string(fromByteCount: totalBytes)
+    }
+}
+
+// MARK: - ScannedFile + Identifiable
+
+/// `Table` requires its data to be `Identifiable`. `ScannedFile.url` is
+/// guaranteed unique within a single scan (the `FileScanner` walks each
+/// path once and skips symlinks), so the URL is a stable identity. Held in
+/// this file rather than on the type so the model layer doesn't pull in a
+/// SwiftUI dependency.
+extension ScannedFile: Identifiable {
+    var id: URL { url }
+}
+
+#Preview("Idle") {
+    LargeOldFilesView(viewModel: LargeOldFilesViewModel(
+        scanner: { [] },
+        deleter: { _ in [] }
+    ))
+    .frame(width: 800, height: 520)
+}

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -132,7 +132,7 @@ final class LargeOldFilesViewModel: ObservableObject {
             let files = try await scanner()
             applyScanResult(files)
         } catch {
-            log.error("Large & Old Files scan failed: \(String(describing: error), privacy: .public)")
+            log.error("Large & Old Files scan failed: \(String(describing: error), privacy: .private(mask: .hash))")
             displayedFiles = []
             phase = .failed(stage: .scanning, message: error.localizedDescription)
         }
@@ -266,7 +266,13 @@ extension LargeOldFilesViewModel {
     /// return the set of URLs whose deletion succeeded. Failures are logged
     /// and skipped — a single locked file must never abort the whole batch,
     /// and the surviving files stay in the table so the user can retry.
-    private static func removeUserFiles(at urls: [URL]) async -> Set<URL> {
+    ///
+    /// Marked `nonisolated` so the synchronous `FileManager.removeItem`
+    /// loop runs off the main actor — without this annotation a static
+    /// member on a `@MainActor`-isolated class inherits main-actor
+    /// isolation, which would block the UI for the duration of a multi-
+    /// gigabyte delete batch.
+    private nonisolated static func removeUserFiles(at urls: [URL]) async -> Set<URL> {
         let log = Logger(subsystem: "com.personal.VaderCleaner",
                          category: "LargeOldFilesViewModel.Deleter")
         var deleted: Set<URL> = []
@@ -276,8 +282,13 @@ extension LargeOldFilesViewModel {
                 try manager.removeItem(at: url)
                 deleted.insert(url)
             } catch {
+                // Both the path and the error message can carry user-
+                // identifying info (full filesystem paths, locale-specific
+                // error descriptions); redact both with hash-masked
+                // private privacy so OSLog displays consistent placeholders
+                // outside the user's own machine.
                 log.debug(
-                    "Skipping unremovable user file \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
+                    "Skipping unremovable user file \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .private(mask: .hash))"
                 )
             }
         }

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -1,0 +1,286 @@
+// LargeOldFilesViewModel.swift
+// State machine, sort order, and selection logic behind the Large & Old Files feature view — drives idle/scanning/results/empty/failed transitions and routes deletions through an injected per-URL deleter.
+
+import Foundation
+import os.log
+
+/// Drives the Large & Old Files feature view (scan → results → delete).
+///
+/// The view-model owns four pieces of state:
+///   - `phase`: the current step in the state machine, bound to the view's
+///     switch on rendered content.
+///   - `displayedFiles`: the post-sort list shown in the table. Recomputed
+///     whenever the underlying file list or `sortOrder` changes so the view
+///     can bind to one stable property.
+///   - `sortOrder`: which column drives the sort. Changing it triggers an
+///     in-VM re-sort rather than handing a `KeyPathComparator` to SwiftUI's
+///     `Table` — keeps a single ordering rule for selection helpers and
+///     future export paths.
+///   - `selectedURLs`: the user's current selection. Cleared when the
+///     containing files vanish (after delete) so the footer's
+///     `totalSelectedSize` is always consistent with the displayed rows.
+///
+/// All collaborators are injected as closures so unit tests can drive every
+/// transition without touching the real filesystem. Production wiring lives
+/// in `LargeOldFilesViewModel.live(...)` below.
+@MainActor
+final class LargeOldFilesViewModel: ObservableObject {
+
+    /// Which step of the flow generated a `.failed` phase, so the view can
+    /// pick the right heading. A delete failure must not be reported as
+    /// "Couldn't complete the scan" — the scan succeeded; deletion blew up.
+    enum FailureStage: Equatable {
+        case scanning
+        case deleting
+    }
+
+    /// Discrete phases the view binds to. `Equatable` so SwiftUI's diffing
+    /// avoids redundant re-renders when an incoming value is unchanged.
+    enum Phase: Equatable {
+        case idle
+        case scanning
+        case results([ScannedFile])
+        case empty
+        case failed(stage: FailureStage, message: String)
+    }
+
+    /// Sort axes exposed by the view's column-header buttons. `Equatable`
+    /// so the view can use `.onChange(of: sortOrder)` if needed.
+    enum SortOrder: Equatable {
+        case sizeDescending
+        case sizeAscending
+        case dateAscending
+        case dateDescending
+        case nameAscending
+    }
+
+    /// Closure type for the scan source. Async + throwing so production can
+    /// wrap `LargeOldFilesScanner.scan(excluding:)` and tests can supply an
+    /// in-memory `[ScannedFile]` (or throw to exercise the failure path).
+    typealias Scanner = () async throws -> [ScannedFile]
+
+    /// Closure type for the deletion sink. Returns the set of URLs that were
+    /// **actually** removed — partial-failure cases (some files locked,
+    /// permission denied, etc.) must report only the URLs that succeeded so
+    /// the surviving files stay in the table.
+    typealias Deleter = ([URL]) async -> Set<URL>
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var selectedURLs: Set<URL> = []
+
+    /// Current sort axis. The setter recomputes `displayedFiles` so the view
+    /// table re-orders without the caller doing the work. Defaults to size-
+    /// descending — the first row should be the biggest forgotten thing on
+    /// disk, which is the entire reason the user opened this feature.
+    @Published var sortOrder: SortOrder = .sizeDescending {
+        didSet {
+            guard oldValue != sortOrder else { return }
+            recomputeDisplayedFiles()
+        }
+    }
+
+    /// Files currently shown in the table, post-sort. Held separately from
+    /// `phase` so re-sorting and per-file deletes don't have to round-trip
+    /// through a phase-replacement.
+    @Published private(set) var displayedFiles: [ScannedFile] = []
+
+    private let scanner: Scanner
+    private let deleter: Deleter
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "LargeOldFilesViewModel")
+
+    /// Running total of bytes for files in `selectedURLs`. Maintained
+    /// incrementally on every `toggleSelection` so the footer label updates
+    /// in O(1) rather than walking `displayedFiles` on every read.
+    @Published private(set) var totalSelectedSize: Int64 = 0
+
+    init(scanner: @escaping Scanner, deleter: @escaping Deleter) {
+        self.scanner = scanner
+        self.deleter = deleter
+    }
+
+    // MARK: - Public surface
+
+    /// Whether `file` is currently selected. The view binds each row's
+    /// checkbox `Toggle` to `Binding(get:set:)` over `isSelected` +
+    /// `toggleSelection`.
+    func isSelected(_ file: ScannedFile) -> Bool {
+        selectedURLs.contains(file.url)
+    }
+
+    /// Flip the selection state for `file` and adjust `totalSelectedSize`
+    /// in lockstep. Idempotent in the sense that two calls in a row return
+    /// the VM to its prior selection.
+    func toggleSelection(_ file: ScannedFile) {
+        if selectedURLs.contains(file.url) {
+            selectedURLs.remove(file.url)
+            totalSelectedSize -= file.size
+        } else {
+            selectedURLs.insert(file.url)
+            totalSelectedSize += file.size
+        }
+    }
+
+    /// Run the injected scanner and land in `.results`, `.empty`, or
+    /// `.failed`. Selection is cleared because the previous list is no
+    /// longer valid.
+    func scan() async {
+        phase = .scanning
+        selectedURLs = []
+        totalSelectedSize = 0
+        do {
+            let files = try await scanner()
+            applyScanResult(files)
+        } catch {
+            log.error("Large & Old Files scan failed: \(String(describing: error), privacy: .public)")
+            displayedFiles = []
+            phase = .failed(stage: .scanning, message: error.localizedDescription)
+        }
+    }
+
+    /// Hand the injected deleter the URLs of every currently-selected file
+    /// and trim the displayed list down to whatever survives. Transitions
+    /// to `.empty` if nothing is left, or stays in `.results` with the
+    /// updated array. A no-op when nothing is selected.
+    func deleteSelected() async {
+        guard !selectedURLs.isEmpty else { return }
+        await delete(urls: Array(selectedURLs))
+    }
+
+    /// Delete a specific set of URLs (used by the right-click "Delete"
+    /// path which targets a single row independent of the broader
+    /// selection). Survivors stay in the table; the selection set drops
+    /// the deleted URLs but otherwise persists.
+    func delete(urls: [URL]) async {
+        guard !urls.isEmpty else { return }
+        let actuallyDeleted = await deleter(urls)
+        let survivors = displayedFiles.filter { !actuallyDeleted.contains($0.url) }
+        displayedFiles = survivors
+        // Drop the deleted URLs from the selection set, then recompute
+        // `totalSelectedSize` from scratch. The incremental upkeep in
+        // `toggleSelection` only handles user-driven add/remove — deletion
+        // removes selected URLs out from under it.
+        selectedURLs.subtract(actuallyDeleted)
+        totalSelectedSize = displayedFiles
+            .filter { selectedURLs.contains($0.url) }
+            .reduce(Int64(0)) { $0 + $1.size }
+        phase = survivors.isEmpty ? .empty : .results(survivors)
+    }
+
+    /// Reset the view-model to `.idle`, dropping the cached results and
+    /// selection so the next scan starts from a clean slate. Wired to the
+    /// "Scan Again" button on the empty / complete states.
+    func scanAgain() {
+        displayedFiles = []
+        selectedURLs = []
+        totalSelectedSize = 0
+        phase = .idle
+    }
+
+    // MARK: - Internals
+
+    /// Lands the scanner output: empty → `.empty`, otherwise sort and stash
+    /// for `.results`. Pulled out so failure recovery and successful scans
+    /// share the same "set displayedFiles + emit phase" sequence.
+    private func applyScanResult(_ files: [ScannedFile]) {
+        if files.isEmpty {
+            displayedFiles = []
+            phase = .empty
+            return
+        }
+        let sorted = Self.sort(files, by: sortOrder)
+        displayedFiles = sorted
+        phase = .results(sorted)
+    }
+
+    /// Re-sort the displayed list in place using the current `sortOrder`.
+    /// Cheap enough to run on every `sortOrder` change; the file count is
+    /// bounded by what the scanner emitted (typically dozens to low
+    /// thousands) and `Array.sorted` is O(n log n).
+    private func recomputeDisplayedFiles() {
+        guard !displayedFiles.isEmpty else { return }
+        displayedFiles = Self.sort(displayedFiles, by: sortOrder)
+        if case .results = phase {
+            phase = .results(displayedFiles)
+        }
+    }
+
+    /// Stable sort that puts `nil` access dates last under date-based
+    /// orderings — files we can't reason about by age shouldn't crowd out
+    /// the meaningful entries. For non-date orderings, `nil` dates are
+    /// irrelevant and the comparator never inspects them.
+    private static func sort(_ files: [ScannedFile], by order: SortOrder) -> [ScannedFile] {
+        switch order {
+        case .sizeDescending:
+            return files.sorted { $0.size > $1.size }
+        case .sizeAscending:
+            return files.sorted { $0.size < $1.size }
+        case .nameAscending:
+            return files.sorted {
+                $0.url.lastPathComponent.localizedCaseInsensitiveCompare($1.url.lastPathComponent) == .orderedAscending
+            }
+        case .dateAscending:
+            return files.sorted { lhs, rhs in
+                switch (lhs.lastAccessDate, rhs.lastAccessDate) {
+                case (nil, nil): return false
+                case (nil, _):   return false   // nil sorts after non-nil
+                case (_, nil):   return true    // non-nil sorts before nil
+                case let (l?, r?): return l < r
+                }
+            }
+        case .dateDescending:
+            return files.sorted { lhs, rhs in
+                switch (lhs.lastAccessDate, rhs.lastAccessDate) {
+                case (nil, nil): return false
+                case (nil, _):   return false   // nil sorts after non-nil
+                case (_, nil):   return true    // non-nil sorts before nil
+                case let (l?, r?): return l > r
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Production wiring
+
+extension LargeOldFilesViewModel {
+
+    /// Build a view-model wired to the real `LargeOldFilesScanner` plus a
+    /// `FileManager`-backed deleter. Mirrors `SystemJunkViewModel.live(...)`
+    /// — the exclusions snapshot is captured per scan so a freshly-added
+    /// Preferences exclusion takes effect on the very next run.
+    @MainActor
+    static func live(exclusions: ExclusionsStore) -> LargeOldFilesViewModel {
+        LargeOldFilesViewModel(
+            scanner: { [weak exclusions] in
+                let excluded = (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
+                return try await LargeOldFilesScanner().scan(excluding: excluded)
+            },
+            deleter: { urls in
+                await Self.removeUserFiles(at: urls)
+            }
+        )
+    }
+
+    /// Default deleter: walk each URL through `FileManager.removeItem` and
+    /// return the set of URLs whose deletion succeeded. Failures are logged
+    /// and skipped — a single locked file must never abort the whole batch,
+    /// and the surviving files stay in the table so the user can retry.
+    private static func removeUserFiles(at urls: [URL]) async -> Set<URL> {
+        let log = Logger(subsystem: "com.personal.VaderCleaner",
+                         category: "LargeOldFilesViewModel.Deleter")
+        var deleted: Set<URL> = []
+        let manager = FileManager.default
+        for url in urls {
+            do {
+                try manager.removeItem(at: url)
+                deleted.insert(url)
+            } catch {
+                log.debug(
+                    "Skipping unremovable user file \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+        return deleted
+    }
+}

--- a/VaderCleaner/UserFilesPathProviding.swift
+++ b/VaderCleaner/UserFilesPathProviding.swift
@@ -1,0 +1,41 @@
+// UserFilesPathProviding.swift
+// Resolves the home-directory subtrees that the Large & Old Files scanner walks, returned as plain root URLs (no category tag — the scanner classifies per-file by size/age).
+
+import Foundation
+
+/// Test seam between `LargeOldFilesScanner` and the real macOS home layout.
+/// Implementations return the concrete `[URL]` to feed into a scan. Tests
+/// inject a stub returning paths under a temp directory, which is why the
+/// production `DefaultUserFilesPathProvider` lives behind the same protocol
+/// instead of being a free function on the scanner.
+///
+/// Distinct from `SystemPathProviding` — that one carries a `ScanCategory`
+/// per root because the System Junk feature decides "this is junk because of
+/// where it lives". Large & Old files are classified by content (size, last
+/// access date), so the root list is pure URLs and the scanner does the
+/// per-file tagging.
+protocol UserFilesPathProviding {
+    func roots() -> [URL]
+}
+
+/// Production implementation that returns the canonical user directories that
+/// might contain large or stale files: `~/Documents`, `~/Downloads`,
+/// `~/Desktop`, `~/Movies`, `~/Music`, `~/Pictures`, and `~/Library`.
+///
+/// `~/Library` is intentionally included — it can hold multi-gigabyte caches
+/// or `Application Support` blobs left behind by uninstalled apps that the
+/// System Junk path provider doesn't touch. The user-confirmation alert in
+/// `LargeOldFilesView` mitigates accidental deletion of live app data.
+struct DefaultUserFilesPathProvider: UserFilesPathProviding {
+
+    private let homeDirectory: URL
+
+    init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        self.homeDirectory = homeDirectory
+    }
+
+    func roots() -> [URL] {
+        ["Documents", "Downloads", "Desktop", "Movies", "Music", "Pictures", "Library"]
+            .map { homeDirectory.appendingPathComponent($0, isDirectory: true) }
+    }
+}

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -1,0 +1,223 @@
+// LargeOldFilesScannerTests.swift
+// Drives LargeOldFilesScanner against temp directories via an injected UserFilesPathProviding stub, covering size/age classification, the both-match tiebreak, the unknown-access-date guard, and exclusion forwarding.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Verifies `LargeOldFilesScanner` end-to-end. Like `SystemJunkScannerTests`,
+/// we never touch the real `~/Documents` etc. — a `StubUserFilesPathProvider`
+/// returns roots under a temp directory so the suite is hermetic and the
+/// machine's actual user files never enter the picture.
+final class LargeOldFilesScannerTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    /// Fixed "now" used to derive the cutoff. All age-bearing fixtures stamp
+    /// their `contentAccessDate` relative to this so the assertions don't
+    /// depend on real time.
+    private let referenceNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    // MARK: - Size classification
+
+    /// A file larger than the threshold must be returned tagged `.largeFile`.
+    /// Sub-threshold files in the same root must be filtered out — the scanner
+    /// is not a generic walker, it only emits files matching at least one
+    /// criterion.
+    func test_scan_findsFilesAboveSizeThreshold() async throws {
+        let root = try makeRoot("documents")
+        let large = try TestHelpers.createDummyFile(
+            named: "big.bin",
+            size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
+            in: root
+        )
+        try TestHelpers.createDummyFile(named: "small.bin", size: 32, in: root)
+        try setRecentAccessDate(at: large)
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(files.count, 1, "Only the > 50 MB file should be emitted")
+        XCTAssertEqual(files.first?.url.lastPathComponent, "big.bin")
+        XCTAssertEqual(files.first?.category, .largeFile)
+    }
+
+    // MARK: - Age classification
+
+    /// A file last accessed before the cutoff must be returned tagged
+    /// `.oldFile`. Recently accessed files in the same root must be filtered
+    /// out so the user is not shown last week's downloads.
+    func test_scan_findsFilesNotAccessedWithinAgeThreshold() async throws {
+        let root = try makeRoot("downloads")
+        let stale = try TestHelpers.createDummyFile(named: "stale.txt", size: 32, in: root)
+        let fresh = try TestHelpers.createDummyFile(named: "fresh.txt", size: 32, in: root)
+        try setAccessDate(at: stale,
+                          to: referenceNow.addingTimeInterval(-LargeOldFilesScanner.ageThresholdSeconds - 86_400))
+        try setAccessDate(at: fresh, to: referenceNow.addingTimeInterval(-3_600))
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(files.count, 1, "Only the stale file should be emitted")
+        XCTAssertEqual(files.first?.url.lastPathComponent, "stale.txt")
+        XCTAssertEqual(files.first?.category, .oldFile)
+    }
+
+    // MARK: - Both-match tiebreak
+
+    /// A file that is both large AND old must be tagged `.largeFile` — size is
+    /// a more deterministic signal than access date (which can be flaky on
+    /// `noatime` mounts), so we prefer it. Documented inline in the scanner.
+    func test_scan_classifiesLargeAndOldFileAsLargeFile() async throws {
+        let root = try makeRoot("desktop")
+        let huge = try TestHelpers.createDummyFile(
+            named: "huge-and-stale.bin",
+            size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
+            in: root
+        )
+        try setAccessDate(at: huge,
+                          to: referenceNow.addingTimeInterval(-LargeOldFilesScanner.ageThresholdSeconds - 86_400))
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files.first?.category, .largeFile,
+                       "Tiebreak: a file matching both criteria is reported as .largeFile")
+    }
+
+    // MARK: - Unknown access date
+
+    /// Files whose `lastAccessDate` is `nil` cannot be classified by age and,
+    /// if also under the size threshold, must not be emitted at all. Mirrors
+    /// the `ScannedFile` doc comment ("`nil` means 'unknown — don't classify
+    /// by age'").
+    func test_scan_skipsFilesWithUnknownAccessDateBelowSizeThreshold() async throws {
+        // We can't synthesize a nil contentAccessDate from APFS in a test
+        // (the FS always tracks one). Instead we drive the scanner through a
+        // FakeFileScanner that emits a synthetic ScannedFile with nil dates,
+        // proving the scanner's classification logic — not the file system —
+        // is the gate.
+        let synthetic = ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-tests/unknown.bin"),
+            size: 32,
+            lastAccessDate: nil,
+            lastModifiedDate: nil,
+            category: .largeFile
+        )
+        let scanner = LargeOldFilesScanner(
+            fileScanner: FakeFileScanner(emitted: [synthetic]),
+            pathProvider: StubUserFilesPathProvider(roots: [tempRoot]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertTrue(files.isEmpty,
+                      "A small file with unknown access date matches neither criterion and must be dropped")
+    }
+
+    // MARK: - Exclusions
+
+    /// `excluding:` is forwarded straight to the underlying `FileScanning`, so
+    /// any path under an excluded URL must not appear in the result —
+    /// regardless of whether it would have qualified as large or old.
+    func test_scan_respectsExclusions() async throws {
+        let root = try makeRoot("pictures")
+        let kept = root.appendingPathComponent("kept", isDirectory: true)
+        let excluded = root.appendingPathComponent("excluded", isDirectory: true)
+        try FileManager.default.createDirectory(at: kept, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: excluded, withIntermediateDirectories: true)
+        let keptLarge = try TestHelpers.createDummyFile(
+            named: "kept-large.bin",
+            size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
+            in: kept
+        )
+        let excludedLarge = try TestHelpers.createDummyFile(
+            named: "excluded-large.bin",
+            size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
+            in: excluded
+        )
+        try setRecentAccessDate(at: keptLarge)
+        try setRecentAccessDate(at: excludedLarge)
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [excluded])
+
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files.first?.url.lastPathComponent, "kept-large.bin")
+    }
+
+    // MARK: - Helpers
+
+    private func makeRoot(_ name: String) throws -> URL {
+        let url = tempRoot.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Stamps `url`'s `contentAccessDate` to a date well within the freshness
+    /// window so size-bound tests don't accidentally trip the age path.
+    private func setRecentAccessDate(at url: URL) throws {
+        try setAccessDate(at: url, to: referenceNow.addingTimeInterval(-3_600))
+    }
+
+    /// Writes both `contentAccessDate` and `contentModificationDate` so the
+    /// underlying file system honors the change even on `relatime`-style
+    /// mounts that update atime opportunistically from mtime.
+    private func setAccessDate(at url: URL, to date: Date) throws {
+        var values = URLResourceValues()
+        values.contentAccessDate = date
+        values.contentModificationDate = date
+        var mutable = url
+        try mutable.setResourceValues(values)
+    }
+}
+
+// MARK: - Stubs
+
+/// Returns a fixed list of root URLs so tests can drive the scanner against a
+/// temp directory rather than the real `~/Documents` etc.
+private struct StubUserFilesPathProvider: UserFilesPathProviding {
+    private let stubbedRoots: [URL]
+    init(roots: [URL]) { self.stubbedRoots = roots }
+    func roots() -> [URL] { stubbedRoots }
+}
+
+/// Lets `test_scan_skipsFilesWithUnknownAccessDateBelowSizeThreshold` synthesize
+/// a `ScannedFile` with `lastAccessDate == nil` — APFS always populates that
+/// timestamp, so we can't produce one through real I/O.
+private struct FakeFileScanner: FileScanning {
+    let emitted: [ScannedFile]
+    func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
+        emitted
+    }
+}

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -83,6 +83,29 @@ final class LargeOldFilesScannerTests: XCTestCase {
         XCTAssertEqual(files.first?.category, .oldFile)
     }
 
+    /// A file last accessed *exactly* at the cutoff must be classified as
+    /// `.oldFile` — the comparison is inclusive (`<=`) so users on
+    /// coarse-resolution file systems aren't told a six-month-old file is
+    /// "still fresh" because the cutoff happened to land on the same
+    /// timestamp. Locks the boundary semantics so future refactors don't
+    /// silently flip the behavior.
+    func test_scan_classifiesFileAccessedExactlyAtCutoffAsOld() async throws {
+        let root = try makeRoot("documents-boundary")
+        let edge = try TestHelpers.createDummyFile(named: "edge.txt", size: 32, in: root)
+        let cutoff = referenceNow.addingTimeInterval(-LargeOldFilesScanner.ageThresholdSeconds)
+        try setAccessDate(at: edge, to: cutoff)
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(files.count, 1, "Cutoff is inclusive: a file at the exact threshold counts as old")
+        XCTAssertEqual(files.first?.category, .oldFile)
+    }
+
     // MARK: - Both-match tiebreak
 
     /// A file that is both large AND old must be tagged `.largeFile` — size is

--- a/VaderCleanerTests/LargeOldFilesViewModelTests.swift
+++ b/VaderCleanerTests/LargeOldFilesViewModelTests.swift
@@ -1,0 +1,253 @@
+// LargeOldFilesViewModelTests.swift
+// Tests the LargeOldFilesViewModel state machine, sort order, selection set, and deleteSelected — driven through injected fake scanner and deleter closures so no real filesystem is touched.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class LargeOldFilesViewModelTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    /// First appearance lands on `.idle` with an empty selection so the view
+    /// renders its "Scan" CTA, not a stale results table.
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertTrue(vm.selectedURLs.isEmpty)
+        XCTAssertEqual(vm.totalSelectedSize, 0)
+    }
+
+    // MARK: - Scan transitions
+
+    /// A successful scan with at least one file lands in `.results` carrying
+    /// the scanner's output — the phase carries the displayable list rather
+    /// than forcing the view to query a separate property.
+    func test_scan_withResultsTransitionsToResults() async {
+        let files = [
+            makeFile(name: "a.bin", size: 200, accessDaysAgo: 10, category: .largeFile),
+            makeFile(name: "b.bin", size: 100, accessDaysAgo: 365, category: .oldFile)
+        ]
+        let vm = makeViewModel(scanner: { files })
+
+        await vm.scan()
+
+        if case .results(let returned) = vm.phase {
+            XCTAssertEqual(returned.count, 2)
+        } else {
+            XCTFail("Expected .results, got \(vm.phase)")
+        }
+    }
+
+    /// An empty scan must surface `.empty` rather than an empty `.results` —
+    /// the view has dedicated copy for "Nothing found" and rendering a blank
+    /// table would feel like the scan failed.
+    func test_scan_withNoResultsTransitionsToEmpty() async {
+        let vm = makeViewModel(scanner: { [] })
+
+        await vm.scan()
+
+        XCTAssertEqual(vm.phase, .empty)
+    }
+
+    /// Throwing scanner must surface `.failed` — never leave the user stuck
+    /// on the spinner.
+    func test_scan_failureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let vm = makeViewModel(scanner: { throw BoomError() })
+
+        await vm.scan()
+
+        if case .failed = vm.phase {} else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Default sort
+
+    /// Default sort order must be size-descending so the first row is "the
+    /// biggest thing on disk you forgot about" — the entire reason the user
+    /// opened this feature.
+    func test_displayedFiles_defaultSortIsSizeDescending() async {
+        let files = [
+            makeFile(name: "small", size: 100, accessDaysAgo: 1, category: .largeFile),
+            makeFile(name: "huge",  size: 10_000, accessDaysAgo: 1, category: .largeFile),
+            makeFile(name: "mid",   size: 1_000, accessDaysAgo: 1, category: .largeFile)
+        ]
+        let vm = makeViewModel(scanner: { files })
+
+        await vm.scan()
+
+        XCTAssertEqual(vm.sortOrder, .sizeDescending)
+        XCTAssertEqual(vm.displayedFiles.map(\.size), [10_000, 1_000, 100])
+    }
+
+    /// Switching to date-ascending must reorder by oldest-access-first. The
+    /// VM does the sort itself (rather than handing a `KeyPathComparator` to
+    /// SwiftUI's `Table`) so the same ordering applies to the selection-set
+    /// helpers and to any future export path.
+    func test_displayedFiles_canSortByLastAccessDateAscending() async {
+        let files = [
+            makeFile(name: "recent",  size: 100, accessDaysAgo: 1,    category: .largeFile),
+            makeFile(name: "ancient", size: 100, accessDaysAgo: 1_000, category: .oldFile),
+            makeFile(name: "mid",     size: 100, accessDaysAgo: 100,  category: .oldFile)
+        ]
+        let vm = makeViewModel(scanner: { files })
+        await vm.scan()
+
+        vm.sortOrder = .dateAscending
+
+        XCTAssertEqual(vm.displayedFiles.map(\.url.lastPathComponent),
+                       ["ancient", "mid", "recent"])
+    }
+
+    /// Files with `nil` access date sort *last* under either date order so
+    /// they don't crowd out the meaningful entries — they're displayed but
+    /// can't be reasoned about by age.
+    func test_displayedFiles_filesWithoutAccessDateSortLast() async {
+        let withDate = makeFile(name: "dated", size: 100, accessDaysAgo: 200, category: .oldFile)
+        let undated = ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-vm/undated"),
+            size: 100,
+            lastAccessDate: nil,
+            lastModifiedDate: nil,
+            category: .largeFile
+        )
+        let vm = makeViewModel(scanner: { [undated, withDate] })
+        await vm.scan()
+
+        vm.sortOrder = .dateAscending
+        XCTAssertEqual(vm.displayedFiles.map(\.url.lastPathComponent), ["dated", "undated"])
+
+        vm.sortOrder = .dateDescending
+        XCTAssertEqual(vm.displayedFiles.map(\.url.lastPathComponent), ["dated", "undated"])
+    }
+
+    // MARK: - Selection
+
+    /// `totalSelectedSize` must reflect only currently-selected URLs and
+    /// update on every toggle — the view binds it to the "Delete N items
+    /// (X.X MB)" footer label.
+    func test_toggleSelection_updatesTotalSelectedSize() async {
+        let a = makeFile(name: "a", size: 100, accessDaysAgo: 1, category: .largeFile)
+        let b = makeFile(name: "b", size: 250, accessDaysAgo: 1, category: .largeFile)
+        let vm = makeViewModel(scanner: { [a, b] })
+        await vm.scan()
+
+        XCTAssertEqual(vm.totalSelectedSize, 0)
+
+        vm.toggleSelection(a)
+        XCTAssertEqual(vm.totalSelectedSize, 100)
+        XCTAssertTrue(vm.isSelected(a))
+
+        vm.toggleSelection(b)
+        XCTAssertEqual(vm.totalSelectedSize, 350)
+
+        vm.toggleSelection(a)
+        XCTAssertEqual(vm.totalSelectedSize, 250)
+        XCTAssertFalse(vm.isSelected(a))
+    }
+
+    // MARK: - Delete
+
+    /// `deleteSelected()` hands the deleter only the currently-selected files
+    /// and drops them from `displayedFiles`. The rest of the list stays put.
+    func test_deleteSelected_removesDeletedFilesFromResults() async {
+        let a = makeFile(name: "a", size: 100, accessDaysAgo: 1, category: .largeFile)
+        let b = makeFile(name: "b", size: 200, accessDaysAgo: 1, category: .largeFile)
+        let c = makeFile(name: "c", size: 300, accessDaysAgo: 1, category: .largeFile)
+        let recorded = ActorBox<[URL]>([])
+        let vm = makeViewModel(
+            scanner: { [a, b, c] },
+            deleter: { urls in
+                await recorded.set(urls)
+                return urls.reduce(into: Set<URL>()) { $0.insert($1) }
+            }
+        )
+
+        await vm.scan()
+        vm.toggleSelection(a)
+        vm.toggleSelection(c)
+
+        await vm.deleteSelected()
+
+        let received = await recorded.value
+        XCTAssertEqual(Set(received), [a.url, c.url])
+        XCTAssertEqual(vm.displayedFiles.map(\.url), [b.url],
+                       "Only the surviving file should remain")
+        XCTAssertTrue(vm.selectedURLs.isEmpty,
+                      "Selection set must clear once the deleted files are gone")
+    }
+
+    /// Deleting the last item must transition to `.empty` so the view drops
+    /// the table for the empty-state copy. Staying on `.results([])` would
+    /// leave the user looking at an empty table with a disabled Delete
+    /// button — no signal that the operation succeeded.
+    func test_deleteSelected_emptyResultsTransitionsToEmpty() async {
+        let only = makeFile(name: "solo", size: 100, accessDaysAgo: 1, category: .largeFile)
+        let vm = makeViewModel(
+            scanner: { [only] },
+            deleter: { Set($0) }
+        )
+        await vm.scan()
+        vm.toggleSelection(only)
+
+        await vm.deleteSelected()
+
+        XCTAssertEqual(vm.phase, .empty)
+    }
+
+    /// A deleter that succeeds for only some files must leave the failures in
+    /// the displayed list — we report what actually happened, not what was
+    /// requested. The deleter contract returns the set of URLs successfully
+    /// removed; the VM trusts that.
+    func test_deleteSelected_keepsFilesThatWereNotDeleted() async {
+        let a = makeFile(name: "a", size: 100, accessDaysAgo: 1, category: .largeFile)
+        let b = makeFile(name: "b", size: 200, accessDaysAgo: 1, category: .largeFile)
+        let vm = makeViewModel(
+            scanner: { [a, b] },
+            deleter: { _ in [a.url] }
+        )
+        await vm.scan()
+        vm.toggleSelection(a)
+        vm.toggleSelection(b)
+
+        await vm.deleteSelected()
+
+        XCTAssertEqual(vm.displayedFiles.map(\.url), [b.url])
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        scanner: @escaping () async throws -> [ScannedFile] = { [] },
+        deleter: @escaping ([URL]) async -> Set<URL> = { Set($0) }
+    ) -> LargeOldFilesViewModel {
+        LargeOldFilesViewModel(scanner: scanner, deleter: deleter)
+    }
+
+    private func makeFile(
+        name: String,
+        size: Int64,
+        accessDaysAgo: Double,
+        category: ScanCategory
+    ) -> ScannedFile {
+        let date = Date().addingTimeInterval(-accessDaysAgo * 86_400)
+        return ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-vm/\(name)"),
+            size: size,
+            lastAccessDate: date,
+            lastModifiedDate: date,
+            category: category
+        )
+    }
+}
+
+/// Same actor-box pattern used in `SystemJunkViewModelTests` — lets the
+/// `@Sendable` deleter closure record the inputs it received without tripping
+/// strict-concurrency warnings.
+private actor ActorBox<Value: Sendable> {
+    private(set) var value: Value
+    init(_ initial: Value) { self.value = initial }
+    func set(_ newValue: Value) { value = newValue }
+}

--- a/todo.md
+++ b/todo.md
@@ -29,7 +29,7 @@
 - [x] **Prompt 12** — File scanner infrastructure (FileScanner, ScanCategory, ScanResult)
 - [x] **Prompt 13** — System Junk scanner (all 8 categories)
 - [x] **Prompt 14** — System Junk UI + deletion (scan → preview → clean flow)
-- [ ] **Prompt 15** — Large & Old Files scanner + UI
+- [x] **Prompt 15** — Large & Old Files scanner + UI
 - [ ] **Prompt 16** — Space Lens disk scanner (DiskNode tree + DiskScanner)
 - [ ] **Prompt 17** — Space Lens treemap UI (squarified treemap + drill-down)
 


### PR DESCRIPTION
## Summary
- Adds `LargeOldFilesScanner` that walks the user's home subtrees and tags each file `.largeFile` (> 50 MB) or `.oldFile` (untouched 6+ months), with an explicit tiebreak that classifies dual-match files as `.largeFile`.
- Adds `LargeOldFilesViewModel` (idle/scanning/results/empty/failed) with an in-VM sort axis, an incremental selection set + total, and `delete(urls:)` / `deleteSelected()` paths used by the footer button and the right-click menu.
- Adds `LargeOldFilesView` — sortable Table with checkbox column, file-icon Name, Size, Last Accessed, Path; toolbar Sort picker; right-click "Show in Finder" / "Delete"; destructive-action confirmation alert. Wires into `ContentView.detailView` and triggers `NotificationThresholdMonitor.triggerLargeFilesFound` once per non-empty scan.

Closes #31

## Test plan
- [x] `xcodebuild test` — 214 unit tests pass (16 new across `LargeOldFilesScannerTests` + `LargeOldFilesViewModelTests`)
- [x] UI tests pass (no regression in `SystemJunkUITests` / app launch)
- [ ] Manual: open Large & Old Files in the app, run a scan, sort columns, toggle checkboxes, confirm Delete prompt, verify selected rows leave the table
- [ ] Manual: right-click a single row → "Show in Finder" / "Delete" (single-row confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large & Old Files view: scan progress, results table (sortable by size/date), empty/failed states, and rescan
  * Select files (per-row or bulk) with total selected size shown; delete selected with confirmation
  * Notifications when a scan finds large files

* **Tests**
  * Added end-to-end and view-model tests covering scanning, sorting, selection, deletion, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->