### PR TITLE
Move Privacy sizing and clearing off the main actor

### DIFF
--- a/VaderCleaner/BrowserDataClearer.swift
+++ b/VaderCleaner/BrowserDataClearer.swift
@@ -11,7 +11,7 @@ import os.log
 /// which makes the whole pipeline trivially testable against a temp dir.
 /// Errors on individual files surface as throws from `clear`; a missing
 /// path is treated as already-cleared and silently skipped.
-struct BrowserDataClearer {
+struct BrowserDataClearer: Sendable {
 
     typealias Remover = (URL) throws -> Void
 

--- a/VaderCleaner/BrowserDataClearer.swift
+++ b/VaderCleaner/BrowserDataClearer.swift
@@ -16,10 +16,7 @@ struct BrowserDataClearer {
     typealias Remover = (URL) throws -> Void
 
     private let pathProvider: BrowserDataPathProviding
-    private let fileManager: FileManager
-    private let remover: Remover
-    private let log = Logger(subsystem: "com.personal.VaderCleaner",
-                             category: "BrowserDataClearer")
+    private let worker: BrowserDataWorker
 
     init(
         pathProvider: BrowserDataPathProviding,
@@ -27,21 +24,19 @@ struct BrowserDataClearer {
         remover: Remover? = nil
     ) {
         self.pathProvider = pathProvider
-        self.fileManager = fileManager
-        self.remover = remover ?? { url in
-            try fileManager.removeItem(at: url)
-        }
+        self.worker = BrowserDataWorker(
+            pathProvider: pathProvider,
+            fileManager: fileManager,
+            remover: remover
+        )
     }
 
     /// Sum of bytes across every existing path the provider returns for
     /// `(browser, category)`. Files contribute their `fileSize`,
     /// directories contribute the recursive total. Missing paths are
     /// silently skipped — they contribute 0.
-    func previewSize(for category: PrivacyCategory, browser: Browser) -> Int64 {
-        let paths = pathProvider.dataPaths(for: browser, category: category)
-        return paths.reduce(into: Int64(0)) { acc, url in
-            acc += sizeOnDisk(at: url)
-        }
+    func previewSize(for category: PrivacyCategory, browser: Browser) async throws -> Int64 {
+        try await worker.previewSize(for: category, browser: browser)
     }
 
     /// All on-disk paths the provider knows about for `(browser, category)`.
@@ -53,9 +48,49 @@ struct BrowserDataClearer {
 
     /// Remove every existing path for `(browser, category)`. Throws on the
     /// first remover failure; missing paths are silently skipped.
+    func clear(category: PrivacyCategory, browser: Browser) async throws {
+        try await worker.clear(category: category, browser: browser)
+    }
+}
+
+/// Serializes browser-data filesystem work away from the main actor.
+/// `FileManager` calls here are synchronous, so isolating them to this
+/// actor keeps Privacy view-model orchestration responsive while also
+/// giving repeated scans / clears one cooperative cancellation path.
+private actor BrowserDataWorker {
+
+    private let pathProvider: BrowserDataPathProviding
+    private let fileManager: FileManager
+    private let remover: BrowserDataClearer.Remover
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "BrowserDataClearer")
+
+    init(
+        pathProvider: BrowserDataPathProviding,
+        fileManager: FileManager,
+        remover: BrowserDataClearer.Remover?
+    ) {
+        self.pathProvider = pathProvider
+        self.fileManager = fileManager
+        self.remover = remover ?? { url in
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    func previewSize(for category: PrivacyCategory, browser: Browser) throws -> Int64 {
+        try Task.checkCancellation()
+        let paths = pathProvider.dataPaths(for: browser, category: category)
+        return try paths.reduce(into: Int64(0)) { acc, url in
+            try Task.checkCancellation()
+            acc += try sizeOnDisk(at: url)
+        }
+    }
+
     func clear(category: PrivacyCategory, browser: Browser) throws {
+        try Task.checkCancellation()
         let paths = pathProvider.dataPaths(for: browser, category: category)
         for url in paths {
+            try Task.checkCancellation()
             guard fileManager.fileExists(atPath: url.path) else {
                 log.debug("Skipping missing path: \(url.path, privacy: .public)")
                 continue
@@ -70,7 +105,8 @@ struct BrowserDataClearer {
     /// the process can't read. Directories enumerate via
     /// `FileManager.enumerator` with file-size + directory keys so the walk
     /// runs in one pass without a separate stat for every entry.
-    private func sizeOnDisk(at url: URL) -> Int64 {
+    private func sizeOnDisk(at url: URL) throws -> Int64 {
+        try Task.checkCancellation()
         guard fileManager.fileExists(atPath: url.path) else { return 0 }
 
         let resourceKeys: Set<URLResourceKey> = [.isDirectoryKey, .totalFileAllocatedSizeKey, .fileSizeKey]
@@ -92,6 +128,7 @@ struct BrowserDataClearer {
 
         var total: Int64 = 0
         for case let entry as URL in enumerator {
+            try Task.checkCancellation()
             if let entryValues = try? entry.resourceValues(forKeys: resourceKeys),
                entryValues.isDirectory == false {
                 total += Int64(entryValues.fileSize ?? 0)

--- a/VaderCleaner/BrowserDataPathProviding.swift
+++ b/VaderCleaner/BrowserDataPathProviding.swift
@@ -7,7 +7,7 @@ import Foundation
 /// layout. The clearer knows nothing about where Chrome's `History` lives;
 /// the provider does. Tests inject a stub that returns paths under a temp
 /// directory so every clearer / view-model test runs hermetically.
-protocol BrowserDataPathProviding {
+protocol BrowserDataPathProviding: Sendable {
     /// All on-disk paths to read (for size preview) or remove (for clear)
     /// for a given `(browser, category)` pair. Missing paths are not
     /// filtered here — the clearer skips ones that don't exist — so callers
@@ -18,7 +18,7 @@ protocol BrowserDataPathProviding {
 /// Production resolver. Returns the real macOS paths for each
 /// `(browser, category)` pair, anchored to an injectable home directory so
 /// tests can drive every code path without touching the user's actual data.
-struct DefaultBrowserDataPathProvider: BrowserDataPathProviding {
+struct DefaultBrowserDataPathProvider: BrowserDataPathProviding, @unchecked Sendable {
 
     private let homeDirectory: URL
     private let fileManager: FileManager

--- a/VaderCleaner/BrowserDetector.swift
+++ b/VaderCleaner/BrowserDetector.swift
@@ -15,10 +15,10 @@ protocol BrowserDetecting {
 /// not uninstallable through normal channels), and includes any other
 /// browser whose `.app` exists under `/Applications` or
 /// `~/Applications`.
-struct DefaultBrowserDetector: BrowserDetecting {
+struct DefaultBrowserDetector: BrowserDetecting, Sendable {
 
     private let homeDirectory: URL
-    private let existsAt: (URL) -> Bool
+    private let existsAt: @Sendable (URL) -> Bool
 
     /// - Parameter existsAt: closure that answers "does a file/directory
     ///   exist at this URL?". Defaults to `FileManager.fileExists`. The
@@ -26,7 +26,7 @@ struct DefaultBrowserDetector: BrowserDetecting {
     ///   `/Applications` on the host.
     init(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        existsAt: @escaping (URL) -> Bool = { url in
+        existsAt: @escaping @Sendable (URL) -> Bool = { url in
             FileManager.default.fileExists(atPath: url.path)
         }
     ) {

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -47,11 +47,11 @@ final class PrivacyViewModel: ObservableObject {
         let category: PrivacyCategory
     }
 
-    typealias Detector             = () async throws -> [Browser]
-    typealias Sizer                = (Browser, PrivacyCategory) async throws -> Int64
-    typealias PathsResolver        = (Browser, PrivacyCategory) -> [URL]
-    typealias Clearer              = (Browser, PrivacyCategory) async throws -> Void
-    typealias RecentFilesClearer   = () async throws -> Void
+    typealias Detector             = @Sendable () async throws -> [Browser]
+    typealias Sizer                = @Sendable (Browser, PrivacyCategory) async throws -> Int64
+    typealias PathsResolver        = @Sendable (Browser, PrivacyCategory) -> [URL]
+    typealias Clearer              = @Sendable (Browser, PrivacyCategory) async throws -> Void
+    typealias RecentFilesClearer   = @MainActor @Sendable () async throws -> Void
 
     @Published private(set) var phase: Phase = .idle
     @Published private(set) var detectedBrowsers: [Browser] = []

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -81,6 +81,11 @@ final class PrivacyViewModel: ObservableObject {
     /// view's row labels and `totalSelectedSize` compute in O(1).
     private var sizesByBrowserCategory: [Selection: Int64] = [:]
 
+    /// Cached per-cell paths, populated alongside preview sizes so SwiftUI
+    /// rendering and checkbox toggles don't synchronously resolve browser
+    /// profile directories on the main actor.
+    private var pathsByBrowserCategory: [Selection: [URL]] = [:]
+
     init(
         detector: @escaping Detector,
         sizer: @escaping Sizer,
@@ -140,7 +145,7 @@ final class PrivacyViewModel: ObservableObject {
     /// History") rather than as a checkbox the user can toggle, so
     /// the UI never claims to do something it can't.
     func isCategoryActionable(browser: Browser, category: PrivacyCategory) -> Bool {
-        !pathsFor(browser, category).isEmpty
+        !paths(for: browser, category: category).isEmpty
     }
 
     /// Currently-checked selections in a stable
@@ -178,7 +183,7 @@ final class PrivacyViewModel: ObservableObject {
             for category in PrivacyCategory.allCases {
                 let selection = Selection(browser: browser, category: category)
                 guard selections.contains(selection) else { continue }
-                let paths = pathsFor(browser, category)
+                let paths = paths(for: browser, category: category)
                 guard !paths.isEmpty else { continue }
                 let firstUnseen = paths.first { !visitedPaths.contains($0) }
                 if firstUnseen != nil {
@@ -190,6 +195,11 @@ final class PrivacyViewModel: ObservableObject {
         return total
     }
 
+    private func paths(for browser: Browser, category: PrivacyCategory) -> [URL] {
+        let selection = Selection(browser: browser, category: category)
+        return pathsByBrowserCategory[selection] ?? pathsFor(browser, category)
+    }
+
     // MARK: - Actions
 
     /// Run detection + sizing and land in `.preview` (or `.failed`).
@@ -198,43 +208,59 @@ final class PrivacyViewModel: ObservableObject {
     func preview() async {
         let generation = beginOperation()
         phase = .scanning
+        let detector = detector
+        let sizer = sizer
+        let pathsFor = pathsFor
+        let log = log
 
-        let task = Task { [weak self] in
-            guard let self else { return }
+        let task = Task.detached {
             do {
                 let browsers = try await detector()
                 var sizes: [Selection: Int64] = [:]
+                var pathsBySelection: [Selection: [URL]] = [:]
                 var checked: Set<Selection> = []
                 for browser in browsers {
                     for category in PrivacyCategory.allCases {
                         try Task.checkCancellation()
                         let selection = Selection(browser: browser, category: category)
                         sizes[selection] = try await sizer(browser, category)
+                        pathsBySelection[selection] = pathsFor(browser, category)
                         checked.insert(selection)
                     }
                 }
                 try Task.checkCancellation()
-                guard self.operationGeneration == generation else { return }
-                self.detectedBrowsers = browsers
-                self.sizesByBrowserCategory = sizes
-                self.checkedSelections = checked
-                self.isClearRecentsChecked = true
-                self.phase = .preview
+                let sizesSnapshot = sizes
+                let pathsSnapshot = pathsBySelection
+                let checkedSnapshot = checked
+                await MainActor.run { [weak self] in
+                    guard let self, self.operationGeneration == generation else { return }
+                    self.detectedBrowsers = browsers
+                    self.sizesByBrowserCategory = sizesSnapshot
+                    self.pathsByBrowserCategory = pathsSnapshot
+                    self.checkedSelections = checkedSnapshot
+                    self.isClearRecentsChecked = true
+                    self.phase = .preview
+                }
             } catch is CancellationError {
-                guard self.operationGeneration == generation else { return }
-                self.clearPreviewState()
-                self.phase = .idle
+                await MainActor.run { [weak self] in
+                    guard let self, self.operationGeneration == generation else { return }
+                    self.clearPreviewState()
+                    self.phase = .idle
+                }
             } catch {
-                guard self.operationGeneration == generation else { return }
                 // Log error description as `.private` — `error.localizedDescription`
                 // can include user-specific filesystem paths or browser
                 // profile names, which we don't want in unredacted unified-
                 // log output of a Privacy feature.
                 log.error("Privacy preview failed: \(String(describing: error), privacy: .private)")
-                self.detectedBrowsers = []
-                self.sizesByBrowserCategory = [:]
-                self.checkedSelections = []
-                self.phase = .failed(stage: .scanning, message: error.localizedDescription)
+                await MainActor.run { [weak self] in
+                    guard let self, self.operationGeneration == generation else { return }
+                    self.detectedBrowsers = []
+                    self.sizesByBrowserCategory = [:]
+                    self.pathsByBrowserCategory = [:]
+                    self.checkedSelections = []
+                    self.phase = .failed(stage: .scanning, message: error.localizedDescription)
+                }
             }
         }
 
@@ -276,50 +302,8 @@ final class PrivacyViewModel: ObservableObject {
         detectedBrowsers = []
         checkedSelections = []
         sizesByBrowserCategory = [:]
+        pathsByBrowserCategory = [:]
         isClearRecentsChecked = true
-    }
-
-    /// Restore a failed / cancelled clear back to the last preview rather
-    /// than dropping the user to idle. Some browser data may already have
-    /// been cleared, but keeping the user's selection visible is the least
-    /// surprising recovery path for a retry or manual adjustment.
-    private func restorePreviewAfterClearCancellation() {
-        phase = .preview
-    }
-
-    /// Execute the destructive clear operation for a captured selection
-    /// snapshot. Capturing the inputs before the task starts keeps the
-    /// operation stable even if the UI toggles state after `.clearing`.
-    private func runClear(
-        generation: Int,
-        bytesPlanned: Int64,
-        shouldClearRecents: Bool,
-        selections: [Selection]
-    ) async {
-        do {
-            if shouldClearRecents {
-                try await clearRecentFiles()
-            }
-            // Iterate selections in a deterministic
-            // (browser × category) order so a mid-run failure aborts at
-            // a predictable point — `Set` iteration order is undefined,
-            // which would make retries and bug reports inconsistent.
-            for selection in selections {
-                try Task.checkCancellation()
-                try await clearer(selection.browser, selection.category)
-            }
-            try Task.checkCancellation()
-            guard operationGeneration == generation else { return }
-            phase = .complete(bytesFreed: bytesPlanned)
-        } catch is CancellationError {
-            guard operationGeneration == generation else { return }
-            restorePreviewAfterClearCancellation()
-        } catch {
-            guard operationGeneration == generation else { return }
-            // See `preview()` — same reasoning for `.private`.
-            log.error("Privacy clear failed: \(String(describing: error), privacy: .private)")
-            phase = .failed(stage: .clearing, message: error.localizedDescription)
-        }
     }
 
     /// Hand each checked selection to the injected clearer and (when the
@@ -341,15 +325,44 @@ final class PrivacyViewModel: ObservableObject {
         let selections = orderedCheckedSelections()
         let generation = beginOperation()
         phase = .clearing
+        let clearRecentFiles = clearRecentFiles
+        let clearer = clearer
+        let log = log
 
-        let task = Task { [weak self] in
-            guard let self else { return }
-            await self.runClear(
-                generation: generation,
-                bytesPlanned: bytesPlanned,
-                shouldClearRecents: shouldClearRecents,
-                selections: selections
-            )
+        let task = Task {
+            do {
+                if shouldClearRecents {
+                    try await clearRecentFiles()
+                }
+                // Iterate selections in a deterministic
+                // (browser × category) order so a mid-run failure aborts at
+                // a predictable point — `Set` iteration order is undefined,
+                // which would make retries and bug reports inconsistent.
+                for selection in selections {
+                    try Task.checkCancellation()
+                    try await clearer(selection.browser, selection.category)
+                }
+                try Task.checkCancellation()
+                await MainActor.run { [weak self] in
+                    guard let self, self.operationGeneration == generation else { return }
+                    self.phase = .complete(bytesFreed: bytesPlanned)
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    guard let self, self.operationGeneration == generation else { return }
+                    // Some browser data may already have been cleared, but
+                    // keeping the selection visible is the least surprising
+                    // recovery path for a retry or manual adjustment.
+                    self.phase = .preview
+                }
+            } catch {
+                // See `preview()` — same reasoning for `.private`.
+                log.error("Privacy clear failed: \(String(describing: error), privacy: .private)")
+                await MainActor.run { [weak self] in
+                    guard let self, self.operationGeneration == generation else { return }
+                    self.phase = .failed(stage: .clearing, message: error.localizedDescription)
+                }
+            }
         }
 
         currentOperationTask = task

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -48,7 +48,7 @@ final class PrivacyViewModel: ObservableObject {
     }
 
     typealias Detector             = () async throws -> [Browser]
-    typealias Sizer                = (Browser, PrivacyCategory) -> Int64
+    typealias Sizer                = (Browser, PrivacyCategory) async throws -> Int64
     typealias PathsResolver        = (Browser, PrivacyCategory) -> [URL]
     typealias Clearer              = (Browser, PrivacyCategory) async throws -> Void
     typealias RecentFilesClearer   = () async throws -> Void
@@ -66,6 +66,17 @@ final class PrivacyViewModel: ObservableObject {
     private let log = Logger(subsystem: "com.personal.VaderCleaner",
                              category: "PrivacyViewModel")
 
+    /// Monotonically increasing token for preview / clear work. When a
+    /// newer operation starts, older tasks can still finish winding down,
+    /// but they must not publish stale results back into the UI.
+    private var operationGeneration: Int = 0
+
+    /// Handle for the currently-running Privacy operation. A new preview,
+    /// clear, reset, or view-model teardown cancels the old one so expensive
+    /// browser-data filesystem work does not keep competing in the
+    /// background after the user has moved on.
+    private var currentOperationTask: Task<Void, Never>?
+
     /// Cached per-cell sizes, populated at the end of `preview()` so the
     /// view's row labels and `totalSelectedSize` compute in O(1).
     private var sizesByBrowserCategory: [Selection: Int64] = [:]
@@ -82,6 +93,10 @@ final class PrivacyViewModel: ObservableObject {
         self.pathsFor = pathsFor
         self.clearer = clearer
         self.clearRecentFiles = clearRecentFiles
+    }
+
+    deinit {
+        currentOperationTask?.cancel()
     }
 
     // MARK: - Public surface
@@ -181,33 +196,129 @@ final class PrivacyViewModel: ObservableObject {
     /// Marks every detected `(browser, category)` checked by default
     /// (and the recent-items toggle on) so the user is at "select all".
     func preview() async {
+        let generation = beginOperation()
         phase = .scanning
-        do {
-            let browsers = try await detector()
-            var sizes: [Selection: Int64] = [:]
-            var checked: Set<Selection> = []
-            for browser in browsers {
-                for category in PrivacyCategory.allCases {
-                    let selection = Selection(browser: browser, category: category)
-                    sizes[selection] = sizer(browser, category)
-                    checked.insert(selection)
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let browsers = try await detector()
+                var sizes: [Selection: Int64] = [:]
+                var checked: Set<Selection> = []
+                for browser in browsers {
+                    for category in PrivacyCategory.allCases {
+                        try Task.checkCancellation()
+                        let selection = Selection(browser: browser, category: category)
+                        sizes[selection] = try await sizer(browser, category)
+                        checked.insert(selection)
+                    }
                 }
+                try Task.checkCancellation()
+                guard self.operationGeneration == generation else { return }
+                self.detectedBrowsers = browsers
+                self.sizesByBrowserCategory = sizes
+                self.checkedSelections = checked
+                self.isClearRecentsChecked = true
+                self.phase = .preview
+            } catch is CancellationError {
+                guard self.operationGeneration == generation else { return }
+                self.clearPreviewState()
+                self.phase = .idle
+            } catch {
+                guard self.operationGeneration == generation else { return }
+                // Log error description as `.private` — `error.localizedDescription`
+                // can include user-specific filesystem paths or browser
+                // profile names, which we don't want in unredacted unified-
+                // log output of a Privacy feature.
+                log.error("Privacy preview failed: \(String(describing: error), privacy: .private)")
+                self.detectedBrowsers = []
+                self.sizesByBrowserCategory = [:]
+                self.checkedSelections = []
+                self.phase = .failed(stage: .scanning, message: error.localizedDescription)
             }
-            self.detectedBrowsers = browsers
-            self.sizesByBrowserCategory = sizes
-            self.checkedSelections = checked
-            self.isClearRecentsChecked = true
-            self.phase = .preview
+        }
+
+        currentOperationTask = task
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        finishOperation(generation)
+    }
+
+    /// Start a new operation by cancelling the old one and invalidating any
+    /// late-arriving writes it might try to publish.
+    private func beginOperation() -> Int {
+        currentOperationTask?.cancel()
+        operationGeneration += 1
+        return operationGeneration
+    }
+
+    /// Clear the operation handle only if it still belongs to the task that
+    /// just completed. A newer operation will have advanced the generation.
+    private func finishOperation(_ generation: Int) {
+        if operationGeneration == generation {
+            currentOperationTask = nil
+        }
+    }
+
+    /// Cancel work without immediately replacing it. Used by `scanAgain()`
+    /// so the reset state wins even if a background task completes later.
+    private func cancelCurrentOperation() {
+        currentOperationTask?.cancel()
+        currentOperationTask = nil
+        operationGeneration += 1
+    }
+
+    /// Clear cached preview state while preserving the current phase choice.
+    private func clearPreviewState() {
+        detectedBrowsers = []
+        checkedSelections = []
+        sizesByBrowserCategory = [:]
+        isClearRecentsChecked = true
+    }
+
+    /// Restore a failed / cancelled clear back to the last preview rather
+    /// than dropping the user to idle. Some browser data may already have
+    /// been cleared, but keeping the user's selection visible is the least
+    /// surprising recovery path for a retry or manual adjustment.
+    private func restorePreviewAfterClearCancellation() {
+        phase = .preview
+    }
+
+    /// Execute the destructive clear operation for a captured selection
+    /// snapshot. Capturing the inputs before the task starts keeps the
+    /// operation stable even if the UI toggles state after `.clearing`.
+    private func runClear(
+        generation: Int,
+        bytesPlanned: Int64,
+        shouldClearRecents: Bool,
+        selections: [Selection]
+    ) async {
+        do {
+            if shouldClearRecents {
+                try await clearRecentFiles()
+            }
+            // Iterate selections in a deterministic
+            // (browser × category) order so a mid-run failure aborts at
+            // a predictable point — `Set` iteration order is undefined,
+            // which would make retries and bug reports inconsistent.
+            for selection in selections {
+                try Task.checkCancellation()
+                try await clearer(selection.browser, selection.category)
+            }
+            try Task.checkCancellation()
+            guard operationGeneration == generation else { return }
+            phase = .complete(bytesFreed: bytesPlanned)
+        } catch is CancellationError {
+            guard operationGeneration == generation else { return }
+            restorePreviewAfterClearCancellation()
         } catch {
-            // Log error description as `.private` — `error.localizedDescription`
-            // can include user-specific filesystem paths or browser
-            // profile names, which we don't want in unredacted unified-
-            // log output of a Privacy feature.
-            log.error("Privacy preview failed: \(String(describing: error), privacy: .private)")
-            self.detectedBrowsers = []
-            self.sizesByBrowserCategory = [:]
-            self.checkedSelections = []
-            self.phase = .failed(stage: .scanning, message: error.localizedDescription)
+            guard operationGeneration == generation else { return }
+            // See `preview()` — same reasoning for `.private`.
+            log.error("Privacy clear failed: \(String(describing: error), privacy: .private)")
+            phase = .failed(stage: .clearing, message: error.localizedDescription)
         }
     }
 
@@ -226,24 +337,28 @@ final class PrivacyViewModel: ObservableObject {
     func clear() async {
         guard phase == .preview else { return }
         let bytesPlanned = totalSelectedSize
+        let shouldClearRecents = isClearRecentsChecked
+        let selections = orderedCheckedSelections()
+        let generation = beginOperation()
         phase = .clearing
-        do {
-            if isClearRecentsChecked {
-                try await clearRecentFiles()
-            }
-            // Iterate selections in a deterministic
-            // (browser × category) order so a mid-run failure aborts at
-            // a predictable point — `Set` iteration order is undefined,
-            // which would make retries and bug reports inconsistent.
-            for selection in orderedCheckedSelections() {
-                try await clearer(selection.browser, selection.category)
-            }
-            self.phase = .complete(bytesFreed: bytesPlanned)
-        } catch {
-            // See `preview()` — same reasoning for `.private`.
-            log.error("Privacy clear failed: \(String(describing: error), privacy: .private)")
-            self.phase = .failed(stage: .clearing, message: error.localizedDescription)
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.runClear(
+                generation: generation,
+                bytesPlanned: bytesPlanned,
+                shouldClearRecents: shouldClearRecents,
+                selections: selections
+            )
         }
+
+        currentOperationTask = task
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        finishOperation(generation)
     }
 
     /// Flip the per-cell checkbox.
@@ -263,10 +378,8 @@ final class PrivacyViewModel: ObservableObject {
 
     /// Reset to `.idle`, dropping cached preview state.
     func scanAgain() {
-        detectedBrowsers = []
-        checkedSelections = []
-        sizesByBrowserCategory = [:]
-        isClearRecentsChecked = true
+        cancelCurrentOperation()
+        clearPreviewState()
         phase = .idle
     }
 }
@@ -288,13 +401,13 @@ extension PrivacyViewModel {
         return PrivacyViewModel(
             detector: { detector.installedBrowsers() },
             sizer: { browser, category in
-                clearer.previewSize(for: category, browser: browser)
+                try await clearer.previewSize(for: category, browser: browser)
             },
             pathsFor: { browser, category in
                 clearer.paths(for: category, browser: browser)
             },
             clearer: { browser, category in
-                try clearer.clear(category: category, browser: browser)
+                try await clearer.clear(category: category, browser: browser)
             },
             clearRecentFiles: {
                 // `RecentFilesManager` is `@MainActor`, and this closure

--- a/VaderCleaner/RecentFilesManager.swift
+++ b/VaderCleaner/RecentFilesManager.swift
@@ -28,14 +28,14 @@ struct RecentFilesManager {
 
     private let homeDirectory: URL
     private let fileManager: FileManager
-    private let clearAppRecentDocuments: () -> Void
+    private let clearAppRecentDocuments: @MainActor () -> Void
     private let log = Logger(subsystem: "com.personal.VaderCleaner",
                              category: "RecentFilesManager")
 
     init(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         fileManager: FileManager = .default,
-        clearAppRecentDocuments: @escaping () -> Void = {
+        clearAppRecentDocuments: @escaping @MainActor () -> Void = {
             NSDocumentController.shared.clearRecentDocuments(nil)
         }
     ) {

--- a/VaderCleanerTests/BrowserDataClearerTests.swift
+++ b/VaderCleanerTests/BrowserDataClearerTests.swift
@@ -26,7 +26,7 @@ final class BrowserDataClearerTests: XCTestCase {
     /// contribute the recursive total. The clearer's contract with the UI
     /// is "show what we'd actually free", so a wrong total here misleads
     /// the user about how much the action will reclaim.
-    func test_previewSize_sumsBytesAcrossFilesAndDirectories() throws {
+    func test_previewSize_sumsBytesAcrossFilesAndDirectories() async throws {
         let history = try TestHelpers.createDummyFile(named: "History.db", size: 100, in: tempRoot)
         let cacheDir = tempRoot.appendingPathComponent("Cache", isDirectory: true)
         try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
@@ -35,27 +35,54 @@ final class BrowserDataClearerTests: XCTestCase {
         let provider = StubProvider(paths: [.history: [history, cacheDir]])
         let clearer = BrowserDataClearer(pathProvider: provider)
 
-        let bytes = clearer.previewSize(for: .history, browser: .chrome)
+        let bytes = try await clearer.previewSize(for: .history, browser: .chrome)
         XCTAssertEqual(bytes, 100 + 150)
     }
 
     /// Missing paths must not crash or throw — every browser-data path is
     /// optional in practice (e.g. the user never used cookies), so a
     /// non-existent path simply contributes 0 to the total.
-    func test_previewSize_returnsZeroForMissingPaths() {
+    func test_previewSize_returnsZeroForMissingPaths() async throws {
         let bogus = tempRoot.appendingPathComponent("does-not-exist")
         let provider = StubProvider(paths: [.cookies: [bogus]])
         let clearer = BrowserDataClearer(pathProvider: provider)
 
-        XCTAssertEqual(clearer.previewSize(for: .cookies, browser: .chrome), 0)
+        let bytes = try await clearer.previewSize(for: .cookies, browser: .chrome)
+        XCTAssertEqual(bytes, 0)
     }
 
     /// When the provider returns no paths (e.g. Firefox without a profile
     /// yet) the size must be 0 with no I/O at all.
-    func test_previewSize_returnsZeroForEmptyProviderResult() {
+    func test_previewSize_returnsZeroForEmptyProviderResult() async throws {
         let provider = StubProvider(paths: [:])
         let clearer = BrowserDataClearer(pathProvider: provider)
-        XCTAssertEqual(clearer.previewSize(for: .history, browser: .firefox), 0)
+        let bytes = try await clearer.previewSize(for: .history, browser: .firefox)
+        XCTAssertEqual(bytes, 0)
+    }
+
+    /// Cancellation must interrupt large recursive sizing walks so a
+    /// restarted Privacy preview doesn't keep burning I/O in the background.
+    func test_previewSize_honorsCancellationDuringDirectoryWalk() async throws {
+        let cacheDir = tempRoot.appendingPathComponent("Cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 1_000, size: 1, in: cacheDir)
+
+        let provider = StubProvider(paths: [.cache: [cacheDir]])
+        let clearer = BrowserDataClearer(pathProvider: provider)
+
+        let task = Task {
+            try await clearer.previewSize(for: .cache, browser: .chrome)
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation to throw")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
     }
 
     // MARK: - clear
@@ -64,7 +91,7 @@ final class BrowserDataClearerTests: XCTestCase {
     /// directories alike — the clearer doesn't try to be selective inside a
     /// directory because the whole point of a "Clear Cache" action is to
     /// drop the lot.
-    func test_clear_removesEveryExistingPath() throws {
+    func test_clear_removesEveryExistingPath() async throws {
         let history = try TestHelpers.createDummyFile(named: "History.db", size: 100, in: tempRoot)
         let cacheDir = tempRoot.appendingPathComponent("Cache", isDirectory: true)
         try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
@@ -73,7 +100,7 @@ final class BrowserDataClearerTests: XCTestCase {
         let provider = StubProvider(paths: [.history: [history, cacheDir]])
         let clearer = BrowserDataClearer(pathProvider: provider)
 
-        try clearer.clear(category: .history, browser: .chrome)
+        try await clearer.clear(category: .history, browser: .chrome)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: history.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: cacheDir.path))
@@ -83,14 +110,18 @@ final class BrowserDataClearerTests: XCTestCase {
     /// (e.g. cookies file exists but cache dir doesn't) doesn't raise an
     /// error mid-clear and leave the user staring at a misleading "couldn't
     /// finish" message when, in fact, everything reachable was cleared.
-    func test_clear_silentlySkipsMissingPaths() throws {
+    func test_clear_silentlySkipsMissingPaths() async throws {
         let bogus = tempRoot.appendingPathComponent("does-not-exist")
         let real = try TestHelpers.createDummyFile(named: "Cookies", size: 50, in: tempRoot)
 
         let provider = StubProvider(paths: [.cookies: [bogus, real]])
         let clearer = BrowserDataClearer(pathProvider: provider)
 
-        XCTAssertNoThrow(try clearer.clear(category: .cookies, browser: .chrome))
+        do {
+            try await clearer.clear(category: .cookies, browser: .chrome)
+        } catch {
+            XCTFail("Expected missing paths to be skipped, got \(error)")
+        }
         XCTAssertFalse(FileManager.default.fileExists(atPath: real.path),
                        "Real cookies file should be removed even when sibling path is missing")
     }
@@ -99,7 +130,7 @@ final class BrowserDataClearerTests: XCTestCase {
     /// error must surface so the view-model can transition to `.failed`.
     /// Suppressing it would leave the UI claiming "Cleared" when nothing
     /// happened.
-    func test_clear_throwsWhenInjectedRemoverThrows() {
+    func test_clear_throwsWhenInjectedRemoverThrows() async {
         let real = tempRoot.appendingPathComponent("Cookies")
         FileManager.default.createFile(atPath: real.path, contents: Data(repeating: 0, count: 8))
 
@@ -109,7 +140,10 @@ final class BrowserDataClearerTests: XCTestCase {
             remover: { _ in throw FailingRemoverError.boom }
         )
 
-        XCTAssertThrowsError(try clearer.clear(category: .cookies, browser: .chrome)) { error in
+        do {
+            try await clearer.clear(category: .cookies, browser: .chrome)
+            XCTFail("Expected injected remover to throw")
+        } catch {
             XCTAssertTrue(error is FailingRemoverError)
         }
     }

--- a/VaderCleanerTests/PrivacyViewModelTests.swift
+++ b/VaderCleanerTests/PrivacyViewModelTests.swift
@@ -101,6 +101,71 @@ final class PrivacyViewModelTests: XCTestCase {
         }
     }
 
+    /// A slow async sizer must yield the main actor while filesystem work is
+    /// in flight. This protects the SwiftUI spinner / repaint loop from
+    /// being pinned by Privacy preview work.
+    func test_preview_yieldsMainActorWhileSizingIsSuspended() async {
+        let sizerStarted = expectation(description: "sizer started")
+        let mainActorWasFree = expectation(description: "main actor accepted another task")
+        var didSuspendSizer = false
+        var releaseSizer: CheckedContinuation<Void, Never>?
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in
+                if !didSuspendSizer {
+                    didSuspendSizer = true
+                    sizerStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        releaseSizer = continuation
+                    }
+                }
+                return 1
+            }
+        )
+
+        let previewTask = Task { await vm.preview() }
+        await fulfillment(of: [sizerStarted], timeout: 1)
+        Task { @MainActor in mainActorWasFree.fulfill() }
+        await fulfillment(of: [mainActorWasFree], timeout: 1)
+
+        releaseSizer?.resume()
+        await previewTask.value
+        XCTAssertEqual(vm.phase, .preview)
+    }
+
+    /// Starting a fresh preview must cancel the old one and ignore any stale
+    /// result it might try to publish after cancellation unwinds.
+    func test_preview_restartCancelsInFlightScanAndKeepsLatestResult() async {
+        let firstSizerStarted = expectation(description: "first sizer started")
+        var detectorCalls = 0
+        var sizerCalls = 0
+        let vm = makeViewModel(
+            detector: {
+                detectorCalls += 1
+                return detectorCalls == 1 ? [.safari] : [.chrome]
+            },
+            sizer: { _, _ in
+                sizerCalls += 1
+                if sizerCalls == 1 {
+                    firstSizerStarted.fulfill()
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                }
+                return 25
+            }
+        )
+
+        let firstPreview = Task { await vm.preview() }
+        await fulfillment(of: [firstSizerStarted], timeout: 1)
+
+        let secondPreview = Task { await vm.preview() }
+        await secondPreview.value
+        await firstPreview.value
+
+        XCTAssertEqual(vm.phase, .preview)
+        XCTAssertEqual(vm.detectedBrowsers, [.chrome])
+        XCTAssertEqual(vm.size(for: .chrome, category: .history), 25)
+    }
+
     // MARK: - Actionability
 
     /// `isCategoryActionable` is the contract the view uses to decide
@@ -373,6 +438,35 @@ final class PrivacyViewModelTests: XCTestCase {
         } else {
             XCTFail("Expected .failed, got \(vm.phase)")
         }
+    }
+
+    /// Resetting while a clear is in progress must cancel the operation and
+    /// leave the VM in a clean idle state, with any late task completion
+    /// prevented from publishing `.complete`.
+    func test_scanAgain_cancelsInFlightClearAndLeavesIdle() async {
+        let firstClearStarted = expectation(description: "first clear started")
+        var clearCalls = 0
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 50 },
+            clearer: { _, _ in
+                clearCalls += 1
+                if clearCalls == 1 {
+                    firstClearStarted.fulfill()
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                }
+            }
+        )
+
+        await vm.preview()
+        let clearTask = Task { await vm.clear() }
+        await fulfillment(of: [firstClearStarted], timeout: 1)
+
+        vm.scanAgain()
+        await clearTask.value
+
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.totalSelectedSize, 0)
     }
 
     // MARK: - Reset

--- a/VaderCleanerTests/PrivacyViewModelTests.swift
+++ b/VaderCleanerTests/PrivacyViewModelTests.swift
@@ -214,6 +214,31 @@ final class PrivacyViewModelTests: XCTestCase {
         }
     }
 
+    /// Path resolution can touch disk for Firefox profile discovery, so the
+    /// VM must cache paths during preview and avoid calling the resolver from
+    /// hot UI getters after the preview state has landed.
+    func test_preview_cachesPathsForActionabilityAndTotals() async {
+        var resolverCalls = 0
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, _ in 10 },
+            pathsFor: { browser, category in
+                resolverCalls += 1
+                return [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+
+        await vm.preview()
+        let callsAfterPreview = resolverCalls
+
+        XCTAssertTrue(vm.isCategoryActionable(browser: .safari, category: .history))
+        XCTAssertEqual(vm.totalSelectedSize, 50)
+        vm.toggle(browser: .safari, category: .history)
+        XCTAssertEqual(vm.totalSelectedSize, 40)
+        XCTAssertEqual(vm.sizeOnDisk(for: .safari), 50)
+        XCTAssertEqual(resolverCalls, callsAfterPreview)
+    }
+
     // MARK: - Selection
 
     /// Toggling a `(browser, category)` selection must update both the


### PR DESCRIPTION
## Summary
- Moved browser-data sizing and clearing into a private worker actor so recursive filesystem work no longer runs on the main actor.
- Updated `PrivacyViewModel` to use async sizing/clearing, cancel stale preview/clear operations, and ignore late results from superseded tasks.
- Added coverage for cancellation, restart behavior, and large directory walks in the Privacy tests.
- Closes https://github.com/jayvicsanantonio/VaderCleaner/issues/42

## Testing
- `xcodebuild test -project VaderCleaner.xcodeproj -scheme VaderCleaner -only-testing:VaderCleanerTests` passed.
- Focused unit tests for `PrivacyViewModel` and `BrowserDataClearer` passed.
- Full scheme UI tests were also exercised; one existing `SystemJunkUITests` flow failed outside the Privacy changes.