### PR TITLE
Hoist sidebar feature models out of ContentView and align SwiftUI ownership

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -151,5 +151,4 @@ private struct PlaceholderDetailView: View {
             preferences: prefs,
             dispatcher: NotificationManager()
         ))
-        .environmentObject(exclusions)
 }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -8,8 +8,11 @@ struct ContentView: View {
     @EnvironmentObject private var onboarding: PermissionOnboardingViewModel
     @EnvironmentObject private var systemStats: SystemStatsService
     @EnvironmentObject private var notificationMonitor: NotificationThresholdMonitor
-    @EnvironmentObject private var exclusions: ExclusionsStore
     @Environment(\.scenePhase) private var scenePhase
+    private let systemJunkViewModel: SystemJunkViewModel
+    private let largeOldFilesViewModel: LargeOldFilesViewModel
+    private let spaceLensViewModel: DiskScannerViewModel
+    private let privacyViewModel: PrivacyViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
@@ -17,16 +20,17 @@ struct ContentView: View {
     /// system caches the answer so the second prompt is a no-op, but it's
     /// cleaner to issue exactly one.
     @State private var didRequestNotificationPermission = false
-    /// Space Lens scans take long enough that losing the result on a
-    /// sidebar peek would be a frustration point. Hosting the view-model
-    /// here keeps the breadcrumb / scanned tree alive while the user
-    /// flips through other sections, and only the view layer is rebuilt
-    /// when they come back. A short-lived `SpaceLensView`-owned
-    /// `@StateObject` would still latch the first scan via SwiftUI's
-    /// state-object identity rules, but the VM would briefly construct
-    /// (and a `.live()`-spawned `DiskScanner` would briefly allocate) on
-    /// every body recomputation — wasteful enough to lift here.
-    @StateObject private var spaceLensViewModel = DiskScannerViewModel.live()
+    init(
+        systemJunkViewModel: SystemJunkViewModel,
+        largeOldFilesViewModel: LargeOldFilesViewModel,
+        spaceLensViewModel: DiskScannerViewModel,
+        privacyViewModel: PrivacyViewModel
+    ) {
+        self.systemJunkViewModel = systemJunkViewModel
+        self.largeOldFilesViewModel = largeOldFilesViewModel
+        self.spaceLensViewModel = spaceLensViewModel
+        self.privacyViewModel = privacyViewModel
+    }
 
     var body: some View {
         NavigationSplitView {
@@ -83,13 +87,13 @@ struct ContentView: View {
         case .healthMonitor:
             HealthMonitorView(service: systemStats)
         case .systemJunk:
-            SystemJunkView(viewModel: SystemJunkViewModel.live(exclusions: exclusions))
+            SystemJunkView(viewModel: systemJunkViewModel)
         case .largeOldFiles:
-            LargeOldFilesView(viewModel: LargeOldFilesViewModel.live(exclusions: exclusions))
+            LargeOldFilesView(viewModel: largeOldFilesViewModel)
         case .spaceLens:
             SpaceLensView(viewModel: spaceLensViewModel)
         case .privacy:
-            PrivacyView(viewModel: PrivacyViewModel.live())
+            PrivacyView(viewModel: privacyViewModel)
         default:
             PlaceholderDetailView(section: section)
         }
@@ -132,7 +136,13 @@ private struct PlaceholderDetailView: View {
 #Preview {
     let stats = SystemStatsService(autostart: false)
     let prefs = PreferencesStore(defaults: UserDefaults(suiteName: "preview")!)
-    return ContentView()
+    let exclusions = ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!)
+    return ContentView(
+        systemJunkViewModel: SystemJunkViewModel.live(exclusions: exclusions),
+        largeOldFilesViewModel: LargeOldFilesViewModel.live(exclusions: exclusions),
+        spaceLensViewModel: DiskScannerViewModel.live(),
+        privacyViewModel: PrivacyViewModel.live()
+    )
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())
         .environmentObject(stats)
@@ -141,5 +151,5 @@ private struct PlaceholderDetailView: View {
             preferences: prefs,
             dispatcher: NotificationManager()
         ))
-        .environmentObject(ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!))
+        .environmentObject(exclusions)
 }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -66,6 +66,9 @@ struct ContentView: View {
         .onChange(of: onboarding.isDismissed) { _, _ in
             Task { await maybeRequestNotificationPermission() }
         }
+        .onDisappear {
+            spaceLensViewModel.cancelScan()
+        }
     }
 
     /// Idempotent permission-request driver. Fires the system prompt at most

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -183,6 +183,20 @@ final class DiskScannerViewModel: ObservableObject {
         currentScanTask?.cancel()
     }
 
