### PR TITLE
Stream file scan results in batches to reduce memory pressure

### DIFF
--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -14,13 +14,30 @@ struct ScanRoot: Equatable {
 }
 
 /// Protocol surface so feature scanners and tests can inject a fake.
-/// Concrete implementation is `FileScanner` below.
+/// Concrete implementation is `FileScanner` below. The required API emits
+/// batches so feature scanners can filter or publish partial progress without
+/// retaining every file under every scanned root.
 protocol FileScanning {
-    func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile]
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        batchSize: Int,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws
 }
 
-/// Walks each root recursively and returns every regular file as a
-/// `ScannedFile` tagged with the root's category. Symlinks are skipped
+extension FileScanning {
+    func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
+        var results: [ScannedFile] = []
+        try await scan(roots: roots, excluding: excluding, batchSize: FileScanner.defaultBatchSize) { batch in
+            results.append(contentsOf: batch)
+        }
+        return results
+    }
+}
+
+/// Walks each root recursively and emits every regular file as a `ScannedFile`
+/// tagged with the root's category. Symlinks are skipped
 /// outright so the same physical file can never appear twice via different
 /// paths and so links pointing outside the scanned tree don't pull external
 /// content in. Permission errors on subdirectories are logged and the walk
@@ -32,6 +49,10 @@ protocol FileScanning {
 /// `ExclusionsStore.exclusions` snapshot through the `excluding` argument so
 /// this layer never touches a `@MainActor` store directly.
 struct FileScanner: FileScanning {
+
+    static let defaultBatchSize = 2_048
+
+    private static let cancellationCheckInterval = 512
 
     private static let log = Logger(
         subsystem: "com.personal.VaderCleaner",
@@ -55,12 +76,30 @@ struct FileScanner: FileScanning {
     /// every iteration matters when scanning hundreds of thousands of files.
     private static let resourceKeySet = Set(resourceKeys)
 
-    func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        batchSize: Int = defaultBatchSize,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
+        let batchLimit = max(1, batchSize)
         let canonicalExclusions = excluding.map(Self.canonicalize)
         let hasExclusions = !canonicalExclusions.isEmpty
-        var results: [ScannedFile] = []
+        var batch: [ScannedFile] = []
+        batch.reserveCapacity(batchLimit)
+        var visitedCount = 0
+
+        func flushBatch() async throws {
+            guard !batch.isEmpty else { return }
+            let emitted = batch
+            batch.removeAll(keepingCapacity: true)
+            try await onBatch(emitted)
+            try Task.checkCancellation()
+        }
 
         for root in roots {
+            try Task.checkCancellation()
+
             if hasExclusions {
                 let canonicalRootPath = Self.canonicalize(root.url)
                 if Self.isExcluded(path: canonicalRootPath, by: canonicalExclusions) {
@@ -86,7 +125,12 @@ struct FileScanner: FileScanning {
 
             guard let enumerator else { continue }
 
-            for case let url as URL in enumerator {
+            while let url = enumerator.nextObject() as? URL {
+                visitedCount += 1
+                if visitedCount.isMultiple(of: Self.cancellationCheckInterval) {
+                    try Task.checkCancellation()
+                }
+
                 let resourceValues = try? url.resourceValues(forKeys: Self.resourceKeySet)
 
                 if resourceValues?.isSymbolicLink == true {
@@ -118,7 +162,7 @@ struct FileScanner: FileScanning {
 
                 let size = Int64(resourceValues?.fileSize ?? 0)
 
-                results.append(
+                batch.append(
                     ScannedFile(
                         url: url,
                         size: size,
@@ -127,10 +171,13 @@ struct FileScanner: FileScanning {
                         category: root.category
                     )
                 )
+                if batch.count >= batchLimit {
+                    try await flushBatch()
+                }
             }
         }
 
-        return results
+        try await flushBatch()
     }
 
     // MARK: - Path helpers

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -93,6 +93,7 @@ struct FileScanner: FileScanning {
             guard !batch.isEmpty else { return }
             let emitted = batch
             batch.removeAll(keepingCapacity: true)
+            try Task.checkCancellation()
             try await onBatch(emitted)
             try Task.checkCancellation()
         }

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -7,8 +7,8 @@ import Foundation
 /// `UserFilesPathProviding` (which knows where the user keeps their personal
 /// files) with a `FileScanning` (which does the recursive walk) and post-
 /// processes each emitted batch to keep only files matching at least one
-/// criterion. `FileScanner` stays a generic walker, while this scanner avoids
-/// materializing a complete home-folder listing before it starts filtering.
+/// criterion. `FileScanner` stays a generic walker, while this scanner can
+/// stream matched files to callers that want incremental UI updates.
 struct LargeOldFilesScanner {
 
     /// Files larger than this byte count are tagged `.largeFile`. 50 MB is
@@ -36,15 +36,31 @@ struct LargeOldFilesScanner {
         self.now = now
     }
 
-    /// Runs the scan and returns the matching files. `excluding` is forwarded
-    /// straight to the underlying `FileScanning` — the path-component-aware
-    /// match semantics covered in `FileScannerTests` apply unchanged.
+    func scan(excluding: [URL]) async throws -> [ScannedFile] {
+        var matches: [ScannedFile] = []
+        try await scan(
+            excluding: excluding,
+            batchSize: FileScanner.defaultBatchSize
+        ) { matchedBatch in
+            matches.append(contentsOf: matchedBatch)
+        }
+        return matches
+    }
+
+    /// Runs the scan and emits matching files in batches. `excluding` is
+    /// forwarded straight to the underlying `FileScanning` — the
+    /// path-component-aware match semantics covered in `FileScannerTests`
+    /// apply unchanged.
     ///
     /// Walks every root with a placeholder `.largeFile` category tag (the
     /// `ScanRoot` API requires one), then re-tags each file based on the
     /// per-file size and age check. The tiebreak when both apply is
     /// `.largeFile` — see `classify(_:cutoff:)`.
-    func scan(excluding: [URL]) async throws -> [ScannedFile] {
+    func scan(
+        excluding: [URL],
+        batchSize: Int = FileScanner.defaultBatchSize,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
         let roots = pathProvider.roots().map {
             // The placeholder category never reaches the caller — every file
             // is re-tagged below — so the value picked here is irrelevant.
@@ -53,19 +69,17 @@ struct LargeOldFilesScanner {
             ScanRoot(url: $0, category: .largeFile)
         }
         let cutoff = now().addingTimeInterval(-Self.ageThresholdSeconds)
-        var matches: [ScannedFile] = []
         try await fileScanner.scan(
             roots: roots,
             excluding: excluding,
-            batchSize: FileScanner.defaultBatchSize
-        ) { batch in
-            for file in batch {
-                if let match = Self.classify(file, cutoff: cutoff) {
-                    matches.append(match)
-                }
-            }
+            batchSize: batchSize
+        ) { scannedBatch in
+            let matchedBatch = scannedBatch.compactMap { Self.classify($0, cutoff: cutoff) }
+            guard !matchedBatch.isEmpty else { return }
+            try Task.checkCancellation()
+            try await onBatch(matchedBatch)
+            try Task.checkCancellation()
         }
-        return matches
     }
 
     /// Returns the input file with its category re-tagged when it qualifies,

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -1,18 +1,14 @@
 // LargeOldFilesScanner.swift
-// Walks the user-files roots via FileScanner, then filters and re-tags each ScannedFile as .largeFile (size > 50 MB) or .oldFile (not accessed in 6+ months); files matching neither are dropped.
+// Walks the user-files roots via FileScanner batches, then filters and re-tags each ScannedFile as .largeFile (size > 50 MB) or .oldFile (not accessed in 6+ months); files matching neither are dropped.
 
 import Foundation
 
 /// Top-level entry point for the Large & Old Files feature. Composes a
 /// `UserFilesPathProviding` (which knows where the user keeps their personal
 /// files) with a `FileScanning` (which does the recursive walk) and post-
-/// processes the output to keep only files matching at least one criterion.
-///
-/// Two-pass design — walk-then-classify — instead of teaching `FileScanner`
-/// about size/age predicates: keeps `FileScanner` a generic walker, lets the
-/// thresholds be injected per-test, and means the same `FileScanner` instance
-/// can be shared with `SystemJunkScanner` without either one growing
-/// feature-specific knobs.
+/// processes each emitted batch to keep only files matching at least one
+/// criterion. `FileScanner` stays a generic walker, while this scanner avoids
+/// materializing a complete home-folder listing before it starts filtering.
 struct LargeOldFilesScanner {
 
     /// Files larger than this byte count are tagged `.largeFile`. 50 MB is
@@ -56,9 +52,20 @@ struct LargeOldFilesScanner {
             // synthetic "unclassified" case to the public `ScanCategory` enum.
             ScanRoot(url: $0, category: .largeFile)
         }
-        let everything = try await fileScanner.scan(roots: roots, excluding: excluding)
         let cutoff = now().addingTimeInterval(-Self.ageThresholdSeconds)
-        return everything.compactMap { Self.classify($0, cutoff: cutoff) }
+        var matches: [ScannedFile] = []
+        try await fileScanner.scan(
+            roots: roots,
+            excluding: excluding,
+            batchSize: FileScanner.defaultBatchSize
+        ) { batch in
+            for file in batch {
+                if let match = Self.classify(file, cutoff: cutoff) {
+                    matches.append(match)
+                }
+            }
+        }
+        return matches
     }
 
     /// Returns the input file with its category re-tagged when it qualifies,

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -113,6 +113,36 @@ final class FileScannerTests: XCTestCase {
         }
     }
 
+    func test_scan_doesNotDeliverBufferedBatchAfterTaskCancellation() async throws {
+        try TestHelpers.createDummyFile(named: "pending.bin", size: 8, in: tempRoot)
+
+        let scanner = FileScanner()
+        var didDeliverBatch = false
+        let task = Task {
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            try await scanner.scan(
+                roots: [ScanRoot(url: tempRoot, category: .userCache)],
+                excluding: [],
+                batchSize: 10
+            ) { _ in
+                didDeliverBatch = true
+            }
+        }
+
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("Expected cancellation to stop the scan")
+        } catch is CancellationError {
+            XCTAssertFalse(didDeliverBatch)
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
     // MARK: - Exclusions
 
     func test_scan_skipsFilesUnderExcludedPath() async throws {

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -72,6 +72,47 @@ final class FileScannerTests: XCTestCase {
         XCTAssertEqual(files.filter { $0.category == .trash }.count, 1)
     }
 
+    func test_scan_emitsMultipleBatchesBeforeCompleting() async throws {
+        try TestHelpers.createDummyFiles(count: 5, size: 8, in: tempRoot)
+
+        let scanner = FileScanner()
+        var batchSizes: [Int] = []
+        try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: [],
+            batchSize: 2
+        ) { batch in
+            batchSizes.append(batch.count)
+        }
+
+        XCTAssertEqual(batchSizes, [2, 2, 1])
+    }
+
+    func test_scan_stopsWhenBatchConsumerCancels() async throws {
+        try TestHelpers.createDummyFiles(count: 20, size: 8, in: tempRoot)
+
+        let scanner = FileScanner()
+        var deliveredCount = 0
+
+        do {
+            try await scanner.scan(
+                roots: [ScanRoot(url: tempRoot, category: .userCache)],
+                excluding: [],
+                batchSize: 1
+            ) { batch in
+                deliveredCount += batch.count
+                if deliveredCount == 3 {
+                    throw CancellationError()
+                }
+            }
+            XCTFail("Expected cancellation to stop the scan")
+        } catch is CancellationError {
+            XCTAssertEqual(deliveredCount, 3)
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
     // MARK: - Exclusions
 
     func test_scan_skipsFilesUnderExcludedPath() async throws {

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -164,6 +164,38 @@ final class LargeOldFilesScannerTests: XCTestCase {
                       "A small file with unknown access date matches neither criterion and must be dropped")
     }
 
+    func test_scan_filtersBatchesWithoutReturningNonMatches() async throws {
+        let nonMatchingFiles = (0..<1_000).map { index in
+            ScannedFile(
+                url: URL(fileURLWithPath: "/tmp/large-old-tests/small-\(index).txt"),
+                size: 32,
+                lastAccessDate: referenceNow.addingTimeInterval(-3_600),
+                lastModifiedDate: nil,
+                category: .largeFile
+            )
+        }
+        let matchingFile = ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-tests/match.bin"),
+            size: LargeOldFilesScanner.sizeThresholdBytes + 1,
+            lastAccessDate: referenceNow.addingTimeInterval(-3_600),
+            lastModifiedDate: nil,
+            category: .largeFile
+        )
+        let fakeScanner = FakeFileScanner(emittedBatches: [
+            Array(nonMatchingFiles.prefix(500)),
+            Array(nonMatchingFiles.suffix(500)) + [matchingFile]
+        ])
+        let scanner = LargeOldFilesScanner(
+            fileScanner: fakeScanner,
+            pathProvider: StubUserFilesPathProvider(roots: [tempRoot]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(files, [matchingFile])
+    }
+
     // MARK: - Exclusions
 
     /// `excluding:` is forwarded straight to the underlying `FileScanning`, so
@@ -239,8 +271,24 @@ private struct StubUserFilesPathProvider: UserFilesPathProviding {
 /// a `ScannedFile` with `lastAccessDate == nil` — APFS always populates that
 /// timestamp, so we can't produce one through real I/O.
 private struct FakeFileScanner: FileScanning {
-    let emitted: [ScannedFile]
-    func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
-        emitted
+    let emittedBatches: [[ScannedFile]]
+
+    init(emitted: [ScannedFile]) {
+        self.emittedBatches = [emitted]
+    }
+
+    init(emittedBatches: [[ScannedFile]]) {
+        self.emittedBatches = emittedBatches
+    }
+
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        batchSize: Int,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
+        for batch in emittedBatches {
+            try await onBatch(batch)
+        }
     }
 }

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -196,6 +196,57 @@ final class LargeOldFilesScannerTests: XCTestCase {
         XCTAssertEqual(files, [matchingFile])
     }
 
+    func test_scanBatchAPI_emitsOnlyMatchingFilesPerUnderlyingBatch() async throws {
+        let nonMatchingFile = ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-tests/small.txt"),
+            size: 32,
+            lastAccessDate: referenceNow.addingTimeInterval(-3_600),
+            lastModifiedDate: nil,
+            category: .largeFile
+        )
+        let largeFile = ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-tests/large.bin"),
+            size: LargeOldFilesScanner.sizeThresholdBytes + 1,
+            lastAccessDate: referenceNow.addingTimeInterval(-3_600),
+            lastModifiedDate: nil,
+            category: .largeFile
+        )
+        let oldFile = ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-tests/old.txt"),
+            size: 32,
+            lastAccessDate: referenceNow.addingTimeInterval(-LargeOldFilesScanner.ageThresholdSeconds - 86_400),
+            lastModifiedDate: nil,
+            category: .largeFile
+        )
+        let fakeScanner = FakeFileScanner(emittedBatches: [
+            [nonMatchingFile, largeFile],
+            [oldFile]
+        ])
+        let scanner = LargeOldFilesScanner(
+            fileScanner: fakeScanner,
+            pathProvider: StubUserFilesPathProvider(roots: [tempRoot]),
+            now: { self.referenceNow }
+        )
+        var emittedBatches: [[ScannedFile]] = []
+
+        try await scanner.scan(excluding: [], batchSize: 2) { batch in
+            emittedBatches.append(batch)
+        }
+
+        XCTAssertEqual(emittedBatches, [
+            [largeFile],
+            [
+                ScannedFile(
+                    url: oldFile.url,
+                    size: oldFile.size,
+                    lastAccessDate: oldFile.lastAccessDate,
+                    lastModifiedDate: oldFile.lastModifiedDate,
+                    category: .oldFile
+                )
+            ]
+        ])
+    }
+
     // MARK: - Exclusions
 
     /// `excluding:` is forwarded straight to the underlying `FileScanning`, so


### PR DESCRIPTION
## Summary
- Changed `FileScanning` to emit scanned files in batches, with a backward-compatible collecting helper for callers that still want an array.
- Updated `FileScanner` to flush results incrementally and check cancellation during long walks.
- Reworked `LargeOldFilesScanner` to classify files batch-by-batch instead of materializing the full scan output first.
- Added unit coverage for batch emission, cancellation, and streamed filtering behavior.
- Closes https://github.com/jayvicsanantonio/VaderCleaner/issues/43

## Testing
- `xcodebuild build -project VaderCleaner.xcodeproj -scheme VaderCleaner -destination platform=macOS`
- Targeted test runs passed for `FileScannerTests`, `LargeOldFilesScannerTests`, and `SystemJunkScannerTests`
- A full scheme UI test for System Junk still times out on the real scan preview in `VaderCleanerUITests/SystemJunkUITests`