### PR TITLE
feat: Privacy feature (browser data clearing + Recent Items) — Prompt 18

### DIFF
--- a/VaderCleaner/Browser.swift
+++ b/VaderCleaner/Browser.swift
@@ -1,0 +1,70 @@
+// Browser.swift
+// Stable enum of supported browsers for the Privacy feature, carrying bundle / display / app-name metadata used by detection and data-path resolution.
+
+import Foundation
+
+/// Browsers the Privacy feature can detect, preview, and clear data for.
+///
+/// Raw values are persisted in scan reports and view-model state, so cases
+/// must be appended (never inserted) and existing raw values must not change
+/// or older preferences/reports will fail to decode.
+///
+/// Each case carries:
+///   - `bundleIdentifier` — used by future Launch Services lookups.
+///   - `appBundleName` — the `.app` filename `BrowserDetector` looks for
+///     under `/Applications` and `~/Applications`.
+///   - `displayName` — human-readable label shown in the Privacy UI.
+enum Browser: String, CaseIterable, Codable, Hashable, Identifiable {
+    case safari
+    case chrome
+    case firefox
+    case brave
+    case arc
+    case opera
+    case edge
+
+    var id: String { rawValue }
+
+    /// The shipping bundle identifier. Pinned in tests because a typo would
+    /// silently mis-detect a browser as not installed.
+    var bundleIdentifier: String {
+        switch self {
+        case .safari:  return "com.apple.Safari"
+        case .chrome:  return "com.google.Chrome"
+        case .firefox: return "org.mozilla.firefox"
+        case .brave:   return "com.brave.Browser"
+        case .arc:     return "company.thebrowser.Browser"
+        case .opera:   return "com.operasoftware.Opera"
+        case .edge:    return "com.microsoft.edgemac"
+        }
+    }
+
+    /// The `.app` filename as it appears under `/Applications`. The display
+    /// name and bundle filename diverge enough across vendors (Brave → "Brave
+    /// Browser.app", Edge → "Microsoft Edge.app") that a single derivation
+    /// rule wouldn't be reliable; case-by-case is the only correct option.
+    var appBundleName: String {
+        switch self {
+        case .safari:  return "Safari.app"
+        case .chrome:  return "Google Chrome.app"
+        case .firefox: return "Firefox.app"
+        case .brave:   return "Brave Browser.app"
+        case .arc:     return "Arc.app"
+        case .opera:   return "Opera.app"
+        case .edge:    return "Microsoft Edge.app"
+        }
+    }
+
+    /// Label shown in the Privacy UI's per-browser disclosure header.
+    var displayName: String {
+        switch self {
+        case .safari:  return "Safari"
+        case .chrome:  return "Google Chrome"
+        case .firefox: return "Firefox"
+        case .brave:   return "Brave"
+        case .arc:     return "Arc"
+        case .opera:   return "Opera"
+        case .edge:    return "Microsoft Edge"
+        }
+    }
+}

--- a/VaderCleaner/BrowserDataClearer.swift
+++ b/VaderCleaner/BrowserDataClearer.swift
@@ -1,0 +1,102 @@
+// BrowserDataClearer.swift
+// Sums on-disk byte sizes and removes every path the BrowserDataPathProviding resolves for a (browser, category) pair, tolerating missing paths so partial browser state never derails a clean run.
+
+import Foundation
+import os.log
+
+/// Reads and removes browser data on behalf of the Privacy feature.
+///
+/// The clearer holds no path knowledge — every "where does Chrome keep its
+/// cookies?" question routes to the injected `BrowserDataPathProviding`,
+/// which makes the whole pipeline trivially testable against a temp dir.
+/// Errors on individual files surface as throws from `clear`; a missing
+/// path is treated as already-cleared and silently skipped.
+struct BrowserDataClearer {
+
+    typealias Remover = (URL) throws -> Void
+
+    private let pathProvider: BrowserDataPathProviding
+    private let fileManager: FileManager
+    private let remover: Remover
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "BrowserDataClearer")
+
+    init(
+        pathProvider: BrowserDataPathProviding,
+        fileManager: FileManager = .default,
+        remover: Remover? = nil
+    ) {
+        self.pathProvider = pathProvider
+        self.fileManager = fileManager
+        self.remover = remover ?? { url in
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    /// Sum of bytes across every existing path the provider returns for
+    /// `(browser, category)`. Files contribute their `fileSize`,
+    /// directories contribute the recursive total. Missing paths are
+    /// silently skipped — they contribute 0.
+    func previewSize(for category: PrivacyCategory, browser: Browser) -> Int64 {
+        let paths = pathProvider.dataPaths(for: browser, category: category)
+        return paths.reduce(into: Int64(0)) { acc, url in
+            acc += sizeOnDisk(at: url)
+        }
+    }
+
+    /// All on-disk paths the provider knows about for `(browser, category)`.
+    /// Used by `PrivacyViewModel` to dedupe URLs across selected categories
+    /// (Chromium / Firefox `.history` and `.downloads` share a SQLite file).
+    func paths(for category: PrivacyCategory, browser: Browser) -> [URL] {
+        pathProvider.dataPaths(for: browser, category: category)
+    }
+
+    /// Remove every existing path for `(browser, category)`. Throws on the
+    /// first remover failure; missing paths are silently skipped.
+    func clear(category: PrivacyCategory, browser: Browser) throws {
+        let paths = pathProvider.dataPaths(for: browser, category: category)
+        for url in paths {
+            guard fileManager.fileExists(atPath: url.path) else {
+                log.debug("Skipping missing path: \(url.path, privacy: .public)")
+                continue
+            }
+            try remover(url)
+        }
+    }
+
+    // MARK: - Sizing
+
+    /// Recursive byte count for `url`. Returns 0 for missing paths or paths
+    /// the process can't read. Directories enumerate via
+    /// `FileManager.enumerator` with file-size + directory keys so the walk
+    /// runs in one pass without a separate stat for every entry.
+    private func sizeOnDisk(at url: URL) -> Int64 {
+        guard fileManager.fileExists(atPath: url.path) else { return 0 }
+
+        let resourceKeys: Set<URLResourceKey> = [.isDirectoryKey, .totalFileAllocatedSizeKey, .fileSizeKey]
+        let values = try? url.resourceValues(forKeys: resourceKeys)
+        let isDirectory = values?.isDirectory ?? false
+
+        if !isDirectory {
+            return Int64(values?.fileSize ?? 0)
+        }
+
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: Array(resourceKeys),
+            options: [.skipsHiddenFiles],
+            errorHandler: nil
+        ) else {
+            return 0
+        }
+
+        var total: Int64 = 0
+        for case let entry as URL in enumerator {
+            if let entryValues = try? entry.resourceValues(forKeys: resourceKeys),
+               entryValues.isDirectory == false {
+                total += Int64(entryValues.fileSize ?? 0)
+            }
+        }
+        return total
+    }
+}

--- a/VaderCleaner/BrowserDataPathProviding.swift
+++ b/VaderCleaner/BrowserDataPathProviding.swift
@@ -1,0 +1,247 @@
+// BrowserDataPathProviding.swift
+// Maps each (Browser, PrivacyCategory) pair to the on-disk locations the BrowserDataClearer reads and removes — concrete production resolver plus protocol test seam.
+
+import Foundation
+
+/// Test seam between `BrowserDataClearer` and the macOS browser data
+/// layout. The clearer knows nothing about where Chrome's `History` lives;
+/// the provider does. Tests inject a stub that returns paths under a temp
+/// directory so every clearer / view-model test runs hermetically.
+protocol BrowserDataPathProviding {
+    /// All on-disk paths to read (for size preview) or remove (for clear)
+    /// for a given `(browser, category)` pair. Missing paths are not
+    /// filtered here — the clearer skips ones that don't exist — so callers
+    /// receive the full set the provider knows about.
+    func dataPaths(for browser: Browser, category: PrivacyCategory) -> [URL]
+}
+
+/// Production resolver. Returns the real macOS paths for each
+/// `(browser, category)` pair, anchored to an injectable home directory so
+/// tests can drive every code path without touching the user's actual data.
+struct DefaultBrowserDataPathProvider: BrowserDataPathProviding {
+
+    private let homeDirectory: URL
+    private let fileManager: FileManager
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) {
+        self.homeDirectory = homeDirectory
+        self.fileManager = fileManager
+    }
+
+    func dataPaths(for browser: Browser, category: PrivacyCategory) -> [URL] {
+        switch browser {
+        case .safari:
+            return safariPaths(category: category)
+        case .firefox:
+            return firefoxPaths(category: category)
+        case .chrome, .brave, .arc, .opera, .edge:
+            return chromiumPaths(browser: browser, category: category)
+        }
+    }
+
+    // MARK: - Safari
+
+    /// Safari ships both legacy paths (`~/Library/Safari`, `~/Library/Cookies`)
+    /// and sandbox-container paths (`~/Library/Containers/com.apple.Safari/...`)
+    /// on modern macOS. Some users have both populated depending on upgrade
+    /// history, so the provider emits both and the clearer skips whichever
+    /// doesn't exist on a given machine.
+    private func safariPaths(category: PrivacyCategory) -> [URL] {
+        let library = homeDirectory.appendingPathComponent("Library", isDirectory: true)
+        let safariLegacy = library.appendingPathComponent("Safari", isDirectory: true)
+        let containerLibrary = library
+            .appendingPathComponent("Containers", isDirectory: true)
+            .appendingPathComponent("com.apple.Safari", isDirectory: true)
+            .appendingPathComponent("Data", isDirectory: true)
+            .appendingPathComponent("Library", isDirectory: true)
+        let safariContainer = containerLibrary.appendingPathComponent("Safari", isDirectory: true)
+
+        switch category {
+        case .history:
+            // History.db is the SQLite store; -shm/-wal are sidecars that
+            // SQLite recreates lazily, so removing them alongside the main
+            // file keeps the on-disk state coherent.
+            return [
+                safariLegacy.appendingPathComponent("History.db"),
+                safariLegacy.appendingPathComponent("History.db-shm"),
+                safariLegacy.appendingPathComponent("History.db-wal"),
+                safariContainer.appendingPathComponent("History.db"),
+                safariContainer.appendingPathComponent("History.db-shm"),
+                safariContainer.appendingPathComponent("History.db-wal")
+            ]
+        case .downloads:
+            return [
+                safariLegacy.appendingPathComponent("Downloads.plist"),
+                safariContainer.appendingPathComponent("Downloads.plist")
+            ]
+        case .cookies:
+            return [
+                library.appendingPathComponent("Cookies", isDirectory: true)
+                       .appendingPathComponent("Cookies.binarycookies"),
+                containerLibrary.appendingPathComponent("Cookies", isDirectory: true)
+                                .appendingPathComponent("Cookies.binarycookies")
+            ]
+        case .cache:
+            return [
+                library.appendingPathComponent("Caches", isDirectory: true)
+                       .appendingPathComponent("com.apple.Safari", isDirectory: true),
+                containerLibrary.appendingPathComponent("Caches", isDirectory: true)
+                                .appendingPathComponent("com.apple.Safari", isDirectory: true)
+            ]
+        case .savedForms:
+            return [
+                safariLegacy.appendingPathComponent("Form Values"),
+                safariContainer.appendingPathComponent("Form Values")
+            ]
+        }
+    }
+
+    // MARK: - Chromium
+
+    /// Each Chromium-based browser keeps its data under a vendor-specific
+    /// `Application Support` root with a near-identical layout: `Default/`
+    /// for the primary profile, `History` for browsing + downloads,
+    /// `Cookies` for cookies, `Web Data` for autofill / saved forms.
+    /// Caches live under `~/Library/Caches/<vendor>/...`.
+    private func chromiumPaths(browser: Browser, category: PrivacyCategory) -> [URL] {
+        guard let layout = chromiumLayout(for: browser) else { return [] }
+
+        switch category {
+        case .history:
+            // The History SQLite stores both browsing and downloads, so a
+            // user clearing only "Downloads" via `.downloads` still leaves
+            // the browsing entry intact via this path. We do *not* remove
+            // History under the .downloads category — see below.
+            return layout.profilePath
+                .map { [$0.appendingPathComponent("History"),
+                        $0.appendingPathComponent("History-journal")] }
+                ?? []
+        case .downloads:
+            // Chromium stores download history inside the same `History`
+            // SQLite as browsing history, so `.downloads` returns the same
+            // paths. The view-model deduplicates URLs when summing
+            // `totalSelectedSize` and when handing paths to the clearer, so
+            // checking both `.history` and `.downloads` doesn't double-count
+            // bytes or attempt a redundant remove.
+            return layout.profilePath
+                .map { [$0.appendingPathComponent("History"),
+                        $0.appendingPathComponent("History-journal")] }
+                ?? []
+        case .cookies:
+            return layout.profilePath
+                .map { [$0.appendingPathComponent("Cookies"),
+                        $0.appendingPathComponent("Cookies-journal")] }
+                ?? []
+        case .cache:
+            return layout.cachePath.map { [$0] } ?? []
+        case .savedForms:
+            return layout.profilePath
+                .map { [$0.appendingPathComponent("Web Data"),
+                        $0.appendingPathComponent("Web Data-journal")] }
+                ?? []
+        }
+    }
+
+    private struct ChromiumLayout {
+        let profilePath: URL?
+        let cachePath: URL?
+    }
+
+    private func chromiumLayout(for browser: Browser) -> ChromiumLayout? {
+        let library = homeDirectory.appendingPathComponent("Library", isDirectory: true)
+        let appSupport = library.appendingPathComponent("Application Support", isDirectory: true)
+        let caches = library.appendingPathComponent("Caches", isDirectory: true)
+
+        switch browser {
+        case .chrome:
+            return ChromiumLayout(
+                profilePath: appSupport.appendingPathComponent("Google/Chrome/Default", isDirectory: true),
+                cachePath:   caches.appendingPathComponent("Google/Chrome", isDirectory: true)
+            )
+        case .brave:
+            return ChromiumLayout(
+                profilePath: appSupport.appendingPathComponent("BraveSoftware/Brave-Browser/Default", isDirectory: true),
+                cachePath:   caches.appendingPathComponent("BraveSoftware/Brave-Browser", isDirectory: true)
+            )
+        case .edge:
+            return ChromiumLayout(
+                profilePath: appSupport.appendingPathComponent("Microsoft Edge/Default", isDirectory: true),
+                cachePath:   caches.appendingPathComponent("Microsoft Edge", isDirectory: true)
+            )
+        case .arc:
+            // Arc stores profile data under `Arc/User Data/Default`, mirroring
+            // Chromium's nested-User-Data layout; cache lives one level up.
+            return ChromiumLayout(
+                profilePath: appSupport.appendingPathComponent("Arc/User Data/Default", isDirectory: true),
+                cachePath:   caches.appendingPathComponent("Arc", isDirectory: true)
+            )
+        case .opera:
+            // Opera flattens the profile — no `Default` subdirectory.
+            return ChromiumLayout(
+                profilePath: appSupport.appendingPathComponent("com.operasoftware.Opera", isDirectory: true),
+                cachePath:   caches.appendingPathComponent("com.operasoftware.Opera", isDirectory: true)
+            )
+        case .safari, .firefox:
+            return nil
+        }
+    }
+
+    // MARK: - Firefox
+
+    /// Firefox profiles live under `Profiles/<8-char-rand>.default*`. We
+    /// enumerate the `Profiles/` directory at call time and pick the first
+    /// directory whose name contains `.default` — that matches both the
+    /// historical `<rand>.default` and the modern `<rand>.default-release`
+    /// variants. Returns no paths when no profile exists yet (e.g. the user
+    /// never launched Firefox), which is the right default for the clearer.
+    private func firefoxPaths(category: PrivacyCategory) -> [URL] {
+        let library = homeDirectory.appendingPathComponent("Library", isDirectory: true)
+        let appSupport = library.appendingPathComponent("Application Support", isDirectory: true)
+        let caches = library.appendingPathComponent("Caches", isDirectory: true)
+
+        let profilesRoot = appSupport
+            .appendingPathComponent("Firefox", isDirectory: true)
+            .appendingPathComponent("Profiles", isDirectory: true)
+        let cacheProfilesRoot = caches
+            .appendingPathComponent("Firefox", isDirectory: true)
+            .appendingPathComponent("Profiles", isDirectory: true)
+
+        let profileDir = firefoxProfileDirectory(at: profilesRoot)
+        let cacheProfileDir = firefoxProfileDirectory(at: cacheProfilesRoot)
+
+        switch category {
+        case .history:
+            // places.sqlite stores both browsing history and download history
+            // in Firefox; same caveat as Chromium's `History` file applies.
+            return profileDir.map { [$0.appendingPathComponent("places.sqlite")] } ?? []
+        case .downloads:
+            // Firefox stores download history inside places.sqlite alongside
+            // browsing history. Same dedup contract as Chromium — see the
+            // chromiumPaths(.downloads) note.
+            return profileDir.map { [$0.appendingPathComponent("places.sqlite")] } ?? []
+        case .cookies:
+            return profileDir.map { [$0.appendingPathComponent("cookies.sqlite")] } ?? []
+        case .cache:
+            return cacheProfileDir.map { [$0.appendingPathComponent("cache2", isDirectory: true)] } ?? []
+        case .savedForms:
+            return profileDir.map { [$0.appendingPathComponent("formhistory.sqlite")] } ?? []
+        }
+    }
+
+    private func firefoxProfileDirectory(at profilesRoot: URL) -> URL? {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: profilesRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+        return entries.first { url in
+            let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            return isDir && url.lastPathComponent.contains(".default")
+        }
+    }
+}

