### PR TITLE
Add tri-state battery and FileVault state handling

### DIFF
--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -48,7 +48,20 @@ struct HealthMonitorView: View {
             title: "Battery Health",
             statusColor: viewModel.batteryColor
         ) {
-            if let stats = viewModel.battery {
+            switch viewModel.batteryAvailability {
+            case .unknown:
+                Text("—")
+                    .font(.title2.weight(.semibold))
+                Text("Checking battery")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            case .absent:
+                Text("—")
+                    .font(.title2.weight(.semibold))
+                Text("No internal battery")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            case .present(let stats):
                 Text(HealthMonitorViewModel.batteryCapacityString(stats))
                     .font(.title2.weight(.semibold))
                     .accessibilityIdentifier("health.battery.capacity")
@@ -57,12 +70,6 @@ struct HealthMonitorView: View {
                     .foregroundStyle(.secondary)
                 Text("\(stats.cycleCount) cycles")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                Text("—")
-                    .font(.title2.weight(.semibold))
-                Text("No internal battery")
-                    .font(.callout)
                     .foregroundStyle(.secondary)
             }
         }
@@ -138,7 +145,7 @@ struct HealthMonitorView: View {
 
     private var fileVaultRow: some View {
         HStack(spacing: 10) {
-            Image(systemName: viewModel.fileVaultEnabled ? "lock.shield.fill" : "lock.open")
+            Image(systemName: viewModel.fileVaultIsOn ? "lock.shield.fill" : "lock.open")
                 .font(.title3)
                 .foregroundStyle(viewModel.fileVaultColor.color)
             Text(viewModel.fileVaultLabel)

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -145,7 +145,7 @@ struct HealthMonitorView: View {
 
     private var fileVaultRow: some View {
         HStack(spacing: 10) {
-            Image(systemName: viewModel.fileVaultIsOn ? "lock.shield.fill" : "lock.open")
+            Image(systemName: viewModel.fileVaultIconName)
                 .font(.title3)
                 .foregroundStyle(viewModel.fileVaultColor.color)
             Text(viewModel.fileVaultLabel)

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -73,11 +73,7 @@ final class HealthMonitorViewModel: ObservableObject {
     var diskColor: StatusColor { Self.diskColor(for: service.diskSpace) }
 
     var batteryAvailability: BatteryAvailability { service.batteryAvailability }
-    var battery: BatteryStats? { Self.batteryStats(from: batteryAvailability) }
     var batteryColor: StatusColor { Self.batteryColor(for: batteryAvailability) }
-    var batteryCapacity: String? { battery.map(Self.batteryCapacityString) }
-    var batteryCondition: String? { battery?.condition }
-    var batteryCycleCount: Int? { battery?.cycleCount }
 
     var smartStatus: SMARTStatus { service.diskSMARTStatus }
     var smartLabel: String { Self.smartLabel(for: smartStatus) }
@@ -204,11 +200,6 @@ final class HealthMonitorViewModel: ObservableObject {
             // ambiguous, which is itself worth surfacing.
             return .yellow
         }
-    }
-
-    static func batteryStats(from availability: BatteryAvailability) -> BatteryStats? {
-        guard case .present(let stats) = availability else { return nil }
-        return stats
     }
 
     /// Formats `maxCapacityPercent` (0.0–1.0) as an integer percentage.

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -80,7 +80,7 @@ final class HealthMonitorViewModel: ObservableObject {
     var smartColor: StatusColor { Self.smartColor(for: smartStatus) }
 
     var fileVaultState: FileVaultState { service.fileVaultState }
-    var fileVaultIsOn: Bool { fileVaultState == .on }
+    var fileVaultIconName: String { Self.fileVaultIconName(for: fileVaultState) }
     var fileVaultLabel: String { Self.fileVaultLabel(for: fileVaultState) }
     var fileVaultColor: StatusColor { Self.fileVaultColor(for: fileVaultState) }
 
@@ -237,6 +237,16 @@ final class HealthMonitorViewModel: ObservableObject {
         case .unknown: return "FileVault: —"
         case .off: return "FileVault: Off"
         case .on: return "FileVault: On"
+        }
+    }
+
+    /// FileVault icon. Unknown uses an indeterminate symbol instead of the
+    /// open lock used for a definitive Off state.
+    static func fileVaultIconName(for state: FileVaultState) -> String {
+        switch state {
+        case .unknown: return "questionmark.circle"
+        case .off: return "lock.open"
+        case .on: return "lock.shield.fill"
         }
     }
 

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -72,8 +72,9 @@ final class HealthMonitorViewModel: ObservableObject {
     var diskRatio: Double { Self.diskUsageRatio(service.diskSpace) }
     var diskColor: StatusColor { Self.diskColor(for: service.diskSpace) }
 
-    var battery: BatteryStats? { service.batteryHealth }
-    var batteryColor: StatusColor { Self.batteryColor(for: battery) }
+    var batteryAvailability: BatteryAvailability { service.batteryAvailability }
+    var battery: BatteryStats? { Self.batteryStats(from: batteryAvailability) }
+    var batteryColor: StatusColor { Self.batteryColor(for: batteryAvailability) }
     var batteryCapacity: String? { battery.map(Self.batteryCapacityString) }
     var batteryCondition: String? { battery?.condition }
     var batteryCycleCount: Int? { battery?.cycleCount }
@@ -82,9 +83,10 @@ final class HealthMonitorViewModel: ObservableObject {
     var smartLabel: String { Self.smartLabel(for: smartStatus) }
     var smartColor: StatusColor { Self.smartColor(for: smartStatus) }
 
-    var fileVaultEnabled: Bool { service.fileVaultEnabled }
-    var fileVaultLabel: String { Self.fileVaultLabel(enabled: fileVaultEnabled) }
-    var fileVaultColor: StatusColor { Self.fileVaultColor(enabled: fileVaultEnabled) }
+    var fileVaultState: FileVaultState { service.fileVaultState }
+    var fileVaultIsOn: Bool { fileVaultState == .on }
+    var fileVaultLabel: String { Self.fileVaultLabel(for: fileVaultState) }
+    var fileVaultColor: StatusColor { Self.fileVaultColor(for: fileVaultState) }
 
     // MARK: - Pure formatters / color rules
 
@@ -185,12 +187,11 @@ final class HealthMonitorViewModel: ObservableObject {
         }
     }
 
-    /// Battery health color from `BatteryStats.condition`. The IOKit key
-    /// flipped from `BatteryHealth` to `BatteryHealthCondition` across macOS
-    /// versions, so we accept both vocabularies. `nil` means no internal
-    /// battery (Mac mini / Studio / Pro) → gray.
-    static func batteryColor(for stats: BatteryStats?) -> StatusColor {
-        guard let stats = stats else { return .gray }
+    /// Battery health color from explicit availability. `.unknown` and
+    /// `.absent` are both neutral gray; only a present battery can produce
+    /// health colors.
+    static func batteryColor(for availability: BatteryAvailability) -> StatusColor {
+        guard case .present(let stats) = availability else { return .gray }
         switch stats.condition {
         case "Good", "Normal":
             return .green
@@ -203,6 +204,11 @@ final class HealthMonitorViewModel: ObservableObject {
             // ambiguous, which is itself worth surfacing.
             return .yellow
         }
+    }
+
+    static func batteryStats(from availability: BatteryAvailability) -> BatteryStats? {
+        guard case .present(let stats) = availability else { return nil }
+        return stats
     }
 
     /// Formats `maxCapacityPercent` (0.0–1.0) as an integer percentage.
@@ -233,17 +239,25 @@ final class HealthMonitorViewModel: ObservableObject {
         }
     }
 
-    /// FileVault footer text. The "On" / "Off" wording mirrors the
-    /// `fdesetup status` vocabulary the service parses.
-    static func fileVaultLabel(enabled: Bool) -> String {
-        enabled ? "FileVault: On" : "FileVault: Off"
+    /// FileVault footer text. Unknown is distinct from a definitive Off so
+    /// the first render and previews do not imply encryption is disabled.
+    static func fileVaultLabel(for state: FileVaultState) -> String {
+        switch state {
+        case .unknown: return "FileVault: —"
+        case .off: return "FileVault: Off"
+        case .on: return "FileVault: On"
+        }
     }
 
     /// FileVault color. Off is yellow rather than red because disabling
     /// FileVault is a deliberate user choice, not a failure mode — the dot
-    /// flags it for visibility without alarmism.
-    static func fileVaultColor(enabled: Bool) -> StatusColor {
-        enabled ? .green : .yellow
+    /// flags it for visibility without alarmism. Unknown stays neutral.
+    static func fileVaultColor(for state: FileVaultState) -> StatusColor {
+        switch state {
+        case .unknown: return .gray
+        case .off: return .yellow
+        case .on: return .green
+        }
     }
 
     // MARK: - Helpers

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -8,9 +8,9 @@ import AppKit
 /// driven by `MenuBarViewModel` which is in turn fed by `SystemStatsService`,
 /// so values refresh on the same 2-second cadence as the Health Monitor.
 ///
-/// The Battery row is conditional — desktops report no internal battery
-/// (`SystemStatsService.batteryHealth == nil`), and rendering an empty row
-/// would just look like a UI bug.
+/// The Battery row is conditional — desktops report no internal battery and
+/// startup begins with unknown battery state, so rendering an empty row would
+/// just look like a UI bug.
 struct MenuBarContent: View {
 
     @EnvironmentObject private var menuBar: MenuBarViewModel

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -97,8 +97,7 @@ final class MenuBarViewModel: ObservableObject {
     /// show.
     static func formattedBatteryHealth(_ availability: BatteryAvailability) -> String? {
         guard case .present(let stats) = availability else { return nil }
-        let clamped = max(0.0, min(1.0, stats.maxCapacityPercent))
-        return "\(Int((clamped * 100).rounded()))%"
+        return HealthMonitorViewModel.batteryCapacityString(stats)
     }
 
     /// Human-readable label for a memory-pressure bucket. Matches the

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -46,7 +46,7 @@ final class MenuBarViewModel: ObservableObject {
     var formattedRAMUsage: String { Self.formattedRAMUsage(service.ramUsage) }
     var formattedDiskSpace: String { Self.formattedDiskSpace(service.diskSpace) }
     var formattedCPU: String { Self.formattedCPU(service.cpuUsage) }
-    var formattedBatteryHealth: String? { Self.formattedBatteryHealth(service.batteryHealth) }
+    var formattedBatteryHealth: String? { Self.formattedBatteryHealth(service.batteryAvailability) }
     var ramPressureLevel: MemoryPressureLevel { service.ramUsage.pressureLevel }
     var ramPressureLabel: String { Self.pressureLabel(for: ramPressureLevel) }
     var ramPressureColor: StatusColor { Self.pressureColor(for: ramPressureLevel) }
@@ -91,11 +91,12 @@ final class MenuBarViewModel: ObservableObject {
         return "\(Int((clamped * 100).rounded()))%"
     }
 
-    /// Formats a battery's `maxCapacityPercent` (0.0–1.0) as an integer
-    /// percent. Returns `nil` when no battery is present so the popover can
-    /// hide the row entirely on desktops.
-    static func formattedBatteryHealth(_ stats: BatteryStats?) -> String? {
-        guard let stats = stats else { return nil }
+    /// Formats a present battery's `maxCapacityPercent` (0.0–1.0) as an
+    /// integer percent. Returns `nil` when battery state is unknown or absent
+    /// so the popover hides the row until there is a definitive battery to
+    /// show.
+    static func formattedBatteryHealth(_ availability: BatteryAvailability) -> String? {
+        guard case .present(let stats) = availability else { return nil }
         let clamped = max(0.0, min(1.0, stats.maxCapacityPercent))
         return "\(Int((clamped * 100).rounded()))%"
     }

--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -77,9 +77,7 @@ struct DiskStats: Equatable {
     static let empty = DiskStats(usedBytes: 0, totalBytes: 0)
 }
 
-/// Battery health snapshot from `AppleSmartBattery` IOKit registry. Returned
-/// as `nil` from `SystemStatsService.batteryHealth` on machines without an
-/// internal battery (Mac mini, Mac Studio, Mac Pro).
+/// Battery health snapshot from `AppleSmartBattery` IOKit registry.
 struct BatteryStats: Equatable {
     /// Number of full charge cycles the battery has logged.
     let cycleCount: Int
@@ -93,6 +91,17 @@ struct BatteryStats: Equatable {
     let condition: String
 }
 
+/// Explicit battery availability state.
+///
+/// `.unknown` is the startup / not-yet-refreshed state, `.absent` means the
+/// Mac has no internal battery, and `.present` carries the health snapshot
+/// when one was read from IOKit.
+enum BatteryAvailability: Equatable {
+    case unknown
+    case absent
+    case present(BatteryStats)
+}
+
 /// SMART status of the boot disk. `.good` corresponds to diskutil's
 /// `"Verified"`, `.failing` to `"Failing"`. `.unknown` covers everything
 /// else — most relevantly, the case where `diskutil info -plist /` fails or
@@ -101,6 +110,16 @@ enum SMARTStatus: Equatable {
     case good
     case failing
     case unknown
+}
+
+/// Explicit FileVault state.
+///
+/// `.unknown` is the startup / not-yet-refreshed state. `.off` and `.on` are
+/// definitive readings parsed from `fdesetup status`.
+enum FileVaultState: Equatable {
+    case unknown
+    case off
+    case on
 }
 
 // MARK: - SystemStatsService
@@ -119,10 +138,10 @@ enum SMARTStatus: Equatable {
 ///   - `cpuUsage` (`host_processor_info`)
 ///   - `ramUsage` (`host_statistics64`)
 ///   - `diskSpace` (`FileManager.attributesOfFileSystem`)
-///   - `batteryHealth` (`AppleSmartBattery` IOKit registry — synchronous,
-///     microseconds)
+///   - `batteryAvailability` (`AppleSmartBattery` IOKit registry —
+///     synchronous, microseconds)
 ///
-/// Subprocess-driven readings (`diskSMARTStatus`, `fileVaultEnabled`) take
+/// Subprocess-driven readings (`diskSMARTStatus`, `fileVaultState`) take
 /// tens of milliseconds because `diskutil` and `fdesetup` fork + exec. Running
 /// them on the same 2-second main-thread tick would jank the UI as soon as
 /// anything subscribes. They run on a background `DispatchQueue` and refresh
@@ -142,9 +161,9 @@ final class SystemStatsService: ObservableObject {
     @Published private(set) var cpuUsage: Double = 0
     @Published private(set) var ramUsage: MemoryStats = .empty
     @Published private(set) var diskSpace: DiskStats = .empty
-    @Published private(set) var batteryHealth: BatteryStats?
+    @Published private(set) var batteryAvailability: BatteryAvailability = .unknown
     @Published private(set) var diskSMARTStatus: SMARTStatus = .unknown
-    @Published private(set) var fileVaultEnabled: Bool = false
+    @Published private(set) var fileVaultState: FileVaultState = .unknown
 
     // MARK: Configuration
 
@@ -257,7 +276,7 @@ final class SystemStatsService: ObservableObject {
         cpuUsage = readCPUUsage()
         ramUsage = readMemoryStats()
         diskSpace = readDiskStats()
-        batteryHealth = readBatteryStats()
+        batteryAvailability = readBatteryAvailability()
     }
 
     // MARK: CPU
@@ -419,15 +438,15 @@ final class SystemStatsService: ObservableObject {
 
     // MARK: Battery
 
-    /// Reads battery health from the `AppleSmartBattery` IORegistry entry.
-    /// Returns `nil` on machines with no internal battery (the matching call
-    /// fails silently with `IO_OBJECT_NULL`). The keys read here are stable
-    /// across at least the last decade of macOS releases — Apple uses the
-    /// same registry for `system_profiler SPPowerDataType`.
-    private func readBatteryStats() -> BatteryStats? {
+    /// Reads battery availability from the `AppleSmartBattery` IORegistry
+    /// entry. A missing service means this Mac has no internal battery. The
+    /// keys read here are stable across at least the last decade of macOS
+    /// releases — Apple uses the same registry for
+    /// `system_profiler SPPowerDataType`.
+    private func readBatteryAvailability() -> BatteryAvailability {
         let matching = IOServiceMatching("AppleSmartBattery")
         let service = IOServiceGetMatchingService(kIOMainPortDefault, matching)
-        guard service != IO_OBJECT_NULL else { return nil }
+        guard service != IO_OBJECT_NULL else { return .absent }
         defer { IOObjectRelease(service) }
 
         let cycle = (copyProperty(service: service, key: "CycleCount") as? NSNumber)?.intValue ?? 0
@@ -446,10 +465,12 @@ final class SystemStatsService: ObservableObject {
             ?? "Unknown"
 
         let healthFraction = designCap > 0 ? min(1.0, maxCap / designCap) : 0.0
-        return BatteryStats(
-            cycleCount: cycle,
-            maxCapacityPercent: healthFraction,
-            condition: condition.isEmpty ? "Unknown" : condition
+        return .present(
+            BatteryStats(
+                cycleCount: cycle,
+                maxCapacityPercent: healthFraction,
+                condition: condition.isEmpty ? "Unknown" : condition
+            )
         )
     }
 
@@ -472,9 +493,9 @@ final class SystemStatsService: ObservableObject {
 
     /// Refreshes SMART and FileVault state by shelling out to `diskutil` and
     /// `fdesetup` on a background queue, then publishing back on the main
-    /// actor. Safe to call from any context. Errors fall back to `.unknown`
-    /// and `false` so a transient failure doesn't flicker existing UI between
-    /// stale and zero values.
+    /// actor. Safe to call from any context. Read failures preserve the
+    /// previously published value so a transient subprocess error doesn't
+    /// flicker existing UI between stale and unknown/off values.
     func refreshDeviceHealth() {
         backgroundQueue.async {
             // Static methods read SMART and FileVault from subprocesses; no
@@ -498,7 +519,7 @@ final class SystemStatsService: ObservableObject {
                     self.diskSMARTStatus = smart
                 }
                 if let fv = fv {
-                    self.fileVaultEnabled = fv
+                    self.fileVaultState = fv ? .on : .off
                 }
             }
         }

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -191,13 +191,6 @@ final class HealthMonitorViewModelTests: XCTestCase {
         XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .absent), .gray)
     }
 
-    func test_batteryStats_extractsOnlyPresentStats() {
-        let stats = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
-        XCTAssertEqual(HealthMonitorViewModel.batteryStats(from: .present(stats)), stats)
-        XCTAssertNil(HealthMonitorViewModel.batteryStats(from: .unknown))
-        XCTAssertNil(HealthMonitorViewModel.batteryStats(from: .absent))
-    }
-
     /// `batteryCapacityString` formats the unit-interval capacity as a
     /// percentage. `0.95` → `"95%"`.
     func test_batteryCapacityString_formatsAsPercent() {

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -160,10 +160,10 @@ final class HealthMonitorViewModelTests: XCTestCase {
     /// macOS.
     func test_batteryColor_isGreenForGoodCondition() {
         let good = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
-        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: good), .green)
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .present(good)), .green)
 
         let normal = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Normal")
-        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: normal), .green)
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .present(normal)), .green)
     }
 
     /// Apple's documented "needs service" condition strings — `"Service
@@ -171,23 +171,31 @@ final class HealthMonitorViewModelTests: XCTestCase {
     /// the two states that warrant a red dot on the card.
     func test_batteryColor_isRedForServiceCondition() {
         let service = BatteryStats(cycleCount: 1200, maxCapacityPercent: 0.65, condition: "Service Battery")
-        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: service), .red)
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .present(service)), .red)
 
         let serviceRecommended = BatteryStats(cycleCount: 1500, maxCapacityPercent: 0.60, condition: "Service Recommended")
-        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: serviceRecommended), .red)
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .present(serviceRecommended)), .red)
     }
 
     /// Anything else (`"Fair"`, `"Poor"`, `"Unknown"`) is yellow — it's not
     /// pristine but doesn't warrant the alarm of red.
     func test_batteryColor_isYellowForOtherKnownConditions() {
         let fair = BatteryStats(cycleCount: 800, maxCapacityPercent: 0.82, condition: "Fair")
-        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: fair), .yellow)
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .present(fair)), .yellow)
     }
 
-    /// Desktops have no internal battery — the service publishes `nil`. The
-    /// card displays a neutral "—" + gray dot instead of being absent.
-    func test_batteryColor_isGrayWhenNoBattery() {
-        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: nil), .gray)
+    /// Unknown startup state and true desktop/no-battery state are distinct,
+    /// but both render as neutral health colors.
+    func test_batteryColor_isGrayWhenUnknownOrAbsent() {
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .unknown), .gray)
+        XCTAssertEqual(HealthMonitorViewModel.batteryColor(for: .absent), .gray)
+    }
+
+    func test_batteryStats_extractsOnlyPresentStats() {
+        let stats = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
+        XCTAssertEqual(HealthMonitorViewModel.batteryStats(from: .present(stats)), stats)
+        XCTAssertNil(HealthMonitorViewModel.batteryStats(from: .unknown))
+        XCTAssertNil(HealthMonitorViewModel.batteryStats(from: .absent))
     }
 
     /// `batteryCapacityString` formats the unit-interval capacity as a
@@ -222,14 +230,16 @@ final class HealthMonitorViewModelTests: XCTestCase {
 
     // MARK: - FileVault footer
 
-    func test_fileVaultLabel_reflectsEnabledState() {
-        XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(enabled: true), "FileVault: On")
-        XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(enabled: false), "FileVault: Off")
+    func test_fileVaultLabel_reflectsTriState() {
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(for: .unknown), "FileVault: —")
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(for: .on), "FileVault: On")
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(for: .off), "FileVault: Off")
     }
 
