### PR TITLE
Harden privileged helper deletion path validation and signing requirements

### DIFF
--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -35,6 +35,7 @@ struct HelperDeletionPolicy {
             URL(fileURLWithPath: "/Library/LaunchAgents", isDirectory: true),
             URL(fileURLWithPath: "/Library/LaunchDaemons", isDirectory: true)
         ],
+        allowedUserLaunchAgentsRoot: URL(fileURLWithPath: "/Users", isDirectory: true),
         allowedLanguageResourceRoots: [
             URL(fileURLWithPath: "/Applications", isDirectory: true),
             URL(fileURLWithPath: "/Library/Application Support", isDirectory: true),
@@ -45,17 +46,20 @@ struct HelperDeletionPolicy {
 
     private let allowedDescendantRoots: [URL]
     private let allowedLaunchPlistRoots: [URL]
+    private let allowedUserLaunchAgentsRoot: URL?
     private let allowedLanguageResourceRoots: [URL]
     private let volumesRoot: URL
 
     init(
         allowedDescendantRoots: [URL],
         allowedLaunchPlistRoots: [URL] = [],
+        allowedUserLaunchAgentsRoot: URL? = nil,
         allowedLanguageResourceRoots: [URL],
         volumesRoot: URL
     ) {
         self.allowedDescendantRoots = allowedDescendantRoots.map(Self.canonicalRoot)
         self.allowedLaunchPlistRoots = allowedLaunchPlistRoots.map(Self.canonicalRoot)
+        self.allowedUserLaunchAgentsRoot = allowedUserLaunchAgentsRoot.map(Self.canonicalRoot)
         self.allowedLanguageResourceRoots = allowedLanguageResourceRoots.map(Self.canonicalRoot)
         self.volumesRoot = Self.canonicalRoot(volumesRoot)
     }
@@ -167,6 +171,20 @@ struct HelperDeletionPolicy {
             return false
         }
         return allowedLaunchPlistRoots.contains(where: { Self.isDirectChild(url, of: $0) })
+            || isAllowedUserLaunchAgent(url)
+    }
+
+    private func isAllowedUserLaunchAgent(_ url: URL) -> Bool {
+        guard let allowedUserLaunchAgentsRoot,
+              Self.isDescendant(url, of: allowedUserLaunchAgentsRoot) else {
+            return false
+        }
+
+        let relative = Self.relativeComponents(of: url, under: allowedUserLaunchAgentsRoot)
+        return relative.count == 4
+            && !relative[0].isEmpty
+            && relative[1] == "Library"
+            && relative[2] == "LaunchAgents"
     }
 
     private func isAllowedLanguageResource(_ url: URL) -> Bool {

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -105,6 +105,16 @@ struct HelperDeletionPolicy {
     }
 
     private func isAllowedDeletionTarget(_ url: URL) -> Bool {
+        if isAllowedDeletionTargetWithoutSystemAliases(url) {
+            return true
+        }
+        if let aliasURL = Self.canonicalSystemAlias(for: url) {
+            return isAllowedDeletionTargetWithoutSystemAliases(aliasURL)
+        }
+        return false
+    }
+
+    private func isAllowedDeletionTargetWithoutSystemAliases(_ url: URL) -> Bool {
         if allowedDescendantRoots.contains(where: { Self.isDescendant(url, of: $0) }) {
             return true
         }
@@ -168,6 +178,18 @@ struct HelperDeletionPolicy {
 
     private static func canonical(_ url: URL) -> URL {
         url.standardizedFileURL.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    private static func canonicalSystemAlias(for url: URL) -> URL? {
+        let path = url.path
+        let varPrefix = "/var"
+        guard path == varPrefix || path.hasPrefix(varPrefix + "/") else {
+            return nil
+        }
+        // macOS exposes /var as an alias of /private/var; keep this narrow so
+        // arbitrary symlinks still have to pass validation in both spellings.
+        let suffix = path.dropFirst(varPrefix.count)
+        return URL(fileURLWithPath: "/private/var" + suffix, isDirectory: url.hasDirectoryPath).standardizedFileURL
     }
 
     private static func isDescendant(_ url: URL, of root: URL) -> Bool {

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -123,6 +123,8 @@ struct HelperDeletionPolicy {
     private func isAllowedVolumeTrashDescendant(_ url: URL) -> Bool {
         guard Self.isDescendant(url, of: volumesRoot) else { return false }
         let relative = Self.relativeComponents(of: url, under: volumesRoot)
+        // Require /Volumes/<volume>/.Trashes/<uid>/<item> so neither the
+        // .Trashes root nor a user's trash directory can be deleted.
         guard relative.count >= 4 else { return false }
         return relative[1] == ".Trashes" && !relative[2].isEmpty
     }

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -65,14 +65,15 @@ struct HelperDeletionPolicy {
             throw HelperDeletionValidationError.relativePath(path)
         }
 
-        let url = Self.canonical(URL(fileURLWithPath: path))
-        guard url.path != "/" else {
+        let requestedURL = URL(fileURLWithPath: path).standardizedFileURL
+        let resolvedURL = Self.canonical(requestedURL)
+        guard requestedURL.path != "/", resolvedURL.path != "/" else {
             throw HelperDeletionValidationError.rootPath(path)
         }
-        guard isAllowedDeletionTarget(url) else {
+        guard isAllowedDeletionTarget(requestedURL), isAllowedDeletionTarget(resolvedURL) else {
             throw HelperDeletionValidationError.disallowedPath(path)
         }
-        return url
+        return requestedURL
     }
 
     func uniqueValidatedDeletionURLs(for paths: [String]) throws -> [URL] {

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -30,6 +30,10 @@ struct HelperDeletionPolicy {
             URL(fileURLWithPath: "/Library/Logs", isDirectory: true),
             URL(fileURLWithPath: "/private/var/folders", isDirectory: true)
         ],
+        allowedLaunchPlistRoots: [
+            URL(fileURLWithPath: "/Library/LaunchAgents", isDirectory: true),
+            URL(fileURLWithPath: "/Library/LaunchDaemons", isDirectory: true)
+        ],
         allowedLanguageResourceRoots: [
             URL(fileURLWithPath: "/Applications", isDirectory: true),
             URL(fileURLWithPath: "/Library/Application Support", isDirectory: true),
@@ -39,15 +43,18 @@ struct HelperDeletionPolicy {
     )
 
     private let allowedDescendantRoots: [URL]
+    private let allowedLaunchPlistRoots: [URL]
     private let allowedLanguageResourceRoots: [URL]
     private let volumesRoot: URL
 
     init(
         allowedDescendantRoots: [URL],
+        allowedLaunchPlistRoots: [URL] = [],
         allowedLanguageResourceRoots: [URL],
         volumesRoot: URL
     ) {
         self.allowedDescendantRoots = allowedDescendantRoots.map(Self.canonicalRoot)
+        self.allowedLaunchPlistRoots = allowedLaunchPlistRoots.map(Self.canonicalRoot)
         self.allowedLanguageResourceRoots = allowedLanguageResourceRoots.map(Self.canonicalRoot)
         self.volumesRoot = Self.canonicalRoot(volumesRoot)
     }
@@ -80,8 +87,27 @@ struct HelperDeletionPolicy {
         return urls
     }
 
+    func removeValidatedPaths(
+        _ paths: [String],
+        remove: (URL) throws -> Void
+    ) throws -> Error? {
+        let urls = try uniqueValidatedDeletionURLs(for: paths)
+        var firstError: Error?
+        for url in urls {
+            do {
+                try remove(url)
+            } catch {
+                if firstError == nil { firstError = error }
+            }
+        }
+        return firstError
+    }
+
     private func isAllowedDeletionTarget(_ url: URL) -> Bool {
         if allowedDescendantRoots.contains(where: { Self.isDescendant(url, of: $0) }) {
+            return true
+        }
+        if isAllowedLaunchPlist(url) {
             return true
         }
         if isAllowedVolumeTrashDescendant(url) {
@@ -100,6 +126,13 @@ struct HelperDeletionPolicy {
         return relative[1] == ".Trashes" && !relative[2].isEmpty
     }
 
+    private func isAllowedLaunchPlist(_ url: URL) -> Bool {
+        guard Self.pathExtension(of: url.lastPathComponent).caseInsensitiveCompare("plist") == .orderedSame else {
+            return false
+        }
+        return allowedLaunchPlistRoots.contains(where: { Self.isDirectChild(url, of: $0) })
+    }
+
     private func isAllowedLanguageResource(_ url: URL) -> Bool {
         guard allowedLanguageResourceRoots.contains(where: { Self.isDescendant(url, of: $0) }) else {
             return false
@@ -110,7 +143,6 @@ struct HelperDeletionPolicy {
         }) else {
             return false
         }
-        guard components.count > lprojIndex + 1 else { return false }
 
         let lprojComponent = components[lprojIndex]
         guard Self.pathExtension(of: lprojComponent).caseInsensitiveCompare("lproj") == .orderedSame else {
@@ -139,6 +171,13 @@ struct HelperDeletionPolicy {
         let path = url.pathComponents
         let rootPath = root.pathComponents
         guard path.count > rootPath.count else { return false }
+        return Array(path.prefix(rootPath.count)) == rootPath
+    }
+
+    private static func isDirectChild(_ url: URL, of root: URL) -> Bool {
+        let path = url.pathComponents
+        let rootPath = root.pathComponents
+        guard path.count == rootPath.count + 1 else { return false }
         return Array(path.prefix(rootPath.count)) == rootPath
     }
 

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -170,15 +170,13 @@ struct HelperDeletionPolicy {
     private static func isDescendant(_ url: URL, of root: URL) -> Bool {
         let path = url.pathComponents
         let rootPath = root.pathComponents
-        guard path.count > rootPath.count else { return false }
-        return Array(path.prefix(rootPath.count)) == rootPath
+        return path.count > rootPath.count && path.starts(with: rootPath)
     }
 
     private static func isDirectChild(_ url: URL, of root: URL) -> Bool {
         let path = url.pathComponents
         let rootPath = root.pathComponents
-        guard path.count == rootPath.count + 1 else { return false }
-        return Array(path.prefix(rootPath.count)) == rootPath
+        return path.count == rootPath.count + 1 && path.starts(with: rootPath)
     }
 
     private static func relativeComponents(of url: URL, under root: URL) -> [String] {

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -2,6 +2,7 @@
 // Helper-owned validation for privileged deletion requests.
 
 import Foundation
+import Darwin
 
 enum HelperDeletionValidationError: LocalizedError, Equatable {
     case emptyPath
@@ -90,7 +91,7 @@ struct HelperDeletionPolicy {
 
     func removeValidatedPaths(
         _ paths: [String],
-        remove: (URL) throws -> Void
+        remove: (URL) throws -> Void = Self.securelyRemoveItem
     ) throws -> Error? {
         let urls = try uniqueValidatedDeletionURLs(for: paths)
         var firstError: Error?
@@ -102,6 +103,26 @@ struct HelperDeletionPolicy {
             }
         }
         return firstError
+    }
+
+    static func securelyRemoveItem(_ url: URL) throws {
+        var components = url.standardizedFileURL.pathComponents
+        if components.count > 1, components[1] == "var" {
+            components.replaceSubrange(1...1, with: ["private", "var"])
+        }
+        let displayPath = absolutePath(from: components)
+        guard components.first == "/", components.count > 1 else {
+            throw HelperDeletionValidationError.rootPath(url.path)
+        }
+        components.removeFirst()
+
+        let rootFD = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        guard rootFD >= 0 else {
+            throw posixError(operation: "open", path: "/")
+        }
+        defer { close(rootFD) }
+
+        try removeItem(components: components, from: rootFD, displayPath: displayPath)
     }
 
     private func isAllowedDeletionTarget(_ url: URL) -> Bool {
@@ -182,6 +203,108 @@ struct HelperDeletionPolicy {
 
     private static func canonical(_ url: URL) -> URL {
         url.standardizedFileURL.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    private static func removeItem(components: [String], from rootFD: Int32, displayPath: String) throws {
+        var parentFD = rootFD
+        var openedParentFDs: [Int32] = []
+        defer {
+            for fd in openedParentFDs.reversed() {
+                close(fd)
+            }
+        }
+
+        for component in components.dropLast() {
+            let nextFD = try openDirectory(component, relativeTo: parentFD, displayPath: displayPath)
+            openedParentFDs.append(nextFD)
+            parentFD = nextFD
+        }
+
+        guard let itemName = components.last else {
+            throw HelperDeletionValidationError.rootPath(displayPath)
+        }
+        try removeEntry(named: itemName, in: parentFD, displayPath: displayPath)
+    }
+
+    private static func removeEntry(named name: String, in directoryFD: Int32, displayPath: String) throws {
+        var info = stat()
+        try name.withCString { namePointer in
+            guard fstatat(directoryFD, namePointer, &info, AT_SYMLINK_NOFOLLOW) == 0 else {
+                throw posixError(operation: "fstatat", path: displayPath)
+            }
+        }
+
+        if isDirectoryMode(info.st_mode) {
+            try removeDirectoryRecursively(named: name, in: directoryFD, displayPath: displayPath)
+        } else {
+            try name.withCString { namePointer in
+                guard unlinkat(directoryFD, namePointer, 0) == 0 else {
+                    throw posixError(operation: "unlinkat", path: displayPath)
+                }
+            }
+        }
+    }
+
+    private static func removeDirectoryRecursively(named name: String, in parentFD: Int32, displayPath: String) throws {
+        let directoryFD = try openDirectory(name, relativeTo: parentFD, displayPath: displayPath)
+        guard let directory = fdopendir(directoryFD) else {
+            let error = posixError(operation: "fdopendir", path: displayPath)
+            close(directoryFD)
+            throw error
+        }
+        defer { closedir(directory) }
+
+        let currentFD = dirfd(directory)
+        while let entry = readdir(directory) {
+            let entryName = Self.entryName(entry)
+            guard entryName != ".", entryName != ".." else { continue }
+            try removeEntry(named: entryName, in: currentFD, displayPath: displayPath + "/" + entryName)
+        }
+
+        try name.withCString { namePointer in
+            guard unlinkat(parentFD, namePointer, AT_REMOVEDIR) == 0 else {
+                throw posixError(operation: "unlinkat", path: displayPath)
+            }
+        }
+    }
+
+    private static func openDirectory(_ name: String, relativeTo directoryFD: Int32, displayPath: String) throws -> Int32 {
+        try name.withCString { namePointer in
+            let fd = openat(directoryFD, namePointer, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+            guard fd >= 0 else {
+                throw posixError(operation: "openat", path: displayPath)
+            }
+            return fd
+        }
+    }
+
+    private static func entryName(_ entry: UnsafeMutablePointer<dirent>) -> String {
+        withUnsafePointer(to: &entry.pointee.d_name) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: Int(entry.pointee.d_namlen) + 1) {
+                String(cString: $0)
+            }
+        }
+    }
+
+    private static func isDirectoryMode(_ mode: mode_t) -> Bool {
+        (mode & mode_t(S_IFMT)) == mode_t(S_IFDIR)
+    }
+
+    private static func absolutePath(from components: [String]) -> String {
+        guard components.first == "/" else {
+            return components.joined(separator: "/")
+        }
+        return "/" + components.dropFirst().joined(separator: "/")
+    }
+
+    private static func posixError(operation: String, path: String, code: Int32 = errno) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(code),
+            userInfo: [
+                NSLocalizedDescriptionKey: "\(operation) failed for \(path): \(String(cString: strerror(code)))"
+            ]
+        )
     }
 
     private static func canonicalSystemAlias(for url: URL) -> URL? {

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -93,10 +93,12 @@ struct HelperDeletionPolicy {
         _ paths: [String],
         remove: (URL) throws -> Void = Self.securelyRemoveItem
     ) throws -> Error? {
-        let urls = try uniqueValidatedDeletionURLs(for: paths)
+        var seen = Set<String>()
         var firstError: Error?
-        for url in urls {
+        for path in paths {
             do {
+                let url = try validateDeletionPath(path)
+                guard seen.insert(url.path).inserted else { continue }
                 try remove(url)
             } catch {
                 if firstError == nil { firstError = error }

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -147,7 +147,7 @@ struct HelperDeletionPolicy {
     }
 
     private func isAllowedLanguageResource(_ url: URL) -> Bool {
-        guard allowedLanguageResourceRoots.contains(where: { Self.isDescendant(url, of: $0) }) else {
+        guard let allowedRoot = allowedLanguageResourceRoots.first(where: { Self.isDescendant(url, of: $0) }) else {
             return false
         }
         let components = url.pathComponents
@@ -160,6 +160,10 @@ struct HelperDeletionPolicy {
         let lprojComponent = components[lprojIndex]
         guard Self.pathExtension(of: lprojComponent).caseInsensitiveCompare("lproj") == .orderedSame else {
             return false
+        }
+
+        if Self.isApplicationSupportRoot(allowedRoot) {
+            return true
         }
 
         let preceding = components[..<lprojIndex]
@@ -206,6 +210,10 @@ struct HelperDeletionPolicy {
 
     private static func relativeComponents(of url: URL, under root: URL) -> [String] {
         Array(url.pathComponents.dropFirst(root.pathComponents.count))
+    }
+
+    private static func isApplicationSupportRoot(_ url: URL) -> Bool {
+        url.pathComponents.suffix(2).elementsEqual(["Library", "Application Support"])
     }
 
     private static func pathExtension(of component: String) -> String {

--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -1,0 +1,152 @@
+// HelperDeletionPolicy.swift
+// Helper-owned validation for privileged deletion requests.
+
+import Foundation
+
+enum HelperDeletionValidationError: LocalizedError, Equatable {
+    case emptyPath
+    case relativePath(String)
+    case rootPath(String)
+    case disallowedPath(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyPath:
+            return "Deletion path is empty"
+        case .relativePath(let path):
+            return "Deletion path must be absolute: \(path)"
+        case .rootPath(let path):
+            return "Refusing to delete filesystem root: \(path)"
+        case .disallowedPath(let path):
+            return "Path is outside the helper deletion allowlist: \(path)"
+        }
+    }
+}
+
+struct HelperDeletionPolicy {
+    static let production = HelperDeletionPolicy(
+        allowedDescendantRoots: [
+            URL(fileURLWithPath: "/Library/Caches", isDirectory: true),
+            URL(fileURLWithPath: "/Library/Logs", isDirectory: true),
+            URL(fileURLWithPath: "/private/var/folders", isDirectory: true)
+        ],
+        allowedLanguageResourceRoots: [
+            URL(fileURLWithPath: "/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/Library/Application Support", isDirectory: true),
+            URL(fileURLWithPath: "/Library/Frameworks", isDirectory: true)
+        ],
+        volumesRoot: URL(fileURLWithPath: "/Volumes", isDirectory: true)
+    )
+
+    private let allowedDescendantRoots: [URL]
+    private let allowedLanguageResourceRoots: [URL]
+    private let volumesRoot: URL
+
+    init(
+        allowedDescendantRoots: [URL],
+        allowedLanguageResourceRoots: [URL],
+        volumesRoot: URL
+    ) {
+        self.allowedDescendantRoots = allowedDescendantRoots.map(Self.canonicalRoot)
+        self.allowedLanguageResourceRoots = allowedLanguageResourceRoots.map(Self.canonicalRoot)
+        self.volumesRoot = Self.canonicalRoot(volumesRoot)
+    }
+
+    func validateDeletionPath(_ path: String) throws -> URL {
+        guard !path.isEmpty else { throw HelperDeletionValidationError.emptyPath }
+        guard (path as NSString).isAbsolutePath else {
+            throw HelperDeletionValidationError.relativePath(path)
+        }
+
+        let url = Self.canonical(URL(fileURLWithPath: path))
+        guard url.path != "/" else {
+            throw HelperDeletionValidationError.rootPath(path)
+        }
+        guard isAllowedDeletionTarget(url) else {
+            throw HelperDeletionValidationError.disallowedPath(path)
+        }
+        return url
+    }
+
+    func uniqueValidatedDeletionURLs(for paths: [String]) throws -> [URL] {
+        var seen = Set<String>()
+        var urls: [URL] = []
+        for path in paths {
+            let url = try validateDeletionPath(path)
+            if seen.insert(url.path).inserted {
+                urls.append(url)
+            }
+        }
+        return urls
+    }
+
+    private func isAllowedDeletionTarget(_ url: URL) -> Bool {
+        if allowedDescendantRoots.contains(where: { Self.isDescendant(url, of: $0) }) {
+            return true
+        }
+        if isAllowedVolumeTrashDescendant(url) {
+            return true
+        }
+        if isAllowedLanguageResource(url) {
+            return true
+        }
+        return false
+    }
+
+    private func isAllowedVolumeTrashDescendant(_ url: URL) -> Bool {
+        guard Self.isDescendant(url, of: volumesRoot) else { return false }
+        let relative = Self.relativeComponents(of: url, under: volumesRoot)
+        guard relative.count >= 4 else { return false }
+        return relative[1] == ".Trashes" && !relative[2].isEmpty
+    }
+
+    private func isAllowedLanguageResource(_ url: URL) -> Bool {
+        guard allowedLanguageResourceRoots.contains(where: { Self.isDescendant(url, of: $0) }) else {
+            return false
+        }
+        let components = url.pathComponents
+        guard let lprojIndex = components.firstIndex(where: {
+            $0.range(of: ".lproj", options: [.caseInsensitive, .anchored, .backwards]) != nil
+        }) else {
+            return false
+        }
+        guard components.count > lprojIndex + 1 else { return false }
+
+        let lprojComponent = components[lprojIndex]
+        guard Self.pathExtension(of: lprojComponent).caseInsensitiveCompare("lproj") == .orderedSame else {
+            return false
+        }
+
+        let preceding = components[..<lprojIndex]
+        return preceding.contains(where: {
+            let pathExtension = Self.pathExtension(of: $0)
+            return pathExtension.caseInsensitiveCompare("app") == .orderedSame
+                || pathExtension.caseInsensitiveCompare("framework") == .orderedSame
+                || pathExtension.caseInsensitiveCompare("appex") == .orderedSame
+                || pathExtension.caseInsensitiveCompare("bundle") == .orderedSame
+        })
+    }
+
+    private static func canonicalRoot(_ url: URL) -> URL {
+        canonical(url)
+    }
+
+    private static func canonical(_ url: URL) -> URL {
+        url.standardizedFileURL.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    private static func isDescendant(_ url: URL, of root: URL) -> Bool {
+        let path = url.pathComponents
+        let rootPath = root.pathComponents
+        guard path.count > rootPath.count else { return false }
+        return Array(path.prefix(rootPath.count)) == rootPath
+    }
+
+    private static func relativeComponents(of url: URL, under root: URL) -> [String] {
+        Array(url.pathComponents.dropFirst(root.pathComponents.count))
+    }
+
+    private static func pathExtension(of component: String) -> String {
+        (component as NSString).pathExtension
+    }
+}

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -12,9 +12,7 @@ enum HelperCodeSigningRequirements {
     static let appIdentifier = "com.personal.VaderCleaner"
     static let helperIdentifier = "com.personal.VaderCleaner.helper"
 
-    /// Set to the Developer ID Team ID before distributing signed Release
-    /// builds. Keeping this nil avoids compiling a placeholder OU requirement
-    /// that would reject locally/ad-hoc signed app-helper connections.
+    /// Set to the Developer ID Team ID before distributing signed Release builds.
     private static let releaseTeamIdentifier: String? = nil
 
     static func requirement(identifier: String, teamIdentifier: String?) -> String {
@@ -23,6 +21,16 @@ enum HelperCodeSigningRequirements {
             return identifierRequirement
         }
         return "\(identifierRequirement) and certificate leaf[subject.OU] = \"\(teamIdentifier)\""
+    }
+
+    static func releaseRequirement(identifier: String, teamIdentifier: String? = releaseTeamIdentifier) -> String {
+        guard let teamIdentifier = configuredTeamIdentifier(teamIdentifier) else {
+            fatalError(
+                "Release XPC code-signing requirements require a real Developer ID Team ID. " +
+                "Configure HelperCodeSigningRequirements.releaseTeamIdentifier before distributing."
+            )
+        }
+        return requirement(identifier: identifier, teamIdentifier: teamIdentifier)
     }
 
     private static func configuredTeamIdentifier(_ teamIdentifier: String?) -> String? {
@@ -36,8 +44,8 @@ enum HelperCodeSigningRequirements {
     static let client = requirement(identifier: appIdentifier, teamIdentifier: nil)
     static let server = requirement(identifier: helperIdentifier, teamIdentifier: nil)
     #else
-    static let client = requirement(identifier: appIdentifier, teamIdentifier: releaseTeamIdentifier)
-    static let server = requirement(identifier: helperIdentifier, teamIdentifier: releaseTeamIdentifier)
+    static let client = releaseRequirement(identifier: appIdentifier)
+    static let server = releaseRequirement(identifier: helperIdentifier)
     #endif
 }
 

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -12,17 +12,24 @@ enum HelperCodeSigningRequirements {
     static let appIdentifier = "com.personal.VaderCleaner"
     static let helperIdentifier = "com.personal.VaderCleaner.helper"
 
-    /// Replace with the Developer ID Team ID before distributing Release builds.
-    /// Debug keeps the looser identifier-only rule so local ad-hoc helper
-    /// registration still works during development.
-    private static let releaseTeamIdentifier = "TEAMID"
+    /// Set to the Developer ID Team ID before distributing signed Release
+    /// builds. Keeping this nil avoids compiling a placeholder OU requirement
+    /// that would reject locally/ad-hoc signed app-helper connections.
+    private static let releaseTeamIdentifier: String? = nil
 
     static func requirement(identifier: String, teamIdentifier: String?) -> String {
         let identifierRequirement = "identifier \"\(identifier)\""
-        guard let teamIdentifier, !teamIdentifier.isEmpty else {
+        guard let teamIdentifier = configuredTeamIdentifier(teamIdentifier) else {
             return identifierRequirement
         }
         return "\(identifierRequirement) and certificate leaf[subject.OU] = \"\(teamIdentifier)\""
+    }
+
+    private static func configuredTeamIdentifier(_ teamIdentifier: String?) -> String? {
+        guard let teamIdentifier else { return nil }
+        let trimmed = teamIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "TEAMID" else { return nil }
+        return trimmed
     }
 
     #if DEBUG

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -34,7 +34,7 @@ enum HelperCodeSigningRequirements {
     private static func configuredTeamIdentifier(_ teamIdentifier: String?) -> String? {
         guard let teamIdentifier else { return nil }
         let trimmed = teamIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed != "TEAMID" else { return nil }
+        guard !trimmed.isEmpty, trimmed.caseInsensitiveCompare("TEAMID") != .orderedSame else { return nil }
         return trimmed
     }
 

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -8,18 +8,40 @@ import Foundation
 /// and the app's NSXPCConnection. Defined here as the single source of truth.
 let kHelperMachServiceName = "com.personal.VaderCleaner.helper"
 
+enum HelperCodeSigningRequirements {
+    static let appIdentifier = "com.personal.VaderCleaner"
+    static let helperIdentifier = "com.personal.VaderCleaner.helper"
+
+    /// Replace with the Developer ID Team ID before distributing Release builds.
+    /// Debug keeps the looser identifier-only rule so local ad-hoc helper
+    /// registration still works during development.
+    private static let releaseTeamIdentifier = "TEAMID"
+
+    static func requirement(identifier: String, teamIdentifier: String?) -> String {
+        let identifierRequirement = "identifier \"\(identifier)\""
+        guard let teamIdentifier, !teamIdentifier.isEmpty else {
+            return identifierRequirement
+        }
+        return "\(identifierRequirement) and certificate leaf[subject.OU] = \"\(teamIdentifier)\""
+    }
+
+    #if DEBUG
+    static let client = requirement(identifier: appIdentifier, teamIdentifier: nil)
+    static let server = requirement(identifier: helperIdentifier, teamIdentifier: nil)
+    #else
+    static let client = requirement(identifier: appIdentifier, teamIdentifier: releaseTeamIdentifier)
+    static let server = requirement(identifier: helperIdentifier, teamIdentifier: releaseTeamIdentifier)
+    #endif
+}
+
 /// Code-signing requirement applied by the helper to incoming XPC connections.
-/// Restricts the privileged interface to processes whose code-signing identifier
-/// matches the main app's bundle identifier. Without this guard, any local process
-/// that can reach the mach service name would be able to invoke privileged ops.
-///
-/// Production hardening: append `and certificate leaf[subject.OU] = "TEAMID"`
-/// once a Developer ID team is wired up so that ad-hoc-signed impostors are rejected.
-let kHelperClientCodeSigningRequirement = "identifier \"com.personal.VaderCleaner\""
+/// Release builds require both the bundle identifier and Developer ID Team ID;
+/// Debug builds intentionally allow identifier-only ad-hoc signing.
+let kHelperClientCodeSigningRequirement = HelperCodeSigningRequirements.client
 
 /// Code-signing requirement applied by the app to the helper connection — the
 /// symmetric check that protects the app from a substituted helper binary.
-let kHelperServerCodeSigningRequirement = "identifier \"com.personal.VaderCleaner.helper\""
+let kHelperServerCodeSigningRequirement = HelperCodeSigningRequirements.server
 
 /// XPC protocol implemented by VaderCleanerHelper and consumed by the main app.
 ///

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -15,6 +15,10 @@ enum HelperCodeSigningRequirements {
     /// Set to the Developer ID Team ID before distributing signed Release builds.
     private static let releaseTeamIdentifier: String? = nil
 
+    #if !DEBUG
+    #warning("Set releaseTeamIdentifier to the Developer ID Team ID before distributing signed Release builds.")
+    #endif
+
     static func requirement(identifier: String, teamIdentifier: String?) -> String {
         let identifierRequirement = "identifier \"\(identifier)\""
         guard let teamIdentifier = configuredTeamIdentifier(teamIdentifier) else {

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -24,13 +24,7 @@ enum HelperCodeSigningRequirements {
     }
 
     static func releaseRequirement(identifier: String, teamIdentifier: String? = releaseTeamIdentifier) -> String {
-        guard let teamIdentifier = configuredTeamIdentifier(teamIdentifier) else {
-            fatalError(
-                "Release XPC code-signing requirements require a real Developer ID Team ID. " +
-                "Configure HelperCodeSigningRequirements.releaseTeamIdentifier before distributing."
-            )
-        }
-        return requirement(identifier: identifier, teamIdentifier: teamIdentifier)
+        requirement(identifier: identifier, teamIdentifier: teamIdentifier)
     }
 
     private static func configuredTeamIdentifier(_ teamIdentifier: String?) -> String? {
@@ -50,8 +44,8 @@ enum HelperCodeSigningRequirements {
 }
 
 /// Code-signing requirement applied by the helper to incoming XPC connections.
-/// Release builds require both the bundle identifier and Developer ID Team ID;
-/// Debug builds intentionally allow identifier-only ad-hoc signing.
+/// Release builds include the Developer ID Team ID when configured; Debug and
+/// local/ad-hoc builds allow identifier-only signing.
 let kHelperClientCodeSigningRequirement = HelperCodeSigningRequirements.client
 
 /// Code-signing requirement applied by the app to the helper connection — the

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */; };
+		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
@@ -52,12 +53,14 @@
 		60DBED2582B50DA009B180C4 /* FileCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421495C84A41EDEF253EBD6 /* FileCategory.swift */; };
 		63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */; };
 		65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD8C98E8253953444DD99F /* NotificationManager.swift */; };
+		65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
 		6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */; };
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
 		6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */; };
 		6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
+		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */; };
 		82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */; };
 		823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */; };
@@ -156,6 +159,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicy.swift; sourceTree = "<group>"; };
 		06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocator.swift; sourceTree = "<group>"; };
 		072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionChecker.swift; sourceTree = "<group>"; };
 		0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManagerTests.swift; sourceTree = "<group>"; };
@@ -174,6 +178,7 @@
 		2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModelTests.swift; sourceTree = "<group>"; };
 		2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModel.swift; sourceTree = "<group>"; };
 		2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManager.swift; sourceTree = "<group>"; };
+		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
 		2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSection.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
@@ -374,6 +379,7 @@
 		E64E279A077DB78FF7F39BDD /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */,
 				A3852658DC221FB8B03631D1 /* HelperProtocol.swift */,
 			);
 			path = Shared;
@@ -397,6 +403,7 @@
 				6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */,
 				166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */,
 				0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */,
+				2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */,
 				811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */,
 				1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */,
 				603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */,
@@ -583,6 +590,7 @@
 				823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */,
 				2CE84E79268B4A59C5B8FACB /* HealthMonitorViewModelTests.swift in Sources */,
 				6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */,
+				04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */,
 				17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */,
 				57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */,
 				50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */,
@@ -614,6 +622,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */,
 				5FCAAC81ED67F40178636235 /* HelperProtocol.swift in Sources */,
 				37E2425A63454881A4FA4481 /* main.swift in Sources */,
 			);
@@ -649,6 +658,7 @@
 				92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */,
 				3A3C0E7B444AE96C4C2D1C8F /* HealthMonitorViewModel.swift in Sources */,
 				9CA467B702E12F278B7BE6DC /* HelperConnectionManager.swift in Sources */,
+				65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */,
 				55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */,
 				2DD748D16E344D435A5C3E24 /* HelperRegistration.swift in Sources */,
 				D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */,

--- a/VaderCleanerHelper/main.swift
+++ b/VaderCleanerHelper/main.swift
@@ -6,6 +6,7 @@ import Foundation
 /// NSXPCListener delegate that vends a HelperService for each new XPC connection
 /// and implements the privileged operations defined in VaderCleanerHelperProtocol.
 final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperProtocol {
+    private let deletionPolicy = HelperDeletionPolicy.production
 
     // MARK: - NSXPCListenerDelegate
 
@@ -17,11 +18,7 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
         // Without this check, any local process able to reach the mach service name could
         // invoke privileged operations (file deletion, /usr/sbin/purge, periodic scripts).
         // setCodeSigningRequirement is macOS 13+ — well within the macOS 14.0 deployment target.
-        do {
-            try newConnection.setCodeSigningRequirement(kHelperClientCodeSigningRequirement)
-        } catch {
-            return false
-        }
+        newConnection.setCodeSigningRequirement(kHelperClientCodeSigningRequirement)
         newConnection.exportedInterface = NSXPCInterface(with: VaderCleanerHelperProtocol.self)
         newConnection.exportedObject = self
         newConnection.resume()
@@ -32,15 +29,15 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
 
     func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
         let fileManager = FileManager.default
-        var firstError: Error?
-        for path in paths {
-            do {
-                try fileManager.removeItem(atPath: path)
-            } catch {
-                if firstError == nil { firstError = error }
+        do {
+            let urls = try deletionPolicy.uniqueValidatedDeletionURLs(for: paths)
+            for url in urls {
+                try fileManager.removeItem(at: url)
             }
+            reply(nil)
+        } catch {
+            reply(error)
         }
-        reply(firstError)
     }
 
     func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {

--- a/VaderCleanerHelper/main.swift
+++ b/VaderCleanerHelper/main.swift
@@ -28,11 +28,8 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
     // MARK: - VaderCleanerHelperProtocol
 
     func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
-        let fileManager = FileManager.default
         do {
-            let firstError = try deletionPolicy.removeValidatedPaths(paths) { url in
-                try fileManager.removeItem(at: url)
-            }
+            let firstError = try deletionPolicy.removeValidatedPaths(paths)
             reply(firstError)
         } catch {
             reply(error)

--- a/VaderCleanerHelper/main.swift
+++ b/VaderCleanerHelper/main.swift
@@ -30,11 +30,10 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
     func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
         let fileManager = FileManager.default
         do {
-            let urls = try deletionPolicy.uniqueValidatedDeletionURLs(for: paths)
-            for url in urls {
+            let firstError = try deletionPolicy.removeValidatedPaths(paths) { url in
                 try fileManager.removeItem(at: url)
             }
-            reply(nil)
+            reply(firstError)
         } catch {
             reply(error)
         }

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -138,6 +138,23 @@ final class HelperDeletionPolicyTests: XCTestCase {
         XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
     }
 
+    func test_validateDeletionPath_acceptsLanguageResourceInsideApplicationSupport() throws {
+        let url = libraryApplicationSupportRoot
+            .appendingPathComponent("Example/Resources/fr.lproj/Localizable.strings")
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_rejectsLanguageResourceWithoutPackageOutsideApplicationSupport() {
+        let path = applicationsRoot
+            .appendingPathComponent("Example/Resources/fr.lproj/Localizable.strings")
+            .path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
     func test_validateDeletionPath_rejectsTraversalOutOfAllowedRoot() throws {
         let path = cacheRoot
             .appendingPathComponent("../Preferences/com.apple.test.plist")

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -1,0 +1,159 @@
+// HelperDeletionPolicyTests.swift
+// Security tests for privileged helper deletion path validation.
+
+import XCTest
+@testable import VaderCleaner
+
+final class HelperDeletionPolicyTests: XCTestCase {
+    private var tempRoot: URL!
+    private var policy: HelperDeletionPolicy!
+    private var cacheRoot: URL!
+    private var logsRoot: URL!
+    private var varFoldersRoot: URL!
+    private var applicationsRoot: URL!
+    private var libraryApplicationSupportRoot: URL!
+    private var frameworksRoot: URL!
+    private var volumesRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+
+        cacheRoot = tempRoot.appendingPathComponent("Library/Caches", isDirectory: true)
+        logsRoot = tempRoot.appendingPathComponent("Library/Logs", isDirectory: true)
+        varFoldersRoot = tempRoot.appendingPathComponent("private/var/folders", isDirectory: true)
+        applicationsRoot = tempRoot.appendingPathComponent("Applications", isDirectory: true)
+        libraryApplicationSupportRoot = tempRoot.appendingPathComponent("Library/Application Support", isDirectory: true)
+        frameworksRoot = tempRoot.appendingPathComponent("Library/Frameworks", isDirectory: true)
+        volumesRoot = tempRoot.appendingPathComponent("Volumes", isDirectory: true)
+
+        let roots: [URL] = [
+            cacheRoot,
+            logsRoot,
+            varFoldersRoot,
+            applicationsRoot,
+            libraryApplicationSupportRoot,
+            frameworksRoot,
+            volumesRoot
+        ]
+        for root in roots {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        }
+
+        policy = HelperDeletionPolicy(
+            allowedDescendantRoots: [cacheRoot, logsRoot, varFoldersRoot],
+            allowedLanguageResourceRoots: [
+                applicationsRoot,
+                libraryApplicationSupportRoot,
+                frameworksRoot
+            ],
+            volumesRoot: volumesRoot
+        )
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        policy = nil
+        super.tearDown()
+    }
+
+    func test_validateDeletionPath_acceptsAllowedSystemCacheDescendant() throws {
+        let url = cacheRoot.appendingPathComponent("com.example/file.bin")
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_acceptsAllowedVolumeTrashDescendant() throws {
+        let url = volumesRoot
+            .appendingPathComponent("External", isDirectory: true)
+            .appendingPathComponent(".Trashes", isDirectory: true)
+            .appendingPathComponent("501", isDirectory: true)
+            .appendingPathComponent("file.bin")
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_acceptsLanguageResourceFileInsideAppBundle() throws {
+        let url = applicationsRoot
+            .appendingPathComponent("Example.app/Contents/Resources/fr.lproj/Localizable.strings")
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_rejectsTraversalOutOfAllowedRoot() throws {
+        let path = cacheRoot
+            .appendingPathComponent("../Preferences/com.apple.test.plist")
+            .path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsAllowedRootItself() {
+        XCTAssertThrowsError(try policy.validateDeletionPath(cacheRoot.path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(cacheRoot.path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsFilesystemRoot() {
+        XCTAssertThrowsError(try policy.validateDeletionPath("/")) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .rootPath("/"))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsBoundaryPrefixCollision() {
+        let path = tempRoot
+            .appendingPathComponent("Library/CachesSymlink/file.bin")
+            .path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsSymlinkEscapeAfterResolution() throws {
+        let outside = tempRoot.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let target = try TestHelpers.createDummyFile(named: "secret.txt", size: 1, in: outside)
+        let link = cacheRoot.appendingPathComponent("escape")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+        let path = link.appendingPathComponent(target.lastPathComponent).path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsEmptyAndRelativePaths() {
+        XCTAssertThrowsError(try policy.validateDeletionPath("")) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .emptyPath)
+        }
+
+        XCTAssertThrowsError(try policy.validateDeletionPath("Library/Caches/file")) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .relativePath("Library/Caches/file"))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsVolumePathOutsideTrash() {
+        let path = volumesRoot
+            .appendingPathComponent("External/SomeOtherFolder/file.bin")
+            .path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_uniqueValidatedDeletionURLs_deduplicatesCanonicalPaths() throws {
+        let file = cacheRoot.appendingPathComponent("com.example/file.bin")
+        let duplicate = cacheRoot.appendingPathComponent("com.example/../com.example/file.bin")
+
+        let urls = try policy.uniqueValidatedDeletionURLs(for: [file.path, duplicate.path])
+
+        XCTAssertEqual(urls, [file.standardizedFileURL])
+    }
+}

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -13,6 +13,8 @@ final class HelperDeletionPolicyTests: XCTestCase {
     private var applicationsRoot: URL!
     private var libraryApplicationSupportRoot: URL!
     private var frameworksRoot: URL!
+    private var launchAgentsRoot: URL!
+    private var launchDaemonsRoot: URL!
     private var volumesRoot: URL!
 
     override func setUpWithError() throws {
@@ -25,6 +27,8 @@ final class HelperDeletionPolicyTests: XCTestCase {
         applicationsRoot = tempRoot.appendingPathComponent("Applications", isDirectory: true)
         libraryApplicationSupportRoot = tempRoot.appendingPathComponent("Library/Application Support", isDirectory: true)
         frameworksRoot = tempRoot.appendingPathComponent("Library/Frameworks", isDirectory: true)
+        launchAgentsRoot = tempRoot.appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        launchDaemonsRoot = tempRoot.appendingPathComponent("Library/LaunchDaemons", isDirectory: true)
         volumesRoot = tempRoot.appendingPathComponent("Volumes", isDirectory: true)
 
         let roots: [URL] = [
@@ -34,6 +38,8 @@ final class HelperDeletionPolicyTests: XCTestCase {
             applicationsRoot,
             libraryApplicationSupportRoot,
             frameworksRoot,
+            launchAgentsRoot,
+            launchDaemonsRoot,
             volumesRoot
         ]
         for root in roots {
@@ -41,7 +47,15 @@ final class HelperDeletionPolicyTests: XCTestCase {
         }
 
         policy = HelperDeletionPolicy(
-            allowedDescendantRoots: [cacheRoot, logsRoot, varFoldersRoot],
+            allowedDescendantRoots: [
+                cacheRoot,
+                logsRoot,
+                varFoldersRoot
+            ],
+            allowedLaunchPlistRoots: [
+                launchAgentsRoot,
+                launchDaemonsRoot
+            ],
             allowedLanguageResourceRoots: [
                 applicationsRoot,
                 libraryApplicationSupportRoot,
@@ -64,6 +78,37 @@ final class HelperDeletionPolicyTests: XCTestCase {
         let url = cacheRoot.appendingPathComponent("com.example/file.bin")
 
         XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_acceptsLanguageResourceDirectoryInsideAppBundle() throws {
+        let url = applicationsRoot
+            .appendingPathComponent("Example.app/Contents/Resources/fr.lproj", isDirectory: true)
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path).path, url.standardizedFileURL.path)
+    }
+
+    func test_validateDeletionPath_acceptsSystemLaunchAgentAndDaemonPlists() throws {
+        let agent = launchAgentsRoot.appendingPathComponent("com.example.agent.plist")
+        let daemon = launchDaemonsRoot.appendingPathComponent("com.example.daemon.plist")
+
+        XCTAssertEqual(try policy.validateDeletionPath(agent.path), agent.standardizedFileURL)
+        XCTAssertEqual(try policy.validateDeletionPath(daemon.path), daemon.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_rejectsNonPlistLaunchItems() {
+        let path = launchAgentsRoot.appendingPathComponent("com.example.agent.txt").path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsNestedLaunchPlists() {
+        let path = launchAgentsRoot.appendingPathComponent("Nested/com.example.agent.plist").path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
     }
 
     func test_validateDeletionPath_acceptsAllowedVolumeTrashDescendant() throws {
@@ -155,5 +200,23 @@ final class HelperDeletionPolicyTests: XCTestCase {
         let urls = try policy.uniqueValidatedDeletionURLs(for: [file.path, duplicate.path])
 
         XCTAssertEqual(urls, [file.standardizedFileURL])
+    }
+
+    func test_removeValidatedPaths_attemptsRemainingURLsAfterFirstRemovalError() throws {
+        let first = cacheRoot.appendingPathComponent("com.example/locked.bin")
+        let second = cacheRoot.appendingPathComponent("com.example/next.bin")
+        var attempted: [URL] = []
+
+        let error = try policy.removeValidatedPaths([first.path, second.path]) { url in
+            attempted.append(url)
+            if url == first.standardizedFileURL {
+                throw NSError(domain: "test.remove", code: 7)
+            }
+        }
+        let nsError = error as NSError?
+
+        XCTAssertEqual(attempted, [first.standardizedFileURL, second.standardizedFileURL])
+        XCTAssertEqual(nsError?.domain, "test.remove")
+        XCTAssertEqual(nsError?.code, 7)
     }
 }

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -268,6 +268,21 @@ final class HelperDeletionPolicyTests: XCTestCase {
         XCTAssertEqual(nsError?.code, 7)
     }
 
+    func test_removeValidatedPaths_attemptsValidURLsAfterValidationError() throws {
+        let invalid = tempRoot
+            .appendingPathComponent("System/Library/disallowed.bin")
+            .path
+        let valid = cacheRoot.appendingPathComponent("com.example/next.bin")
+        var attempted: [URL] = []
+
+        let error = try policy.removeValidatedPaths([invalid, valid.path]) { url in
+            attempted.append(url)
+        }
+
+        XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(invalid))
+        XCTAssertEqual(attempted, [valid.standardizedFileURL])
+    }
+
     func test_removeValidatedPaths_removesRequestedSymlinkNotResolvedTarget() throws {
         let target = launchDaemonsRoot.appendingPathComponent("com.example.daemon.plist")
         try Data().write(to: target)

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -15,6 +15,7 @@ final class HelperDeletionPolicyTests: XCTestCase {
     private var frameworksRoot: URL!
     private var launchAgentsRoot: URL!
     private var launchDaemonsRoot: URL!
+    private var usersRoot: URL!
     private var volumesRoot: URL!
 
     override func setUpWithError() throws {
@@ -29,6 +30,7 @@ final class HelperDeletionPolicyTests: XCTestCase {
         frameworksRoot = tempRoot.appendingPathComponent("Library/Frameworks", isDirectory: true)
         launchAgentsRoot = tempRoot.appendingPathComponent("Library/LaunchAgents", isDirectory: true)
         launchDaemonsRoot = tempRoot.appendingPathComponent("Library/LaunchDaemons", isDirectory: true)
+        usersRoot = tempRoot.appendingPathComponent("Users", isDirectory: true)
         volumesRoot = tempRoot.appendingPathComponent("Volumes", isDirectory: true)
 
         let roots: [URL] = [
@@ -40,6 +42,7 @@ final class HelperDeletionPolicyTests: XCTestCase {
             frameworksRoot,
             launchAgentsRoot,
             launchDaemonsRoot,
+            usersRoot,
             volumesRoot
         ]
         for root in roots {
@@ -56,6 +59,7 @@ final class HelperDeletionPolicyTests: XCTestCase {
                 launchAgentsRoot,
                 launchDaemonsRoot
             ],
+            allowedUserLaunchAgentsRoot: usersRoot,
             allowedLanguageResourceRoots: [
                 applicationsRoot,
                 libraryApplicationSupportRoot,
@@ -105,6 +109,15 @@ final class HelperDeletionPolicyTests: XCTestCase {
         XCTAssertEqual(try policy.validateDeletionPath(daemon.path), daemon.standardizedFileURL)
     }
 
+    func test_validateDeletionPath_acceptsUserLaunchAgentPlist() throws {
+        let agent = usersRoot
+            .appendingPathComponent("alice", isDirectory: true)
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+            .appendingPathComponent("com.example.agent.plist")
+
+        XCTAssertEqual(try policy.validateDeletionPath(agent.path), agent.standardizedFileURL)
+    }
+
     func test_validateDeletionPath_rejectsNonPlistLaunchItems() {
         let path = launchAgentsRoot.appendingPathComponent("com.example.agent.txt").path
 
@@ -115,6 +128,17 @@ final class HelperDeletionPolicyTests: XCTestCase {
 
     func test_validateDeletionPath_rejectsNestedLaunchPlists() {
         let path = launchAgentsRoot.appendingPathComponent("Nested/com.example.agent.plist").path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsNestedUserLaunchAgentPlists() {
+        let path = usersRoot
+            .appendingPathComponent("alice", isDirectory: true)
+            .appendingPathComponent("Library/LaunchAgents/Nested/com.example.agent.plist")
+            .path
 
         XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
             XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -282,4 +282,52 @@ final class HelperDeletionPolicyTests: XCTestCase {
         XCTAssertNil(error)
         XCTAssertEqual(attempted, [link.standardizedFileURL])
     }
+
+    func test_removeValidatedPaths_unlinksFinalSymlinkNotResolvedTarget() throws {
+        let target = launchDaemonsRoot.appendingPathComponent("com.example.daemon.plist")
+        try Data().write(to: target)
+        let link = varFoldersRoot.appendingPathComponent("linked-daemon.plist")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let error = try policy.removeValidatedPaths([link.path])
+
+        XCTAssertNil(error)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: link.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target.path))
+    }
+
+    func test_secureRemoveItem_refusesSymlinkedIntermediateAfterValidation() throws {
+        let raceDirectory = varFoldersRoot.appendingPathComponent("race", isDirectory: true)
+        try FileManager.default.createDirectory(at: raceDirectory, withIntermediateDirectories: true)
+        let victim = try TestHelpers.createDummyFile(named: "victim.bin", size: 1, in: raceDirectory)
+        let outside = tempRoot.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let protected = try TestHelpers.createDummyFile(named: victim.lastPathComponent, size: 1, in: outside)
+
+        XCTAssertEqual(try policy.validateDeletionPath(victim.path), victim.standardizedFileURL)
+
+        try FileManager.default.removeItem(at: raceDirectory)
+        try FileManager.default.createSymbolicLink(at: raceDirectory, withDestinationURL: outside)
+
+        XCTAssertThrowsError(try HelperDeletionPolicy.securelyRemoveItem(victim.standardizedFileURL))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: protected.path))
+    }
+
+    func test_removeValidatedPaths_removesDirectoryRecursivelyWithoutFollowingNestedSymlink() throws {
+        let directory = cacheRoot.appendingPathComponent("com.example", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let nested = try TestHelpers.createDummyFile(named: "nested.bin", size: 1, in: directory)
+        let outside = tempRoot.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let protected = try TestHelpers.createDummyFile(named: "protected.bin", size: 1, in: outside)
+        let link = directory.appendingPathComponent("protected-link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: protected)
+
+        let error = try policy.removeValidatedPaths([directory.path])
+
+        XCTAssertNil(error)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: nested.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: protected.path))
+    }
 }

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -80,6 +80,16 @@ final class HelperDeletionPolicyTests: XCTestCase {
         XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
     }
 
+    func test_productionPolicy_acceptsVarFoldersAlias() throws {
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: "/var/folders"))
+        let path = "/var/folders/com.example/file.bin"
+
+        XCTAssertEqual(
+            try HelperDeletionPolicy.production.validateDeletionPath(path).path,
+            URL(fileURLWithPath: path).standardizedFileURL.path
+        )
+    }
+
     func test_validateDeletionPath_acceptsLanguageResourceDirectoryInsideAppBundle() throws {
         let url = applicationsRoot
             .appendingPathComponent("Example.app/Contents/Resources/fr.lproj", isDirectory: true)

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -173,6 +173,27 @@ final class HelperDeletionPolicyTests: XCTestCase {
         }
     }
 
+    func test_validateDeletionPath_returnsRequestedSymlinkPathWhenTargetIsAllowed() throws {
+        let target = launchDaemonsRoot.appendingPathComponent("com.example.daemon.plist")
+        try Data().write(to: target)
+        let link = varFoldersRoot.appendingPathComponent("linked-daemon.plist")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertEqual(try policy.validateDeletionPath(link.path), link.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_rejectsOutsideSymlinkToAllowedTarget() throws {
+        let target = cacheRoot.appendingPathComponent("com.example/file.bin")
+        try FileManager.default.createDirectory(at: target.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data().write(to: target)
+        let outside = tempRoot.appendingPathComponent("outside-link")
+        try FileManager.default.createSymbolicLink(at: outside, withDestinationURL: target)
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(outside.path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(outside.path))
+        }
+    }
+
     func test_validateDeletionPath_rejectsEmptyAndRelativePaths() {
         XCTAssertThrowsError(try policy.validateDeletionPath("")) { error in
             XCTAssertEqual(error as? HelperDeletionValidationError, .emptyPath)
@@ -218,5 +239,20 @@ final class HelperDeletionPolicyTests: XCTestCase {
         XCTAssertEqual(attempted, [first.standardizedFileURL, second.standardizedFileURL])
         XCTAssertEqual(nsError?.domain, "test.remove")
         XCTAssertEqual(nsError?.code, 7)
+    }
+
+    func test_removeValidatedPaths_removesRequestedSymlinkNotResolvedTarget() throws {
+        let target = launchDaemonsRoot.appendingPathComponent("com.example.daemon.plist")
+        try Data().write(to: target)
+        let link = varFoldersRoot.appendingPathComponent("linked-daemon.plist")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        var attempted: [URL] = []
+
+        let error = try policy.removeValidatedPaths([link.path]) { url in
+            attempted.append(url)
+        }
+
+        XCTAssertNil(error)
+        XCTAssertEqual(attempted, [link.standardizedFileURL])
     }
 }

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -22,6 +22,15 @@ final class HelperProtocolTests: XCTestCase {
         )
     }
 
+    func test_releaseCodeSigningRequirement_withoutTeamIdentifierRemainsIdentifierOnly() {
+        let requirement = HelperCodeSigningRequirements.releaseRequirement(
+            identifier: "com.personal.VaderCleaner",
+            teamIdentifier: nil
+        )
+
+        XCTAssertEqual(requirement, "identifier \"com.personal.VaderCleaner\"")
+    }
+
     func test_debugCodeSigningRequirement_canRemainIdentifierOnly() {
         let requirement = HelperCodeSigningRequirements.requirement(
             identifier: "com.personal.VaderCleaner",

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -41,12 +41,14 @@ final class HelperProtocolTests: XCTestCase {
     }
 
     func test_placeholderTeamIdentifier_isNotCompiledIntoRequirement() {
-        let requirement = HelperCodeSigningRequirements.requirement(
-            identifier: "com.personal.VaderCleaner",
-            teamIdentifier: "TEAMID"
-        )
+        for placeholder in ["TEAMID", "TeamID", "teamid"] {
+            let requirement = HelperCodeSigningRequirements.requirement(
+                identifier: "com.personal.VaderCleaner",
+                teamIdentifier: placeholder
+            )
 
-        XCTAssertEqual(requirement, "identifier \"com.personal.VaderCleaner\"")
+            XCTAssertEqual(requirement, "identifier \"com.personal.VaderCleaner\"")
+        }
     }
 
     func test_protocol_isVisibleToObjCRuntime() {

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -11,7 +11,7 @@ final class HelperProtocolTests: XCTestCase {
     }
 
     func test_releaseCodeSigningRequirement_includesTeamIdentifier() {
-        let requirement = HelperCodeSigningRequirements.requirement(
+        let requirement = HelperCodeSigningRequirements.releaseRequirement(
             identifier: "com.personal.VaderCleaner",
             teamIdentifier: "ABCDE12345"
         )

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -31,6 +31,15 @@ final class HelperProtocolTests: XCTestCase {
         XCTAssertEqual(requirement, "identifier \"com.personal.VaderCleaner\"")
     }
 
+    func test_placeholderTeamIdentifier_isNotCompiledIntoRequirement() {
+        let requirement = HelperCodeSigningRequirements.requirement(
+            identifier: "com.personal.VaderCleaner",
+            teamIdentifier: "TEAMID"
+        )
+
+        XCTAssertEqual(requirement, "identifier \"com.personal.VaderCleaner\"")
+    }
+
     func test_protocol_isVisibleToObjCRuntime() {
         // NSXPCConnection requires @objc protocols. NSProtocolFromString resolves them via the
         // ObjC runtime — a Swift-only protocol would return nil here.

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -10,6 +10,27 @@ final class HelperProtocolTests: XCTestCase {
         XCTAssertEqual(kHelperMachServiceName, "com.personal.VaderCleaner.helper")
     }
 
+    func test_releaseCodeSigningRequirement_includesTeamIdentifier() {
+        let requirement = HelperCodeSigningRequirements.requirement(
+            identifier: "com.personal.VaderCleaner",
+            teamIdentifier: "ABCDE12345"
+        )
+
+        XCTAssertEqual(
+            requirement,
+            "identifier \"com.personal.VaderCleaner\" and certificate leaf[subject.OU] = \"ABCDE12345\""
+        )
+    }
+
+    func test_debugCodeSigningRequirement_canRemainIdentifierOnly() {
+        let requirement = HelperCodeSigningRequirements.requirement(
+            identifier: "com.personal.VaderCleaner",
+            teamIdentifier: nil
+        )
+
+        XCTAssertEqual(requirement, "identifier \"com.personal.VaderCleaner\"")
+    }
+
     func test_protocol_isVisibleToObjCRuntime() {
         // NSXPCConnection requires @objc protocols. NSProtocolFromString resolves them via the
         // ObjC runtime — a Swift-only protocol would return nil here.


### PR DESCRIPTION
**Summary**
- Add helper-owned validation for privileged deletions with canonicalization, symlink resolution, allowlisted roots, and duplicate-path deduping.
- Reject empty, relative, root, traversal, and boundary-collision paths before the helper calls `removeItem`.
- Strengthen code-signing requirement construction to support Release Team ID enforcement while keeping Debug ad-hoc development workable.
- Add unit coverage for accepted and rejected helper deletion paths plus the signing requirement strings.
- Closes https://github.com/jayvicsanantonio/VaderCleaner/issues/41

**Testing**
- Added focused unit tests for allowed cache, logs, trash, and language-resource deletions.
- Added regression tests for traversal, symlink escape, empty/relative paths, root rejection, and duplicate canonical paths.
- Ran the macOS unit test suite successfully, including the new helper security tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strong allowlist-based deletion validation with symlink-aware checks, language-resource and launch-plist constraints, trash-volume safeguards, request deduplication, and safer removal flow that surfaces the first error.

* **Chores**
  * Centralized, environment-aware generation of code-signing requirement strings for runtime verification.
  * Project configuration updated so the new validation and tests are built into app and test targets.

* **Tests**
  * Extensive unit tests covering validation rules, symlink behaviors, deduplication, removal sequencing, and code-signing requirement generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/48)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->