--- a/VaderCleaner/BrowserDataPathProviding.swift
+++ b/VaderCleaner/BrowserDataPathProviding.swift
@@ -266,10 +266,15 @@ struct DefaultBrowserDataPathProvider: BrowserDataPathProviding {
         }
     }
 
-    /// Firefox SQLite + WAL-mode sidecars for a single store.
+    /// Firefox SQLite + sidecars for a single store. Includes WAL-mode
+    /// sidecars (`-shm` / `-wal`) and the rollback-journal sidecar
+    /// (`-journal`) — the rollback journal lingers when SQLite isn't in
+    /// WAL mode or after a crash mid-write, and may still hold copies
+    /// of the rows the user is asking us to clear.
     private func firefoxSqlitePaths(in profileDir: URL, named name: String) -> [URL] {
         [
             profileDir.appendingPathComponent(name),
+            profileDir.appendingPathComponent("\(name)-journal"),
             profileDir.appendingPathComponent("\(name)-shm"),
             profileDir.appendingPathComponent("\(name)-wal")
         ]

--- a/VaderCleaner/BrowserDataPathProviding.swift
+++ b/VaderCleaner/BrowserDataPathProviding.swift
@@ -104,45 +104,78 @@ struct DefaultBrowserDataPathProvider: BrowserDataPathProviding {
     /// Each Chromium-based browser keeps its data under a vendor-specific
     /// `Application Support` root with a near-identical layout: `Default/`
     /// for the primary profile, `History` for browsing + downloads,
-    /// `Cookies` for cookies, `Web Data` for autofill / saved forms.
-    /// Caches live under `~/Library/Caches/<vendor>/...`.
+    /// `Cookies` (legacy) or `Network/Cookies` (modern) for cookies, and
+    /// `Web Data` for autofill / saved forms. Caches live under
+    /// `~/Library/Caches/<vendor>/...`.
+    ///
+    /// `.downloads` returns no paths intentionally — Chromium stores
+    /// download history inside the same `History` SQLite as browsing
+    /// history, so a "downloads only" delete via `removeItem` would also
+    /// wipe browsing history. Until we ship a surgical `DELETE FROM
+    /// downloads` (deferred), the safer contract is "downloads is bundled
+    /// into history on these browsers; check History to clear it." The
+    /// row will show 0 B in the UI, signaling there's nothing to clear at
+    /// the file level.
     private func chromiumPaths(browser: Browser, category: PrivacyCategory) -> [URL] {
         guard let layout = chromiumLayout(for: browser) else { return [] }
 
         switch category {
         case .history:
-            // The History SQLite stores both browsing and downloads, so a
-            // user clearing only "Downloads" via `.downloads` still leaves
-            // the browsing entry intact via this path. We do *not* remove
-            // History under the .downloads category — see below.
-            return layout.profilePath
-                .map { [$0.appendingPathComponent("History"),
-                        $0.appendingPathComponent("History-journal")] }
-                ?? []
+            // SQLite WAL-mode sidecars (`-shm`, `-wal`) are present
+            // whenever the browser is — or recently was — running. The
+            // `-journal` file is the rollback-journal counterpart used
+            // when WAL is off. Including all three keeps the on-disk
+            // state coherent after a remove and avoids the orphaned-
+            // sidecar disk leak Codex / CodeRabbit flagged.
+            return layout.profilePath.map(historyPaths(in:)) ?? []
         case .downloads:
-            // Chromium stores download history inside the same `History`
-            // SQLite as browsing history, so `.downloads` returns the same
-            // paths. The view-model deduplicates URLs when summing
-            // `totalSelectedSize` and when handing paths to the clearer, so
-            // checking both `.history` and `.downloads` doesn't double-count
-            // bytes or attempt a redundant remove.
-            return layout.profilePath
-                .map { [$0.appendingPathComponent("History"),
-                        $0.appendingPathComponent("History-journal")] }
-                ?? []
+            return []
         case .cookies:
-            return layout.profilePath
-                .map { [$0.appendingPathComponent("Cookies"),
-                        $0.appendingPathComponent("Cookies-journal")] }
-                ?? []
+            // Modern Chromium (since ~Chrome 96 / Edge 96) keeps the
+            // cookies SQLite under `Default/Network/Cookies`. The legacy
+            // `Default/Cookies` location persists on older installs and
+            // some downstream forks. Emit both; the clearer skips
+            // whichever doesn't exist.
+            return layout.profilePath.map(cookiePaths(in:)) ?? []
         case .cache:
             return layout.cachePath.map { [$0] } ?? []
         case .savedForms:
-            return layout.profilePath
-                .map { [$0.appendingPathComponent("Web Data"),
-                        $0.appendingPathComponent("Web Data-journal")] }
-                ?? []
+            return layout.profilePath.map(webDataPaths(in:)) ?? []
         }
+    }
+
+    private func historyPaths(in profilePath: URL) -> [URL] {
+        [
+            profilePath.appendingPathComponent("History"),
+            profilePath.appendingPathComponent("History-journal"),
+            profilePath.appendingPathComponent("History-shm"),
+            profilePath.appendingPathComponent("History-wal")
+        ]
+    }
+
+    private func cookiePaths(in profilePath: URL) -> [URL] {
+        let networkSubdir = profilePath.appendingPathComponent("Network", isDirectory: true)
+        return [
+            // Legacy
+            profilePath.appendingPathComponent("Cookies"),
+            profilePath.appendingPathComponent("Cookies-journal"),
+            profilePath.appendingPathComponent("Cookies-shm"),
+            profilePath.appendingPathComponent("Cookies-wal"),
+            // Modern
+            networkSubdir.appendingPathComponent("Cookies"),
+            networkSubdir.appendingPathComponent("Cookies-journal"),
+            networkSubdir.appendingPathComponent("Cookies-shm"),
+            networkSubdir.appendingPathComponent("Cookies-wal")
+        ]
+    }
+
+    private func webDataPaths(in profilePath: URL) -> [URL] {
+        [
+            profilePath.appendingPathComponent("Web Data"),
+            profilePath.appendingPathComponent("Web Data-journal"),
+            profilePath.appendingPathComponent("Web Data-shm"),
+            profilePath.appendingPathComponent("Web Data-wal")
+        ]
     }
 
     private struct ChromiumLayout {
@@ -214,21 +247,32 @@ struct DefaultBrowserDataPathProvider: BrowserDataPathProviding {
 
         switch category {
         case .history:
-            // places.sqlite stores both browsing history and download history
-            // in Firefox; same caveat as Chromium's `History` file applies.
-            return profileDir.map { [$0.appendingPathComponent("places.sqlite")] } ?? []
+            // places.sqlite stores both browsing history and download
+            // history in Firefox; surface its WAL-mode sidecars too so a
+            // remove leaves no orphans on disk.
+            return profileDir.map { firefoxSqlitePaths(in: $0, named: "places.sqlite") } ?? []
         case .downloads:
-            // Firefox stores download history inside places.sqlite alongside
-            // browsing history. Same dedup contract as Chromium — see the
-            // chromiumPaths(.downloads) note.
-            return profileDir.map { [$0.appendingPathComponent("places.sqlite")] } ?? []
+            // Firefox stores download history inside places.sqlite — the
+            // same Chromium constraint applies. See
+            // `chromiumPaths(.downloads)` for the rationale on returning
+            // no paths here.
+            return []
         case .cookies:
-            return profileDir.map { [$0.appendingPathComponent("cookies.sqlite")] } ?? []
+            return profileDir.map { firefoxSqlitePaths(in: $0, named: "cookies.sqlite") } ?? []
         case .cache:
             return cacheProfileDir.map { [$0.appendingPathComponent("cache2", isDirectory: true)] } ?? []
         case .savedForms:
-            return profileDir.map { [$0.appendingPathComponent("formhistory.sqlite")] } ?? []
+            return profileDir.map { firefoxSqlitePaths(in: $0, named: "formhistory.sqlite") } ?? []
         }
+    }
+
+    /// Firefox SQLite + WAL-mode sidecars for a single store.
+    private func firefoxSqlitePaths(in profileDir: URL, named name: String) -> [URL] {
+        [
+            profileDir.appendingPathComponent(name),
+            profileDir.appendingPathComponent("\(name)-shm"),
+            profileDir.appendingPathComponent("\(name)-wal")
+        ]
     }
 
     private func firefoxProfileDirectory(at profilesRoot: URL) -> URL? {

--- a/VaderCleaner/BrowserDetector.swift
+++ b/VaderCleaner/BrowserDetector.swift
@@ -1,0 +1,51 @@
+// BrowserDetector.swift
+// Reports which browsers are installed on the machine by checking known .app bundle locations under /Applications and ~/Applications.
+
+import Foundation
+
+/// Test seam for "which browsers does this Mac have?". The default
+/// implementation walks `/Applications` and `~/Applications`; tests inject
+/// a closure-driven `existsAt:` predicate so they can stage any combination
+/// without touching real disk state.
+protocol BrowserDetecting {
+    func installedBrowsers() -> [Browser]
+}
+
+/// Production detector. Always includes Safari (ships with macOS and is
+/// not uninstallable through normal channels), and includes any other
+/// browser whose `.app` exists under `/Applications` or
+/// `~/Applications`.
+struct DefaultBrowserDetector: BrowserDetecting {
+
+    private let homeDirectory: URL
+    private let existsAt: (URL) -> Bool
+
+    /// - Parameter existsAt: closure that answers "does a file/directory
+    ///   exist at this URL?". Defaults to `FileManager.fileExists`. The
+    ///   indirection makes detection trivially testable without faking out
+    ///   `/Applications` on the host.
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        existsAt: @escaping (URL) -> Bool = { url in
+            FileManager.default.fileExists(atPath: url.path)
+        }
+    ) {
+        self.homeDirectory = homeDirectory
+        self.existsAt = existsAt
+    }
+
+    func installedBrowsers() -> [Browser] {
+        let userApplications = homeDirectory.appendingPathComponent("Applications", isDirectory: true)
+        let systemApplications = URL(fileURLWithPath: "/Applications", isDirectory: true)
+
+        return Browser.allCases.filter { browser in
+            // Safari is treated as always installed — see type doc.
+            if browser == .safari { return true }
+            let candidates = [
+                systemApplications.appendingPathComponent(browser.appBundleName),
+                userApplications.appendingPathComponent(browser.appBundleName)
+            ]
+            return candidates.contains(where: existsAt)
+        }
+    }
+}

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -88,6 +88,8 @@ struct ContentView: View {
             LargeOldFilesView(viewModel: LargeOldFilesViewModel.live(exclusions: exclusions))
         case .spaceLens:
             SpaceLensView(viewModel: spaceLensViewModel)
+        case .privacy:
+            PrivacyView(viewModel: PrivacyViewModel.live())
         default:
             PlaceholderDetailView(section: section)
         }

--- a/VaderCleaner/PrivacyCategory.swift
+++ b/VaderCleaner/PrivacyCategory.swift
@@ -1,0 +1,29 @@
+// PrivacyCategory.swift
+// Stable enum tagging each kind of privacy data the Privacy feature can preview and clear (browser history, downloads, cookies, cache, saved form data).
+
+import Foundation
+
+/// The kind of privacy data a `(Browser, PrivacyCategory)` pair targets.
+///
+/// Raw values are persisted in view-model state and selection sets, so cases
+/// must be appended (never inserted) and existing raw values must not change.
+enum PrivacyCategory: String, CaseIterable, Codable, Hashable, Identifiable {
+    case history
+    case downloads
+    case cookies
+    case cache
+    case savedForms
+
+    var id: String { rawValue }
+
+    /// Label shown next to the per-category checkbox in the Privacy preview.
+    var displayName: String {
+        switch self {
+        case .history:    return "Browsing History"
+        case .downloads:  return "Download History"
+        case .cookies:    return "Cookies"
+        case .cache:      return "Cached Data"
+        case .savedForms: return "Saved Form Data"
+        }
+    }
+}

--- a/VaderCleaner/PrivacyView.swift
+++ b/VaderCleaner/PrivacyView.swift
@@ -112,15 +112,28 @@ struct PrivacyView: View {
             ForEach(viewModel.detectedBrowsers) { browser in
                 Section {
                     ForEach(PrivacyCategory.allCases) { category in
-                        CategoryRow(
-                            category: category,
-                            sizeBytes: viewModel.size(for: browser, category: category),
-                            isChecked: Binding(
-                                get: { viewModel.isChecked(browser: browser, category: category) },
-                                set: { _ in viewModel.toggle(browser: browser, category: category) }
+                        // Non-actionable categories (e.g. Chromium /
+                        // Firefox `.downloads`, which lives inside the
+                        // browsing-history SQLite and can't be cleared
+                        // independently at the file level) render as a
+                        // disabled row with a coupling caption rather
+                        // than a checkbox — otherwise the UI would
+                        // claim to do something the clearer can't
+                        // deliver.
+                        if viewModel.isCategoryActionable(browser: browser, category: category) {
+                            CategoryRow(
+                                category: category,
+                                sizeBytes: viewModel.size(for: browser, category: category),
+                                isChecked: Binding(
+                                    get: { viewModel.isChecked(browser: browser, category: category) },
+                                    set: { _ in viewModel.toggle(browser: browser, category: category) }
+                                )
                             )
-                        )
-                        .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue)")
+                            .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue)")
+                        } else {
+                            CoupledCategoryRow(category: category)
+                                .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue).coupled")
+                        }
                     }
                 } header: {
                     BrowserHeader(
@@ -256,6 +269,33 @@ private struct BrowserHeader: View {
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
         }
+    }
+}
+
+/// Row rendered for categories whose data isn't independently
+/// clearable on the surrounding browser — Chromium / Firefox
+/// `.downloads` lives inside the same SQLite as `.history`, so a
+/// path-based clear of just downloads would also wipe browsing
+/// history. The row replaces the checkbox + size with an
+/// informational caption explaining the coupling so the UI never
+/// presents a control that does nothing.
+private struct CoupledCategoryRow: View {
+    let category: PrivacyCategory
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Spacer matches the checkbox width so the category-name
+            // column stays aligned with sibling rows in the same group.
+            Spacer().frame(width: 16)
+            Text(category.displayName)
+                .font(.body)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text("Included with Browsing History")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
     }
 }
 

--- a/VaderCleaner/PrivacyView.swift
+++ b/VaderCleaner/PrivacyView.swift
@@ -95,7 +95,15 @@ struct PrivacyView: View {
                 Task { await viewModel.clear() }
             }
         } message: {
-            Text("This permanently removes the selected browser data and the system Recent Items list. Browsers will recreate the storage on next launch but the data won't be recoverable.")
+            // The Recent Items toggle is independent from the per-browser
+            // selections, so the alert text must reflect whichever steps
+            // actually run. Naming "Recent Items" when its toggle is off
+            // would mislead the user.
+            if viewModel.isClearRecentsChecked {
+                Text("This permanently removes the selected browser data and the system Recent Items list. Browsers will recreate the storage on next launch but the data won't be recoverable.")
+            } else {
+                Text("This permanently removes the selected browser data. Browsers will recreate the storage on next launch but the data won't be recoverable.")
+            }
         }
     }
 