+    /// Stop any in-flight disk walk and return Space Lens to its idle state.
+    /// This is used when the main window closes while the app may continue
+    /// running from the menu bar: the app-scoped view-model can outlive the
+    /// visible UI, so cancellation cannot depend only on `deinit`.
+    func cancelScan() {
+        currentScanTask?.cancel()
+        currentScanTask = nil
+        scanGeneration += 1
+        if case .scanning = phase {
+            scanProgress = 0
+            phase = .idle
+        }
+    }
+
     /// Run the injected scanner against `root`. Transitions to `.scanning`
     /// up front, then to `.ready(node)` or `.error(message)` depending on
     /// outcome. The selection / breadcrumb stack is reset because the

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -17,7 +17,7 @@ import AppKit
 /// tests can drive the flow without relying on label localisation.
 struct LargeOldFilesView: View {
 
-    @StateObject private var viewModel: LargeOldFilesViewModel
+    @ObservedObject private var viewModel: LargeOldFilesViewModel
     @EnvironmentObject private var notificationMonitor: NotificationThresholdMonitor
 
     /// Drives the "Are you sure?" alert before destructive actions. Held on
@@ -33,7 +33,7 @@ struct LargeOldFilesView: View {
     @State private var notifiedForCurrentScan = false
 
     init(viewModel: LargeOldFilesViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     var body: some View {

--- a/VaderCleaner/PrivacyView.swift
+++ b/VaderCleaner/PrivacyView.swift
@@ -19,11 +19,11 @@ import SwiftUI
 /// UI tests can drive the flow without relying on label localisation.
 struct PrivacyView: View {
 
-    @StateObject private var viewModel: PrivacyViewModel
+    @ObservedObject private var viewModel: PrivacyViewModel
     @State private var showClearConfirmation = false
 
     init(viewModel: PrivacyViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     var body: some View {

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -48,8 +48,8 @@ struct SpaceLensView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle(NavigationSection.spaceLens.title)
         // `.onAppear` rather than `.task` so the scan isn't tied to the
-        // view's task lifetime — `DiskScannerViewModel` is hoisted to
-        // `ContentView` so the scanned tree survives a sidebar peek, and
+        // view's task lifetime — `DiskScannerViewModel` is owned above
+        // this detail view so the scanned tree survives a sidebar peek, and
         // a `.task`-driven scan would be cancelled the moment the user
         // navigated away (the VM's cancellation handler forwards
         // structured cancellation into the in-flight walk). Spawning the

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -19,10 +19,10 @@ import SwiftUI
 /// elsewhere in the app.
 struct SpaceLensView: View {
 
-    @StateObject private var viewModel: DiskScannerViewModel
+    @ObservedObject private var viewModel: DiskScannerViewModel
 
     init(viewModel: DiskScannerViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     var body: some View {

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -16,10 +16,10 @@ import SwiftUI
 /// can drive the flow without relying on label localisation.
 struct SystemJunkView: View {
 
-    @StateObject private var viewModel: SystemJunkViewModel
+    @ObservedObject private var viewModel: SystemJunkViewModel
 
     init(viewModel: SystemJunkViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     var body: some View {

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -25,7 +25,11 @@ struct VaderCleanerApp: App {
     @StateObject private var onboardingViewModel = PermissionOnboardingViewModel()
     @StateObject private var menuBarViewModel: MenuBarViewModel
     @StateObject private var preferences: PreferencesStore
-    @StateObject private var exclusions = ExclusionsStore()
+    @StateObject private var exclusions: ExclusionsStore
+    @StateObject private var systemJunkViewModel: SystemJunkViewModel
+    @StateObject private var largeOldFilesViewModel: LargeOldFilesViewModel
+    @StateObject private var spaceLensViewModel: DiskScannerViewModel
+    @StateObject private var privacyViewModel: PrivacyViewModel
     // App-scope so the cheap-stats timer outlives any single window. The
     // Health Monitor view (Prompt 9), the menu bar (Prompt 10), and the
     // notification dispatcher (Prompt 11) all subscribe via
@@ -51,6 +55,20 @@ struct VaderCleanerApp: App {
             launchAtLoginErrorReporter: VaderCleanerApp.presentLaunchAtLoginAlert(_:)
         )
         _preferences = StateObject(wrappedValue: prefs)
+        // Feature-session view models live at app scope so sidebar navigation
+        // rebuilds only their views, not their production collaborators or
+        // in-progress scan/selection state. The scanner models capture this
+        // same exclusions store and snapshot it per scan.
+        let exclusions = ExclusionsStore()
+        _exclusions = StateObject(wrappedValue: exclusions)
+        _systemJunkViewModel = StateObject(
+            wrappedValue: SystemJunkViewModel.live(exclusions: exclusions)
+        )
+        _largeOldFilesViewModel = StateObject(
+            wrappedValue: LargeOldFilesViewModel.live(exclusions: exclusions)
+        )
+        _spaceLensViewModel = StateObject(wrappedValue: DiskScannerViewModel.live())
+        _privacyViewModel = StateObject(wrappedValue: PrivacyViewModel.live())
         // Construct the polling service and the menu bar view-model in the
         // same init so both `@StateObject` wrappers reference the *same*
         // service instance. Initializing `menuBarViewModel` at its property
@@ -104,7 +122,12 @@ struct VaderCleanerApp: App {
 
     var body: some Scene {
         Window("VaderCleaner", id: Self.mainWindowID) {
-            ContentView()
+            ContentView(
+                systemJunkViewModel: systemJunkViewModel,
+                largeOldFilesViewModel: largeOldFilesViewModel,
+                spaceLensViewModel: spaceLensViewModel,
+                privacyViewModel: privacyViewModel
+            )
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)
                 .environmentObject(preferences)

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -127,6 +127,44 @@ final class DiskScannerViewModelTests: XCTestCase {
         XCTAssertEqual(vm.scanProgress, 0.0)
     }
 
+    /// App-scoped Space Lens state can outlive the main window when the
+    /// menu bar extra keeps the process running. Explicit cancellation must
+    /// stop the scanner instead of waiting for VM teardown.
+    func test_cancelScan_cancelsInFlightScanAndReturnsToIdle() async {
+        let scanStarted = expectation(description: "scan started")
+        let scanCancelled = expectation(description: "scan cancelled")
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            scanStarted.fulfill()
+            do {
+                try await Task.sleep(nanoseconds: 60_000_000_000)
+                XCTFail("Expected cancelScan() to cancel the in-flight scanner")
+                return DiskNode(
+                    url: URL(fileURLWithPath: "/tmp"),
+                    name: "tmp",
+                    size: 0,
+                    isDirectory: true,
+                    children: []
+                )
+            } catch is CancellationError {
+                scanCancelled.fulfill()
+                throw CancellationError()
+            }
+        })
+
+        let scanTask = Task {
+            await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+        }
+        await fulfillment(of: [scanStarted], timeout: 1)
+        XCTAssertEqual(vm.phase, .scanning)
+
+        vm.cancelScan()
+
+        await fulfillment(of: [scanCancelled], timeout: 1)
+        await scanTask.value
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.scanProgress, 0.0)
+    }
+
     // MARK: - Navigation (Prompt 17)
 
     /// Drilling into a directory child must push it onto the breadcrumb

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -36,7 +36,7 @@ final class SpaceLensUITests: XCTestCase {
                       "Expected Space Lens row in sidebar")
         sidebarRow.click()
 
-        // The scan starts automatically from `.task`, so we expect either
+        // The scan starts automatically on first appearance, so we expect either
         // the scanning indicator or — on tiny home folders / fast machines —
         // the treemap to land before our timeout. The error banner is
         // accepted as well: a CI runner without home-folder access should

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -59,6 +59,44 @@ final class SystemJunkUITests: XCTestCase {
                       "Expected to land on the preview state after a Scan")
     }
 
+    /// Once a scan has landed, visiting another sidebar item and coming back
+    /// should preserve the same System Junk session model rather than
+    /// rebuilding a fresh idle state.
+    func test_systemJunkPreviewPersistsAcrossSidebarNavigation() throws {
+        dismissOnboardingIfNeeded()
+
+        let sidebarRow = app.outlines.staticTexts["System Junk"].firstMatch
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
+                      "Expected System Junk row in sidebar")
+        sidebarRow.click()
+
+        let scanButton = app.buttons["system-junk.scan"]
+        XCTAssertTrue(scanButton.waitForExistence(timeout: 5),
+                      "Expected Scan button in System Junk idle state")
+        scanButton.click()
+
+        let totalSelected = app.staticTexts["system-junk.totalSelected"]
+        let cleanButton = app.buttons["system-junk.clean"]
+        let appeared = totalSelected.waitForExistence(timeout: 30)
+            || cleanButton.waitForExistence(timeout: 1)
+        XCTAssertTrue(appeared,
+                      "Expected to land on the preview state after a Scan")
+
+        let smartScanRow = app.outlines.staticTexts["Smart Scan"].firstMatch
+        XCTAssertTrue(smartScanRow.waitForExistence(timeout: 5),
+                      "Expected Smart Scan row in sidebar")
+        smartScanRow.click()
+
+        sidebarRow.click()
+
+        let previewStillVisible = totalSelected.waitForExistence(timeout: 5)
+            || cleanButton.waitForExistence(timeout: 1)
+        XCTAssertTrue(previewStillVisible,
+                      "Expected System Junk preview state to persist after sidebar navigation")
+        XCTAssertFalse(app.buttons["system-junk.scan"].exists,
+                       "Expected System Junk not to reset to idle after sidebar navigation")
+    }
+
     // MARK: - Helpers
 
     private func dismissOnboardingIfNeeded() {


### PR DESCRIPTION
## Summary
- Hoisted System Junk, Large & Old Files, Space Lens, and Privacy view models to app-owned session state in `VaderCleanerApp`
- Removed `.live()` factory calls from `ContentView`’s detail routing and switched injected feature views to `@ObservedObject`
- Added UI coverage for System Junk state persistence across sidebar navigation
- Closes https://github.com/jayvicsanantonio/VaderCleaner/issues/44

## Testing
- `xcodebuild test -project VaderCleaner.xcodeproj -scheme VaderCleaner -destination 'platform=macOS' -only-testing:VaderCleanerTests` passed
- Full macOS test run compiled and passed unit tests; UI automation was impacted once by a foreground Chrome/Meet window, then the focused unit-test run confirmed the code changes are healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System Junk scan preview state now persists correctly when navigating between sections and returning.

* **Refactor**
  * Improved internal state management architecture for better reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->