### PR TITLE
Space Lens disk scanner (DiskNode tree + DiskScanner)

### DIFF
--- a/VaderCleaner/DiskNode.swift
+++ b/VaderCleaner/DiskNode.swift
@@ -1,0 +1,89 @@
+// DiskNode.swift
+// Reference-typed tree node carrying URL, name, byte size, directory flag, accessibility, and children for the Space Lens disk visualization.
+
+import Foundation
+
+/// One node in the disk-tree built by `DiskScanner`. Reference type because
+/// the treemap UI in Prompt 17 navigates the same node graph from multiple
+/// places (breadcrumb stack + currently-rendered tile) and needs identity-
+/// based equality so a re-render doesn't consider two snapshots of the
+/// "same" node distinct.
+///
+/// The node holds no I/O machinery — all enumeration happens in
+/// `DiskScanner` and the result is fixed once a scan finishes. The class
+/// adopts `ObservableObject` so future incremental-scan work (Prompt 17 may
+/// add live-update during a long scan) can republish without touching the
+/// public API.
+///
+/// `size` is always pre-rolled-up by the scanner: a directory's value is
+/// the sum of its descendants. The treemap relies on this so it can size
+/// each tile from a single property read.
+final class DiskNode: Identifiable, ObservableObject {
+
+    /// Stable identity for SwiftUI diffing. Generated per node so two
+    /// scans of the same path produce different IDs — the UI treats them
+    /// as fresh trees, which matches the user's mental model of a "rescan".
+    let id: UUID
+
+    /// Absolute file URL this node represents. Kept so right-click "Show
+    /// in Finder" actions in the upcoming UI can hand the URL to
+    /// `NSWorkspace`.
+    let url: URL
+
+    /// `lastPathComponent`-style display name. Stored separately so the
+    /// scanner can supply a friendlier name for volume roots (e.g.
+    /// "Macintosh HD" instead of "/").
+    let name: String
+
+    /// Bytes occupied. For directories, this is the sum of all
+    /// descendants. For files, the on-disk size returned by
+    /// `URLResourceValues.fileSize`. Inaccessible directories report 0
+    /// because we never enumerated them.
+    let size: Int64
+
+    let isDirectory: Bool
+
+    let children: [DiskNode]
+
+    /// `false` when the scanner could not enumerate this node's contents
+    /// (typically permission denied). Lets the UI render a "locked"
+    /// affordance instead of pretending the directory is empty.
+    let isAccessible: Bool
+
+    init(
+        id: UUID = UUID(),
+        url: URL,
+        name: String,
+        size: Int64,
+        isDirectory: Bool,
+        children: [DiskNode],
+        isAccessible: Bool = true
+    ) {
+        self.id = id
+        self.url = url
+        self.name = name
+        self.size = size
+        self.isDirectory = isDirectory
+        self.children = children
+        self.isAccessible = isAccessible
+    }
+
+    /// Pretty-printed byte count for status labels and tile tooltips.
+    /// `.useAll` lets the formatter pick the most readable unit for any
+    /// magnitude, which is what users expect from a finder-like view.
+    var formattedSize: String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = .useAll
+        formatter.countStyle = .binary
+        return formatter.string(fromByteCount: size)
+    }
+
+    /// This node's share of `parent` as a value in `[0, 1]`. Returns 0
+    /// when the parent reports zero bytes — empty directories hit that
+    /// path naturally and would otherwise produce a NaN that crashes the
+    /// treemap layout.
+    func percentOfParent(_ parent: DiskNode) -> Double {
+        guard parent.size > 0 else { return 0 }
+        return Double(size) / Double(parent.size)
+    }
+}

--- a/VaderCleaner/DiskNode.swift
+++ b/VaderCleaner/DiskNode.swift
@@ -68,14 +68,24 @@ final class DiskNode: Identifiable, ObservableObject {
         self.isAccessible = isAccessible
     }
 
+    /// Shared, pre-configured formatter so each `formattedSize` access
+    /// doesn't pay a fresh `ByteCountFormatter` allocation. The treemap
+    /// in Prompt 17 will call this on every visible tile and tooltip,
+    /// often hundreds of times per render — `ByteCountFormatter` is
+    /// thread-safe for `string(fromByteCount:)` reads, so a single
+    /// instance is the right shape.
+    private static let sizeFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = .useAll
+        formatter.countStyle = .binary
+        return formatter
+    }()
+
     /// Pretty-printed byte count for status labels and tile tooltips.
     /// `.useAll` lets the formatter pick the most readable unit for any
     /// magnitude, which is what users expect from a finder-like view.
     var formattedSize: String {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = .useAll
-        formatter.countStyle = .binary
-        return formatter.string(fromByteCount: size)
+        Self.sizeFormatter.string(fromByteCount: size)
     }
 
     /// This node's share of `parent` as a value in `[0, 1]`. Returns 0

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -12,6 +12,25 @@ protocol DiskScanning {
     func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode
 }
 
+/// Conditions under which a scan can't run at all, as distinct from a
+/// per-file/per-dir permission denial inside the walk (which is
+/// recovered as an inaccessible `DiskNode`). Surfaced so the view-model
+/// can land in `.error` instead of producing a misleading zero-byte
+/// tree that looks like a successful empty scan.
+enum DiskScanError: LocalizedError, Equatable {
+    /// The root URL handed to `scan(root:progress:)` is missing,
+    /// unreadable, or on an unmounted volume. The recursive walker
+    /// can't recover from this — there's no parent to mark inaccessible.
+    case rootInaccessible(URL)
+
+    var errorDescription: String? {
+        switch self {
+        case .rootInaccessible(let url):
+            return "Couldn't read “\(url.lastPathComponent)”. The location may have been moved, deleted, or the volume is unmounted."
+        }
+    }
+}
+
 /// Walks a root URL recursively and returns a `DiskNode` graph whose
 /// directory sizes are bottom-up rollups of every regular file underneath.
 ///