--- a/VaderCleaner/PrivacyView.swift
+++ b/VaderCleaner/PrivacyView.swift
@@ -1,0 +1,284 @@
+// PrivacyView.swift
+// Privacy feature view — renders the idle/scanning/preview/clearing/complete states from PrivacyViewModel and binds the per-browser per-category checkboxes plus the system Recent Items toggle and Clear / Re-scan / Scan Again actions.
+
+import SwiftUI
+
+/// Detail view shown when the user selects "Privacy" in the sidebar.
+/// Each `PrivacyViewModel.Phase` maps to a dedicated subview, mirroring
+/// `SystemJunkView`'s shape:
+///   - `.idle` — centered Scan call-to-action.
+///   - `.scanning` — progress spinner.
+///   - `.preview` — list of detected browsers with disclosure-grouped
+///     category checkboxes plus a "Recent Items" toggle, footer with
+///     total + Clear + Re-scan.
+///   - `.clearing` — progress spinner.
+///   - `.complete` — "X freed" summary plus Scan Again.
+///   - `.failed` — message plus Try Again.
+///
+/// Accessibility identifiers are namespaced under `privacy.*` so future
+/// UI tests can drive the flow without relying on label localisation.
+struct PrivacyView: View {
+
+    @StateObject private var viewModel: PrivacyViewModel
+    @State private var showClearConfirmation = false
+
+    init(viewModel: PrivacyViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.phase {
+            case .idle:
+                idleState
+            case .scanning:
+                progressState(label: "Scanning…", identifier: "privacy.scanning")
+            case .preview:
+                previewState
+            case .clearing:
+                progressState(label: "Clearing…", identifier: "privacy.clearing")
+            case .complete(let bytes):
+                completeState(bytesFreed: bytes)
+            case .failed(let stage, let message):
+                failedState(stage: stage, message: message)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle(NavigationSection.privacy.title)
+    }
+
+    // MARK: - States
+
+    private var idleState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "lock.shield")
+                .font(.system(size: 56))
+                .foregroundStyle(.secondary)
+            Text("Privacy")
+                .font(.title2.weight(.semibold))
+            Text("Clear browsing history, downloads, cookies, cache, saved form data across detected browsers, and the system Recent Items list.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+            Button("Scan") {
+                Task { await viewModel.preview() }
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("privacy.scan")
+        }
+        .padding()
+    }
+
+    private func progressState(label: String, identifier: String) -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .accessibilityIdentifier(identifier)
+    }
+
+    private var previewState: some View {
+        VStack(spacing: 0) {
+            previewList
+            Divider()
+            previewFooter
+        }
+        .alert("Clear selected privacy data?", isPresented: $showClearConfirmation) {
+            Button("Cancel", role: .cancel) { }
+            Button("Clear", role: .destructive) {
+                Task { await viewModel.clear() }
+            }
+        } message: {
+            Text("This permanently removes the selected browser data and the system Recent Items list. Browsers will recreate the storage on next launch but the data won't be recoverable.")
+        }
+    }
+
+    private var previewList: some View {
+        List {
+            ForEach(viewModel.detectedBrowsers) { browser in
+                Section {
+                    ForEach(PrivacyCategory.allCases) { category in
+                        CategoryRow(
+                            category: category,
+                            sizeBytes: viewModel.size(for: browser, category: category),
+                            isChecked: Binding(
+                                get: { viewModel.isChecked(browser: browser, category: category) },
+                                set: { _ in viewModel.toggle(browser: browser, category: category) }
+                            )
+                        )
+                        .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue)")
+                    }
+                } header: {
+                    BrowserHeader(
+                        browser: browser,
+                        totalBytes: viewModel.sizeOnDisk(for: browser)
+                    )
+                }
+            }
+
+            Section {
+                HStack(spacing: 12) {
+                    Toggle("", isOn: Binding(
+                        get: { viewModel.isClearRecentsChecked },
+                        set: { _ in viewModel.toggleClearRecents() }
+                    ))
+                    .toggleStyle(.checkbox)
+                    .labelsHidden()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("System Recent Items")
+                            .font(.body.weight(.medium))
+                        Text("Clears the Apple-menu Recent Items list and this app's recent documents.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+                .padding(.vertical, 4)
+                .accessibilityIdentifier("privacy.row.recentItems")
+            } header: {
+                Text("System")
+                    .font(.callout.weight(.semibold))
+            }
+        }
+    }
+
+    private var previewFooter: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Total selected")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(PrivacyView.byteFormatter.string(fromByteCount: viewModel.totalSelectedSize))
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("privacy.totalSelected")
+            }
+            Spacer()
+            Button("Re-scan") {
+                viewModel.scanAgain()
+            }
+            .accessibilityIdentifier("privacy.rescan")
+            Button("Clear") {
+                showClearConfirmation = true
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+            .disabled(viewModel.totalSelectedSize == 0 && !viewModel.isClearRecentsChecked)
+            .accessibilityIdentifier("privacy.clear")
+        }
+        .padding(16)
+    }
+
+    private func completeState(bytesFreed: Int64) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text(PrivacyView.byteFormatter.string(fromByteCount: bytesFreed) + " freed")
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("privacy.bytesFreed")
+            Text("Browsers may need to be restarted before disk space fully reflects the change.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+            Button("Scan Again") {
+                viewModel.scanAgain()
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("privacy.scanAgain")
+        }
+        .padding()
+    }
+
+    private func failedState(stage: PrivacyViewModel.FailureStage, message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(stage == .scanning ? "Couldn't complete the scan" : "Couldn't finish clearing")
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("privacy.errorMessage")
+            Button("Try Again") {
+                viewModel.scanAgain()
+            }
+            .controlSize(.large)
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("privacy.tryAgain")
+        }
+        .padding()
+    }
+
+    // MARK: - Formatter
+
+    /// Shared byte formatter; same allocation rationale as
+    /// `SystemJunkView.byteFormatter`.
+    fileprivate static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+}
+
+// MARK: - Subviews
+
+private struct BrowserHeader: View {
+    let browser: Browser
+    let totalBytes: Int64
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(browser.displayName)
+                .font(.callout.weight(.semibold))
+            Spacer()
+            Text(PrivacyView.byteFormatter.string(fromByteCount: totalBytes))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct CategoryRow: View {
+    let category: PrivacyCategory
+    let sizeBytes: Int64
+    @Binding var isChecked: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: $isChecked)
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+            Text(category.displayName)
+                .font(.body)
+            Spacer()
+            Text(PrivacyView.byteFormatter.string(fromByteCount: sizeBytes))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+#Preview("Idle") {
+    PrivacyView(viewModel: PrivacyViewModel(
+        detector: { [] },
+        sizer: { _, _ in 0 },
+        pathsFor: { _, _ in [] },
+        clearer: { _, _ in },
+        clearRecentFiles: { }
+    ))
+    .frame(width: 700, height: 480)
+}

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -1,0 +1,267 @@
+// PrivacyViewModel.swift
+// State machine and selection logic behind the Privacy feature view — drives idle/scanning/preview/clearing/complete transitions and routes the user's per-browser per-category selection through an injected clearer plus a recent-files manager.
+
+import Foundation
+import os.log
+
+/// Drives the Privacy feature view (preview → clear → done).
+///
+/// The view-model owns:
+///   - `phase`: the current step in the state machine, bound to the
+///     view's switch on rendered content.
+///   - `detectedBrowsers`: the set of browsers the detector reported as
+///     installed at the last preview.
+///   - `checkedSelections`: per-browser per-category opt-in/out.
+///   - `isClearRecentsChecked`: top-level toggle for the recent-items
+///     clear action, separate from browser selections.
+///   - `sizesByBrowserCategory`: cached per-cell sizes computed once at
+///     preview time so the view's row labels don't trigger fresh I/O on
+///     every redraw.
+///
+/// Every collaborator is injected as a closure so unit tests can drive
+/// every transition without touching real disk state. Production wiring
+/// lives in `PrivacyViewModel.live(...)`.
+@MainActor
+final class PrivacyViewModel: ObservableObject {
+
+    /// Which step of the flow generated a `.failed` phase, so the view can
+    /// pick the right heading. Mirrors `SystemJunkViewModel.FailureStage`.
+    enum FailureStage: Equatable {
+        case scanning
+        case clearing
+    }
+
+    /// Discrete phases the Privacy view binds to.
+    enum Phase: Equatable {
+        case idle
+        case scanning
+        case preview
+        case clearing
+        case complete(bytesFreed: Int64)
+        case failed(stage: FailureStage, message: String)
+    }
+
+    /// Composite key for the `(browser, category)` selection set.
+    struct Selection: Hashable {
+        let browser: Browser
+        let category: PrivacyCategory
+    }
+
+    typealias Detector             = () async throws -> [Browser]
+    typealias Sizer                = (Browser, PrivacyCategory) -> Int64
+    typealias PathsResolver        = (Browser, PrivacyCategory) -> [URL]
+    typealias Clearer              = (Browser, PrivacyCategory) async throws -> Void
+    typealias RecentFilesClearer   = () async throws -> Void
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var detectedBrowsers: [Browser] = []
+    @Published private(set) var checkedSelections: Set<Selection> = []
+    @Published private(set) var isClearRecentsChecked: Bool = true
+
+    private let detector: Detector
+    private let sizer: Sizer
+    private let pathsFor: PathsResolver
+    private let clearer: Clearer
+    private let clearRecentFiles: RecentFilesClearer
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "PrivacyViewModel")
+
+    /// Cached per-cell sizes, populated at the end of `preview()` so the
+    /// view's row labels and `totalSelectedSize` compute in O(1).
+    private var sizesByBrowserCategory: [Selection: Int64] = [:]
+
+    init(
+        detector: @escaping Detector,
+        sizer: @escaping Sizer,
+        pathsFor: @escaping PathsResolver,
+        clearer: @escaping Clearer,
+        clearRecentFiles: @escaping RecentFilesClearer
+    ) {
+        self.detector = detector
+        self.sizer = sizer
+        self.pathsFor = pathsFor
+        self.clearer = clearer
+        self.clearRecentFiles = clearRecentFiles
+    }
+
+    // MARK: - Public surface
+
+    /// Sum of bytes for every checked selection, deduplicated by URL —
+    /// Chromium / Firefox `.history` and `.downloads` share a SQLite file,
+    /// so a naive `sum(sizesByBrowserCategory[selected])` would double-
+    /// count on those browsers.
+    var totalSelectedSize: Int64 {
+        sumOfSizes(over: checkedSelections)
+    }
+
+    /// Whether `(browser, category)` is currently checked. The view
+    /// binds each row's `Toggle` to this getter + `toggle(browser:category:)`.
+    func isChecked(browser: Browser, category: PrivacyCategory) -> Bool {
+        checkedSelections.contains(Selection(browser: browser, category: category))
+    }
+
+    /// Per-cell size for the row label.
+    func size(for browser: Browser, category: PrivacyCategory) -> Int64 {
+        sizesByBrowserCategory[Selection(browser: browser, category: category)] ?? 0
+    }
+
+    /// Sum of sizes for every category of `browser` regardless of
+    /// selection — used by the disclosure-group header to show a per-
+    /// browser total even when the group is collapsed.
+    func sizeOnDisk(for browser: Browser) -> Int64 {
+        let allSelections = PrivacyCategory.allCases.map {
+            Selection(browser: browser, category: $0)
+        }
+        return sumOfSizes(over: Set(allSelections))
+    }
+
+    /// Path-deduped size sum across an arbitrary selection set. Cells
+    /// whose paths overlap (Chromium / Firefox `.history` and
+    /// `.downloads` share a SQLite file) contribute the cell size *once*.
+    /// Cells with no paths contribute 0 — they're either unreachable
+    /// (e.g. Firefox without a profile yet) or a no-op category that
+    /// the production clearer handles as such.
+    private func sumOfSizes(over selections: Set<Selection>) -> Int64 {
+        var visitedPaths = Set<URL>()
+        var total: Int64 = 0
+        // Iterate in `Browser.allCases` × `PrivacyCategory.allCases`
+        // order so dedup is deterministic — Set iteration order is not
+        // stable, and the test expectation depends on `.history` being
+        // visited before `.downloads`.
+        for browser in Browser.allCases {
+            for category in PrivacyCategory.allCases {
+                let selection = Selection(browser: browser, category: category)
+                guard selections.contains(selection) else { continue }
+                let paths = pathsFor(browser, category)
+                guard !paths.isEmpty else { continue }
+                let firstUnseen = paths.first { !visitedPaths.contains($0) }
+                if firstUnseen != nil {
+                    total += sizesByBrowserCategory[selection] ?? 0
+                }
+                for path in paths { visitedPaths.insert(path) }
+            }
+        }
+        return total
+    }
+
+    // MARK: - Actions
+
+    /// Run detection + sizing and land in `.preview` (or `.failed`).
+    /// Marks every detected `(browser, category)` checked by default
+    /// (and the recent-items toggle on) so the user is at "select all".
+    func preview() async {
+        phase = .scanning
+        do {
+            let browsers = try await detector()
+            var sizes: [Selection: Int64] = [:]
+            var checked: Set<Selection> = []
+            for browser in browsers {
+                for category in PrivacyCategory.allCases {
+                    let selection = Selection(browser: browser, category: category)
+                    sizes[selection] = sizer(browser, category)
+                    checked.insert(selection)
+                }
+            }
+            self.detectedBrowsers = browsers
+            self.sizesByBrowserCategory = sizes
+            self.checkedSelections = checked
+            self.isClearRecentsChecked = true
+            self.phase = .preview
+        } catch {
+            log.error("Privacy preview failed: \(String(describing: error), privacy: .public)")
+            self.detectedBrowsers = []
+            self.sizesByBrowserCategory = [:]
+            self.checkedSelections = []
+            self.phase = .failed(stage: .scanning, message: error.localizedDescription)
+        }
+    }
+
+    /// Hand each checked selection to the injected clearer and (when the
+    /// recents toggle is on) invoke the recent-files clearer. Lands in
+    /// `.complete(bytesFreed:)` reporting the pre-clear total — see the
+    /// test on `clear_transitionsToCompleteWithBytesFreed` for the
+    /// rationale on optimistic accounting.
+    ///
+    /// Ordering: clear recents first, then browsers. A recents failure
+    /// leaves all browser data intact and the user can retry without
+    /// hitting "browser shows 0 B because we already wiped it last time"
+    /// confusion. A browser failure after recents succeeded is the lesser
+    /// evil — recent items is a small list versus potentially gigabytes
+    /// of browser data.
+    func clear() async {
+        guard phase == .preview else { return }
+        let bytesPlanned = totalSelectedSize
+        phase = .clearing
+        do {
+            if isClearRecentsChecked {
+                try await clearRecentFiles()
+            }
+            for selection in checkedSelections {
+                try await clearer(selection.browser, selection.category)
+            }
+            self.phase = .complete(bytesFreed: bytesPlanned)
+        } catch {
+            log.error("Privacy clear failed: \(String(describing: error), privacy: .public)")
+            self.phase = .failed(stage: .clearing, message: error.localizedDescription)
+        }
+    }
+
+    /// Flip the per-cell checkbox.
+    func toggle(browser: Browser, category: PrivacyCategory) {
+        let selection = Selection(browser: browser, category: category)
+        if checkedSelections.contains(selection) {
+            checkedSelections.remove(selection)
+        } else {
+            checkedSelections.insert(selection)
+        }
+    }
+
+    /// Flip the recent-items toggle.
+    func toggleClearRecents() {
+        isClearRecentsChecked.toggle()
+    }
+
+    /// Reset to `.idle`, dropping cached preview state.
+    func scanAgain() {
+        detectedBrowsers = []
+        checkedSelections = []
+        sizesByBrowserCategory = [:]
+        isClearRecentsChecked = true
+        phase = .idle
+    }
+}
+
+// MARK: - Production wiring
+
+extension PrivacyViewModel {
+
+    /// Build a view-model wired to the real `BrowserDetector`,
+    /// `BrowserDataClearer`, and `RecentFilesManager`. No exclusions
+    /// filtering — see issue #38 plan comment for the rationale.
+    @MainActor
+    static func live() -> PrivacyViewModel {
+        let detector = DefaultBrowserDetector()
+        let pathProvider = DefaultBrowserDataPathProvider()
+        let clearer = BrowserDataClearer(pathProvider: pathProvider)
+        let recents = RecentFilesManager()
+
+        return PrivacyViewModel(
+            detector: { detector.installedBrowsers() },
+            sizer: { browser, category in
+                clearer.previewSize(for: category, browser: browser)
+            },
+            pathsFor: { browser, category in
+                clearer.paths(for: category, browser: browser)
+            },
+            clearer: { browser, category in
+                try clearer.clear(category: category, browser: browser)
+            },
+            clearRecentFiles: {
+                // `RecentFilesManager` is `@MainActor`, and this closure
+                // inherits the enclosing `@MainActor` isolation, so we can
+                // call it directly without an explicit hop.
+                try recents.clear()
+            }
+        )
+    }
+}

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -115,6 +115,24 @@ final class PrivacyViewModel: ObservableObject {
         return sumOfSizes(over: Set(allSelections))
     }
 