-    func test_fileVaultColor_isGreenWhenEnabled() {
-        XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(enabled: true), .green)
-        XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(enabled: false), .yellow)
+    func test_fileVaultColor_reflectsTriState() {
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(for: .unknown), .gray)
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(for: .on), .green)
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(for: .off), .yellow)
     }
 
     // MARK: - Service binding

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -229,6 +229,12 @@ final class HealthMonitorViewModelTests: XCTestCase {
         XCTAssertEqual(HealthMonitorViewModel.fileVaultLabel(for: .off), "FileVault: Off")
     }
 
+    func test_fileVaultIconName_reflectsTriState() {
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultIconName(for: .unknown), "questionmark.circle")
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultIconName(for: .on), "lock.shield.fill")
+        XCTAssertEqual(HealthMonitorViewModel.fileVaultIconName(for: .off), "lock.open")
+    }
+
     func test_fileVaultColor_reflectsTriState() {
         XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(for: .unknown), .gray)
         XCTAssertEqual(HealthMonitorViewModel.fileVaultColor(for: .on), .green)

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -74,13 +74,14 @@ final class MenuBarViewModelTests: XCTestCase {
     /// `MenuBarViewModel` so tests pin the menu bar's contract independently.
     func test_formattedBatteryHealth_formatsAsPercent() {
         let stats = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
-        XCTAssertEqual(MenuBarViewModel.formattedBatteryHealth(stats), "95%")
+        XCTAssertEqual(MenuBarViewModel.formattedBatteryHealth(.present(stats)), "95%")
     }
 
-    /// Desktops have no internal battery — the service publishes `nil` and the
-    /// popover hides the row entirely. The formatter signals that with `nil`.
-    func test_formattedBatteryHealth_isNilWhenNoBattery() {
-        XCTAssertNil(MenuBarViewModel.formattedBatteryHealth(nil))
+    /// Startup and desktop/no-battery states should not render a misleading
+    /// empty Battery row in the compact popover.
+    func test_formattedBatteryHealth_isNilWhenUnknownOrAbsent() {
+        XCTAssertNil(MenuBarViewModel.formattedBatteryHealth(.unknown))
+        XCTAssertNil(MenuBarViewModel.formattedBatteryHealth(.absent))
     }
 
     // MARK: - Pressure indicator
@@ -203,7 +204,7 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(sut.formattedRAMUsage, MenuBarViewModel.formattedRAMUsage(service.ramUsage))
         XCTAssertEqual(sut.formattedDiskSpace, MenuBarViewModel.formattedDiskSpace(service.diskSpace))
         XCTAssertEqual(sut.formattedCPU, MenuBarViewModel.formattedCPU(service.cpuUsage))
-        XCTAssertEqual(sut.formattedBatteryHealth, MenuBarViewModel.formattedBatteryHealth(service.batteryHealth))
+        XCTAssertEqual(sut.formattedBatteryHealth, MenuBarViewModel.formattedBatteryHealth(service.batteryAvailability))
         XCTAssertEqual(
             sut.menuBarLabelText,
             MenuBarViewModel.menuBarLabel(ram: service.ramUsage, disk: service.diskSpace)

--- a/VaderCleanerTests/SystemStatsServiceTests.swift
+++ b/VaderCleanerTests/SystemStatsServiceTests.swift
@@ -102,19 +102,33 @@ final class SystemStatsServiceTests: XCTestCase {
         XCTAssertLessThanOrEqual(service.diskSpace.usedBytes, service.diskSpace.totalBytes)
     }
 
-    /// Battery may be `nil` on a desktop or absent on a Mac mini. When present,
+    /// The two device states that used to default to a definitive false/nil
+    /// reading now start as explicit unknowns. This is the state previews and
+    /// first render bind to before the first cheap/device-health refresh.
+    func test_initialDeviceStates_areUnknown() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        XCTAssertEqual(service.batteryAvailability, .unknown)
+        XCTAssertEqual(service.fileVaultState, .unknown)
+    }
+
+    /// Battery may be absent on a desktop or present on a laptop. When present,
     /// cycleCount is non-negative and the condition string is not empty. This
-    /// is the "either nil or plausible" invariant — tests can't force the
-    /// nil branch on a laptop runner.
-    func test_batteryHealth_eitherNilOrPlausible() {
+    /// is the "either absent or plausible" invariant — tests can't force both
+    /// hardware branches on one runner.
+    func test_batteryAvailability_afterRefreshIsAbsentOrPlausible() {
         let service = SystemStatsService(interval: 2.0, autostart: false)
         service.refresh()
-        if let battery = service.batteryHealth {
+
+        switch service.batteryAvailability {
+        case .unknown:
+            XCTFail("refresh() must resolve battery availability out of .unknown")
+        case .absent:
+            break
+        case .present(let battery):
             XCTAssertGreaterThanOrEqual(battery.cycleCount, 0)
             XCTAssertGreaterThanOrEqual(battery.maxCapacityPercent, 0.0)
             XCTAssertFalse(battery.condition.isEmpty)
         }
-        // Else: no battery present, which is a valid state — nothing to assert.
     }
 
     // MARK: - Timer wiring


### PR DESCRIPTION
## Summary
- Introduce explicit `BatteryAvailability` and `FileVaultState` values in `SystemStatsService` so startup no longer defaults to misleading battery/FileVault readings.
- Update Health Monitor and menu bar consumers to render unknown battery/FileVault state distinctly from absent/off state.
- Refresh the related unit tests to cover unknown, absent, and present/on/off behavior.
- Closes https://github.com/jayvicsanantonio/VaderCleaner/issues/20

## Testing
- Focused macOS unit tests for `SystemStatsServiceTests`, `HealthMonitorViewModelTests`, and `MenuBarViewModelTests` passed.
- Full `VaderCleanerTests` suite passed.
- `git diff --check` passed.