@@ -70,6 +89,18 @@ struct DiskScanner: DiskScanning {
     }
 
     func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode {
+        // Validate the root up front. Inside `buildNode` we `try?`
+        // metadata reads so a single broken descendant doesn't abort
+        // the walk — but at the root, the same forgiveness silently
+        // emits a zero-byte "file" node and the user sees a
+        // successful empty scan. Throw a typed error here so the VM
+        // can render `.error` for missing paths and unmounted volumes.
+        do {
+            _ = try root.resourceValues(forKeys: Self.resourceKeySet)
+        } catch {
+            throw DiskScanError.rootInaccessible(root)
+        }
+
         let counter = FileCounter()
         return try await Self.buildNode(
             at: root,

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -89,6 +89,18 @@ struct DiskScanner: DiskScanning {
     }
 
     func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode {
+        // Resolve symlinks at the root only. macOS exposes `/tmp`,
+        // `/var`, and `/etc` as symlinks to `/private/...`; if the user
+        // picks one as a Space Lens root, the symlink-skip branch
+        // inside the walk would hand back a zero-byte "file" node.
+        // Inside `buildNode` we still skip symlinks unconditionally
+        // (cycle prevention + no double-counting); the asymmetry is
+        // deliberate, the root is the one place where there's no
+        // parent to omit it from. Errors continue to reference the
+        // *original* URL so the user sees the path they actually
+        // selected.
+        let resolvedRoot = root.resolvingSymlinksInPath()
+
         // Validate the root up front. Inside `buildNode` we `try?`
         // metadata reads so a single broken descendant doesn't abort
         // the walk — but at the root, the same forgiveness silently
@@ -96,14 +108,14 @@ struct DiskScanner: DiskScanning {
         // successful empty scan. Throw a typed error here so the VM
         // can render `.error` for missing paths and unmounted volumes.
         do {
-            _ = try root.resourceValues(forKeys: Self.resourceKeySet)
+            _ = try resolvedRoot.resourceValues(forKeys: Self.resourceKeySet)
         } catch {
             throw DiskScanError.rootInaccessible(root)
         }
 
         let counter = FileCounter()
         return try await Self.buildNode(
-            at: root,
+            at: resolvedRoot,
             counter: counter,
             progress: progress,
             isRoot: true

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -105,7 +105,8 @@ struct DiskScanner: DiskScanning {
         return try await Self.buildNode(
             at: root,
             counter: counter,
-            progress: progress
+            progress: progress,
+            isRoot: true
         )
     }
 
@@ -113,6 +114,14 @@ struct DiskScanner: DiskScanning {
     /// every accessible child. Permission errors on the `contentsOfDirectory`
     /// call surface as an inaccessible node so the rest of the walk
     /// continues; per-file metadata errors fall back to zero size.
+    ///
+    /// `isRoot` distinguishes the scan's root call from recursive
+    /// descendant calls. Listing failure on a descendant produces an
+    /// inaccessible node (the parent shows it as a locked child);
+    /// listing failure on the root has nowhere to render — the scan
+    /// would otherwise quietly succeed with a zero-byte tree — so it's
+    /// rethrown as `DiskScanError.rootInaccessible` for the VM to
+    /// route to `.error`.
     ///
     /// Iterative cancellation + cooperative yield at every directory
     /// boundary: `Task.checkCancellation()` lets a freshly-started scan
@@ -125,7 +134,8 @@ struct DiskScanner: DiskScanning {
     private static func buildNode(
         at url: URL,
         counter: FileCounter,
-        progress: @escaping (Int) -> Void
+        progress: @escaping (Int) -> Void,
+        isRoot: Bool = false
     ) async throws -> DiskNode {
         try Task.checkCancellation()
         await Task.yield()
@@ -178,6 +188,15 @@ struct DiskScanner: DiskScanning {
                 options: []
             )
         } catch {
+            // Root listing failure: the chmod-000 / protected-folder
+            // case Codex flagged. `resourceValues` succeeds via stat
+            // through the parent, but the user can't enumerate the
+            // contents — so the scan can't actually run. Fail loudly
+            // rather than emit a single inaccessible node that the VM
+            // would surface as `.ready(emptyTree)`.
+            if isRoot {
+                throw DiskScanError.rootInaccessible(url)
+            }
             log.debug(
                 "Skipping unreadable directory \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
             )

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -1,0 +1,174 @@
+// DiskScanner.swift
+// Recursive disk-tree builder for Space Lens — enumerates a root URL into a DiskNode graph, skips symlinks to avoid cycles, and tolerates permission-denied subdirectories.
+
+import Foundation
+import os.log
+
+/// Protocol surface mostly here for symmetry with `FileScanning`; tests
+/// drive the concrete struct directly via real temp directories rather
+/// than through a fake. Listed so future features (Smart Scan, etc.) can
+/// substitute their own walker if needed.
+protocol DiskScanning {
+    func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode
+}
+
+/// Walks a root URL recursively and returns a `DiskNode` graph whose
+/// directory sizes are bottom-up rollups of every regular file underneath.
+///
+/// Built on `FileManager.contentsOfDirectory(at:...)` rather than
+/// `FileManager.enumerator(at:...)` so we can preserve parent → child
+/// structure (the enumerator returns descendants flat, which is wrong
+/// shape for a treemap) and so we can trap permission errors per
+/// directory instead of for the whole walk.
+///
+/// **Symlink policy** — symlinks are skipped entirely, both file and
+/// directory. Dropping directory symlinks is the only reliable way to
+/// avoid cycles (a single `~/Library` link loop would otherwise spin
+/// forever). Dropping file symlinks is a deliberate consequence of the
+/// same uniform rule: counting them would either double-count (when the
+/// target lives under the same root) or pull external bytes into the
+/// volume's "used space" picture (when it lives outside). Space Lens is
+/// asked "where on this volume are the bytes" — the unique on-disk
+/// content is the right answer.
+///
+/// **Progress** — the callback fires once per regular file processed,
+/// with the running total. The view-model layer is responsible for
+/// translating the count into a 0–1 progress bar; the scanner doesn't
+/// know how many files exist up front (an upfront enumeration pass would
+/// double the wall-clock cost of every scan).
+struct DiskScanner: DiskScanning {
+
+    private static let log = Logger(
+        subsystem: "com.personal.VaderCleaner",
+        category: "DiskScanner"
+    )
+
+    /// Resource keys we ask `URL.resourceValues(forKeys:)` to populate.
+    /// We use logical `.fileSizeKey` rather than allocated size: allocated
+    /// size rounds every file up to the volume block (4 KB on APFS), which
+    /// would cause the treemap to over-report directories full of small
+    /// files. Finder's "Get Info" shows logical size for the same reason —
+    /// matching that mental model is more important here than reporting
+    /// the exact byte count the volume loses to each file.
+    private static let resourceKeys: [URLResourceKey] = [
+        .isRegularFileKey,
+        .isDirectoryKey,
+        .isSymbolicLinkKey,
+        .fileSizeKey,
+        .nameKey
+    ]
+
+    private static let resourceKeySet = Set(resourceKeys)
+
+    func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode {
+        var fileCounter = 0
+        return try Self.buildNode(
+            at: root,
+            counter: &fileCounter,
+            progress: progress
+        )
+    }
+
+    /// Recursive builder. Returns the node for `url`, having recursed into
+    /// every accessible child. Permission errors on the `contentsOfDirectory`
+    /// call surface as an inaccessible node so the rest of the walk
+    /// continues; per-file metadata errors fall back to zero size.
+    ///
+    /// Iterative cancellation check: `Task.checkCancellation()` runs at
+    /// every directory boundary. A user kicking off a fresh scan while
+    /// one is in flight cancels the parent task — without this, the old
+    /// scan would keep churning until the volume was fully walked.
+    private static func buildNode(
+        at url: URL,
+        counter: inout Int,
+        progress: @escaping (Int) -> Void
+    ) throws -> DiskNode {
+        try Task.checkCancellation()
+
+        let resourceValues = try? url.resourceValues(forKeys: resourceKeySet)
+        let name = resourceValues?.name ?? url.lastPathComponent
+        let isSymlink = resourceValues?.isSymbolicLink ?? false
+
+        // The recursion entry point should never receive a symlink — the
+        // parent loop filters them. Defensively short-circuit anyway so a
+        // future caller can't accidentally start a scan at a link.
+        if isSymlink {
+            return DiskNode(
+                url: url,
+                name: name,
+                size: 0,
+                isDirectory: false,
+                children: [],
+                isAccessible: true
+            )
+        }
+
+        let isDirectory = resourceValues?.isDirectory ?? false
+
+        if !isDirectory {
+            // Regular file: logical byte count (see `resourceKeys`
+            // comment) and a single progress tick.
+            let bytes = Int64(resourceValues?.fileSize ?? 0)
+            counter += 1
+            progress(counter)
+            return DiskNode(
+                url: url,
+                name: name,
+                size: bytes,
+                isDirectory: false,
+                children: [],
+                isAccessible: true
+            )
+        }
+
+        // Directory — list its contents; if that throws, surface as
+        // inaccessible and let the parent walk continue.
+        let entries: [URL]
+        do {
+            // No skip flags: dot-prefixed caches and config dirs are part
+            // of the volume's used space and must show up in the treemap.
+            entries = try FileManager.default.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: resourceKeys,
+                options: []
+            )
+        } catch {
+            log.debug(
+                "Skipping unreadable directory \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
+            )
+            return DiskNode(
+                url: url,
+                name: name,
+                size: 0,
+                isDirectory: true,
+                children: [],
+                isAccessible: false
+            )
+        }
+
+        var children: [DiskNode] = []
+        children.reserveCapacity(entries.count)
+        var rolledUpSize: Int64 = 0
+
+        for entry in entries {
+            let entryValues = try? entry.resourceValues(forKeys: resourceKeySet)
+            if entryValues?.isSymbolicLink == true {
+                // Symlinks are skipped wholesale — see the top-of-file
+                // policy note.
+                continue
+            }
+            let child = try buildNode(at: entry, counter: &counter, progress: progress)
+            rolledUpSize += child.size
+            children.append(child)
+        }
+
+        return DiskNode(
+            url: url,
+            name: name,
+            size: rolledUpSize,
+            isDirectory: true,
+            children: children,
+            isAccessible: true
+        )
+    }
+}

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -60,11 +60,20 @@ struct DiskScanner: DiskScanning {
 
     private static let resourceKeySet = Set(resourceKeys)
 
+    /// Reference-typed counter so the recursion can mutate a shared
+    /// running total across `await` suspension points. Swift forbids
+    /// `inout` parameters across `await`, and a class instance threads
+    /// the same value through every recursive call without that
+    /// restriction.
+    private final class FileCounter {
+        var value: Int = 0
+    }
+
     func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode {
-        var fileCounter = 0
-        return try Self.buildNode(
+        let counter = FileCounter()
+        return try await Self.buildNode(
             at: root,
-            counter: &fileCounter,
+            counter: counter,
             progress: progress
         )
     }
@@ -74,16 +83,21 @@ struct DiskScanner: DiskScanning {
     /// call surface as an inaccessible node so the rest of the walk
     /// continues; per-file metadata errors fall back to zero size.
     ///
-    /// Iterative cancellation check: `Task.checkCancellation()` runs at
-    /// every directory boundary. A user kicking off a fresh scan while
-    /// one is in flight cancels the parent task — without this, the old
-    /// scan would keep churning until the volume was fully walked.
+    /// Iterative cancellation + cooperative yield at every directory
+    /// boundary: `Task.checkCancellation()` lets a freshly-started scan
+    /// abort an older one immediately, and `await Task.yield()`
+    /// surrenders the cooperative thread so a multi-million-file walk
+    /// doesn't hold one thread off the pool for the whole scan. The
+    /// yield runs *after* the cancellation check so a cancelled task
+    /// throws right away instead of giving the queue a chance to run
+    /// other ready work first.
     private static func buildNode(
         at url: URL,
-        counter: inout Int,
+        counter: FileCounter,
         progress: @escaping (Int) -> Void
-    ) throws -> DiskNode {
+    ) async throws -> DiskNode {
         try Task.checkCancellation()
+        await Task.yield()
 
         let resourceValues = try? url.resourceValues(forKeys: resourceKeySet)
         let name = resourceValues?.name ?? url.lastPathComponent
@@ -109,8 +123,8 @@ struct DiskScanner: DiskScanning {
             // Regular file: logical byte count (see `resourceKeys`
             // comment) and a single progress tick.
             let bytes = Int64(resourceValues?.fileSize ?? 0)
-            counter += 1
-            progress(counter)
+            counter.value += 1
+            progress(counter.value)
             return DiskNode(
                 url: url,
                 name: name,
@@ -157,7 +171,7 @@ struct DiskScanner: DiskScanning {
                 // policy note.
                 continue
             }
-            let child = try buildNode(at: entry, counter: &counter, progress: progress)
+            let child = try await buildNode(at: entry, counter: counter, progress: progress)
             rolledUpSize += child.size
             children.append(child)
         }

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -76,8 +76,16 @@ final class DiskScannerViewModel: ObservableObject {
     /// avoid. Single-threaded access: `DiskScanner.buildNode` invokes
     /// the closure from one recursive task chain, so no synchronization
     /// is required.
+    ///
+    /// `didScheduleTerminal` latches once the count crosses the
+    /// estimate so a real scan with more files than the default
+    /// estimate (e.g. 1M files on a 250k-file estimate) doesn't keep
+    /// scheduling a Task per file after the bar is already pinned at
+    /// 1.0. Without the latch, every post-estimate file would bypass
+    /// the bucket gate via the `isTerminal` branch.
     private final class ProgressGate {
         var lastScheduledBucket: Int = -1
+        var didScheduleTerminal: Bool = false
     }
 
     /// Monotonically increasing token bumped at the start of every
@@ -167,12 +175,23 @@ final class DiskScannerViewModel: ObservableObject {
         //      progress writes that would otherwise regress a final
         //      `.ready` state back to a fractional value).
         let progressHandler: (Int) -> Void = { [weak self] count in
+            // Once we've already scheduled the terminal 1.0 write, every
+            // subsequent file would still satisfy `isTerminal` and would
+            // bypass the bucket gate. Latch that single-shot event here
+            // so post-estimate files contribute exactly zero scheduled
+            // tasks. (For a 1M-file scan against a 250k estimate that's
+            // 750 000 tasks saved.)
+            if gate.didScheduleTerminal { return }
             let bucket = count / bucketSize
-            // Schedule only when the bucket advances *or* the count has
-            // reached the divisor (terminal — guarantees the bar can
-            // reach 1.0 even when the final file lands mid-bucket).
+            // Treat the *first* crossing to the estimate as terminal —
+            // guarantees the bar reaches 1.0 even when the final file
+            // lands mid-bucket — and remember that we did, so later
+            // files don't schedule again.
             let isTerminal = count >= divisor
             guard isTerminal || bucket > gate.lastScheduledBucket else { return }
+            if isTerminal {
+                gate.didScheduleTerminal = true
+            }
             gate.lastScheduledBucket = bucket
             let fraction = min(1.0, Double(count) / Double(divisor))
             Task { @MainActor [weak self] in

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -64,9 +64,21 @@ final class DiskScannerViewModel: ObservableObject {
     /// actor and starve the UI thread. 0.5% (200 buckets across the 0–1
     /// range) is fine-grained enough that the bar never visibly jumps
     /// while keeping the queued-task count to a couple hundred for the
-    /// largest volumes. The terminal value (`1.0`) and the initial-bump
-    /// case bypass the gate so the bar definitely reaches full.
+    /// largest volumes. The terminal value (`1.0`) bypasses the gate so
+    /// the bar definitely reaches full.
     private static let progressUpdateThreshold: Double = 0.005
+
+    /// Reference-typed bucket tracker so the off-actor progress closure
+    /// can decide *before* hopping to the main actor whether the new
+    /// count crosses the throttle threshold. Without this, the gate ran
+    /// inside the queued main-actor task and we still spawned one
+    /// `Task` per file — the very behaviour the throttle is meant to
+    /// avoid. Single-threaded access: `DiskScanner.buildNode` invokes
+    /// the closure from one recursive task chain, so no synchronization
+    /// is required.
+    private final class ProgressGate {
+        var lastScheduledBucket: Int = -1
+    }
 
     /// Monotonically increasing token bumped at the start of every
     /// `startScan`. Late-arriving progress callbacks and the post-scan
@@ -109,31 +121,41 @@ final class DiskScannerViewModel: ObservableObject {
         navigationPath = []
 
         let divisor = max(1, estimatedFileCount)
+        // Width (in files) of one throttle bucket. With the default
+        // 0.5% threshold and a 250 000-file estimate this is 1 250 —
+        // i.e. at most ~200 main-actor Tasks per scan. `ceil` so the
+        // bucket is at least 1 even for tiny estimates (the test suite
+        // uses divisors of 100 and below).
+        let bucketSize = max(1, Int((Double(divisor) * Self.progressUpdateThreshold).rounded(.up)))
+        let gate = ProgressGate()
 
         // Wrap the synchronous `progress` callback the scanner will fire
-        // off-actor. Each invocation hops to the main actor (so the
-        // `@Published` write is serialized with view reads), but only
-        // applies the new fraction when:
+        // off-actor. The throttle gate runs *here*, before the main-actor
+        // hop, so a 250 000-file scan only ever schedules ~200 Tasks
+        // (one per crossed bucket plus the terminal write). Each
+        // scheduled Task still re-checks generation + phase on the main
+        // actor for two defense-in-depth reasons:
         //
-        //   1. the scan that produced it is still the current one
+        //   1. the scan that produced it must still be the current one
         //      (`scanGeneration` match — guards against concurrent
-        //      `startScan` calls),
-        //   2. the phase is still `.scanning` (guards against late
+        //      `startScan` calls), and
+        //   2. the phase must still be `.scanning` (guards against late
         //      progress writes that would otherwise regress a final
-        //      `.ready` state back to a fractional value),
-        //   3. the fraction has moved at least `progressUpdateThreshold`
-        //      since the last published value, or it's the terminal
-        //      `1.0` (throttle — without this a 250 000-file scan would
-        //      queue 250 000 main-actor tasks).
+        //      `.ready` state back to a fractional value).
         let progressHandler: (Int) -> Void = { [weak self] count in
+            let bucket = count / bucketSize
+            // Schedule only when the bucket advances *or* the count has
+            // reached the divisor (terminal — guarantees the bar can
+            // reach 1.0 even when the final file lands mid-bucket).
+            let isTerminal = count >= divisor
+            guard isTerminal || bucket > gate.lastScheduledBucket else { return }
+            gate.lastScheduledBucket = bucket
             let fraction = min(1.0, Double(count) / Double(divisor))
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 guard self.scanGeneration == myGeneration else { return }
                 guard case .scanning = self.phase else { return }
-                if fraction == 1.0 || fraction >= self.scanProgress + Self.progressUpdateThreshold {
-                    self.scanProgress = fraction
-                }
+                self.scanProgress = fraction
             }
         }
 

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -1,0 +1,150 @@
+// DiskScannerViewModel.swift
+// State machine and progress tracker behind Space Lens — drives idle/scanning/ready/error transitions and clamps the injected scanner's progress callbacks into a 0–1 published value.
+
+import Foundation
+import os.log
+
+/// Drives the Space Lens detail view. Holds the discrete `Phase` the view
+/// switches on, the breadcrumb stack the upcoming treemap UI (Prompt 17)
+/// will push/pop, and the running progress value bound to the in-flight
+/// scan's progress bar.
+///
+/// All collaborators are injected — production wires
+/// `DiskScannerViewModel.live(...)` through `DiskScanner().scan(...)`,
+/// while unit tests inject a closure that returns a synthetic
+/// `DiskNode` and drives the progress callback at controlled points.
+@MainActor
+final class DiskScannerViewModel: ObservableObject {
+
+    /// Type of the injected scan closure. Async + throwing so the
+    /// production wiring can wrap `DiskScanner.scan(root:progress:)` and
+    /// tests can supply an in-memory tree (or throw to exercise the
+    /// failure path). The progress callback is invoked with a running
+    /// file count.
+    typealias Scanner = (URL, @escaping (Int) -> Void) async throws -> DiskNode
+
+    /// Discrete phases the view binds to. Manual `Equatable` because
+    /// `DiskNode` is a class without `Equatable` conformance — the synth
+    /// would compile but test fixtures comparing `.ready(node)` snapshots
+    /// would always disagree. Identity (`===`) is the right semantic
+    /// here: a fresh scan really is a different tree, even if its bytes
+    /// match the previous one.
+    enum Phase {
+        case idle
+        case scanning
+        case ready(DiskNode)
+        case error(String)
+    }
+
+    @Published private(set) var phase: Phase = .idle
+
+    /// 0.0 – 1.0 progress for the currently-running scan. Clamped to 1.0
+    /// so an under-estimated `estimatedFileCount` (typical on volumes
+    /// with more files than the default heuristic) doesn't push the bar
+    /// past full. Resets to 0 when a new scan starts and on `.error`.
+    @Published private(set) var scanProgress: Double = 0
+
+    /// Breadcrumb stack the treemap (Prompt 17) will use to record the
+    /// user's drill-down path. Kept here because the navigation state
+    /// belongs with the scan it's navigating; the helper `drillDown(into:)`
+    /// / `navigateUp()` methods land in Prompt 17 alongside the UI that
+    /// invokes them.
+    @Published var navigationPath: [DiskNode] = []
+
+    /// Convenience accessor used by the upcoming view binding so the
+    /// treemap doesn't have to pattern-match on `phase` to find the root.
+    var root: DiskNode? {
+        if case .ready(let node) = phase { return node }
+        return nil
+    }
+
+    private let scanner: Scanner
+    private let log = Logger(
+        subsystem: "com.personal.VaderCleaner",
+        category: "DiskScannerViewModel"
+    )
+
+    init(scanner: @escaping Scanner) {
+        self.scanner = scanner
+    }
+
+    /// Run the injected scanner against `root`. Transitions to `.scanning`
+    /// up front, then to `.ready(node)` or `.error(message)` depending on
+    /// outcome. The selection / breadcrumb stack is reset because the
+    /// previous tree is no longer valid.
+    ///
+    /// `estimatedFileCount` is the divisor for `scanProgress`. The
+    /// scanner doesn't know the total ahead of time (an upfront walk
+    /// would double the wall-clock cost), so we settle for an estimate
+    /// and clamp the bar at 1.0 once it reaches the ceiling. The bar is
+    /// for the user's sense of motion — actual completion is signaled by
+    /// the phase landing on `.ready`, not by progress hitting 1.0.
+    func startScan(root: URL, estimatedFileCount: Int = 250_000) async {
+        phase = .scanning
+        scanProgress = 0
+        navigationPath = []
+
+        let divisor = max(1, estimatedFileCount)
+
+        // Wrap the synchronous `progress` callback the scanner will fire
+        // off-actor. Hopping each update through a `MainActor` task keeps
+        // `scanProgress` updates serialized — without this hop the
+        // `@Published` write would race with view reads.
+        let progressHandler: (Int) -> Void = { [weak self] count in
+            let fraction = min(1.0, Double(count) / Double(divisor))
+            Task { @MainActor [weak self] in
+                self?.scanProgress = fraction
+            }
+        }
+
+        do {
+            let node = try await scanner(root, progressHandler)
+            // Yield once so any in-flight progress updates the scanner
+            // enqueued via `Task { @MainActor … }` finish applying before
+            // we stamp the final 1.0. Without this, the last fractional
+            // progress write could land *after* our explicit 1.0 below
+            // and leave the bar visibly short of full.
+            await Task.yield()
+            scanProgress = 1.0
+            phase = .ready(node)
+        } catch {
+            log.error("Disk scan failed: \(String(describing: error), privacy: .private(mask: .hash))")
+            scanProgress = 0
+            phase = .error(error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Phase Equatable
+
+/// Manual `Equatable` so the view can use `.onChange(of: phase)` and the
+/// test suite can assert exact matches. `.ready` compares by node
+/// identity (see the `Phase` doc comment); `.error` compares by message.
+extension DiskScannerViewModel.Phase: Equatable {
+    static func == (lhs: DiskScannerViewModel.Phase, rhs: DiskScannerViewModel.Phase) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.scanning, .scanning):
+            return true
+        case let (.ready(l), .ready(r)):
+            return l === r
+        case let (.error(l), .error(r)):
+            return l == r
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - Production wiring
+
+extension DiskScannerViewModel {
+
+    /// Build a view-model wired to the real `DiskScanner`. Mirrors the
+    /// `LargeOldFilesViewModel.live(...)` pattern.
+    @MainActor
+    static func live() -> DiskScannerViewModel {
+        DiskScannerViewModel(scanner: { url, progress in
+            try await DiskScanner().scan(root: url, progress: progress)
+        })
+    }
+}

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -91,6 +91,15 @@ final class DiskScannerViewModel: ObservableObject {
     /// `.ready` / `.error` / `.idle`.
     private var scanGeneration: Int = 0
 
+    /// Handle on the currently-running scan so a fresh `startScan`
+    /// (rescan, root switch) can actually cancel the previous walk
+    /// instead of just ignoring its eventual writes. Without this the
+    /// generation guard kept the UI consistent but `DiskScanner` kept
+    /// reading the entire disk in the background, doubling I/O during
+    /// the overlap window. `Task.checkCancellation()` inside
+    /// `buildNode` honors the cancel at every directory boundary.
+    private var currentScanTask: Task<Void, Never>?
+
     private let scanner: Scanner
     private let log = Logger(
         subsystem: "com.personal.VaderCleaner",
@@ -99,6 +108,14 @@ final class DiskScannerViewModel: ObservableObject {
 
     init(scanner: @escaping Scanner) {
         self.scanner = scanner
+    }
+
+    /// Cancel any in-flight walk if the view-model is torn down while a
+    /// scan is running (e.g. the user dismisses Space Lens mid-scan).
+    /// `Task.cancel()` is `Sendable`-safe so this is fine to call from a
+    /// non-isolated deinit on a `@MainActor` class.
+    deinit {
+        currentScanTask?.cancel()
     }
 
     /// Run the injected scanner against `root`. Transitions to `.scanning`
@@ -113,6 +130,13 @@ final class DiskScannerViewModel: ObservableObject {
     /// for the user's sense of motion — actual completion is signaled by
     /// the phase landing on `.ready`, not by progress hitting 1.0.
     func startScan(root: URL, estimatedFileCount: Int = 250_000) async {
+        // Cancel any walk still in flight from a previous startScan.
+        // Cancellation is cooperative — `DiskScanner.buildNode` checks
+        // it at every directory boundary and throws `CancellationError`,
+        // which the previous Task's catch handler swallows (and the
+        // generation guard below ensures it can't clobber our state).
+        currentScanTask?.cancel()
+
         scanGeneration += 1
         let myGeneration = scanGeneration
 
@@ -159,28 +183,44 @@ final class DiskScannerViewModel: ObservableObject {
             }
         }
 
-        do {
-            let node = try await scanner(root, progressHandler)
-            // Generation-guard the terminal write so a stale scan that
-            // resumes after a newer one has started doesn't clobber the
-            // newer scan's `.scanning` (or `.ready`) state.
-            guard scanGeneration == myGeneration else { return }
-            scanProgress = 1.0
-            phase = .ready(node)
-        } catch is CancellationError {
-            // A cancellation is a clean dismissal — the user (or a fresh
-            // scan) chose to stop the in-flight walk. Surfacing this as
-            // `.error("The operation couldn't be completed…")` would
-            // misrepresent it as a failure in the upcoming UI.
-            guard scanGeneration == myGeneration else { return }
-            scanProgress = 0
-            phase = .idle
-        } catch {
-            guard scanGeneration == myGeneration else { return }
-            log.error("Disk scan failed: \(String(describing: error), privacy: .private(mask: .hash))")
-            scanProgress = 0
-            phase = .error(error.localizedDescription)
+        // Wrap the scan in a Task we can hold onto, so a future
+        // `startScan` (rescan / root switch) can call `cancel()` on
+        // it and break out of `DiskScanner.buildNode`. `[weak self]`
+        // because the Task's lifetime is bounded by the scan itself,
+        // not by the VM — without it, dismissing Space Lens mid-scan
+        // would keep the VM alive until the walk finished.
+        let task: Task<Void, Never> = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let node = try await self.scanner(root, progressHandler)
+                // Generation-guard the terminal write so a stale scan
+                // that resumes after a newer one has started doesn't
+                // clobber the newer scan's `.scanning` / `.ready` state.
+                guard self.scanGeneration == myGeneration else { return }
+                self.scanProgress = 1.0
+                self.phase = .ready(node)
+            } catch is CancellationError {
+                // A cancellation is a clean dismissal — the user (or a
+                // fresh scan) chose to stop the in-flight walk.
+                // Surfacing this as `.error("The operation couldn't be
+                // completed…")` would misrepresent it as a failure.
+                guard self.scanGeneration == myGeneration else { return }
+                self.scanProgress = 0
+                self.phase = .idle
+            } catch {
+                guard self.scanGeneration == myGeneration else { return }
+                self.log.error("Disk scan failed: \(String(describing: error), privacy: .private(mask: .hash))")
+                self.scanProgress = 0
+                self.phase = .error(error.localizedDescription)
+            }
         }
+        currentScanTask = task
+        // Suspend until *this* scan finishes so callers `await
+        // vm.startScan(...)` still observe the terminal state on
+        // return. The previous (cancelled) task continues winding
+        // down in parallel; its catch handler drops its writes via
+        // the generation guard.
+        await task.value
     }
 }
 

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -239,7 +239,18 @@ final class DiskScannerViewModel: ObservableObject {
         // return. The previous (cancelled) task continues winding
         // down in parallel; its catch handler drops its writes via
         // the generation guard.
-        await task.value
+        //
+        // The cancellation handler forwards caller-side cancellation
+        // to the unstructured scan task — without it, a SwiftUI
+        // `.task` torn down on view dismissal would leave the disk
+        // walk running. `deinit` can't rescue us here because this
+        // `await` keeps `self` alive; the only way out is to cancel
+        // the inner task explicitly when the caller is cancelled.
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 }
 

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -58,6 +58,27 @@ final class DiskScannerViewModel: ObservableObject {
         return nil
     }
 
+    /// Smallest fractional change worth republishing. A real-volume scan
+    /// can fire the progress callback hundreds of thousands of times;
+    /// without this gate every call would queue a `Task` on the main
+    /// actor and starve the UI thread. 0.5% (200 buckets across the 0–1
+    /// range) is fine-grained enough that the bar never visibly jumps
+    /// while keeping the queued-task count to a couple hundred for the
+    /// largest volumes. The terminal value (`1.0`) and the initial-bump
+    /// case bypass the gate so the bar definitely reaches full.
+    private static let progressUpdateThreshold: Double = 0.005
+
+    /// Monotonically increasing token bumped at the start of every
+    /// `startScan`. Late-arriving progress callbacks and the post-scan
+    /// final-state assignment both compare against the value captured at
+    /// the start of *their* scan; a mismatch means a newer scan has
+    /// already started, so the older one's writes are dropped on the
+    /// floor. Pairs with the `.scanning` phase guard for defense in
+    /// depth — the generation token catches concurrent restarts, the
+    /// phase guard catches in-flight progress callbacks that land after
+    /// `.ready` / `.error` / `.idle`.
+    private var scanGeneration: Int = 0
+
     private let scanner: Scanner
     private let log = Logger(
         subsystem: "com.personal.VaderCleaner",
@@ -80,6 +101,9 @@ final class DiskScannerViewModel: ObservableObject {
     /// for the user's sense of motion — actual completion is signaled by
     /// the phase landing on `.ready`, not by progress hitting 1.0.
     func startScan(root: URL, estimatedFileCount: Int = 250_000) async {
+        scanGeneration += 1
+        let myGeneration = scanGeneration
+
         phase = .scanning
         scanProgress = 0
         navigationPath = []
@@ -87,27 +111,50 @@ final class DiskScannerViewModel: ObservableObject {
         let divisor = max(1, estimatedFileCount)
 
         // Wrap the synchronous `progress` callback the scanner will fire
-        // off-actor. Hopping each update through a `MainActor` task keeps
-        // `scanProgress` updates serialized — without this hop the
-        // `@Published` write would race with view reads.
+        // off-actor. Each invocation hops to the main actor (so the
+        // `@Published` write is serialized with view reads), but only
+        // applies the new fraction when:
+        //
+        //   1. the scan that produced it is still the current one
+        //      (`scanGeneration` match — guards against concurrent
+        //      `startScan` calls),
+        //   2. the phase is still `.scanning` (guards against late
+        //      progress writes that would otherwise regress a final
+        //      `.ready` state back to a fractional value),
+        //   3. the fraction has moved at least `progressUpdateThreshold`
+        //      since the last published value, or it's the terminal
+        //      `1.0` (throttle — without this a 250 000-file scan would
+        //      queue 250 000 main-actor tasks).
         let progressHandler: (Int) -> Void = { [weak self] count in
             let fraction = min(1.0, Double(count) / Double(divisor))
             Task { @MainActor [weak self] in
-                self?.scanProgress = fraction
+                guard let self else { return }
+                guard self.scanGeneration == myGeneration else { return }
+                guard case .scanning = self.phase else { return }
+                if fraction == 1.0 || fraction >= self.scanProgress + Self.progressUpdateThreshold {
+                    self.scanProgress = fraction
+                }
             }
         }
 
         do {
             let node = try await scanner(root, progressHandler)
-            // Yield once so any in-flight progress updates the scanner
-            // enqueued via `Task { @MainActor … }` finish applying before
-            // we stamp the final 1.0. Without this, the last fractional
-            // progress write could land *after* our explicit 1.0 below
-            // and leave the bar visibly short of full.
-            await Task.yield()
+            // Generation-guard the terminal write so a stale scan that
+            // resumes after a newer one has started doesn't clobber the
+            // newer scan's `.scanning` (or `.ready`) state.
+            guard scanGeneration == myGeneration else { return }
             scanProgress = 1.0
             phase = .ready(node)
+        } catch is CancellationError {
+            // A cancellation is a clean dismissal — the user (or a fresh
+            // scan) chose to stop the in-flight walk. Surfacing this as
+            // `.error("The operation couldn't be completed…")` would
+            // misrepresent it as a failure in the upcoming UI.
+            guard scanGeneration == myGeneration else { return }
+            scanProgress = 0
+            phase = .idle
         } catch {
+            guard scanGeneration == myGeneration else { return }
             log.error("Disk scan failed: \(String(describing: error), privacy: .private(mask: .hash))")
             scanProgress = 0
             phase = .error(error.localizedDescription)

--- a/VaderCleanerTests/DiskNodeTests.swift
+++ b/VaderCleanerTests/DiskNodeTests.swift
@@ -1,0 +1,97 @@
+// DiskNodeTests.swift
+// Locks DiskNode's directory size = sum of children invariant and the percent-of-parent helper, including the parent-size-zero guard.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Unit tests for `DiskNode`. The node type is pure data — it does no I/O —
+/// so these tests build trees by hand. Disk-walking behaviour lives in
+/// `DiskScannerTests`.
+final class DiskNodeTests: XCTestCase {
+
+    // MARK: - Size rollup
+
+    /// A directory's `size` must equal the sum of its children's sizes,
+    /// recursively. The treemap UI in Prompt 17 reads this rolled-up value
+    /// to size each tile, so any drift between the stored size and the
+    /// actual contents would render the visualization wrong.
+    func test_size_isSumOfChildrenForDirectory() {
+        let leafA = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/a.bin"),
+            name: "a.bin",
+            size: 32,
+            isDirectory: false,
+            children: []
+        )
+        let leafB = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/b.bin"),
+            name: "b.bin",
+            size: 64,
+            isDirectory: false,
+            children: []
+        )
+        let nestedDir = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/nested"),
+            name: "nested",
+            size: 64,
+            isDirectory: true,
+            children: [leafB]
+        )
+        let parent = DiskNode(
+            url: URL(fileURLWithPath: "/tmp"),
+            name: "tmp",
+            size: 96, // 32 + 64
+            isDirectory: true,
+            children: [leafA, nestedDir]
+        )
+
+        XCTAssertEqual(parent.size, leafA.size + nestedDir.size)
+        XCTAssertEqual(nestedDir.size, leafB.size)
+    }
+
+    // MARK: - percentOfParent
+
+    /// `percentOfParent` returns the child's share of the parent as a value
+    /// in [0, 1]. Used by the treemap to decide which tiles are visible at
+    /// a given zoom level.
+    func test_percentOfParent_returnsRatioOfChildToParent() {
+        let parent = DiskNode(
+            url: URL(fileURLWithPath: "/tmp"),
+            name: "tmp",
+            size: 1000,
+            isDirectory: true,
+            children: []
+        )
+        let child = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/a.bin"),
+            name: "a.bin",
+            size: 250,
+            isDirectory: false,
+            children: []
+        )
+
+        XCTAssertEqual(child.percentOfParent(parent), 0.25, accuracy: 0.0001)
+    }
+
+    /// When the parent reports zero bytes, the ratio is undefined; the
+    /// helper must return 0 rather than divide-by-zero. Empty directories
+    /// (no contents) hit this naturally and would otherwise crash the UI.
+    func test_percentOfParent_returnsZeroWhenParentSizeIsZero() {
+        let parent = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/empty"),
+            name: "empty",
+            size: 0,
+            isDirectory: true,
+            children: []
+        )
+        let child = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/empty/a.bin"),
+            name: "a.bin",
+            size: 0,
+            isDirectory: false,
+            children: []
+        )
+
+        XCTAssertEqual(child.percentOfParent(parent), 0)
+    }
+}

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -1,0 +1,171 @@
+// DiskScannerTests.swift
+// Drives DiskScanner against real temp directories to verify tree shape, size aggregation, symlink avoidance, permission tolerance, and progress reporting.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Integration tests for `DiskScanner`. We use real temp directories rather
+/// than a mock file system because the scanner's whole job is to read what's
+/// actually on disk — mocking `FileManager` would test the mock, not the
+/// behaviour we ship.
+final class DiskScannerTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tree shape and size aggregation
+
+    /// A nested fixture (`a/1.bin` (32B) + `a/b/2.bin` (64B)) must produce a
+    /// tree where every directory's reported size equals the sum of its
+    /// descendants' sizes, and the leaves carry their on-disk byte count.
+    /// This locks both the recursion shape and the bottom-up rollup.
+    func test_scan_buildsCorrectTreeForKnownDirectory() async throws {
+        let aDir = tempRoot.appendingPathComponent("a", isDirectory: true)
+        let bDir = aDir.appendingPathComponent("b", isDirectory: true)
+        try FileManager.default.createDirectory(at: bDir, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "1.bin", size: 32, in: aDir)
+        try TestHelpers.createDummyFile(named: "2.bin", size: 64, in: bDir)
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(root: tempRoot, progress: { _ in })
+
+        // Root's only child should be `a`.
+        XCTAssertTrue(root.isDirectory)
+        XCTAssertEqual(root.children.count, 1)
+        let aNode = try XCTUnwrap(root.children.first { $0.name == "a" })
+        XCTAssertTrue(aNode.isDirectory)
+
+        // `a` has one file (32B) and one subdir.
+        let oneBin = try XCTUnwrap(aNode.children.first { $0.name == "1.bin" })
+        XCTAssertFalse(oneBin.isDirectory)
+        XCTAssertEqual(oneBin.size, 32)
+
+        let bNode = try XCTUnwrap(aNode.children.first { $0.name == "b" })
+        XCTAssertTrue(bNode.isDirectory)
+
+        let twoBin = try XCTUnwrap(bNode.children.first { $0.name == "2.bin" })
+        XCTAssertEqual(twoBin.size, 64)
+
+        // Rollup: b = 64, a = 32 + 64 = 96, root = 96.
+        XCTAssertEqual(bNode.size, 64)
+        XCTAssertEqual(aNode.size, 96)
+        XCTAssertEqual(root.size, 96)
+    }
+
+    // MARK: - Symlink handling
+
+    /// A symlink whose target is the scan's own root would cause infinite
+    /// recursion if followed. The scanner must complete and the link's
+    /// target contents must not appear under the link's path.
+    ///
+    /// Policy note: this test deliberately uses a directory symlink. The
+    /// scanner's documented behaviour is to skip *all* symlinks (file and
+    /// directory) — see `DiskScanner` for the rationale. Locking the
+    /// directory case here covers the cycle-prevention guarantee that the
+    /// prompt explicitly calls out.
+    func test_scan_doesNotFollowSymlinksAndAvoidsCycles() async throws {
+        let realDir = tempRoot.appendingPathComponent("real", isDirectory: true)
+        try FileManager.default.createDirectory(at: realDir, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "leaf.bin", size: 16, in: realDir)
+
+        // Cycle: tempRoot/real/loopback -> tempRoot
+        let loopback = realDir.appendingPathComponent("loopback")
+        try FileManager.default.createSymbolicLink(at: loopback, withDestinationURL: tempRoot)
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(root: tempRoot, progress: { _ in })
+
+        let realNode = try XCTUnwrap(root.children.first { $0.name == "real" })
+        // Only the leaf file should appear; the symlink is skipped entirely
+        // (not followed and not added as a stub).
+        let names = realNode.children.map(\.name).sorted()
+        XCTAssertEqual(names, ["leaf.bin"])
+        XCTAssertEqual(realNode.size, 16)
+    }
+
+    // MARK: - Permission denied
+
+    /// A subdirectory the current user cannot read must surface as a node
+    /// with `isAccessible == false` and `size == 0`, and the scan of its
+    /// peers must continue. Without this, one locked Library subfolder
+    /// would abort the whole volume scan.
+    ///
+    /// Skipped when the current process can still read a `chmod 000`
+    /// directory (e.g. running as root inside a CI container) — the test
+    /// would fail spuriously and the behaviour is unobservable in that
+    /// environment.
+    func test_scan_marksPermissionDeniedDirectoriesAsInaccessible() async throws {
+        let readable = tempRoot.appendingPathComponent("readable", isDirectory: true)
+        let locked = tempRoot.appendingPathComponent("locked", isDirectory: true)
+        try FileManager.default.createDirectory(at: readable, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: locked, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "open.bin", size: 8, in: readable)
+        try TestHelpers.createDummyFile(named: "secret.bin", size: 999, in: locked)
+
+        // Restore permissions in a defer so teardown can actually delete the
+        // temp tree — `try?` removal on a chmod 000 directory silently fails.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o000))],
+            ofItemAtPath: locked.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o755))],
+                ofItemAtPath: locked.path
+            )
+        }
+
+        // Confirm the precondition: this process actually cannot read the
+        // locked directory. If it can (root, weird sandbox), the assertion
+        // we want to make is unobservable.
+        let canStillRead = (try? FileManager.default.contentsOfDirectory(atPath: locked.path)) != nil
+        try XCTSkipIf(canStillRead, "Current process can read chmod 000 directories — cannot exercise the deny path here.")
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(root: tempRoot, progress: { _ in })
+
+        let readableNode = try XCTUnwrap(root.children.first { $0.name == "readable" })
+        XCTAssertEqual(readableNode.size, 8, "Sibling enumeration must continue after a permission failure")
+
+        let lockedNode = try XCTUnwrap(root.children.first { $0.name == "locked" })
+        XCTAssertFalse(lockedNode.isAccessible, "A directory we couldn't read must be marked inaccessible")
+        XCTAssertEqual(lockedNode.size, 0, "Inaccessible directories report zero bytes — we never enumerated them")
+        XCTAssertTrue(lockedNode.children.isEmpty)
+    }
+
+    // MARK: - Progress
+
+    /// The scanner must invoke its progress callback as it processes files,
+    /// with a monotonically non-decreasing count, and the final count must
+    /// equal the total number of regular files in the fixture. The Space
+    /// Lens UI uses this to drive its progress bar.
+    func test_scan_reportsProgressAsItScans() async throws {
+        let fileCount = 5
+        try TestHelpers.createDummyFiles(count: fileCount, size: 16, in: tempRoot)
+
+        var observed: [Int] = []
+        let scanner = DiskScanner()
+        _ = try await scanner.scan(root: tempRoot, progress: { count in
+            observed.append(count)
+        })
+
+        XCTAssertFalse(observed.isEmpty, "Progress callback must be invoked at least once")
+        XCTAssertEqual(observed.last, fileCount, "Final progress count should equal the regular-file count")
+        // Monotonic non-decreasing.
+        for (lhs, rhs) in zip(observed, observed.dropFirst()) {
+            XCTAssertLessThanOrEqual(lhs, rhs, "Progress counts must never decrease")
+        }
+    }
+}

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -147,6 +147,47 @@ final class DiskScannerTests: XCTestCase {
 
     // MARK: - Missing root
 
+    /// A root that exists *and* has readable metadata (so the upfront
+    /// `resourceValues` validation passes) but whose contents the user
+    /// can't enumerate — `chmod 000`, sandbox-protected folders, certain
+    /// volume-root permission denials — must throw rather than emit a
+    /// single inaccessible node. There is no parent to render the locked
+    /// state, so the VM would otherwise land in `.ready(emptyTree)` and
+    /// the upcoming UI would lie that the scan succeeded.
+    ///
+    /// Skipped when the current process can read `chmod 000` directories
+    /// (root in a CI container, etc.); same gating as the descendant
+    /// permission test.
+    func test_scan_throwsWhenRootIsUnreadable() async throws {
+        let unreadableRoot = tempRoot.appendingPathComponent("locked-root", isDirectory: true)
+        try FileManager.default.createDirectory(at: unreadableRoot, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "secret.bin", size: 8, in: unreadableRoot)
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o000))],
+            ofItemAtPath: unreadableRoot.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o755))],
+                ofItemAtPath: unreadableRoot.path
+            )
+        }
+
+        let canStillRead = (try? FileManager.default.contentsOfDirectory(atPath: unreadableRoot.path)) != nil
+        try XCTSkipIf(canStillRead, "Current process can read chmod 000 directories — cannot exercise the deny path here.")
+
+        let scanner = DiskScanner()
+        do {
+            _ = try await scanner.scan(root: unreadableRoot, progress: { _ in })
+            XCTFail("Expected scan to throw for an unreadable root")
+        } catch let error as DiskScanError {
+            XCTAssertEqual(error, .rootInaccessible(unreadableRoot))
+        } catch {
+            XCTFail("Expected DiskScanError.rootInaccessible, got \(error)")
+        }
+    }
+
     /// A root URL that doesn't exist (deleted directory, unmounted
     /// volume) must surface as a thrown `DiskScanError.rootInaccessible`
     /// rather than a successful empty `DiskNode`. Without this guarantee

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -145,6 +145,31 @@ final class DiskScannerTests: XCTestCase {
         XCTAssertTrue(lockedNode.children.isEmpty)
     }
 
+    // MARK: - Symlinked root
+
+    /// macOS exposes `/tmp`, `/var`, and `/etc` as symlinks to
+    /// `/private/...`. If the user starts Space Lens at one of those
+    /// (or at any user-created directory symlink they think of as
+    /// "the folder"), we must scan the *target*, not return a single
+    /// zero-byte file node. Inside the walk we still skip symlinks
+    /// (cycle prevention + no double-counting) — this asserts the
+    /// asymmetry at the root is real and verified.
+    func test_scan_resolvesSymlinkedRootToTarget() async throws {
+        let target = tempRoot.appendingPathComponent("target", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "leaf.bin", size: 16, in: target)
+
+        let symlinkRoot = tempRoot.appendingPathComponent("link", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: symlinkRoot, withDestinationURL: target)
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(root: symlinkRoot, progress: { _ in })
+
+        XCTAssertTrue(root.isDirectory, "Resolved root should be treated as a directory, not a symlink leaf")
+        XCTAssertEqual(root.size, 16, "Tree must reflect the target's contents, not 0 bytes")
+        XCTAssertEqual(root.children.map(\.name).sorted(), ["leaf.bin"])
+    }
+
     // MARK: - Missing root
 
     /// A root that exists *and* has readable metadata (so the upfront

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -145,6 +145,28 @@ final class DiskScannerTests: XCTestCase {
         XCTAssertTrue(lockedNode.children.isEmpty)
     }
 
+    // MARK: - Missing root
+
+    /// A root URL that doesn't exist (deleted directory, unmounted
+    /// volume) must surface as a thrown `DiskScanError.rootInaccessible`
+    /// rather than a successful empty `DiskNode`. Without this guarantee
+    /// the upcoming UI would render a zero-byte tree as a "scan
+    /// finished, nothing here" state instead of letting the user know
+    /// the scan couldn't run.
+    func test_scan_throwsWhenRootIsMissing() async {
+        let missingRoot = tempRoot.appendingPathComponent("does-not-exist", isDirectory: true)
+        let scanner = DiskScanner()
+
+        do {
+            _ = try await scanner.scan(root: missingRoot, progress: { _ in })
+            XCTFail("Expected scan to throw for a missing root")
+        } catch let error as DiskScanError {
+            XCTAssertEqual(error, .rootInaccessible(missingRoot))
+        } catch {
+            XCTFail("Expected DiskScanError.rootInaccessible, got \(error)")
+        }
+    }
+
     // MARK: - Progress
 
     /// The scanner must invoke its progress callback as it processes files,

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -62,9 +62,18 @@ final class DiskScannerViewModelTests: XCTestCase {
     // MARK: - Progress
 
     /// The injected progress callback must drive `scanProgress` toward 1.0
-    /// as the count climbs. Locks the divisor (estimated file count) and
-    /// the clamp at 1.0 — counts above the estimate must not push the bar
-    /// past full.
+    /// as the count climbs. Locks the divisor (estimated file count), the
+    /// clamp at 1.0 (counts above the estimate must not push past full),
+    /// and the throttle bypass for the terminal value.
+    ///
+    /// `await Task.yield()` between progress calls is deliberate: the VM
+    /// hops every published update through `Task { @MainActor … }` so
+    /// the writes serialize with view reads. In production the scanner
+    /// runs off-actor and naturally yields between tree directories; the
+    /// test mirrors that pacing so each queued main-actor write applies
+    /// while the phase is still `.scanning`. Without yields the writes
+    /// would all queue, then bail on the post-scan phase guard, and the
+    /// test would only see the explicit final 1.0.
     func test_startScan_updatesScanProgressFromCallback() async {
         let synthetic = DiskNode(
             url: URL(fileURLWithPath: "/tmp"),
@@ -76,8 +85,11 @@ final class DiskScannerViewModelTests: XCTestCase {
         var observed: [Double] = []
         let vm = DiskScannerViewModel(scanner: { _, progress in
             progress(10)   // 10% of 100
+            await Task.yield()
             progress(50)   // 50% of 100
+            await Task.yield()
             progress(150)  // > 100 → clamped to 1.0
+            await Task.yield()
             return synthetic
         })
 
@@ -95,5 +107,23 @@ final class DiskScannerViewModelTests: XCTestCase {
                       "scanProgress must never exceed 1.0")
         // Final value (post-scan) is 1.0.
         XCTAssertEqual(vm.scanProgress, 1.0)
+    }
+
+    // MARK: - Cancellation
+
+    /// A `CancellationError` is a clean dismissal (a fresh scan replaced
+    /// this one, or the user navigated away), not a failure. The VM must
+    /// route it back to `.idle` rather than `.error("The operation
+    /// couldn't be completed…")`, which the upcoming UI would render as
+    /// a scan failure banner.
+    func test_startScan_treatsCancellationErrorAsCleanDismissal() async {
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            throw CancellationError()
+        })
+
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+
+        XCTAssertEqual(vm.phase, .idle, "Cancellation should land back in .idle, not .error")
+        XCTAssertEqual(vm.scanProgress, 0.0)
     }
 }

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -1,0 +1,99 @@
+// DiskScannerViewModelTests.swift
+// Verifies DiskScannerViewModel's state machine (.idle → .scanning → .ready / .error) and that injected progress callbacks update scanProgress on the main actor.
+
+import XCTest
+import Combine
+@testable import VaderCleaner
+
+/// Drives `DiskScannerViewModel` against an injected scanner closure so the
+/// transitions can be exercised without touching the real filesystem. The
+/// closure also lets us drive the progress callback at controlled points
+/// to lock the threading contract on `scanProgress`.
+@MainActor
+final class DiskScannerViewModelTests: XCTestCase {
+
+    // MARK: - Happy path
+
+    /// A successful scan must transition `.idle → .scanning → .ready(node)`
+    /// and surface the produced root via `phase`. `scanProgress` lands at
+    /// 1.0 once the scan is finished.
+    func test_startScan_transitionsToReadyOnSuccess() async {
+        let synthetic = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root"),
+            name: "root",
+            size: 100,
+            isDirectory: true,
+            children: []
+        )
+        let vm = DiskScannerViewModel(scanner: { _, progress in
+            // Drive progress mid-scan so the test also pins the in-flight
+            // value path through the VM.
+            progress(50)
+            return synthetic
+        })
+
+        XCTAssertEqual(vm.phase, .idle)
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 100)
+
+        XCTAssertEqual(vm.phase, .ready(synthetic))
+        XCTAssertEqual(vm.scanProgress, 1.0)
+    }
+
+    // MARK: - Failure path
+
+    /// An error thrown by the injected scanner must surface as `.error`
+    /// carrying the localized description so the view can render it. The
+    /// `scanProgress` value is reset back to 0 — leaving the bar
+    /// half-full would lie about state.
+    func test_startScan_transitionsToErrorOnThrow() async {
+        struct ScanFailure: LocalizedError {
+            var errorDescription: String? { "boom" }
+        }
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            throw ScanFailure()
+        })
+
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+
+        XCTAssertEqual(vm.phase, .error("boom"))
+        XCTAssertEqual(vm.scanProgress, 0.0)
+    }
+
+    // MARK: - Progress
+
+    /// The injected progress callback must drive `scanProgress` toward 1.0
+    /// as the count climbs. Locks the divisor (estimated file count) and
+    /// the clamp at 1.0 — counts above the estimate must not push the bar
+    /// past full.
+    func test_startScan_updatesScanProgressFromCallback() async {
+        let synthetic = DiskNode(
+            url: URL(fileURLWithPath: "/tmp"),
+            name: "tmp",
+            size: 0,
+            isDirectory: true,
+            children: []
+        )
+        var observed: [Double] = []
+        let vm = DiskScannerViewModel(scanner: { _, progress in
+            progress(10)   // 10% of 100
+            progress(50)   // 50% of 100
+            progress(150)  // > 100 → clamped to 1.0
+            return synthetic
+        })
+
+        // Snapshot scanProgress every time the published value changes.
+        let cancellable = vm.$scanProgress.sink { observed.append($0) }
+        defer { cancellable.cancel() }
+
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 100)
+
+        // Progress callback must have produced at least one value strictly
+        // between 0 and 1 during the scan, never exceeding 1.0.
+        XCTAssertTrue(observed.contains { $0 > 0 && $0 < 1 },
+                      "scanProgress should report intermediate values during a scan")
+        XCTAssertTrue(observed.allSatisfy { $0 <= 1.0 },
+                      "scanProgress must never exceed 1.0")
+        // Final value (post-scan) is 1.0.
+        XCTAssertEqual(vm.scanProgress, 1.0)
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -30,7 +30,7 @@
 - [x] **Prompt 13** — System Junk scanner (all 8 categories)
 - [x] **Prompt 14** — System Junk UI + deletion (scan → preview → clean flow)
 - [x] **Prompt 15** — Large & Old Files scanner + UI
-- [ ] **Prompt 16** — Space Lens disk scanner (DiskNode tree + DiskScanner)
+- [x] **Prompt 16** — Space Lens disk scanner (DiskNode tree + DiskScanner)
 - [ ] **Prompt 17** — Space Lens treemap UI (squarified treemap + drill-down)
 
 ## Phase 3 — Privacy & Apps


### PR DESCRIPTION
## Summary
- Adds the Space Lens data layer behind the upcoming treemap UI: `DiskNode` (reference-typed tree with bottom-up size rollup), `DiskScanner` (recursive walker that skips symlinks, tolerates permission denials, and reports progress), and `DiskScannerViewModel` (`@MainActor` state machine with clamped 0–1 progress).
- Symlink policy: skip all symlinks (file *and* directory) — only reliable way to avoid cycles, and the right answer for "where on this volume are the bytes." Documented inline.
- Permission-denied subdirectories surface as `isAccessible == false` nodes (`size = 0`) so the rest of the scan continues. UI in Prompt 17 can show a locked affordance.
- Logical file size (`.fileSizeKey`), not allocated size — matches Finder's "Get Info" and avoids over-reporting directories of small files (APFS rounds to 4 KB blocks).

Closes #34.

## Test plan
- [x] `xcodebuild test -only-testing:VaderCleanerTests` (225 tests, all green)
- [x] New `DiskNodeTests` (3): size rollup invariant, percentOfParent ratio + zero-parent guard
- [x] New `DiskScannerTests` (4): tree shape + size aggregation, symlink cycle avoidance, permission-denied tolerance (`XCTSkipIf` when chmod 000 is bypassable, e.g. CI as root), progress callback monotonicity
- [x] New `DiskScannerViewModelTests` (3): `.idle → .scanning → .ready` happy path, `.error` on throw with `scanProgress` reset, clamped progress with intermediate values observable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk scanning with recursive file/folder tree visualization and formatted size display
  * Real-time scan progress reporting and cancellation handling
  * Graceful handling of access-restricted items and skipping of symbolic links

* **Bug Fixes**
  * Accurate bottom-up size aggregation for directories and safe percent calculations

* **Tests**
  * New unit and integration tests covering scanning, progress, error, and cancellation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->