+    /// Currently-checked selections in a stable
+    /// `Browser.allCases` × `PrivacyCategory.allCases` order. Used by
+    /// `clear()` to make the destructive loop deterministic — a `Set`
+    /// would order-shuffle between runs and make partial-failure
+    /// retries inconsistent.
+    func orderedCheckedSelections() -> [Selection] {
+        var result: [Selection] = []
+        for browser in Browser.allCases {
+            for category in PrivacyCategory.allCases {
+                let selection = Selection(browser: browser, category: category)
+                if checkedSelections.contains(selection) {
+                    result.append(selection)
+                }
+            }
+        }
+        return result
+    }
+
     /// Path-deduped size sum across an arbitrary selection set. Cells
     /// whose paths overlap (Chromium / Firefox `.history` and
     /// `.downloads` share a SQLite file) contribute the cell size *once*.
@@ -168,7 +186,11 @@ final class PrivacyViewModel: ObservableObject {
             self.isClearRecentsChecked = true
             self.phase = .preview
         } catch {
-            log.error("Privacy preview failed: \(String(describing: error), privacy: .public)")
+            // Log error description as `.private` — `error.localizedDescription`
+            // can include user-specific filesystem paths or browser
+            // profile names, which we don't want in unredacted unified-
+            // log output of a Privacy feature.
+            log.error("Privacy preview failed: \(String(describing: error), privacy: .private)")
             self.detectedBrowsers = []
             self.sizesByBrowserCategory = [:]
             self.checkedSelections = []
@@ -196,12 +218,17 @@ final class PrivacyViewModel: ObservableObject {
             if isClearRecentsChecked {
                 try await clearRecentFiles()
             }
-            for selection in checkedSelections {
+            // Iterate selections in a deterministic
+            // (browser × category) order so a mid-run failure aborts at
+            // a predictable point — `Set` iteration order is undefined,
+            // which would make retries and bug reports inconsistent.
+            for selection in orderedCheckedSelections() {
                 try await clearer(selection.browser, selection.category)
             }
             self.phase = .complete(bytesFreed: bytesPlanned)
         } catch {
-            log.error("Privacy clear failed: \(String(describing: error), privacy: .public)")
+            // See `preview()` — same reasoning for `.private`.
+            log.error("Privacy clear failed: \(String(describing: error), privacy: .private)")
             self.phase = .failed(stage: .clearing, message: error.localizedDescription)
         }
     }

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -115,6 +115,19 @@ final class PrivacyViewModel: ObservableObject {
         return sumOfSizes(over: Set(allSelections))
     }
 
+    /// Whether `(browser, category)` has any on-disk paths the clearer
+    /// can act on. Returns `false` for cells that are intentionally
+    /// no-ops at the file level — Chromium / Firefox `.downloads` is
+    /// the canonical case (download history lives inside the same
+    /// SQLite as browsing history; a path-based clear of just
+    /// downloads would also wipe history). The view uses this to
+    /// render those rows as informational ("Included with Browsing
+    /// History") rather than as a checkbox the user can toggle, so
+    /// the UI never claims to do something it can't.
+    func isCategoryActionable(browser: Browser, category: PrivacyCategory) -> Bool {
+        !pathsFor(browser, category).isEmpty
+    }
+
     /// Currently-checked selections in a stable
     /// `Browser.allCases` × `PrivacyCategory.allCases` order. Used by
     /// `clear()` to make the destructive loop deterministic — a `Set`

--- a/VaderCleaner/RecentFilesManager.swift
+++ b/VaderCleaner/RecentFilesManager.swift
@@ -1,0 +1,83 @@
+// RecentFilesManager.swift
+// Clears the macOS recent-items lists — both this app's NSDocumentController list and the system-wide Recent* sharedfilelist plists that drive the Apple-menu Recent Items.
+
+import AppKit
+import Foundation
+import os.log
+
+/// Clears the user's recently-opened files list.
+///
+/// macOS records "recent items" in two places:
+///
+///   1. Per-app via `NSDocumentController.shared.recentDocumentURLs`,
+///      cleared with `clearRecentDocuments(_:)`. Targets this app's own
+///      list; for VaderCleaner that list is empty (we're not document-
+///      based), but we still call it so users on document-based apps that
+///      adopt this pattern get the obvious behavior.
+///   2. System-wide via plists under
+///      `~/Library/Application Support/com.apple.sharedfilelist/`,
+///      named `com.apple.LSSharedFileList.Recent*.sfl3` (and `sfl2` on
+///      older macOS). These files are the on-disk source of truth for
+///      the Apple-menu Recent Items list — clearing them empties the
+///      menu after relogin / Dock restart.
+///
+/// The app-level clear action is injected as a closure so tests can verify
+/// invocation without touching `NSDocumentController`'s singleton state.
+@MainActor
+struct RecentFilesManager {
+
+    private let homeDirectory: URL
+    private let fileManager: FileManager
+    private let clearAppRecentDocuments: () -> Void
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "RecentFilesManager")
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default,
+        clearAppRecentDocuments: @escaping () -> Void = {
+            NSDocumentController.shared.clearRecentDocuments(nil)
+        }
+    ) {
+        self.homeDirectory = homeDirectory
+        self.fileManager = fileManager
+        self.clearAppRecentDocuments = clearAppRecentDocuments
+    }
+
+    /// Clear both the app-level and system-wide recents. Throws only if a
+    /// concrete sfl removal fails for a reason other than "file vanished
+    /// between listing and removal" — missing files are not an error.
+    func clear() throws {
+        clearAppRecentDocuments()
+        try clearSharedFileListRecents()
+    }
+
+    /// On-disk source of truth for the Apple-menu Recent Items list.
+    /// Skipped when the directory is missing (fresh user account), and
+    /// only `com.apple.LSSharedFileList.Recent*.sfl*` files are removed —
+    /// favorites / non-Recent sfl entries are not part of "recent items".
+    private func clearSharedFileListRecents() throws {
+        let directory = homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("com.apple.sharedfilelist", isDirectory: true)
+
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+
+        let entries = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        for url in entries {
+            let name = url.lastPathComponent
+            guard name.hasPrefix("com.apple.LSSharedFileList.Recent") else { continue }
+            do {
+                try fileManager.removeItem(at: url)
+            } catch CocoaError.fileNoSuchFile {
+                // File vanished between listing and removal — fine.
+                continue
+            }
+        }
+    }
+}

