### PR TITLE
Space Lens treemap UI (squarified treemap + drill-down)

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -76,6 +76,8 @@ struct ContentView: View {
             SystemJunkView(viewModel: SystemJunkViewModel.live(exclusions: exclusions))
         case .largeOldFiles:
             LargeOldFilesView(viewModel: LargeOldFilesViewModel.live(exclusions: exclusions))
+        case .spaceLens:
+            SpaceLensView(viewModel: DiskScannerViewModel.live())
         default:
             PlaceholderDetailView(section: section)
         }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -17,6 +17,16 @@ struct ContentView: View {
     /// system caches the answer so the second prompt is a no-op, but it's
     /// cleaner to issue exactly one.
     @State private var didRequestNotificationPermission = false
+    /// Space Lens scans take long enough that losing the result on a
+    /// sidebar peek would be a frustration point. Hosting the view-model
+    /// here keeps the breadcrumb / scanned tree alive while the user
+    /// flips through other sections, and only the view layer is rebuilt
+    /// when they come back. A short-lived `SpaceLensView`-owned
+    /// `@StateObject` would still latch the first scan via SwiftUI's
+    /// state-object identity rules, but the VM would briefly construct
+    /// (and a `.live()`-spawned `DiskScanner` would briefly allocate) on
+    /// every body recomputation — wasteful enough to lift here.
+    @StateObject private var spaceLensViewModel = DiskScannerViewModel.live()
 
     var body: some View {
         NavigationSplitView {
@@ -77,7 +87,7 @@ struct ContentView: View {
         case .largeOldFiles:
             LargeOldFilesView(viewModel: LargeOldFilesViewModel.live(exclusions: exclusions))
         case .spaceLens:
-            SpaceLensView(viewModel: DiskScannerViewModel.live())
+            SpaceLensView(viewModel: spaceLensViewModel)
         default:
             PlaceholderDetailView(section: section)
         }

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -58,6 +58,53 @@ final class DiskScannerViewModel: ObservableObject {
         return nil
     }
 
+    /// The node the treemap should currently render — root when the
+    /// breadcrumb stack is empty, otherwise the deepest crumb. Returns
+    /// `nil` outside the `.ready` phase so the view falls back to its
+    /// idle / scanning / error placeholders rather than rendering a
+    /// stale tree.
+    var currentNode: DiskNode? {
+        guard let root else { return nil }
+        return navigationPath.last ?? root
+    }
+
+    // MARK: - Navigation
+
+    /// Drill into a directory child. Pushes onto `navigationPath` so the
+    /// treemap re-renders the child's contents and the breadcrumb grows
+    /// by one entry.
+    ///
+    /// **No-op for non-directories** — files have no children, so a
+    /// drill-down would land the view on an empty rectangle. Centralising
+    /// the guard here means the view layer doesn't have to check before
+    /// every tile click.
+    func drillDown(into node: DiskNode) {
+        guard node.isDirectory else { return }
+        navigationPath.append(node)
+    }
+
+    /// Pop the breadcrumb stack by one entry. No-op when already at root,
+    /// so the back button can stay enabled without checking
+    /// `navigationPath.isEmpty` upstream.
+    func navigateUp() {
+        guard !navigationPath.isEmpty else { return }
+        navigationPath.removeLast()
+    }
+
+    /// Truncate `navigationPath` so `node` becomes the new tail. Powers
+    /// the breadcrumb's "jump to ancestor" affordance — clicking the
+    /// third crumb pops back two levels in one gesture.
+    ///
+    /// **No-op when `node` isn't on the current path** — a stale crumb
+    /// reference (e.g. captured in a SwiftUI closure across a rescan)
+    /// shouldn't desync the displayed tree. Identity comparison (`===`)
+    /// because two snapshots of the same path under different scans are
+    /// distinct nodes by design (see `DiskNode` doc comment).
+    func navigate(to node: DiskNode) {
+        guard let index = navigationPath.firstIndex(where: { $0 === node }) else { return }
+        navigationPath = Array(navigationPath.prefix(through: index))
+    }
+
     /// Smallest fractional change worth republishing. A real-volume scan
     /// can fire the progress callback hundreds of thousands of times;
     /// without this gate every call would queue a `Task` on the main

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -91,6 +91,16 @@ final class DiskScannerViewModel: ObservableObject {
         navigationPath.removeLast()
     }
 
+    /// Empty the breadcrumb stack so the treemap re-renders against the
+    /// scan root. Wired to the root crumb in the Space Lens breadcrumb;
+    /// kept on the VM (rather than the view writing
+    /// `navigationPath = []` directly) so any future side-effects of
+    /// jumping to root — telemetry, in-flight cancellation — have a
+    /// single hook.
+    func navigateToRoot() {
+        navigationPath = []
+    }
+
     /// Truncate `navigationPath` so `node` becomes the new tail. Powers
     /// the breadcrumb's "jump to ancestor" affordance — clicking the
     /// third crumb pops back two levels in one gesture.

--- a/VaderCleaner/FileCategory.swift
+++ b/VaderCleaner/FileCategory.swift
@@ -73,20 +73,47 @@ enum FileCategory: Hashable {
 
     // MARK: - Internals
 
-    /// Path-prefix heuristic for directories. `~/Library`, `/System`,
-    /// `/usr`, `/private` are the canonical system locations on macOS;
-    /// anything underneath them is treated as system content. Everything
-    /// else falls into `.other`, which is the right answer for user-managed
-    /// directories like `~/Projects` or `/Users/example/Documents`.
+    /// Path-component heuristic for directories. `~/Library`, `/Library`,
+    /// `/System`, `/usr`, `/private` are the canonical system locations on
+    /// macOS; the directory itself and anything underneath them is treated
+    /// as system content. Everything else falls into `.other`, which is the
+    /// right answer for user-managed directories like `~/Projects` or
+    /// `/Users/example/Documents`.
+    ///
+    /// **Component-based, not substring-based.** `path.hasPrefix("/usr")`
+    /// matches a user's own `/Users/example/usr_data`, and
+    /// `path.contains("/Library/")` matches `/Users/example/Projects/Library/foo`.
+    /// Both would be misclassified as system. Splitting on `/` and comparing
+    /// whole components avoids those false positives, and incidentally lets
+    /// us recognize the Library directory itself (e.g. the top-level
+    /// `~/Library` tile in a Space Lens scan of the home folder), which
+    /// the substring rule missed because the path doesn't end with a slash.
     private static func categoryForDirectoryPath(_ path: String) -> FileCategory {
-        if path.hasPrefix("/System") { return .system }
-        if path.hasPrefix("/usr")    { return .system }
-        if path.hasPrefix("/private") { return .system }
-        // `/Library/...` covers both the system-wide Library and the
-        // per-user `~/Library` (which expands to `/Users/<name>/Library`).
-        // The substring check is sufficient — there's no legitimate path
-        // containing `/Library/` that the user manages by hand.
-        if path.contains("/Library/") { return .system }
+        // `pathComponents` returns `["/", "System", ...]` for an absolute
+        // path, so the second element (index 1) is the first real component.
+        let components = URL(fileURLWithPath: path).pathComponents
+        guard components.count >= 2 else { return .other }
+
+        switch components[1] {
+        case "System", "usr", "private":
+            return .system
+        case "Library":
+            // `/Library` and `/Library/...` — system-wide Library.
+            return .system
+        default:
+            break
+        }
+
+        // `~/Library` expands to `/Users/<name>/Library`. Match the
+        // four-component shape exactly (root + "Users" + name + "Library")
+        // rather than checking `components.contains("Library")`, which
+        // would still misclassify a user-created `~/Projects/Library/...`.
+        if components.count >= 4,
+           components[1] == "Users",
+           components[3] == "Library" {
+            return .system
+        }
+
         return .other
     }
 

--- a/VaderCleaner/FileCategory.swift
+++ b/VaderCleaner/FileCategory.swift
@@ -1,0 +1,109 @@
+// FileCategory.swift
+// Maps a DiskNode to a coarse type bucket (documents/media/apps/system/other) used to color tiles in the Space Lens treemap.
+
+import Foundation
+import SwiftUI
+
+/// Coarse category assigned to every tile in the Space Lens treemap. The
+/// categories are deliberately broad — finer-grained types (e.g. "Office
+/// document" vs. "PDF") would split colors into a pattern the eye can no
+/// longer parse at a glance, defeating the whole point of the colored
+/// visualization.
+enum FileCategory: Hashable {
+    /// Office-style documents: text, spreadsheets, presentations, markup.
+    case documents
+    /// Images, audio, video.
+    case media
+    /// Application bundles. Stored as `.app` directories on disk; the
+    /// categorizer recognises the bundle extension before it falls into
+    /// the directory branch.
+    case apps
+    /// Library contents, system frameworks, logs, plists. Anything the user
+    /// rarely manages by hand.
+    case system
+    /// Fallback bucket — unknown extensions, plain user directories.
+    case other
+
+    /// Tile color in the treemap. Held with the enum rather than at the
+    /// view layer so a future use (legend, tooltip swatch) can read it
+    /// directly without re-implementing the mapping.
+    var color: Color {
+        switch self {
+        case .documents: return .blue
+        case .media:     return .purple
+        case .apps:      return .orange
+        case .system:    return .red
+        case .other:     return .gray
+        }
+    }
+
+    /// Pretty label used by tooltips and the (eventual) legend. Localized
+    /// via `String(localized:)` so a future translation pass picks them up.
+    var displayName: String {
+        switch self {
+        case .documents: return String(localized: "Documents")
+        case .media:     return String(localized: "Media")
+        case .apps:      return String(localized: "Apps")
+        case .system:    return String(localized: "System")
+        case .other:     return String(localized: "Other")
+        }
+    }
+
+    /// Categorize a `DiskNode` based on its URL and directory flag.
+    ///
+    /// Resolution order matters: `.app` bundles are technically directories,
+    /// so we check the extension first; otherwise every application would
+    /// land in the directory branch and pick up the `.system` / `.other`
+    /// fallback. After the bundle check, directories route by path prefix
+    /// (system locations) and files route by extension.
+    static func from(node: DiskNode) -> FileCategory {
+        let ext = node.url.pathExtension.lowercased()
+
+        if ext == "app" { return .apps }
+
+        if node.isDirectory {
+            return categoryForDirectoryPath(node.url.path)
+        }
+
+        if Self.documentExtensions.contains(ext) { return .documents }
+        if Self.mediaExtensions.contains(ext)    { return .media }
+        if Self.systemExtensions.contains(ext)   { return .system }
+        return .other
+    }
+
+    // MARK: - Internals
+
+    /// Path-prefix heuristic for directories. `~/Library`, `/System`,
+    /// `/usr`, `/private` are the canonical system locations on macOS;
+    /// anything underneath them is treated as system content. Everything
+    /// else falls into `.other`, which is the right answer for user-managed
+    /// directories like `~/Projects` or `/Users/example/Documents`.
+    private static func categoryForDirectoryPath(_ path: String) -> FileCategory {
+        if path.hasPrefix("/System") { return .system }
+        if path.hasPrefix("/usr")    { return .system }
+        if path.hasPrefix("/private") { return .system }
+        // `/Library/...` covers both the system-wide Library and the
+        // per-user `~/Library` (which expands to `/Users/<name>/Library`).
+        // The substring check is sufficient — there's no legitimate path
+        // containing `/Library/` that the user manages by hand.
+        if path.contains("/Library/") { return .system }
+        return .other
+    }
+
+    private static let documentExtensions: Set<String> = [
+        "pdf", "doc", "docx", "txt", "rtf", "pages",
+        "xls", "xlsx", "numbers", "ppt", "pptx", "key",
+        "md", "csv", "odt", "epub"
+    ]
+
+    private static let mediaExtensions: Set<String> = [
+        "jpg", "jpeg", "png", "gif", "tiff", "tif", "bmp", "heic", "heif", "raw", "webp", "svg",
+        "mp4", "mov", "avi", "mkv", "m4v", "wmv", "flv",
+        "mp3", "wav", "aac", "flac", "m4a", "ogg", "opus"
+    ]
+
+    private static let systemExtensions: Set<String> = [
+        "dylib", "framework", "kext", "plist", "log", "ips", "diag",
+        "bundle", "appex"
+    ]
+}

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -20,11 +20,6 @@ import SwiftUI
 struct SpaceLensView: View {
 
     @StateObject private var viewModel: DiskScannerViewModel
-    /// Latched once per view lifetime so we don't re-scan every time
-    /// SwiftUI re-fires `.task` (which can happen on environment
-    /// changes). The user can still trigger a fresh scan via the
-    /// Re-scan button.
-    @State private var didStartInitialScan = false
 
     init(viewModel: DiskScannerViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -52,10 +47,19 @@ struct SpaceLensView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle(NavigationSection.spaceLens.title)
-        .task {
-            guard !didStartInitialScan else { return }
-            didStartInitialScan = true
-            await runScan()
+        // `.onAppear` rather than `.task` so the scan isn't tied to the
+        // view's task lifetime — `DiskScannerViewModel` is hoisted to
+        // `ContentView` so the scanned tree survives a sidebar peek, and
+        // a `.task`-driven scan would be cancelled the moment the user
+        // navigated away (the VM's cancellation handler forwards
+        // structured cancellation into the in-flight walk). Spawning the
+        // scan from an unstructured `Task` inside `onAppear` lets the
+        // walk run to completion even while the user browses other
+        // sections; `phase`-guarded so re-entering an already-loaded
+        // tree doesn't restart the scan.
+        .onAppear {
+            guard case .idle = viewModel.phase else { return }
+            Task { await runScan() }
         }
     }
 
@@ -203,11 +207,12 @@ struct SpaceLensView: View {
         Button {
             // The root crumb empties the path; intermediate crumbs
             // truncate via `navigate(to:)`. Both end with the named
-            // crumb at `currentNode`, but the root-special case avoids
-            // requiring `navigate(to:)` to know about the synthetic
-            // "[root] + path" prefix.
+            // crumb at `currentNode`, but the root-special case routes
+            // through `navigateToRoot()` so the VM owns the "jump to
+            // root" semantics instead of the view mutating
+            // `navigationPath` directly.
             if isRoot {
-                viewModel.navigationPath = []
+                viewModel.navigateToRoot()
             } else {
                 viewModel.navigate(to: crumb)
             }

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -1,0 +1,280 @@
+// SpaceLensView.swift
+// Top-level Space Lens detail view — drives the idle/scanning/ready/empty/error states from DiskScannerViewModel, hosts the breadcrumb plus TreemapView, and runs the home-directory scan on first appearance.
+
+import SwiftUI
+
+/// Detail view for the Space Lens sidebar section. Owns nothing of its
+/// own — every piece of state lives on `DiskScannerViewModel`. Each
+/// `Phase` maps to a dedicated subview (idle → scan call-to-action,
+/// scanning → progress bar, ready → breadcrumb + treemap + footer,
+/// error → message + try again). The empty case is implicit: a `.ready`
+/// node whose subtree has no displayable children renders the empty
+/// placeholder inside the same layout, so the breadcrumb stays in
+/// reach for navigating back up.
+///
+/// The first-launch scan targets the user's home directory per the
+/// product plan (plan.md line 961). A volume / drive picker lands later
+/// once Privacy and App Uninstaller settle. Until then a "Re-scan"
+/// button lets the user re-run the same root after deleting files
+/// elsewhere in the app.
+struct SpaceLensView: View {
+
+    @StateObject private var viewModel: DiskScannerViewModel
+    /// Latched once per view lifetime so we don't re-scan every time
+    /// SwiftUI re-fires `.task` (which can happen on environment
+    /// changes). The user can still trigger a fresh scan via the
+    /// Re-scan button.
+    @State private var didStartInitialScan = false
+
+    init(viewModel: DiskScannerViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.phase {
+            case .idle:
+                idleState
+            case .scanning:
+                scanningState
+            case .ready:
+                if let current = viewModel.currentNode {
+                    readyState(current: current)
+                } else {
+                    // Defensive: `.ready` should always supply a node, but
+                    // if `currentNode` somehow returns nil (programming
+                    // error), render the idle CTA so the user can recover.
+                    idleState
+                }
+            case .error(let message):
+                errorState(message: message)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle(NavigationSection.spaceLens.title)
+        .task {
+            guard !didStartInitialScan else { return }
+            didStartInitialScan = true
+            await runScan()
+        }
+    }
+
+    // MARK: - States
+
+    private var idleState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: NavigationSection.spaceLens.icon)
+                .font(.system(size: 56))
+                .foregroundStyle(.secondary)
+            Text("Space Lens")
+                .font(.title2.weight(.semibold))
+            Text("Visualize disk usage in your home folder. Scan to see which folders take up the most space.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+            Button("Scan") {
+                Task { await runScan() }
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("space-lens.scan")
+        }
+        .padding()
+    }
+
+    private var scanningState: some View {
+        VStack(spacing: 16) {
+            ProgressView(value: viewModel.scanProgress)
+                .progressViewStyle(.linear)
+                .frame(maxWidth: 360)
+            Text("Scanning…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .accessibilityIdentifier("space-lens.scanning")
+    }
+
+    private func readyState(current: DiskNode) -> some View {
+        VStack(spacing: 0) {
+            breadcrumb(current: current)
+            Divider()
+            treemapOrEmpty(current: current)
+            Divider()
+            footer(current: current)
+        }
+    }
+
+    /// Empty placeholder shown when the current node has no displayable
+    /// children. Takes the treemap's slot inside `readyState` rather than
+    /// the whole detail surface so the breadcrumb stays available — the
+    /// user can still navigate back up.
+    private func treemapOrEmpty(current: DiskNode) -> some View {
+        Group {
+            if hasDisplayableChildren(current) {
+                TreemapView(viewModel: viewModel, node: current)
+            } else {
+                emptyTreemapPlaceholder
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyTreemapPlaceholder: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "tray")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+            Text("This folder appears to be empty")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("space-lens.empty")
+    }
+
+    private func errorState(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text("Couldn't complete the scan")
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("space-lens.errorMessage")
+            Button("Try Again") {
+                Task { await runScan() }
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("space-lens.tryAgain")
+        }
+        .padding()
+        .accessibilityIdentifier("space-lens.error")
+    }
+
+    // MARK: - Breadcrumb + footer
+
+    /// Renders `[root] + viewModel.navigationPath` as clickable chevrons.
+    /// The trailing crumb is the current node and is not interactive
+    /// (clicking it would be a no-op). Earlier crumbs route through
+    /// `viewModel.navigate(to:)` which truncates the path in one call.
+    @ViewBuilder
+    private func breadcrumb(current: DiskNode) -> some View {
+        // Build the crumb sequence from `[root, ...path]`. Avoid using
+        // `currentNode` here because the root crumb has special handling
+        // (clicking it pops back to root regardless of how deep we are).
+        if let root = viewModel.root {
+            let crumbs: [DiskNode] = [root] + viewModel.navigationPath
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(Array(crumbs.enumerated()), id: \.element.id) { index, crumb in
+                        breadcrumbCrumb(
+                            crumb: crumb,
+                            isCurrent: crumb === current,
+                            isRoot: index == 0,
+                            tapIndex: index
+                        )
+                        if index < crumbs.count - 1 {
+                            Image(systemName: "chevron.right")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func breadcrumbCrumb(
+        crumb: DiskNode,
+        isCurrent: Bool,
+        isRoot: Bool,
+        tapIndex: Int
+    ) -> some View {
+        Button {
+            // The root crumb empties the path; intermediate crumbs
+            // truncate via `navigate(to:)`. Both end with the named
+            // crumb at `currentNode`, but the root-special case avoids
+            // requiring `navigate(to:)` to know about the synthetic
+            // "[root] + path" prefix.
+            if isRoot {
+                viewModel.navigationPath = []
+            } else {
+                viewModel.navigate(to: crumb)
+            }
+        } label: {
+            Text(crumb.name)
+                .font(.callout.weight(isCurrent ? .semibold : .regular))
+                .foregroundStyle(isCurrent ? Color.primary : Color.secondary)
+                .lineLimit(1)
+        }
+        .buttonStyle(.plain)
+        .disabled(isCurrent)
+        .accessibilityIdentifier("space-lens.breadcrumb.\(tapIndex)")
+    }
+
+    private func footer(current: DiskNode) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Total")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(current.formattedSize)
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("space-lens.totalSize")
+            }
+            Spacer()
+            Button("Re-scan") {
+                Task { await runScan() }
+            }
+            .accessibilityIdentifier("space-lens.rescan")
+        }
+        .padding(16)
+    }
+
+    // MARK: - Helpers
+
+    private func hasDisplayableChildren(_ node: DiskNode) -> Bool {
+        node.children.contains { $0.size > 0 }
+    }
+
+    /// Kick off a scan rooted at the home directory. The user's home is
+    /// the right default — Space Lens is "where on this volume are *my*
+    /// files" 95% of the time, and scanning the whole volume root would
+    /// stall for minutes on `/System` content the user cannot manage.
+    private func runScan() async {
+        await viewModel.startScan(root: Self.homeDirectoryURL)
+    }
+
+    /// Resolve the home directory once at module load so the runtime
+    /// never re-derives it. `URL(fileURLWithPath:)` against
+    /// `NSHomeDirectory()` returns the same path the rest of the app
+    /// (Large & Old Files, etc.) uses for user-file scans.
+    private static let homeDirectoryURL: URL = {
+        URL(fileURLWithPath: NSHomeDirectory())
+    }()
+}
+
+#Preview("Idle") {
+    SpaceLensView(
+        viewModel: DiskScannerViewModel(scanner: { _, _ in
+            DiskNode(
+                url: URL(fileURLWithPath: "/"),
+                name: "/",
+                size: 0,
+                isDirectory: true,
+                children: []
+            )
+        })
+    )
+    .frame(width: 800, height: 520)
+}

--- a/VaderCleaner/TreemapLayout.swift
+++ b/VaderCleaner/TreemapLayout.swift
@@ -1,0 +1,242 @@
+// TreemapLayout.swift
+// Squarified treemap layout (Bruls/Huijse/van Wijk) — turns a list of weighted items into rectangles inside a bounding box, keeping every tile as close to square as possible.
+
+import CoreGraphics
+
+/// Pure value type. Given a set of weighted items and a bounding rectangle,
+/// produces a list of `(id, CGRect)` whose rectangles partition the bounds
+/// in proportion to the input weights.
+///
+/// Implements the squarified algorithm from Bruls, Huijse & van Wijk (2000).
+/// The naive "slice and dice" alternative is one line shorter to write but
+/// degrades to long stripes whose worst aspect ratio scales linearly with
+/// the input size, defeating the at-a-glance comparison the treemap exists
+/// to enable. The unit-test suite exercises the squarified-quality property
+/// directly with a worst-aspect-ratio gate.
+///
+/// **Generic over `ID`** rather than tied to `DiskNode` so unit tests can
+/// drive it with `Int` ids (no `URL`s, no fixture trees) and so future
+/// callers — Smart Scan summary, Large Files breakdown — can use it
+/// without dragging in the disk-scanner types.
+///
+/// **No state** — every call is independent. The layout result keys back
+/// to the input ids so the SwiftUI view can pair tiles with their source
+/// nodes through a dictionary lookup.
+struct TreemapLayout {
+
+    /// Layout entry point. The result is the same length as `items` (every
+    /// id appears exactly once). Tile order in the result is implementation-
+    /// defined: the algorithm sorts internally so the largest tiles land in
+    /// the upper-left strip first. Callers should look up tiles by id, not
+    /// by position.
+    ///
+    /// **Edge cases:**
+    /// - Empty input → empty output.
+    /// - All-zero weights → every tile reports a zero-area rect at the
+    ///   bounds origin. The SwiftUI view can still iterate the result;
+    ///   tiles below ~4 pt in either dimension are skipped at render time.
+    /// - Negative or NaN weights → clamped to 0. (Treemap weights model
+    ///   on-disk byte counts; negatives are nonsensical and silently
+    ///   discarded rather than trapped — a single corrupt scan record
+    ///   should not crash the visualization.)
+    static func layout<ID: Hashable>(
+        items: [(id: ID, weight: Double)],
+        in bounds: CGRect
+    ) -> [(id: ID, rect: CGRect)] {
+        guard !items.isEmpty else { return [] }
+        guard bounds.width > 0, bounds.height > 0 else {
+            return items.map { (id: $0.id, rect: CGRect(origin: bounds.origin, size: .zero)) }
+        }
+
+        // Clamp negatives / NaN to 0 so a single corrupt input doesn't poison
+        // the totals. `isFinite` guards against an `Double.infinity` leaking
+        // in from a divide-by-zero upstream.
+        let cleaned: [(id: ID, weight: Double)] = items.map { item in
+            let w = item.weight
+            return (id: item.id, weight: (w.isFinite && w > 0) ? w : 0)
+        }
+
+        let totalWeight = cleaned.reduce(0.0) { $0 + $1.weight }
+        guard totalWeight > 0 else {
+            return cleaned.map { (id: $0.id, rect: CGRect(origin: bounds.origin, size: .zero)) }
+        }
+
+        // Convert weights to areas in the bounds' coordinate space. Doing
+        // this once up front lets the recursion compare areas directly to
+        // the remaining-rect dimensions without re-deriving the scale.
+        let scale = Double(bounds.width) * Double(bounds.height) / totalWeight
+        let scaled: [Item<ID>] = cleaned
+            .map { Item(id: $0.id, area: $0.weight * scale) }
+            .sorted { $0.area > $1.area }
+
+        var output: [(id: ID, rect: CGRect)] = []
+        output.reserveCapacity(items.count)
+        squarify(items: scaled, in: bounds, output: &output)
+        return output
+    }
+
+    // MARK: - Internals
+
+    /// Internal pair carried through the recursion. Kept distinct from the
+    /// public input tuple so the algorithm always reasons about pre-scaled
+    /// areas, never raw weights.
+    private struct Item<ID: Hashable> {
+        let id: ID
+        let area: Double
+    }
+
+    /// Recursive driver. Maintains a "row" of items being placed along the
+    /// shorter side of `remaining`. As long as adding the next item to the
+    /// row improves (or ties) the worst aspect ratio, it joins the row;
+    /// otherwise the row is flushed as a strip and recursion continues
+    /// with the leftover rectangle.
+    private static func squarify<ID: Hashable>(
+        items: [Item<ID>],
+        in bounds: CGRect,
+        output: inout [(id: ID, rect: CGRect)]
+    ) {
+        var remaining = bounds
+        var row: [Item<ID>] = []
+        var index = 0
+
+        while index < items.count {
+            let next = items[index]
+            let shortSide = min(Double(remaining.width), Double(remaining.height))
+
+            // Trying the item with the row vs. without. When the row is
+            // empty, "without" is undefined (no aspect ratio yet) and we
+            // always accept the first item. Otherwise we accept whichever
+            // gives the smaller worst ratio.
+            let proposed = row + [next]
+            let worstWith = worstRatio(row: proposed, shortSide: shortSide)
+            let worstWithout = row.isEmpty
+                ? Double.infinity
+                : worstRatio(row: row, shortSide: shortSide)
+
+            if row.isEmpty || worstWith <= worstWithout {
+                row = proposed
+                index += 1
+            } else {
+                // Adding this item makes the row worse — flush the current
+                // row first, then re-try the same item against the new
+                // remaining rectangle.
+                let leftover = layoutRow(row, in: remaining, output: &output)
+                remaining = leftover
+                row = []
+                if remaining.width <= 0 || remaining.height <= 0 {
+                    // Numerical exhaustion — emit zero-area placeholders for
+                    // anything still queued so the output array length
+                    // matches `items.count` (the public contract).
+                    for tail in items[index...] {
+                        output.append((id: tail.id, rect: CGRect(origin: bounds.origin, size: .zero)))
+                    }
+                    return
+                }
+            }
+        }
+
+        if !row.isEmpty {
+            _ = layoutRow(row, in: remaining, output: &output)
+        }
+    }
+
+    /// Worst aspect ratio achievable when `row` is laid as a strip along
+    /// `shortSide`. The Bruls et al. closed form: for a strip with total
+    /// area `s` and `n` items, the worst ratio is the max over items of
+    /// `max(w² · max_a / s², s² / (w² · min_a))` where `w` = shortSide.
+    /// Returns `.infinity` for degenerate inputs (empty row, zero area,
+    /// zero short side) so the caller treats them as unacceptable and
+    /// either flushes or accepts the first item by the empty-row rule.
+    private static func worstRatio<ID: Hashable>(
+        row: [Item<ID>],
+        shortSide: Double
+    ) -> Double {
+        guard !row.isEmpty, shortSide > 0 else { return .infinity }
+        let totalArea = row.reduce(0.0) { $0 + $1.area }
+        guard totalArea > 0 else { return .infinity }
+
+        let s2 = shortSide * shortSide
+        let totalArea2 = totalArea * totalArea
+        var worst = 0.0
+        for item in row {
+            guard item.area > 0 else { continue }
+            let aspectA = (s2 * item.area) / totalArea2
+            let aspectB = totalArea2 / (s2 * item.area)
+            worst = max(worst, max(aspectA, aspectB))
+        }
+        // If every item in the row had zero area, no ratio could be
+        // computed — return `.infinity` so the caller flushes the row
+        // rather than committing zero-byte items to a strip that won't
+        // render anyway.
+        return worst > 0 ? worst : .infinity
+    }
+
+    /// Place the strip and return the rectangle left over for subsequent
+    /// rows. The strip occupies a slab of thickness `totalArea / shortSide`
+    /// against the shorter side of `rect`; items inside the strip are laid
+    /// end-to-end along the longer of the strip's two dimensions.
+    ///
+    /// Returns the unconsumed rectangle. Falls back to the input rect when
+    /// the strip is degenerate (zero area or zero short side) so the
+    /// caller's loop can detect the no-progress case via the
+    /// `remaining.width <= 0` / `<= 0` guard.
+    private static func layoutRow<ID: Hashable>(
+        _ row: [Item<ID>],
+        in rect: CGRect,
+        output: inout [(id: ID, rect: CGRect)]
+    ) -> CGRect {
+        let totalArea = row.reduce(0.0) { $0 + $1.area }
+        let shortSide = min(Double(rect.width), Double(rect.height))
+        guard shortSide > 0, totalArea > 0 else {
+            for item in row {
+                output.append((id: item.id, rect: CGRect(origin: rect.origin, size: .zero)))
+            }
+            return rect
+        }
+
+        let stripThickness = totalArea / shortSide
+
+        if rect.width >= rect.height {
+            // Vertical strip on the left edge: each item takes the full
+            // strip width and a slice of its height.
+            var y = Double(rect.minY)
+            for item in row {
+                let height = item.area / stripThickness
+                let tile = CGRect(
+                    x: Double(rect.minX),
+                    y: y,
+                    width: stripThickness,
+                    height: height
+                )
+                output.append((id: item.id, rect: tile))
+                y += height
+            }
+            return CGRect(
+                x: Double(rect.minX) + stripThickness,
+                y: Double(rect.minY),
+                width: Double(rect.width) - stripThickness,
+                height: Double(rect.height)
+            )
+        } else {
+            // Horizontal strip on the top edge.
+            var x = Double(rect.minX)
+            for item in row {
+                let width = item.area / stripThickness
+                let tile = CGRect(
+                    x: x,
+                    y: Double(rect.minY),
+                    width: width,
+                    height: stripThickness
+                )
+                output.append((id: item.id, rect: tile))
+                x += width
+            }
+            return CGRect(
+                x: Double(rect.minX),
+                y: Double(rect.minY) + stripThickness,
+                width: Double(rect.width),
+                height: Double(rect.height) - stripThickness
+            )
+        }
+    }
+}

--- a/VaderCleaner/TreemapView.swift
+++ b/VaderCleaner/TreemapView.swift
@@ -1,0 +1,140 @@
+// TreemapView.swift
+// SwiftUI treemap rendering for Space Lens — lays out a parent DiskNode's children with TreemapLayout, colors each tile by FileCategory, and routes clicks back to DiskScannerViewModel for drill-down.
+
+import SwiftUI
+
+/// Renders the children of a single `DiskNode` as a squarified treemap.
+/// The view does not own a tree — it binds to whatever `node` the parent
+/// hands it (typically `viewModel.currentNode`), so navigation up and down
+/// the breadcrumb stack just changes which node is passed in.
+///
+/// **Click → drill** — tapping a directory tile calls
+/// `viewModel.drillDown(into:)`. Files are not interactive at this stage;
+/// future "Show in Finder" / "Move to Trash" actions will land alongside
+/// the App Uninstaller polish (Prompt 27).
+///
+/// **Tooltip** — hover surfaces the full path and formatted size via
+/// `.help(...)`, the SwiftUI idiom for native macOS tooltips.
+///
+/// **Tile thresholds** — tiles below ~20 pt on the shorter side hide their
+/// label (the text would overflow into a neighbour). Tiles below ~4 pt
+/// in either dimension are skipped entirely; they're just visual noise at
+/// that scale and the user can drill in to see them.
+struct TreemapView: View {
+
+    @ObservedObject var viewModel: DiskScannerViewModel
+    let node: DiskNode
+
+    /// Smallest tile dimension that still renders. Anything smaller is too
+    /// thin to recognize and would just clutter the canvas.
+    private static let minRenderDimension: CGFloat = 4
+    /// Smallest tile dimension that still draws its name + size labels.
+    /// Below this the labels overflow the tile and bleed into neighbours.
+    private static let minLabelDimension: CGFloat = 60
+    /// Border width between adjacent tiles. Subtle — heavier strokes turn
+    /// the visualization into a grid of frames rather than a continuous
+    /// area chart.
+    private static let tileStroke: CGFloat = 1
+
+    var body: some View {
+        GeometryReader { geometry in
+            let bounds = CGRect(origin: .zero, size: geometry.size)
+            let tiles = computeTiles(in: bounds)
+            ZStack(alignment: .topLeading) {
+                ForEach(tiles, id: \.node.id) { entry in
+                    tileView(for: entry)
+                }
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+        }
+        .accessibilityIdentifier("space-lens.treemap")
+    }
+
+    // MARK: - Tile rendering
+
+    /// Layout output paired back to the source node. Held as a struct so the
+    /// `ForEach` body can reach both the tile rect and the `DiskNode` it
+    /// came from in one keyed pass.
+    private struct TileEntry {
+        let node: DiskNode
+        let rect: CGRect
+        let category: FileCategory
+    }
+
+    private func computeTiles(in bounds: CGRect) -> [TileEntry] {
+        // Filter out zero-byte children up front. A directory with a
+        // mixture of zero-byte and large files would otherwise spend
+        // half its strip budget on slivers that the
+        // `minRenderDimension` filter would discard anyway, leaving
+        // empty space inside the parent tile. Skipping them at the
+        // weight stage means the surviving tiles share the full area.
+        let children = node.children.filter { $0.size > 0 }
+        guard !children.isEmpty else { return [] }
+
+        let weighted = children.map { (id: $0.id, weight: Double($0.size)) }
+        let layout = TreemapLayout.layout(items: weighted, in: bounds)
+        let nodeByID = Dictionary(uniqueKeysWithValues: children.map { ($0.id, $0) })
+
+        return layout.compactMap { tile -> TileEntry? in
+            guard let child = nodeByID[tile.id] else { return nil }
+            // Skip tiles that would render as a sliver. Below the
+            // threshold the rectangle is just visual noise; the user can
+            // drill into the parent if they need to see it.
+            if tile.rect.width < Self.minRenderDimension || tile.rect.height < Self.minRenderDimension {
+                return nil
+            }
+            return TileEntry(
+                node: child,
+                rect: tile.rect,
+                category: FileCategory.from(node: child)
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func tileView(for entry: TileEntry) -> some View {
+        let showLabel = entry.rect.width >= Self.minLabelDimension
+            && entry.rect.height >= Self.minLabelDimension
+
+        Rectangle()
+            .fill(entry.category.color.opacity(entry.node.isDirectory ? 0.55 : 0.7))
+            .overlay(
+                Rectangle()
+                    .strokeBorder(Color.white.opacity(0.6), lineWidth: Self.tileStroke)
+            )
+            .overlay(
+                Group {
+                    if showLabel {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(entry.node.name)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .foregroundStyle(.white)
+                            Text(entry.node.formattedSize)
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.white.opacity(0.85))
+                        }
+                        .padding(6)
+                        .frame(
+                            maxWidth: .infinity,
+                            maxHeight: .infinity,
+                            alignment: .topLeading
+                        )
+                        .allowsHitTesting(false)
+                    }
+                }
+            )
+            .frame(width: entry.rect.width, height: entry.rect.height)
+            .position(
+                x: entry.rect.midX,
+                y: entry.rect.midY
+            )
+            .help("\(entry.node.url.path)\n\(entry.node.formattedSize)")
+            .onTapGesture {
+                viewModel.drillDown(into: entry.node)
+            }
+            .accessibilityIdentifier("space-lens.tile.\(entry.node.url.lastPathComponent)")
+            .accessibilityLabel("\(entry.node.name), \(entry.node.formattedSize)")
+    }
+}

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -204,6 +204,31 @@ final class DiskScannerViewModelTests: XCTestCase {
         XCTAssertTrue(vm.navigationPath.last === a)
     }
 
+    /// `navigateToRoot` empties the breadcrumb stack in one call so the
+    /// root crumb in `SpaceLensView` doesn't have to mutate
+    /// `navigationPath` directly. Multi-level no-op safety: a second call
+    /// against an already-empty path leaves the path empty.
+    func test_navigateToRoot_clearsNavigationPath() {
+        let a = DiskNode(url: URL(fileURLWithPath: "/a"), name: "a",
+                         size: 0, isDirectory: true, children: [])
+        let b = DiskNode(url: URL(fileURLWithPath: "/a/b"), name: "b",
+                         size: 0, isDirectory: true, children: [])
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            DiskNode(url: URL(fileURLWithPath: "/"), name: "/",
+                     size: 0, isDirectory: true, children: [])
+        })
+        vm.navigationPath = [a, b]
+
+        vm.navigateToRoot()
+
+        XCTAssertTrue(vm.navigationPath.isEmpty)
+
+        // Idempotent — calling again from root must not throw or grow
+        // the path back.
+        vm.navigateToRoot()
+        XCTAssertTrue(vm.navigationPath.isEmpty)
+    }
+
     /// `navigateUp` on an empty path is a no-op. Defensive against a
     /// stuck-at-root state where the back button is mistakenly enabled.
     func test_navigateUp_isNoOpWhenPathEmpty() {

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -126,4 +126,178 @@ final class DiskScannerViewModelTests: XCTestCase {
         XCTAssertEqual(vm.phase, .idle, "Cancellation should land back in .idle, not .error")
         XCTAssertEqual(vm.scanProgress, 0.0)
     }
+
+    // MARK: - Navigation (Prompt 17)
+
+    /// Drilling into a directory child must push it onto the breadcrumb
+    /// stack so the treemap re-renders against its children. The order
+    /// matters — `navigationPath.last` is the displayed node, so the
+    /// freshly-clicked child must end up at the tail.
+    func test_drillDown_appendsDirectoryToNavigationPath() async {
+        let dirChild = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root/sub"),
+            name: "sub",
+            size: 50,
+            isDirectory: true,
+            children: []
+        )
+        let root = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root"),
+            name: "root",
+            size: 50,
+            isDirectory: true,
+            children: [dirChild]
+        )
+        let vm = DiskScannerViewModel(scanner: { _, _ in root })
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+
+        vm.drillDown(into: dirChild)
+
+        XCTAssertEqual(vm.navigationPath.count, 1)
+        XCTAssertTrue(vm.navigationPath.last === dirChild)
+    }
+
+    /// Files cannot be drilled into — the treemap renders `node.children`,
+    /// and a file has none, so a misplaced drill-down would land the UI on
+    /// an empty rectangle. The VM must reject the call instead of trusting
+    /// the view to filter it out.
+    func test_drillDown_isNoOpForNonDirectory() async {
+        let fileChild = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root/note.txt"),
+            name: "note.txt",
+            size: 10,
+            isDirectory: false,
+            children: []
+        )
+        let root = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root"),
+            name: "root",
+            size: 10,
+            isDirectory: true,
+            children: [fileChild]
+        )
+        let vm = DiskScannerViewModel(scanner: { _, _ in root })
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+
+        vm.drillDown(into: fileChild)
+
+        XCTAssertTrue(vm.navigationPath.isEmpty,
+                      "drillDown into a file should be a no-op")
+    }
+
+    /// `navigateUp` pops one entry — the back-button affordance behind the
+    /// breadcrumb's leftmost crumb.
+    func test_navigateUp_popsLastEntryFromNavigationPath() {
+        let a = DiskNode(url: URL(fileURLWithPath: "/a"), name: "a",
+                         size: 0, isDirectory: true, children: [])
+        let b = DiskNode(url: URL(fileURLWithPath: "/a/b"), name: "b",
+                         size: 0, isDirectory: true, children: [])
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            DiskNode(url: URL(fileURLWithPath: "/"), name: "/",
+                     size: 0, isDirectory: true, children: [])
+        })
+        vm.navigationPath = [a, b]
+
+        vm.navigateUp()
+
+        XCTAssertEqual(vm.navigationPath.count, 1)
+        XCTAssertTrue(vm.navigationPath.last === a)
+    }
+
+    /// `navigateUp` on an empty path is a no-op. Defensive against a
+    /// stuck-at-root state where the back button is mistakenly enabled.
+    func test_navigateUp_isNoOpWhenPathEmpty() {
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            DiskNode(url: URL(fileURLWithPath: "/"), name: "/",
+                     size: 0, isDirectory: true, children: [])
+        })
+
+        vm.navigateUp()
+
+        XCTAssertTrue(vm.navigationPath.isEmpty)
+    }
+
+    /// Clicking a breadcrumb crumb truncates the path so the named node
+    /// becomes the new tail. Without this, navigating back N levels would
+    /// require N separate `navigateUp` calls and the breadcrumb's
+    /// "jump to ancestor" affordance would be impossible.
+    func test_navigateTo_truncatesNavigationPathAtNode() {
+        let a = DiskNode(url: URL(fileURLWithPath: "/a"), name: "a",
+                         size: 0, isDirectory: true, children: [])
+        let b = DiskNode(url: URL(fileURLWithPath: "/a/b"), name: "b",
+                         size: 0, isDirectory: true, children: [])
+        let c = DiskNode(url: URL(fileURLWithPath: "/a/b/c"), name: "c",
+                         size: 0, isDirectory: true, children: [])
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            DiskNode(url: URL(fileURLWithPath: "/"), name: "/",
+                     size: 0, isDirectory: true, children: [])
+        })
+        vm.navigationPath = [a, b, c]
+
+        vm.navigate(to: b)
+
+        XCTAssertEqual(vm.navigationPath.count, 2)
+        XCTAssertTrue(vm.navigationPath.last === b)
+    }
+
+    /// `navigate(to:)` against a node that isn't on the current path is a
+    /// no-op — happens when the tree is rescanned and a stale crumb
+    /// reference fires while the new tree hasn't reached the view yet.
+    func test_navigateTo_isNoOpWhenNodeNotInPath() {
+        let a = DiskNode(url: URL(fileURLWithPath: "/a"), name: "a",
+                         size: 0, isDirectory: true, children: [])
+        let b = DiskNode(url: URL(fileURLWithPath: "/b"), name: "b",
+                         size: 0, isDirectory: true, children: [])
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            DiskNode(url: URL(fileURLWithPath: "/"), name: "/",
+                     size: 0, isDirectory: true, children: [])
+        })
+        vm.navigationPath = [a]
+
+        vm.navigate(to: b)
+
+        XCTAssertEqual(vm.navigationPath.count, 1)
+        XCTAssertTrue(vm.navigationPath.last === a,
+                      "navigate(to:) should leave the path untouched when the node isn't on it")
+    }
+
+    /// `currentNode` is the displayed node — root when the breadcrumb is
+    /// empty, the deepest crumb otherwise. The treemap binds to its
+    /// `children` so this property is the single source of truth for what
+    /// the view renders.
+    func test_currentNode_isRootWhenPathIsEmpty() async {
+        let root = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root"),
+            name: "root",
+            size: 100,
+            isDirectory: true,
+            children: []
+        )
+        let vm = DiskScannerViewModel(scanner: { _, _ in root })
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+
+        XCTAssertTrue(vm.currentNode === root)
+    }
+
+    func test_currentNode_isLastEntryWhenPathHasNodes() async {
+        let child = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root/sub"),
+            name: "sub",
+            size: 50,
+            isDirectory: true,
+            children: []
+        )
+        let root = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root"),
+            name: "root",
+            size: 50,
+            isDirectory: true,
+            children: [child]
+        )
+        let vm = DiskScannerViewModel(scanner: { _, _ in root })
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+        vm.drillDown(into: child)
+
+        XCTAssertTrue(vm.currentNode === child)
+    }
 }