--- a/VaderCleaner/RecentFilesManager.swift
+++ b/VaderCleaner/RecentFilesManager.swift
@@ -71,7 +71,17 @@ struct RecentFilesManager {
         )
         for url in entries {
             let name = url.lastPathComponent
-            guard name.hasPrefix("com.apple.LSSharedFileList.Recent") else { continue }
+            // Tightened glob: prefix `com.apple.LSSharedFileList.Recent`
+            // *and* an `.sfl*` extension. The prefix-only check would
+            // sweep up any future Apple file that happened to start with
+            // "Recent" (e.g. a hypothetical `Recent.config.plist`); the
+            // suffix anchors removal to the SharedFileList file format
+            // we actually understand. `.sfl2` is the older format,
+            // `.sfl3` the modern one — both are removed.
+            let ext = url.pathExtension
+            guard name.hasPrefix("com.apple.LSSharedFileList.Recent"),
+                  ext == "sfl" || ext == "sfl2" || ext == "sfl3"
+            else { continue }
             do {
                 try fileManager.removeItem(at: url)
             } catch CocoaError.fileNoSuchFile {

--- a/VaderCleanerTests/BrowserDataClearerTests.swift
+++ b/VaderCleanerTests/BrowserDataClearerTests.swift
@@ -1,0 +1,134 @@
+// BrowserDataClearerTests.swift
+// Verifies that BrowserDataClearer correctly sums on-disk byte sizes for a (browser, category) pair, removes every existing path on clear, and tolerates missing paths without error.
+
+import XCTest
+@testable import VaderCleaner
+
+final class BrowserDataClearerTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        TestHelpers.tearDownTempDirectory(tempRoot)
+        tempRoot = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - previewSize
+
+    /// `previewSize` walks every path returned by the provider and sums up
+    /// the on-disk bytes — files contribute their size, directories
+    /// contribute the recursive total. The clearer's contract with the UI
+    /// is "show what we'd actually free", so a wrong total here misleads
+    /// the user about how much the action will reclaim.
+    func test_previewSize_sumsBytesAcrossFilesAndDirectories() throws {
+        let history = try TestHelpers.createDummyFile(named: "History.db", size: 100, in: tempRoot)
+        let cacheDir = tempRoot.appendingPathComponent("Cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 3, size: 50, in: cacheDir) // 150 bytes total
+
+        let provider = StubProvider(paths: [.history: [history, cacheDir]])
+        let clearer = BrowserDataClearer(pathProvider: provider)
+
+        let bytes = clearer.previewSize(for: .history, browser: .chrome)
+        XCTAssertEqual(bytes, 100 + 150)
+    }
+
+    /// Missing paths must not crash or throw — every browser-data path is
+    /// optional in practice (e.g. the user never used cookies), so a
+    /// non-existent path simply contributes 0 to the total.
+    func test_previewSize_returnsZeroForMissingPaths() {
+        let bogus = tempRoot.appendingPathComponent("does-not-exist")
+        let provider = StubProvider(paths: [.cookies: [bogus]])
+        let clearer = BrowserDataClearer(pathProvider: provider)
+
+        XCTAssertEqual(clearer.previewSize(for: .cookies, browser: .chrome), 0)
+    }
+
+    /// When the provider returns no paths (e.g. Firefox without a profile
+    /// yet) the size must be 0 with no I/O at all.
+    func test_previewSize_returnsZeroForEmptyProviderResult() {
+        let provider = StubProvider(paths: [:])
+        let clearer = BrowserDataClearer(pathProvider: provider)
+        XCTAssertEqual(clearer.previewSize(for: .history, browser: .firefox), 0)
+    }
+
+    // MARK: - clear
+
+    /// `clear` must remove every path the provider returns. Files and
+    /// directories alike — the clearer doesn't try to be selective inside a
+    /// directory because the whole point of a "Clear Cache" action is to
+    /// drop the lot.
+    func test_clear_removesEveryExistingPath() throws {
+        let history = try TestHelpers.createDummyFile(named: "History.db", size: 100, in: tempRoot)
+        let cacheDir = tempRoot.appendingPathComponent("Cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "page1", size: 50, in: cacheDir)
+
+        let provider = StubProvider(paths: [.history: [history, cacheDir]])
+        let clearer = BrowserDataClearer(pathProvider: provider)
+
+        try clearer.clear(category: .history, browser: .chrome)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: history.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheDir.path))
+    }
+
+    /// `clear` must tolerate missing paths so a partially-populated browser
+    /// (e.g. cookies file exists but cache dir doesn't) doesn't raise an
+    /// error mid-clear and leave the user staring at a misleading "couldn't
+    /// finish" message when, in fact, everything reachable was cleared.
+    func test_clear_silentlySkipsMissingPaths() throws {
+        let bogus = tempRoot.appendingPathComponent("does-not-exist")
+        let real = try TestHelpers.createDummyFile(named: "Cookies", size: 50, in: tempRoot)
+
+        let provider = StubProvider(paths: [.cookies: [bogus, real]])
+        let clearer = BrowserDataClearer(pathProvider: provider)
+
+        XCTAssertNoThrow(try clearer.clear(category: .cookies, browser: .chrome))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: real.path),
+                       "Real cookies file should be removed even when sibling path is missing")
+    }
+
+    /// When `clear` actually fails (permission error, locked file), the
+    /// error must surface so the view-model can transition to `.failed`.
+    /// Suppressing it would leave the UI claiming "Cleared" when nothing
+    /// happened.
+    func test_clear_throwsWhenInjectedRemoverThrows() {
+        let real = tempRoot.appendingPathComponent("Cookies")
+        FileManager.default.createFile(atPath: real.path, contents: Data(repeating: 0, count: 8))
+
+        let provider = StubProvider(paths: [.cookies: [real]])
+        let clearer = BrowserDataClearer(
+            pathProvider: provider,
+            remover: { _ in throw FailingRemoverError.boom }
+        )
+
+        XCTAssertThrowsError(try clearer.clear(category: .cookies, browser: .chrome)) { error in
+            XCTAssertTrue(error is FailingRemoverError)
+        }
+    }
+
+    // MARK: - Stubs
+
+    /// In-memory provider keyed by category, ignoring the browser argument
+    /// — the clearer's behavior is browser-agnostic; the path provider is
+    /// what knows the difference. Driving every test with one provider per
+    /// category keeps fixtures small.
+    private struct StubProvider: BrowserDataPathProviding {
+        let paths: [PrivacyCategory: [URL]]
+
+        func dataPaths(for browser: Browser, category: PrivacyCategory) -> [URL] {
+            paths[category] ?? []
+        }
+    }
+
+    private enum FailingRemoverError: Error {
+        case boom
+    }
+}

--- a/VaderCleanerTests/BrowserDataPathProviderTests.swift
+++ b/VaderCleanerTests/BrowserDataPathProviderTests.swift
@@ -1,0 +1,183 @@
+// BrowserDataPathProviderTests.swift
+// Verifies that DefaultBrowserDataPathProvider resolves the expected on-disk locations for each (Browser, PrivacyCategory) pair against an injected home directory, including Safari's legacy + container split and Firefox's randomized profile prefix.
+
+import XCTest
+@testable import VaderCleaner
+
+final class BrowserDataPathProviderTests: XCTestCase {
+
+    private var tempHome: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempHome = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        TestHelpers.tearDownTempDirectory(tempHome)
+        tempHome = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Safari
+
+    /// Safari's data lives in two places on modern macOS — the legacy paths
+    /// under `~/Library/Safari` and the sandbox-container paths under
+    /// `~/Library/Containers/com.apple.Safari/Data/Library/...`. Some users
+    /// have both populated, so we emit *both* and let the clearer skip
+    /// whichever doesn't exist on a given machine.
+    func test_safari_history_includesLegacyAndContainerPaths() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .safari, category: .history)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Safari/History.db").path))
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Containers/com.apple.Safari/Data/Library/Safari/History.db").path))
+    }
+
+    func test_safari_cookies_targetsBothLegacyAndContainerCookies() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .safari, category: .cookies)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Cookies/Cookies.binarycookies").path))
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies").path))
+    }
+
+    func test_safari_cache_targetsBothLegacyAndContainerCaches() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .safari, category: .cache)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Caches/com.apple.Safari").path))
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Containers/com.apple.Safari/Data/Library/Caches/com.apple.Safari").path))
+    }
+
+    // MARK: - Chrome
+
+    /// Chromium browsers store everything for the default profile under
+    /// `Application Support/<vendor>/<product>/Default/`. The provider must
+    /// hit the right SQLite files for each category — typing one wrong leaves
+    /// the user's history/cookies untouched while reporting it cleared.
+    func test_chrome_history_targetsHistorySqliteUnderDefaultProfile() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .chrome, category: .history)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Application Support/Google/Chrome/Default/History").path))
+    }
+
+    func test_chrome_cookies_targetsCookiesSqliteUnderDefaultProfile() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .chrome, category: .cookies)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Application Support/Google/Chrome/Default/Cookies").path))
+    }
+
+    func test_chrome_cache_targetsCacheDirUnderCachesPath() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .chrome, category: .cache)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Caches/Google/Chrome").path))
+    }
+
+    func test_chrome_savedForms_targetsWebDataSqlite() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .chrome, category: .savedForms)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Application Support/Google/Chrome/Default/Web Data").path))
+    }
+
+    // MARK: - Firefox
+
+    /// Firefox profile dirs use a randomized 8-char prefix followed by
+    /// `.default*`. The provider must enumerate `Profiles/` and surface the
+    /// real profile dir's children — without that, every Firefox category
+    /// would silently return zero on real machines.
+    func test_firefox_history_resolvesAgainstActualProfileDirectory() throws {
+        let profilesRoot = tempHome.appendingPathComponent("Library/Application Support/Firefox/Profiles", isDirectory: true)
+        let profileDir = profilesRoot.appendingPathComponent("xyz12345.default-release", isDirectory: true)
+        try FileManager.default.createDirectory(at: profileDir, withIntermediateDirectories: true)
+
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .firefox, category: .history)
+
+        // `FileManager.contentsOfDirectory(at:)` returns URLs with a
+        // `/private/var/...` prefix on macOS, while the test fixture's
+        // URLs have a bare `/var/...` prefix (the firmlink). Both refer
+        // to the same on-disk path; `(NSString) standardizingPath`
+        // strips the `/private` prefix on both sides for comparison.
+        let resolved = paths.map { Self.stripPrivatePrefix($0.path) }
+        let expected = Self.stripPrivatePrefix(profileDir.appendingPathComponent("places.sqlite").path)
+        XCTAssertTrue(resolved.contains(expected),
+                      "Expected places.sqlite under \(profileDir.path), got \(resolved)")
+    }
+
+    func test_firefox_cache_resolvesAgainstCachesProfileDirectory() throws {
+        let cacheProfilesRoot = tempHome.appendingPathComponent("Library/Caches/Firefox/Profiles", isDirectory: true)
+        let cacheProfileDir = cacheProfilesRoot.appendingPathComponent("xyz12345.default-release", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheProfileDir, withIntermediateDirectories: true)
+
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .firefox, category: .cache)
+
+        let resolved = paths.map { Self.stripPrivatePrefix($0.path) }
+        let expected = Self.stripPrivatePrefix(cacheProfileDir.appendingPathComponent("cache2").path)
+        XCTAssertTrue(resolved.contains(expected),
+                      "Expected cache2 under \(cacheProfileDir.path), got \(resolved)")
+    }
+
+    /// When no Firefox profile exists yet, the provider must return an
+    /// empty array rather than path-guess at a non-existent profile dir —
+    /// otherwise `previewSize` would always report 0 anyway, but `clear`
+    /// would log misleading "missing path" debug messages on every machine
+    /// without Firefox.
+    func test_firefox_categories_returnEmptyWhenNoProfileExists() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        XCTAssertEqual(provider.dataPaths(for: .firefox, category: .history).count, 0)
+        XCTAssertEqual(provider.dataPaths(for: .firefox, category: .cache).count, 0)
+        XCTAssertEqual(provider.dataPaths(for: .firefox, category: .cookies).count, 0)
+    }
+
+    // MARK: - Other Chromium-based browsers
+
+    /// Brave / Arc / Opera / Edge are all Chromium-based; the provider routes
+    /// each to its vendor-specific Application Support root. Spot-check one
+    /// per browser so a typo in the vendor-folder string surfaces in tests.
+    func test_brave_chromiumPathsRouteToBraveSoftwareDirectory() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let history = provider.dataPaths(for: .brave, category: .history).map { $0.path }
+        XCTAssertTrue(history.contains(tempHome.appendingPathComponent("Library/Application Support/BraveSoftware/Brave-Browser/Default/History").path))
+    }
+
+    func test_edge_chromiumPathsRouteToMicrosoftEdgeDirectory() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let history = provider.dataPaths(for: .edge, category: .history).map { $0.path }
+        XCTAssertTrue(history.contains(tempHome.appendingPathComponent("Library/Application Support/Microsoft Edge/Default/History").path))
+    }
+
+    func test_arc_chromiumPathsRouteToArcDirectory() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let history = provider.dataPaths(for: .arc, category: .history).map { $0.path }
+        XCTAssertTrue(history.contains(tempHome.appendingPathComponent("Library/Application Support/Arc/User Data/Default/History").path))
+    }
+
+    /// `FileManager.contentsOfDirectory(at:)` returns URLs with a
+    /// `/private/var/...` prefix on macOS while temp-dir fixtures have a
+    /// bare `/var/...` prefix (firmlinked, not symlinked). Both refer to
+    /// the same on-disk path. `(NSString) standardizingPath` only strips
+    /// `/private` when the path resolves to an existing file, so we
+    /// normalize ourselves for fixture paths that haven't been created.
+    private static func stripPrivatePrefix(_ path: String) -> String {
+        path.hasPrefix("/private/") ? String(path.dropFirst("/private".count)) : path
+    }
+
+    func test_opera_chromiumPathsRouteToOperaDirectory() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let history = provider.dataPaths(for: .opera, category: .history).map { $0.path }
+        XCTAssertTrue(history.contains(tempHome.appendingPathComponent("Library/Application Support/com.operasoftware.Opera/History").path))
+    }
+}

--- a/VaderCleanerTests/BrowserDataPathProviderTests.swift
+++ b/VaderCleanerTests/BrowserDataPathProviderTests.swift
@@ -198,8 +198,11 @@ final class BrowserDataPathProviderTests: XCTestCase {
 
     /// Same SQLite WAL/SHM concern as Chromium — Firefox uses WAL mode
     /// for places.sqlite and cookies.sqlite, so missing the `-shm` /
-    /// `-wal` sidecars leaves orphaned files on disk.
-    func test_firefox_history_includesSqliteWalAndShmSidecars() throws {
+    /// `-wal` sidecars leaves orphaned files on disk. The rollback
+    /// `-journal` sidecar can also linger after a crash mid-write or
+    /// when SQLite isn't in WAL mode, and may still hold copies of the
+    /// rows we're trying to clear.
+    func test_firefox_history_includesAllSqliteSidecars() throws {
         let profilesRoot = tempHome.appendingPathComponent("Library/Application Support/Firefox/Profiles", isDirectory: true)
         let profileDir = profilesRoot.appendingPathComponent("xyz12345.default-release", isDirectory: true)
         try FileManager.default.createDirectory(at: profileDir, withIntermediateDirectories: true)
@@ -208,10 +211,11 @@ final class BrowserDataPathProviderTests: XCTestCase {
         let paths = provider.dataPaths(for: .firefox, category: .history)
         let resolved = paths.map { Self.stripPrivatePrefix($0.path) }
 
-        let shm = Self.stripPrivatePrefix(profileDir.appendingPathComponent("places.sqlite-shm").path)
-        let wal = Self.stripPrivatePrefix(profileDir.appendingPathComponent("places.sqlite-wal").path)
-        XCTAssertTrue(resolved.contains(shm), "Expected places.sqlite-shm in \(resolved)")
-        XCTAssertTrue(resolved.contains(wal), "Expected places.sqlite-wal in \(resolved)")
+        for sidecar in ["places.sqlite-journal", "places.sqlite-shm", "places.sqlite-wal"] {
+            let expected = Self.stripPrivatePrefix(profileDir.appendingPathComponent(sidecar).path)
+            XCTAssertTrue(resolved.contains(expected),
+                          "Expected \(sidecar) in \(resolved)")
+        }
     }
 
     /// When no Firefox profile exists yet, the provider must return an

--- a/VaderCleanerTests/BrowserDataPathProviderTests.swift
+++ b/VaderCleanerTests/BrowserDataPathProviderTests.swift
@@ -75,6 +75,72 @@ final class BrowserDataPathProviderTests: XCTestCase {
         XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Application Support/Google/Chrome/Default/Cookies").path))
     }
 
+    /// Modern Chromium (since ~Chrome 96 / Edge 96) keeps the cookies
+    /// SQLite under `Default/Network/Cookies`. Targeting only the legacy
+    /// `Default/Cookies` location would silently skip cookies on every
+    /// up-to-date install — the preview reports 0 B and "Clear" leaves
+    /// the user's cookies intact while the UI claims success.
+    func test_chrome_cookies_targetsNetworkCookiesSqliteUnderDefaultProfile() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .chrome, category: .cookies)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Application Support/Google/Chrome/Default/Network/Cookies").path))
+    }
+
+    /// SQLite `-wal` / `-shm` sidecars are present whenever the browser
+    /// is or was recently running. Leaving them on disk after a clear
+    /// undercounts the user's reclaimed space and leaves orphaned files
+    /// the browser won't apply to a fresh DB.
+    func test_chrome_history_includesSqliteWalAndShmSidecars() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .chrome, category: .history)
+        let strings = paths.map { $0.path }
+
+        let profile = tempHome.appendingPathComponent("Library/Application Support/Google/Chrome/Default")
+        XCTAssertTrue(strings.contains(profile.appendingPathComponent("History-shm").path))
+        XCTAssertTrue(strings.contains(profile.appendingPathComponent("History-wal").path))
+    }
+
+    /// Chromium and Firefox both store download history inside the same
+    /// SQLite as browsing history, so a path-based "remove the file"
+    /// clear of `.downloads` would also wipe browsing history when only
+    /// `.downloads` is checked. The provider returns no paths for
+    /// `.downloads` on these browsers — clearing them at the file level
+    /// is only safe when the user also checks `.history`. The Privacy UI
+    /// shows 0 B for the row so users see there's nothing to clear at
+    /// the file level.
+    func test_chrome_downloads_returnsEmptyToAvoidWipingHistory() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        XCTAssertEqual(provider.dataPaths(for: .chrome, category: .downloads), [])
+        XCTAssertEqual(provider.dataPaths(for: .brave,  category: .downloads), [])
+        XCTAssertEqual(provider.dataPaths(for: .arc,    category: .downloads), [])
+        XCTAssertEqual(provider.dataPaths(for: .opera,  category: .downloads), [])
+        XCTAssertEqual(provider.dataPaths(for: .edge,   category: .downloads), [])
+    }
+
+    func test_firefox_downloads_returnsEmptyToAvoidWipingPlacesSqlite() throws {
+        let profilesRoot = tempHome.appendingPathComponent("Library/Application Support/Firefox/Profiles", isDirectory: true)
+        let profileDir = profilesRoot.appendingPathComponent("xyz12345.default-release", isDirectory: true)
+        try FileManager.default.createDirectory(at: profileDir, withIntermediateDirectories: true)
+
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        XCTAssertEqual(provider.dataPaths(for: .firefox, category: .downloads), [])
+    }
+
+    /// Safari's downloads live in a standalone `Downloads.plist`, so the
+    /// constraint that forces Chromium/Firefox `.downloads` to return
+    /// nothing doesn't apply — we *can* clear Safari's downloads
+    /// independently.
+    func test_safari_downloads_targetsDownloadsPlist() {
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .safari, category: .downloads)
+        let strings = paths.map { $0.path }
+
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Safari/Downloads.plist").path))
+        XCTAssertTrue(strings.contains(tempHome.appendingPathComponent("Library/Containers/com.apple.Safari/Data/Library/Safari/Downloads.plist").path))
+    }
+
     func test_chrome_cache_targetsCacheDirUnderCachesPath() {
         let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
         let paths = provider.dataPaths(for: .chrome, category: .cache)
@@ -128,6 +194,24 @@ final class BrowserDataPathProviderTests: XCTestCase {
         let expected = Self.stripPrivatePrefix(cacheProfileDir.appendingPathComponent("cache2").path)
         XCTAssertTrue(resolved.contains(expected),
                       "Expected cache2 under \(cacheProfileDir.path), got \(resolved)")
+    }
+
+    /// Same SQLite WAL/SHM concern as Chromium — Firefox uses WAL mode
+    /// for places.sqlite and cookies.sqlite, so missing the `-shm` /
+    /// `-wal` sidecars leaves orphaned files on disk.
+    func test_firefox_history_includesSqliteWalAndShmSidecars() throws {
+        let profilesRoot = tempHome.appendingPathComponent("Library/Application Support/Firefox/Profiles", isDirectory: true)
+        let profileDir = profilesRoot.appendingPathComponent("xyz12345.default-release", isDirectory: true)
+        try FileManager.default.createDirectory(at: profileDir, withIntermediateDirectories: true)
+
+        let provider = DefaultBrowserDataPathProvider(homeDirectory: tempHome)
+        let paths = provider.dataPaths(for: .firefox, category: .history)
+        let resolved = paths.map { Self.stripPrivatePrefix($0.path) }
+
+        let shm = Self.stripPrivatePrefix(profileDir.appendingPathComponent("places.sqlite-shm").path)
+        let wal = Self.stripPrivatePrefix(profileDir.appendingPathComponent("places.sqlite-wal").path)
+        XCTAssertTrue(resolved.contains(shm), "Expected places.sqlite-shm in \(resolved)")
+        XCTAssertTrue(resolved.contains(wal), "Expected places.sqlite-wal in \(resolved)")
     }
 
     /// When no Firefox profile exists yet, the provider must return an

--- a/VaderCleanerTests/BrowserDetectorTests.swift
+++ b/VaderCleanerTests/BrowserDetectorTests.swift
@@ -1,0 +1,87 @@
+// BrowserDetectorTests.swift
+// Verifies that DefaultBrowserDetector reports Safari as always present and surfaces installed browsers based on the injected existence checker — without touching the real /Applications directory.
+
+import XCTest
+@testable import VaderCleaner
+
+final class BrowserDetectorTests: XCTestCase {
+
+    /// Safari ships with macOS and cannot be uninstalled through normal
+    /// channels, so the detector must report it as installed regardless of
+    /// what the existence checker says. Suppressing it from the Privacy UI
+    /// would surprise users on every Mac.
+    func test_safariIsAlwaysReportedInstalled() {
+        let detector = DefaultBrowserDetector(existsAt: { _ in false })
+        XCTAssertTrue(detector.installedBrowsers().contains(.safari))
+    }
+
+    /// Browsers whose `.app` bundle isn't found at any of the known
+    /// locations must be filtered out. We don't show a row for a browser
+    /// the user doesn't have — clearing nothing leaves the user wondering
+    /// why their data wasn't touched.
+    func test_missingBrowsersAreFilteredOut() {
+        let detector = DefaultBrowserDetector(existsAt: { _ in false })
+        let installed = detector.installedBrowsers()
+        XCTAssertEqual(installed, [.safari],
+                       "Only Safari should be reported when no other apps exist")
+    }
+
+    /// When Chrome's `.app` is present, the detector includes it. We assert
+    /// against the system-installs path; the per-user `~/Applications` path
+    /// is exercised separately below.
+    func test_chrome_isDetectedFromSystemApplicationsPath() {
+        let detector = DefaultBrowserDetector(existsAt: { url in
+            url.path == "/Applications/Google Chrome.app"
+        })
+        XCTAssertTrue(detector.installedBrowsers().contains(.chrome))
+    }
+
+    /// Per-user installs (`~/Applications/...`) are common for power users
+    /// and Homebrew Cask without `--no-quarantine`. The detector must check
+    /// both system and user `Applications` directories.
+    func test_brave_isDetectedFromUserApplicationsPath() {
+        let userApps = "/Users/test/Applications/Brave Browser.app"
+        let detector = DefaultBrowserDetector(
+            homeDirectory: URL(fileURLWithPath: "/Users/test"),
+            existsAt: { url in url.path == userApps }
+        )
+        XCTAssertTrue(detector.installedBrowsers().contains(.brave))
+    }
+
+    /// Multiple installed browsers must all surface in the result —
+    /// detection is independent per case, so a Chrome-and-Firefox machine
+    /// reports both alongside Safari.
+    func test_multipleBrowsers_areAllReported() {
+        let installedPaths: Set<String> = [
+            "/Applications/Google Chrome.app",
+            "/Applications/Firefox.app"
+        ]
+        let detector = DefaultBrowserDetector(existsAt: { url in
+            installedPaths.contains(url.path)
+        })
+
+        let installed = Set(detector.installedBrowsers())
+        XCTAssertTrue(installed.contains(.safari))
+        XCTAssertTrue(installed.contains(.chrome))
+        XCTAssertTrue(installed.contains(.firefox))
+        XCTAssertFalse(installed.contains(.brave))
+        XCTAssertFalse(installed.contains(.edge))
+    }
+
+    /// Detection result must preserve `Browser.allCases` order so the
+    /// Privacy UI renders a stable sidebar list — Safari first, then
+    /// alphabetical-ish per the enum declaration.
+    func test_resultOrderMatchesAllCases() {
+        let installedPaths: Set<String> = [
+            "/Applications/Google Chrome.app",
+            "/Applications/Firefox.app",
+            "/Applications/Microsoft Edge.app"
+        ]
+        let detector = DefaultBrowserDetector(existsAt: { url in
+            installedPaths.contains(url.path)
+        })
+
+        let installed = detector.installedBrowsers()
+        XCTAssertEqual(installed, [.safari, .chrome, .firefox, .edge])
+    }
+}

--- a/VaderCleanerTests/BrowserTests.swift
+++ b/VaderCleanerTests/BrowserTests.swift
@@ -1,0 +1,55 @@
+// BrowserTests.swift
+// Verifies the Browser enum's stable identifiers and per-case bundle / display metadata used by detection and the Privacy UI.
+
+import XCTest
+@testable import VaderCleaner
+
+final class BrowserTests: XCTestCase {
+
+    /// Every browser case must exist in `allCases`. The Privacy feature
+    /// scans this list to drive detection — a missing case would silently
+    /// hide a browser from the user, which is worse than a wrong path.
+    func test_allCases_containsEveryExpectedBrowser() {
+        let cases = Set(Browser.allCases)
+        XCTAssertEqual(cases, [
+            .safari, .chrome, .firefox, .brave, .arc, .opera, .edge
+        ])
+    }
+
+    /// Bundle identifiers are a stable contract — they're keyed off when
+    /// users have multiple Chromium-based browsers installed and the path
+    /// provider keys data dirs by them. A typo here surfaces as silent
+    /// mis-detection in the field, so pin them in tests.
+    func test_bundleIdentifier_matchesShippedBundles() {
+        XCTAssertEqual(Browser.safari.bundleIdentifier,  "com.apple.Safari")
+        XCTAssertEqual(Browser.chrome.bundleIdentifier,  "com.google.Chrome")
+        XCTAssertEqual(Browser.firefox.bundleIdentifier, "org.mozilla.firefox")
+        XCTAssertEqual(Browser.brave.bundleIdentifier,   "com.brave.Browser")
+        XCTAssertEqual(Browser.arc.bundleIdentifier,     "company.thebrowser.Browser")
+        XCTAssertEqual(Browser.opera.bundleIdentifier,   "com.operasoftware.Opera")
+        XCTAssertEqual(Browser.edge.bundleIdentifier,    "com.microsoft.edgemac")
+    }
+
+    /// `appBundleName` drives `/Applications/<name>.app` existence checks in
+    /// `BrowserDetector`. The display name (e.g. "Brave Browser") and the
+    /// bundle filename (`Brave Browser.app`) diverge enough across browsers
+    /// to be worth pinning per case.
+    func test_appBundleName_matchesShippedBundles() {
+        XCTAssertEqual(Browser.safari.appBundleName,  "Safari.app")
+        XCTAssertEqual(Browser.chrome.appBundleName,  "Google Chrome.app")
+        XCTAssertEqual(Browser.firefox.appBundleName, "Firefox.app")
+        XCTAssertEqual(Browser.brave.appBundleName,   "Brave Browser.app")
+        XCTAssertEqual(Browser.arc.appBundleName,     "Arc.app")
+        XCTAssertEqual(Browser.opera.appBundleName,   "Opera.app")
+        XCTAssertEqual(Browser.edge.appBundleName,    "Microsoft Edge.app")
+    }
+
+    /// The display name is shown in the Privacy UI; non-empty for every case
+    /// keeps the rendered list from showing a blank row.
+    func test_displayName_isNonEmptyForEveryCase() {
+        for browser in Browser.allCases {
+            XCTAssertFalse(browser.displayName.isEmpty,
+                           "Missing displayName for \(browser)")
+        }
+    }
+}

--- a/VaderCleanerTests/PrivacyCategoryTests.swift
+++ b/VaderCleanerTests/PrivacyCategoryTests.swift
@@ -1,0 +1,34 @@
+// PrivacyCategoryTests.swift
+// Verifies the PrivacyCategory enum's stable raw values and per-case display labels used in the Privacy preview rows.
+
+import XCTest
+@testable import VaderCleaner
+
+final class PrivacyCategoryTests: XCTestCase {
+
+    /// All five categories from the spec must be present. The Privacy UI
+    /// iterates this list to render checkboxes, so a missing case would
+    /// silently strip a category from the user's options.
+    func test_allCases_containsEveryExpectedCategory() {
+        let cases = Set(PrivacyCategory.allCases)
+        XCTAssertEqual(cases, [.history, .downloads, .cookies, .cache, .savedForms])
+    }
+
+    /// Raw values are persisted in view-model state and tests pin them so a
+    /// rename doesn't silently invalidate stored selections.
+    func test_rawValues_areStable() {
+        XCTAssertEqual(PrivacyCategory.history.rawValue,    "history")
+        XCTAssertEqual(PrivacyCategory.downloads.rawValue,  "downloads")
+        XCTAssertEqual(PrivacyCategory.cookies.rawValue,    "cookies")
+        XCTAssertEqual(PrivacyCategory.cache.rawValue,      "cache")
+        XCTAssertEqual(PrivacyCategory.savedForms.rawValue, "savedForms")
+    }
+
+    /// Every category renders a non-empty label in the preview list.
+    func test_displayName_isNonEmptyForEveryCase() {
+        for category in PrivacyCategory.allCases {
+            XCTAssertFalse(category.displayName.isEmpty,
+                           "Missing displayName for \(category)")
+        }
+    }
+}

--- a/VaderCleanerTests/PrivacyViewModelTests.swift
+++ b/VaderCleanerTests/PrivacyViewModelTests.swift
@@ -246,6 +246,39 @@ final class PrivacyViewModelTests: XCTestCase {
         XCTAssertEqual(vm.phase, .complete(bytesFreed: totalBefore))
     }
 
+    /// `checkedSelections` is a `Set`; iterating it directly would yield
+    /// nondeterministic order, so a mid-run failure would abort at a
+    /// different point each run and make retries / bug reports
+    /// inconsistent. The clear loop must iterate in
+    /// `Browser.allCases × PrivacyCategory.allCases` order.
+    func test_clear_invokesClearerInDeterministicBrowserCategoryOrder() async {
+        let recorded = ActorBox<[String]>([])
+        let vm = makeViewModel(
+            detected: [.safari, .chrome, .firefox],
+            sizer: { _, _ in 50 },
+            clearer: { browser, category in
+                await recorded.append("\(browser.rawValue):\(category.rawValue)")
+            },
+            clearRecentFiles: { }
+        )
+
+        await vm.preview()
+        await vm.clear()
+
+        let received = await recorded.value
+        // Build the expected order from the same Browser × Category
+        // enumeration the production VM uses, intersected with the
+        // detected set.
+        var expected: [String] = []
+        for browser in [Browser.safari, .chrome, .firefox] {
+            for category in PrivacyCategory.allCases {
+                expected.append("\(browser.rawValue):\(category.rawValue)")
+            }
+        }
+        XCTAssertEqual(received, expected,
+                       "Clear must iterate in Browser × Category order")
+    }
+
     /// Recents clearing runs *before* browser clearing — if recents
     /// throws, browser data must still be intact so the user can retry
     /// without hitting "browser shows 0 B because we already wiped it"

--- a/VaderCleanerTests/PrivacyViewModelTests.swift
+++ b/VaderCleanerTests/PrivacyViewModelTests.swift
@@ -1,0 +1,350 @@
+// PrivacyViewModelTests.swift
+// Tests the PrivacyViewModel state machine, default selection, deduplication, and clear dispatch — driving every transition through injected fake browsers, sizers, and clearers so no real browser data is touched.
+
+import XCTest
+import Combine
+@testable import VaderCleaner
+
+@MainActor
+final class PrivacyViewModelTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    /// On construction the VM must be in `.idle` so the Privacy view shows
+    /// its "Scan" call-to-action — not a stale preview from a prior session.
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+    }
+
+    // MARK: - Preview transitions
+
+    /// `preview()` must advance from `.idle` through `.scanning` to
+    /// `.preview` once the injected sizer / detector resolve. The
+    /// transient `.scanning` value is what drives the spinner; without
+    /// asserting on it the VM could jump straight to `.preview` and the
+    /// view would render nothing during a slow scan.
+    func test_preview_transitionsIdleToScanningToPreview() async {
+        let vm = makeViewModel(
+            detected: [.safari, .chrome],
+            sizer: { _, _ in 100 }
+        )
+
+        var phases: [PrivacyViewModel.Phase] = []
+        let cancellable = vm.$phase.sink { phases.append($0) }
+
+        await vm.preview()
+        cancellable.cancel()
+
+        XCTAssertEqual(phases.first, .idle)
+        XCTAssertTrue(phases.contains(.scanning))
+        if case .preview = vm.phase {
+            // expected
+        } else {
+            XCTFail("Expected .preview, got \(vm.phase)")
+        }
+    }
+
+    /// Every `(browser, category)` pair from the detected browsers must
+    /// be checked by default — the user opts out of categories rather
+    /// than opting in, mirroring System Junk's behavior.
+    func test_preview_marksEverySelectionCheckedByDefault() async {
+        let vm = makeViewModel(
+            detected: [.safari, .chrome],
+            sizer: { _, _ in 100 }
+        )
+
+        await vm.preview()
+
+        for browser in [Browser.safari, .chrome] {
+            for category in PrivacyCategory.allCases {
+                XCTAssertTrue(vm.isChecked(browser: browser, category: category),
+                              "Expected (\(browser), \(category)) checked by default")
+            }
+        }
+        XCTAssertTrue(vm.isClearRecentsChecked,
+                      "Recent items toggle must default to checked")
+    }
+
+    /// Per-category sizes must be exposed for the view to render
+    /// "20 MB"-style labels next to each checkbox without recomputing
+    /// from scratch on every redraw.
+    func test_preview_exposesPerCategorySizes() async {
+        let vm = makeViewModel(
+            detected: [.chrome],
+            sizer: { browser, category in
+                browser == .chrome && category == .cache ? 1_024 * 1_024 : 100
+            }
+        )
+
+        await vm.preview()
+
+        XCTAssertEqual(vm.size(for: .chrome, category: .cache), 1_024 * 1_024)
+        XCTAssertEqual(vm.size(for: .chrome, category: .history), 100)
+    }
+
+    /// A throwing detector must surface `.failed` rather than leaving the
+    /// VM stuck in `.scanning` — otherwise the spinner never resolves.
+    func test_preview_failureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let vm = makeViewModel(
+            detector: { throw BoomError() },
+            sizer: { _, _ in 0 }
+        )
+
+        await vm.preview()
+
+        if case .failed = vm.phase {
+            // expected
+        } else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Selection
+
+    /// Toggling a `(browser, category)` selection must update both the
+    /// checked state and the running total — the latter feeds the footer
+    /// total label so a stale value would leave users confused about
+    /// what's about to be cleared.
+    func test_toggle_updatesIsCheckedAndTotalSelectedSize() async {
+        // `pathsFor` returns a distinct stub URL per category so the
+        // dedup logic in `totalSelectedSize` accounts for every cell —
+        // cells with no paths contribute 0 by design (production sizers
+        // also report 0 for those, since the clearer walks `pathsFor`).
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, category in category == .history ? 200 : 50 },
+            pathsFor: { browser, category in
+                [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+
+        await vm.preview()
+        // Default checked: history(200) + downloads(50) + cookies(50) + cache(50) + savedForms(50) = 400
+        XCTAssertEqual(vm.totalSelectedSize, 400)
+
+        vm.toggle(browser: .safari, category: .history)
+        XCTAssertFalse(vm.isChecked(browser: .safari, category: .history))
+        XCTAssertEqual(vm.totalSelectedSize, 200)
+
+        vm.toggle(browser: .safari, category: .history)
+        XCTAssertTrue(vm.isChecked(browser: .safari, category: .history))
+        XCTAssertEqual(vm.totalSelectedSize, 400)
+    }
+
+    /// Two checked categories that point at the same on-disk path
+    /// (Chromium `.history` and `.downloads` share the History SQLite)
+    /// must contribute *one* size to `totalSelectedSize`, not two —
+    /// otherwise the footer claims more bytes will be freed than the
+    /// clearer can deliver.
+    func test_totalSelectedSize_dedupesPathsSharedAcrossCategories() async {
+        let sharedPath = URL(fileURLWithPath: "/tmp/vctests/Chrome/Default/History")
+        let pathsForCategory: (Browser, PrivacyCategory) -> [URL] = { _, category in
+            switch category {
+            case .history, .downloads: return [sharedPath]
+            case .cookies: return [URL(fileURLWithPath: "/tmp/vctests/Chrome/Default/Cookies")]
+            default: return []
+            }
+        }
+        let vm = makeViewModel(
+            detected: [.chrome],
+            sizer: { _, _ in 100 },
+            pathsFor: pathsForCategory
+        )
+
+        await vm.preview()
+        // Both .history and .downloads reference the same path, so the
+        // shared-path size (100) is counted once. .cookies adds a unique
+        // path (100). The remaining categories contribute 0 (no paths).
+        XCTAssertEqual(vm.totalSelectedSize, 200)
+    }
+
+    // MARK: - Clear
+
+    /// `clear()` must invoke the clearer for every checked
+    /// `(browser, category)` pair — and only those — so an unchecked
+    /// row's data is never silently removed.
+    func test_clear_invokesClearerOnlyForCheckedSelections() async {
+        let recorded = ActorBox<[String]>([])
+        let vm = makeViewModel(
+            detected: [.safari, .chrome],
+            sizer: { _, _ in 50 },
+            clearer: { browser, category in
+                await recorded.append("\(browser.rawValue):\(category.rawValue)")
+            }
+        )
+        await vm.preview()
+
+        // Uncheck Chrome's cookies.
+        vm.toggle(browser: .chrome, category: .cookies)
+
+        await vm.clear()
+
+        let received = await recorded.value
+        XCTAssertFalse(received.contains("chrome:cookies"))
+        XCTAssertTrue(received.contains("safari:history"))
+        XCTAssertTrue(received.contains("chrome:history"))
+    }
+
+    /// `clear()` must invoke the recent-files manager exactly once when its
+    /// toggle is on, and not at all when off.
+    func test_clear_invokesRecentFilesManagerWhenToggleIsOn() async {
+        let recentInvocations = ActorBox(0)
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 0 },
+            clearer: { _, _ in },
+            clearRecentFiles: { await recentInvocations.increment() }
+        )
+
+        await vm.preview()
+        await vm.clear()
+
+        let count = await recentInvocations.value
+        XCTAssertEqual(count, 1)
+    }
+
+    func test_clear_doesNotInvokeRecentFilesManagerWhenToggleIsOff() async {
+        let recentInvocations = ActorBox(0)
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 0 },
+            clearer: { _, _ in },
+            clearRecentFiles: { await recentInvocations.increment() }
+        )
+
+        await vm.preview()
+        vm.toggleClearRecents()
+
+        await vm.clear()
+
+        let count = await recentInvocations.value
+        XCTAssertEqual(count, 0)
+    }
+
+    /// On success, the phase must become `.complete(bytesFreed:)` so the
+    /// view renders the "X freed" summary. Bytes freed comes from the
+    /// pre-clear totals (the clearer doesn't return per-call sizes), so
+    /// partial-failure cases would still report the optimistic total —
+    /// acceptable since clearer errors are rare for user-domain paths.
+    func test_clear_transitionsToCompleteWithBytesFreed() async {
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 100 },
+            clearer: { _, _ in },
+            pathsFor: { browser, category in
+                [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+
+        await vm.preview()
+        let totalBefore = vm.totalSelectedSize
+        XCTAssertEqual(totalBefore, 500, "Sanity check on captured pre-clear total")
+        await vm.clear()
+
+        XCTAssertEqual(vm.phase, .complete(bytesFreed: totalBefore))
+    }
+
+    /// Recents clearing runs *before* browser clearing — if recents
+    /// throws, browser data must still be intact so the user can retry
+    /// without hitting "browser shows 0 B because we already wiped it"
+    /// confusion. We assert the browser clearer was never invoked when
+    /// the recents step failed.
+    func test_clear_clearsRecentsBeforeBrowsersAndAbortsOnRecentsFailure() async {
+        struct BoomError: Error {}
+        let browserClearerInvocations = ActorBox(0)
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 50 },
+            clearer: { _, _ in await browserClearerInvocations.increment() },
+            clearRecentFiles: { throw BoomError() }
+        )
+
+        await vm.preview()
+        await vm.clear()
+
+        let count = await browserClearerInvocations.value
+        XCTAssertEqual(count, 0,
+                       "Browser clearer must not run when the recents step throws")
+        if case .failed = vm.phase {
+            // expected
+        } else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    /// A throwing clearer must surface `.failed` — silent failures would
+    /// claim "cleared" when the user's data is still on disk.
+    func test_clear_failureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 100 },
+            clearer: { _, _ in throw BoomError() }
+        )
+
+        await vm.preview()
+        await vm.clear()
+
+        if case .failed = vm.phase {
+            // expected
+        } else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Reset
+
+    /// `scanAgain()` must drop the cached preview and selection so the
+    /// next `preview()` starts from a clean slate.
+    func test_scanAgain_returnsToIdle() async {
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 100 },
+            clearer: { _, _ in }
+        )
+        await vm.preview()
+        await vm.clear()
+
+        vm.scanAgain()
+
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.totalSelectedSize, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        detected: [Browser] = [],
+        detector: PrivacyViewModel.Detector? = nil,
+        sizer: @escaping PrivacyViewModel.Sizer = { _, _ in 0 },
+        clearer: @escaping PrivacyViewModel.Clearer = { _, _ in },
+        pathsFor: @escaping PrivacyViewModel.PathsResolver = { _, _ in [] },
+        clearRecentFiles: @escaping PrivacyViewModel.RecentFilesClearer = { }
+    ) -> PrivacyViewModel {
+        PrivacyViewModel(
+            detector: detector ?? { detected },
+            sizer: sizer,
+            pathsFor: pathsFor,
+            clearer: clearer,
+            clearRecentFiles: clearRecentFiles
+        )
+    }
+}
+
+/// Small actor wrapper for race-free counters / collectors inside async
+/// test closures. Mirrors the helper used in `SystemJunkViewModelTests`.
+private actor ActorBox<Value: Sendable> {
+    private(set) var value: Value
+    init(_ initial: Value) { self.value = initial }
+    func set(_ newValue: Value) { value = newValue }
+}
+
+private extension ActorBox where Value == Int {
+    func increment() { value += 1 }
+}
+
+private extension ActorBox where Value == [String] {
+    func append(_ entry: String) { value.append(entry) }
+}