--- a/VaderCleanerTests/FileCategoryTests.swift
+++ b/VaderCleanerTests/FileCategoryTests.swift
@@ -50,9 +50,43 @@ final class FileCategoryTests: XCTestCase {
         XCTAssertEqual(FileCategory.from(node: node), .system)
     }
 
+    /// The `~/Library` directory itself (without trailing slash / children
+    /// in the path) is the top-level system bucket users actually see in a
+    /// home-directory Space Lens scan. Locks the path-component matching
+    /// against a previous substring rule that missed the bare directory.
+    func test_category_systemForLibraryDirectoryItself() {
+        XCTAssertEqual(FileCategory.from(node: makeDirectory(path: "/Library")), .system)
+        XCTAssertEqual(FileCategory.from(node: makeDirectory(path: "/Users/example/Library")), .system)
+    }
+
     func test_category_systemForSystemAndPrivatePaths() {
         XCTAssertEqual(FileCategory.from(node: makeDirectory(path: "/System/Library")), .system)
         XCTAssertEqual(FileCategory.from(node: makeDirectory(path: "/private/var/log")), .system)
+        XCTAssertEqual(FileCategory.from(node: makeDirectory(path: "/usr/local/bin")), .system)
+    }
+
+    /// Path-prefix matching would misclassify these as `.system`. The
+    /// component-aware implementation must not. Regression guard against
+    /// reintroducing `hasPrefix("/usr")` / `contains("/Library/")` style
+    /// rules that match substrings inside legitimate user paths.
+    func test_category_otherForPathBoundaryFalsePositives() {
+        // `/Users/example/usr_data` — `hasPrefix("/usr")` would have to
+        // not match because the path doesn't start with `/usr`, but a
+        // careless rule that checks `path.contains("usr")` would.
+        let usrLike = makeDirectory(path: "/Users/example/usr_data")
+        XCTAssertEqual(FileCategory.from(node: usrLike), .other)
+
+        // `/Users/example/Projects/LibraryNotes` — the literal substring
+        // "Library" appears, but as part of "LibraryNotes", not as a
+        // path component. Component-aware matching must reject it.
+        let libraryLike = makeDirectory(path: "/Users/example/Projects/LibraryNotes")
+        XCTAssertEqual(FileCategory.from(node: libraryLike), .other)
+
+        // A user-managed folder literally named "Library" inside a deep
+        // Projects tree shouldn't read as system either — only the
+        // canonical `~/Library` and `/Library` shapes do.
+        let deepLibrary = makeDirectory(path: "/Users/example/Projects/Library")
+        XCTAssertEqual(FileCategory.from(node: deepLibrary), .other)
     }
 
     func test_category_systemForLowLevelExecutableExtensions() {

--- a/VaderCleanerTests/FileCategoryTests.swift
+++ b/VaderCleanerTests/FileCategoryTests.swift
@@ -1,0 +1,103 @@
+// FileCategoryTests.swift
+// Verifies FileCategory's mapping from DiskNode to one of documents/media/apps/system/other based on extension and path heuristics.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Unit tests for `FileCategory`. The category drives tile color in the
+/// Space Lens treemap, so misclassifications would surface as misleading
+/// visual cues. Each branch (extension-driven, `.app` bundle, system path,
+/// fallback) is tested in isolation.
+final class FileCategoryTests: XCTestCase {
+
+    // MARK: - Documents
+
+    func test_category_documentsForCommonOfficeExtensions() {
+        for ext in ["pdf", "doc", "docx", "txt", "rtf", "pages",
+                    "xls", "xlsx", "numbers", "ppt", "pptx", "key",
+                    "md", "csv"] {
+            let node = makeFile(name: "report.\(ext)")
+            XCTAssertEqual(FileCategory.from(node: node), .documents,
+                           "Expected .documents for .\(ext)")
+        }
+    }
+
+    // MARK: - Media
+
+    func test_category_mediaForImagesAudioAndVideo() {
+        for ext in ["jpg", "jpeg", "png", "gif", "tiff", "heic",
+                    "mp4", "mov", "avi", "mkv", "m4v",
+                    "mp3", "wav", "aac", "flac", "m4a"] {
+            let node = makeFile(name: "asset.\(ext)")
+            XCTAssertEqual(FileCategory.from(node: node), .media,
+                           "Expected .media for .\(ext)")
+        }
+    }
+
+    // MARK: - Apps
+
+    /// `.app` bundles read as directories on disk, so the categorizer must
+    /// look at the URL extension rather than `isDirectory` alone.
+    func test_category_appsForDotAppBundle() {
+        let node = makeDirectory(path: "/Applications/Pages.app")
+        XCTAssertEqual(FileCategory.from(node: node), .apps)
+    }
+
+    // MARK: - System
+
+    func test_category_systemForLibrarySubpaths() {
+        let node = makeDirectory(path: "/Users/example/Library/Caches/com.example")
+        XCTAssertEqual(FileCategory.from(node: node), .system)
+    }
+
+    func test_category_systemForSystemAndPrivatePaths() {
+        XCTAssertEqual(FileCategory.from(node: makeDirectory(path: "/System/Library")), .system)
+        XCTAssertEqual(FileCategory.from(node: makeDirectory(path: "/private/var/log")), .system)
+    }
+
+    func test_category_systemForLowLevelExecutableExtensions() {
+        for ext in ["dylib", "framework", "kext", "plist", "log"] {
+            let node = makeFile(name: "thing.\(ext)")
+            XCTAssertEqual(FileCategory.from(node: node), .system,
+                           "Expected .system for .\(ext)")
+        }
+    }
+
+    // MARK: - Other
+
+    func test_category_otherFallback() {
+        let unknown = makeFile(name: "weirdfile.xyz")
+        XCTAssertEqual(FileCategory.from(node: unknown), .other)
+
+        let extensionless = makeFile(name: "Makefile")
+        XCTAssertEqual(FileCategory.from(node: extensionless), .other)
+    }
+
+    func test_category_otherForUserDirectoryWithNoSpecialMarker() {
+        let node = makeDirectory(path: "/Users/example/Projects")
+        XCTAssertEqual(FileCategory.from(node: node), .other)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeFile(name: String) -> DiskNode {
+        DiskNode(
+            url: URL(fileURLWithPath: "/tmp/\(name)"),
+            name: name,
+            size: 1024,
+            isDirectory: false,
+            children: []
+        )
+    }
+
+    private func makeDirectory(path: String) -> DiskNode {
+        let url = URL(fileURLWithPath: path)
+        return DiskNode(
+            url: url,
+            name: url.lastPathComponent,
+            size: 0,
+            isDirectory: true,
+            children: []
+        )
+    }
+}

--- a/VaderCleanerTests/TreemapLayoutTests.swift
+++ b/VaderCleanerTests/TreemapLayoutTests.swift
@@ -1,0 +1,161 @@
+// TreemapLayoutTests.swift
+// Locks the squarified treemap layout's invariants: bounds containment, non-overlap, area proportionality, the squarified aspect-ratio property versus naive slicing, and the empty / single-item / zero-weight edge cases.
+
+import XCTest
+import CoreGraphics
+@testable import VaderCleaner
+
+/// Unit tests for `TreemapLayout`. The layout is a pure value type with no
+/// dependence on `DiskNode`, so these tests use lightweight `(Int, Double)`
+/// fixtures. The squarified-quality test is the critical one — without it
+/// a buggy slice-and-dice implementation would still pass the non-overlap
+/// and proportionality assertions.
+final class TreemapLayoutTests: XCTestCase {
+
+    private let bounds = CGRect(x: 0, y: 0, width: 400, height: 300)
+
+    // MARK: - Invariants
+
+    /// Every laid-out tile must sit inside the supplied bounds. Without this
+    /// guarantee, the treemap could draw outside its `GeometryReader` parent
+    /// and clip into neighbouring UI.
+    func test_layout_keepsAllRectanglesWithinBounds() {
+        let items = uniformItems(count: 8)
+        let result = TreemapLayout.layout(items: items, in: bounds)
+
+        let eps: CGFloat = 0.5
+        for tile in result {
+            XCTAssertGreaterThanOrEqual(tile.rect.minX, bounds.minX - eps,
+                                        "Tile \(tile.rect) extends left of bounds")
+            XCTAssertGreaterThanOrEqual(tile.rect.minY, bounds.minY - eps,
+                                        "Tile \(tile.rect) extends above bounds")
+            XCTAssertLessThanOrEqual(tile.rect.maxX, bounds.maxX + eps,
+                                     "Tile \(tile.rect) extends right of bounds")
+            XCTAssertLessThanOrEqual(tile.rect.maxY, bounds.maxY + eps,
+                                     "Tile \(tile.rect) extends below bounds")
+        }
+    }
+
+    /// No two tiles may overlap. Tile order in the output is implementation-
+    /// defined (the squarified algorithm sorts internally), so the test
+    /// compares every pair.
+    func test_layout_producesNonOverlappingRectangles() {
+        let items = mixedItems()
+        let result = TreemapLayout.layout(items: items, in: bounds)
+
+        for i in 0..<result.count {
+            for j in (i + 1)..<result.count {
+                let a = result[i].rect
+                let b = result[j].rect
+                let overlap = a.intersection(b)
+                XCTAssertTrue(
+                    overlap.isEmpty || overlap.width < 0.5 || overlap.height < 0.5,
+                    "Tiles \(a) and \(b) overlap by \(overlap)"
+                )
+            }
+        }
+    }
+
+    /// The sum of tile areas must approximate the bounds' area — the squarified
+    /// algorithm is meant to fill the rectangle, not leave gaps. We allow a
+    /// 1% slack for floating-point drift across the recursive strip splits.
+    func test_layout_sizesRectanglesProportionallyToWeights() {
+        let items = mixedItems()
+        let result = TreemapLayout.layout(items: items, in: bounds)
+
+        let totalArea = result.reduce(0.0) { $0 + Double($1.rect.width * $1.rect.height) }
+        let boundsArea = Double(bounds.width * bounds.height)
+        XCTAssertEqual(totalArea, boundsArea, accuracy: boundsArea * 0.01,
+                       "Total tile area must approximate the bounds area")
+
+        // Ratio between any two tile areas must approximate the ratio between
+        // their input weights. Pick the two largest items so the comparison is
+        // robust to floating-point noise in the very smallest tiles.
+        let totalWeight = items.reduce(0.0) { $0 + $1.weight }
+        let byID = Dictionary(uniqueKeysWithValues: result.map { ($0.id, $0.rect) })
+        for item in items {
+            let rect = byID[item.id]
+            XCTAssertNotNil(rect, "Missing tile for id \(item.id)")
+            let area = Double((rect?.width ?? 0) * (rect?.height ?? 0))
+            let expected = item.weight / totalWeight * boundsArea
+            XCTAssertEqual(area, expected, accuracy: boundsArea * 0.01,
+                           "Tile for id \(item.id) has area \(area), expected ~\(expected)")
+        }
+    }
+
+    /// **The squarified property.** Naive slice-and-dice produces stripes
+    /// whose worst aspect ratio degrades linearly with the input size; the
+    /// squarified algorithm keeps every tile near-square. For 10 equal
+    /// weights in a 400×300 bounds, naive striping yields tiles of either
+    /// 40×300 (ratio 7.5) or 400×30 (ratio 13.3), so a worst-case ratio
+    /// gate of 5 cleanly distinguishes the two algorithms.
+    func test_layout_keepsTilesNearSquare_versusNaiveSlicing() {
+        let items = uniformItems(count: 10)
+        let result = TreemapLayout.layout(items: items, in: bounds)
+
+        let worst = result.map { tile -> Double in
+            let w = max(Double(tile.rect.width), 0.001)
+            let h = max(Double(tile.rect.height), 0.001)
+            return max(w / h, h / w)
+        }.max() ?? .infinity
+
+        XCTAssertLessThan(worst, 5.0,
+                          "Squarified layout should keep tiles near-square; worst ratio \(worst)")
+    }
+
+    // MARK: - Edge cases
+
+    /// Empty input → empty output. SwiftUI binds the layout result via
+    /// `ForEach`, so the empty case must be a valid array (not nil) so the
+    /// view simply renders nothing.
+    func test_layout_returnsEmptyForEmptyInput() {
+        let result = TreemapLayout.layout(items: [(id: Int, weight: Double)](), in: bounds)
+        XCTAssertEqual(result.count, 0)
+    }
+
+    /// Single item must occupy the full bounds. Without this, drilling into
+    /// a folder with one subfolder would render a tiny tile floating inside
+    /// otherwise-empty bounds.
+    func test_layout_givesFullBoundsToSingleItem() {
+        let result = TreemapLayout.layout(items: [(id: 1, weight: 100.0)], in: bounds)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].rect.width, bounds.width, accuracy: 0.01)
+        XCTAssertEqual(result[0].rect.height, bounds.height, accuracy: 0.01)
+    }
+
+    /// All-zero weights must not divide-by-zero. The empty-directory case
+    /// triggers this: every child is an empty file. The contract is that
+    /// each item gets a zero-area placeholder so SwiftUI's `ForEach` still
+    /// has a stable id-keyed list.
+    func test_layout_handlesZeroWeightsWithoutCrashing() {
+        let items = [
+            (id: 1, weight: 0.0),
+            (id: 2, weight: 0.0),
+            (id: 3, weight: 0.0)
+        ]
+        let result = TreemapLayout.layout(items: items, in: bounds)
+        XCTAssertEqual(result.count, 3)
+        for tile in result {
+            XCTAssertEqual(tile.rect.width * tile.rect.height, 0)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func uniformItems(count: Int) -> [(id: Int, weight: Double)] {
+        (0..<count).map { (id: $0, weight: 100.0) }
+    }
+
+    private func mixedItems() -> [(id: Int, weight: Double)] {
+        [
+            (id: 1, weight: 600),
+            (id: 2, weight: 300),
+            (id: 3, weight: 150),
+            (id: 4, weight: 100),
+            (id: 5, weight: 80),
+            (id: 6, weight: 40),
+            (id: 7, weight: 20),
+            (id: 8, weight: 10)
+        ]
+    }
+}

--- a/VaderCleanerTests/TreemapLayoutTests.swift
+++ b/VaderCleanerTests/TreemapLayoutTests.swift
@@ -123,6 +123,34 @@ final class TreemapLayoutTests: XCTestCase {
         XCTAssertEqual(result[0].rect.height, bounds.height, accuracy: 0.01)
     }
 
+    /// Negative, NaN, and ±infinity weights must not crash and must not
+    /// poison the totals. The contract clamps each to zero so a single
+    /// corrupt scan record can't take down the visualization. The output
+    /// length still matches the input so SwiftUI's id-keyed `ForEach`
+    /// stays stable.
+    func test_layout_clampsNonFiniteAndNegativeWeightsToZero() {
+        let items: [(id: Int, weight: Double)] = [
+            (id: 1, weight: -10),
+            (id: 2, weight: .nan),
+            (id: 3, weight: .infinity),
+            (id: 4, weight: -.infinity),
+            (id: 5, weight: 100)
+        ]
+        let result = TreemapLayout.layout(items: items, in: bounds)
+        XCTAssertEqual(result.count, items.count)
+
+        let byID = Dictionary(uniqueKeysWithValues: result.map { ($0.id, $0.rect) })
+        for badID in [1, 2, 3, 4] {
+            let rect = byID[badID]
+            XCTAssertNotNil(rect)
+            XCTAssertEqual((rect?.width ?? 1) * (rect?.height ?? 1), 0,
+                           "Item \(badID) with non-finite/negative weight should yield zero area")
+        }
+        let goodArea = (byID[5]?.width ?? 0) * (byID[5]?.height ?? 0)
+        XCTAssertGreaterThan(goodArea, 0,
+                             "The lone valid weight should still produce a positive-area tile")
+    }
+
     /// All-zero weights must not divide-by-zero. The empty-directory case
     /// triggers this: every child is an empty file. The contract is that
     /// each item gets a zero-area placeholder so SwiftUI's `ForEach` still

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -1,0 +1,65 @@
+// SpaceLensUITests.swift
+// End-to-end UI test for Space Lens — navigates to the section and waits for either the in-progress scan or the post-scan treemap, asserting that the wiring between sidebar selection, view-model, and view reaches the user's home directory.
+
+import XCTest
+
+/// We do not assert on individual treemap tiles here. The home directory
+/// scanned by the test machine is whatever the CI / developer runner
+/// happens to have, so the only stable invariant is that the section
+/// loads and the scan reaches a recognizable state. Tile rendering is
+/// covered by `TreemapLayoutTests` against synthetic fixtures.
+final class SpaceLensUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    /// Sidebar → Space Lens must reach either the in-progress scanning
+    /// indicator or the loaded treemap (or, on a permission-denied home
+    /// directory, the error banner). Any of these is evidence that the
+    /// view-model is alive and the scan kicked off — anything else is a
+    /// wiring regression.
+    func test_navigateToSpaceLens_revealsScanningOrTreemap() throws {
+        dismissOnboardingIfNeeded()
+
+        let sidebarRow = app.outlines.staticTexts["Space Lens"].firstMatch
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
+                      "Expected Space Lens row in sidebar")
+        sidebarRow.click()
+
+        // The scan starts automatically from `.task`, so we expect either
+        // the scanning indicator or — on tiny home folders / fast machines —
+        // the treemap to land before our timeout. The error banner is
+        // accepted as well: a CI runner without home-folder access should
+        // still surface a recognizable state, not hang on a blank canvas.
+        let scanning = app.otherElements["space-lens.scanning"]
+        let treemap = app.otherElements["space-lens.treemap"]
+        let errorBanner = app.otherElements["space-lens.error"]
+        let emptyBanner = app.otherElements["space-lens.empty"]
+
+        let appeared = scanning.waitForExistence(timeout: 5)
+            || treemap.waitForExistence(timeout: 30)
+            || errorBanner.waitForExistence(timeout: 1)
+            || emptyBanner.waitForExistence(timeout: 1)
+        XCTAssertTrue(appeared,
+                      "Expected to land on a recognizable Space Lens state after selection")
+    }
+
+    // MARK: - Helpers
+
+    private func dismissOnboardingIfNeeded() {
+        let continueWithout = app.buttons["Continue Without Access"]
+        if continueWithout.waitForExistence(timeout: 2) {
+            continueWithout.click()
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -31,7 +31,7 @@
 - [x] **Prompt 14** — System Junk UI + deletion (scan → preview → clean flow)
 - [x] **Prompt 15** — Large & Old Files scanner + UI
 - [x] **Prompt 16** — Space Lens disk scanner (DiskNode tree + DiskScanner)
-- [ ] **Prompt 17** — Space Lens treemap UI (squarified treemap + drill-down)
+- [x] **Prompt 17** — Space Lens treemap UI (squarified treemap + drill-down)
 
 ## Phase 3 — Privacy & Apps
 


### PR DESCRIPTION
## Summary
- Implements [Prompt 17](https://github.com/jayvicsanantonio/VaderCleaner/issues/36): squarified treemap (Bruls/Huijse/van Wijk) over the `DiskNode` tree, breadcrumb navigation, and file-category coloring.
- New `TreemapLayout` (pure value type, generic over `ID`), `FileCategory` (extension + path heuristics), `TreemapView`, `SpaceLensView`. Wired into `ContentView` so the Space Lens sidebar section now renders the live home-directory treemap.
- `DiskScannerViewModel` gains `drillDown(into:)`, `navigateUp()`, `navigate(to:)`, and `currentNode`. Drill-down is a no-op for non-directory children; `navigate(to:)` truncates to a named ancestor for one-click breadcrumb jumps.

## Test plan
- [x] `xcodebuild test -only-testing:VaderCleanerTests` — all 252 unit tests pass, including the 7 new `TreemapLayoutTests` (with a squarified-quality gate that rejects naive slice-and-dice), 8 new `FileCategoryTests`, and 7 new `DiskScannerViewModelTests` covering the navigation helpers
- [x] `xcodebuild build-for-testing` — UI test target compiles, including `SpaceLensUITests`
- [ ] Manual smoke test: launch app, select Space Lens sidebar row, confirm scan progress reaches the treemap, drill into a folder, click a breadcrumb crumb to jump back

Closes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Space Lens sidebar view for disk usage visualization as an interactive treemap
  * Disk scanning with progress tracking starting from home directory
  * Breadcrumb-based folder navigation
  * File categorization (Documents, Media, Apps, System, Other) with distinct color coding
  * Accessibility support with tooltips and labels for treemap tiles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->