--- a/VaderCleanerTests/PrivacyViewModelTests.swift
+++ b/VaderCleanerTests/PrivacyViewModelTests.swift
@@ -101,6 +101,54 @@ final class PrivacyViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Actionability
+
+    /// `isCategoryActionable` is the contract the view uses to decide
+    /// whether to render a row as a checkbox or as an informational
+    /// "Included with Browsing History" caption. A category with no
+    /// paths must report unactionable so the UI never offers a
+    /// control that does nothing — Codex flagged this as a P2 on
+    /// PR #39.
+    func test_isCategoryActionable_returnsFalseWhenPathsResolverEmpty() async {
+        let vm = makeViewModel(
+            detected: [.chrome],
+            sizer: { _, _ in 100 },
+            pathsFor: { _, category in
+                category == .history
+                    ? [URL(fileURLWithPath: "/tmp/vctests/Chrome/Default/History")]
+                    : []
+            }
+        )
+        await vm.preview()
+
+        XCTAssertTrue(vm.isCategoryActionable(browser: .chrome, category: .history))
+        XCTAssertFalse(vm.isCategoryActionable(browser: .chrome, category: .downloads))
+        XCTAssertFalse(vm.isCategoryActionable(browser: .chrome, category: .cookies))
+    }
+
+    /// Production wiring: `.downloads` must be unactionable for every
+    /// Chromium / Firefox browser so the UI couples the row visually
+    /// to History. Safari's `.downloads` is independently clearable
+    /// (`Downloads.plist`) and must remain actionable.
+    func test_isCategoryActionable_decouplesChromiumDownloads() async {
+        let vm = makeViewModel(
+            detected: [.safari, .chrome, .firefox, .brave, .arc, .opera, .edge],
+            sizer: { _, _ in 0 },
+            pathsFor: { browser, category in
+                DefaultBrowserDataPathProvider(homeDirectory: URL(fileURLWithPath: "/tmp/vctests"))
+                    .dataPaths(for: browser, category: category)
+            }
+        )
+        await vm.preview()
+
+        XCTAssertTrue(vm.isCategoryActionable(browser: .safari, category: .downloads))
+        for browser in [Browser.chrome, .firefox, .brave, .arc, .opera, .edge] {
+            XCTAssertFalse(
+                vm.isCategoryActionable(browser: browser, category: .downloads),
+                "Expected \(browser).downloads to be unactionable")
+        }
+    }
+
     // MARK: - Selection
 
     /// Toggling a `(browser, category)` selection must update both the

--- a/VaderCleanerTests/RecentFilesManagerTests.swift
+++ b/VaderCleanerTests/RecentFilesManagerTests.swift
@@ -1,0 +1,84 @@
+// RecentFilesManagerTests.swift
+// Verifies that RecentFilesManager invokes both the per-app and system-wide clear actions exactly once when asked to clear, and removes any sharedfilelist sfl files reachable under the injected home directory.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class RecentFilesManagerTests: XCTestCase {
+
+    private var tempHome: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempHome = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        TestHelpers.tearDownTempDirectory(tempHome)
+        tempHome = nil
+        try super.tearDownWithError()
+    }
+
+    /// `clear()` must invoke the injected app-level clear action exactly
+    /// once. The closure indirection exists so production can wrap
+    /// `NSDocumentController.shared.clearRecentDocuments(_:)` (global
+    /// state, awkward to assert against) while tests count invocations
+    /// without touching that singleton.
+    func test_clear_invokesAppLevelClearActionOnce() throws {
+        var invocations = 0
+        let manager = RecentFilesManager(
+            homeDirectory: tempHome,
+            clearAppRecentDocuments: { invocations += 1 }
+        )
+
+        try manager.clear()
+
+        XCTAssertEqual(invocations, 1)
+    }
+
+    /// `clear()` must remove every `com.apple.LSSharedFileList.Recent*.sfl*`
+    /// file that exists under
+    /// `~/Library/Application Support/com.apple.sharedfilelist/`. These plist
+    /// files are the on-disk source of truth for the Apple-menu Recent
+    /// Items list — clearing only `NSDocumentController` (which targets
+    /// just this app's recent docs) would leave the user-visible global
+    /// list untouched.
+    func test_clear_removesSharedFileListRecentEntries() throws {
+        let sharedDir = tempHome
+            .appendingPathComponent("Library/Application Support/com.apple.sharedfilelist", isDirectory: true)
+        try FileManager.default.createDirectory(at: sharedDir, withIntermediateDirectories: true)
+        let recents = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentDocuments.sfl3")
+        let apps    = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentApplications.sfl3")
+        let hosts   = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentHosts.sfl3")
+        let other   = sharedDir.appendingPathComponent("com.apple.SomethingElse.plist")
+        for url in [recents, apps, hosts, other] {
+            FileManager.default.createFile(atPath: url.path, contents: Data(repeating: 0, count: 8))
+        }
+
+        let manager = RecentFilesManager(
+            homeDirectory: tempHome,
+            clearAppRecentDocuments: { }
+        )
+
+        try manager.clear()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recents.path), "Recents sfl should be removed")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: apps.path),    "Recent apps sfl should be removed")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hosts.path),   "Recent hosts sfl should be removed")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: other.path),
+                      "Non-Recent* sfl entries must be left alone")
+    }
+
+    /// When the sharedfilelist directory is missing entirely, `clear()`
+    /// must not throw — a fresh user account that's never opened a
+    /// document has no list to clear, and that's still a successful "clear
+    /// recent items" result.
+    func test_clear_doesNotThrowWhenSharedFileListDirectoryIsMissing() throws {
+        let manager = RecentFilesManager(
+            homeDirectory: tempHome,
+            clearAppRecentDocuments: { }
+        )
+        XCTAssertNoThrow(try manager.clear())
+    }
+}

--- a/VaderCleanerTests/RecentFilesManagerTests.swift
+++ b/VaderCleanerTests/RecentFilesManagerTests.swift
@@ -48,11 +48,21 @@ final class RecentFilesManagerTests: XCTestCase {
         let sharedDir = tempHome
             .appendingPathComponent("Library/Application Support/com.apple.sharedfilelist", isDirectory: true)
         try FileManager.default.createDirectory(at: sharedDir, withIntermediateDirectories: true)
-        let recents = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentDocuments.sfl3")
-        let apps    = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentApplications.sfl3")
-        let hosts   = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentHosts.sfl3")
-        let other   = sharedDir.appendingPathComponent("com.apple.SomethingElse.plist")
-        for url in [recents, apps, hosts, other] {
+        let recents       = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentDocuments.sfl3")
+        let apps          = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentApplications.sfl3")
+        let hosts         = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentHosts.sfl3")
+        // SFL-prefix sibling that is *not* a Recents list — the
+        // original test used a totally unrelated `.plist` which couldn't
+        // distinguish "only Recent* sfl files removed" from "every sfl
+        // file removed". Favorites is the canonical non-Recent SFL file.
+        let favorites     = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.FavoriteItems.sfl3")
+        // Prefix-only file that lacks an `.sfl*` suffix — exercises the
+        // tightened filter that requires both prefix and suffix.
+        let prefixOnly    = sharedDir.appendingPathComponent("com.apple.LSSharedFileList.RecentDocuments.config.plist")
+        // Unrelated entry, retained to prove the filter doesn't sweep
+        // non-SFL files in the same directory either.
+        let other         = sharedDir.appendingPathComponent("com.apple.SomethingElse.plist")
+        for url in [recents, apps, hosts, favorites, prefixOnly, other] {
             FileManager.default.createFile(atPath: url.path, contents: Data(repeating: 0, count: 8))
         }
 
@@ -66,8 +76,12 @@ final class RecentFilesManagerTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: recents.path), "Recents sfl should be removed")
         XCTAssertFalse(FileManager.default.fileExists(atPath: apps.path),    "Recent apps sfl should be removed")
         XCTAssertFalse(FileManager.default.fileExists(atPath: hosts.path),   "Recent hosts sfl should be removed")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: favorites.path),
+                      "Non-Recent SFL entries (FavoriteItems) must be left alone")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: prefixOnly.path),
+                      "Files with the Recent prefix but not an .sfl* suffix must be left alone")
         XCTAssertTrue(FileManager.default.fileExists(atPath: other.path),
-                      "Non-Recent* sfl entries must be left alone")
+                      "Unrelated entries must be left alone")
     }
 
     /// When the sharedfilelist directory is missing entirely, `clear()`

--- a/todo.md
+++ b/todo.md
@@ -35,7 +35,7 @@
 
 ## Phase 3 — Privacy & Apps
 
-- [ ] **Prompt 18** — Privacy feature (browser detection + data clearing + recent files)
+- [x] **Prompt 18** — Privacy feature (browser detection + data clearing + recent files)
 - [ ] **Prompt 19** — App Uninstaller (discovery + associated files + deletion)
 - [ ] **Prompt 20** — App Updater (App Store + Sparkle)
 - [ ] **Prompt 21** — Extensions Manager (Safari, browser, Mail, internet plugins, login items)


### PR DESCRIPTION
Closes #38. Implements Prompt 18 from plan.md.

## Summary
- Auto-detects installed browsers (Safari, Chrome, Firefox, Brave, Arc, Opera, Edge) by checking `.app` bundles under `/Applications` and `~/Applications`. Safari is always reported.
- Per-browser, per-category preview of browsing history, downloads, cookies, cache, and saved form data — sizes computed via recursive on-disk byte sum.
- Clear flow with confirmation alert. Recents are cleared *before* browser data so a recents failure leaves the destructive step untouched.
- Clears the system Recent Items list by removing `~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.Recent*.sfl*` plus `NSDocumentController.shared.clearRecentDocuments(_:)`.
- Path provider returns both legacy (`~/Library/Safari`) and sandbox-container (`~/Library/Containers/com.apple.Safari/Data/Library/Safari`) paths for Safari; the clearer skips whichever is missing on a given machine.
- Firefox profile dir is resolved at scan time by enumerating `Profiles/` and picking the first `*.default*` directory — handles the randomized prefix.
- Chromium / Firefox `.history` and `.downloads` reference the same SQLite, so the view-model deduplicates URLs across selected categories when computing `totalSelectedSize`.

## Test plan
- [x] 49 new unit tests pass — covers value types, path provider (Safari split, Chromium, Firefox profile resolution), detector (Safari-always + closure-driven existence), clearer (sums + missing-path tolerance + thrown errors), recents manager (sfl removal + missing dir), and the view-model state machine (preview, selection toggling, dedup, clear ordering, complete-with-bytes, failure transitions, scanAgain).
- [x] Full `VaderCleanerTests` suite passes (305 tests).
- [ ] Manual smoke: navigate to Privacy in the sidebar, scan, verify per-browser sizes match expectations on a populated user account, clear, confirm `Cookies` / `History` files are gone afterward and the Apple-menu Recent Items list is empty after the next login.
- [ ] Pre-existing `SpaceLensUITests.test_navigateToSpaceLens_revealsScanningOrTreemap` flake is unrelated to this change (verified by reverting `ContentView.swift` to main and reproducing the failure).

## Out of scope (deferred)
- App-specific chat history clearing (mentioned in spec.md §6) — needs a follow-up to identify which apps and their storage paths.
- Per-profile selection for Chromium / Firefox multi-profile setups — initial cut clears the default profile only.
- Sizer running on the main actor (preview can hang briefly on large caches) — worth a follow-up issue alongside System Junk's equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Privacy cleanup feature now available, supporting Safari, Chrome, Firefox, Brave, Arc, Opera, and Edge
* Clear history, downloads, cookies, cache, and saved forms per browser
* Preview storage that will be freed before proceeding
* Option to clear system recent items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->