### PR TITLE
Extract shared system stat formatters for Health Monitor and menu bar

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */; };
 		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
+		0AACE024B8504EE78B14CC01 /* SystemStatsFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AACE023B8504EE78B14CC01 /* SystemStatsFormatters.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
@@ -169,6 +170,7 @@
 		072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionChecker.swift; sourceTree = "<group>"; };
 		0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManagerTests.swift; sourceTree = "<group>"; };
 		0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyCategory.swift; sourceTree = "<group>"; };
+		0AACE023B8504EE78B14CC01 /* SystemStatsFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsFormatters.swift; sourceTree = "<group>"; };
 		0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitor.swift; sourceTree = "<group>"; };
 		0D4E92A146A223EA836C156D /* ScanResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResultTests.swift; sourceTree = "<group>"; };
 		0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensUITests.swift; sourceTree = "<group>"; };
@@ -362,6 +364,7 @@
 				A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */,
 				ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */,
 				D1CC391B523110720320AD89 /* SystemPathProviding.swift */,
+				0AACE023B8504EE78B14CC01 /* SystemStatsFormatters.swift */,
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
 				4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */,
 				50BDB24525760C96625DD266 /* TreemapView.swift */,
@@ -709,6 +712,7 @@
 				B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */,
 				83FF16A5DCFB4B225F33236E /* SystemJunkViewModel.swift in Sources */,
 				BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */,
+				0AACE024B8504EE78B14CC01 /* SystemStatsFormatters.swift in Sources */,
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
 				1947460A68C713844C308694 /* TreemapLayout.swift in Sources */,
 				35F306676A3412253929EF55 /* TreemapView.swift in Sources */,

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -4,19 +4,6 @@
 import Foundation
 import Combine
 
-/// Traffic-light state the Health Monitor cards bind to.
-///
-/// We deliberately don't use `SwiftUI.Color` here so the view-model — and its
-/// tests — stay free of SwiftUI imports. The view layer maps `StatusColor` →
-/// `Color` once at the leaf. The same enum will back the menu bar (Prompt 10)
-/// and notification dispatcher (Prompt 11) palette.
-enum StatusColor: Equatable {
-    case green
-    case yellow
-    case red
-    case gray
-}
-
 /// Drives the Health Monitor feature view.
 ///
 /// The view-model is intentionally thin: it holds a reference to
@@ -93,30 +80,25 @@ final class HealthMonitorViewModel: ObservableObject {
     /// clamp first, but the formatter is the last line of defence and is
     /// reused by the menu bar (Prompt 10) and Smart Scan (Prompt 25).
     static func cpuPercentString(_ usage: Double) -> String {
-        let clamped = cpuRatio(usage)
-        return "\(Int((clamped * 100).rounded()))%"
+        SystemStatsFormatters.cpuPercentString(usage)
     }
 
     /// Returns `usage` clamped to `[0, 1]`. Drives the CPU progress bar.
     static func cpuRatio(_ usage: Double) -> Double {
-        max(0.0, min(1.0, usage))
+        SystemStatsFormatters.unitRatio(usage)
     }
 
     /// Formats RAM byte counts as `"used / total"` in GB. We force the GB unit
     /// (rather than letting `ByteCountFormatter` pick) so 8 GB never renders
     /// as "8,000 MB" on a non-en locale and so the card width stays stable.
     static func ramUsageString(_ stats: MemoryStats) -> String {
-        let used = byteString(stats.usedBytes)
-        let total = byteString(stats.totalBytes)
-        return "\(used) / \(total)"
+        SystemStatsFormatters.memoryUsageString(stats)
     }
 
     /// Formats disk byte counts identically to RAM — see `ramUsageString` for
     /// rationale on locking the unit.
     static func diskSpaceString(_ stats: DiskStats) -> String {
-        let used = byteString(stats.usedBytes)
-        let total = byteString(stats.totalBytes)
-        return "\(used) / \(total)"
+        SystemStatsFormatters.diskUsageString(stats)
     }
 
     /// `usedBytes / totalBytes` clamped to `[0, 1]`. Returns `0` for zero-byte
@@ -169,20 +151,12 @@ final class HealthMonitorViewModel: ObservableObject {
     /// off `MemoryPressureLevel` (whose thresholds are pinned in
     /// `SystemStatsService`).
     static func pressureColor(for level: MemoryPressureLevel) -> StatusColor {
-        switch level {
-        case .nominal: return .green
-        case .fair: return .yellow
-        case .critical: return .red
-        }
+        SystemStatsFormatters.pressureColor(for: level)
     }
 
     /// Human-readable label for a memory-pressure bucket.
     static func pressureLabel(for level: MemoryPressureLevel) -> String {
-        switch level {
-        case .nominal: return "Nominal"
-        case .fair: return "Fair"
-        case .critical: return "Critical"
-        }
+        SystemStatsFormatters.pressureLabel(for: level)
     }
 
     /// Battery health color from `BatteryStats.condition`. The IOKit key
@@ -207,8 +181,7 @@ final class HealthMonitorViewModel: ObservableObject {
 
     /// Formats `maxCapacityPercent` (0.0–1.0) as an integer percentage.
     static func batteryCapacityString(_ stats: BatteryStats) -> String {
-        let clamped = max(0.0, min(1.0, stats.maxCapacityPercent))
-        return "\(Int((clamped * 100).rounded()))%"
+        SystemStatsFormatters.batteryCapacityString(stats)
     }
 
     /// SMART status color. Only `.failing` warrants red — the user needs to
@@ -246,23 +219,4 @@ final class HealthMonitorViewModel: ObservableObject {
         enabled ? .green : .yellow
     }
 
-    // MARK: - Helpers
-
-    /// Shared `ByteCountFormatter` configured for GB output. Reused so we
-    /// don't re-allocate one per card on every 2-second tick.
-    ///
-    /// `.useGB` forces the unit even for sub-1 GB inputs ("0.7 GB" rather
-    /// than "700 MB"), which keeps the card layout stable as the value
-    /// changes. `countStyle = .file` matches what Finder shows.
-    private static let byteFormatter: ByteCountFormatter = {
-        let f = ByteCountFormatter()
-        f.allowedUnits = [.useGB]
-        f.countStyle = .file
-        f.includesUnit = true
-        return f
-    }()
-
-    private static func byteString(_ bytes: UInt64) -> String {
-        byteFormatter.string(fromByteCount: Int64(min(bytes, UInt64(Int64.max))))
-    }
 }

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -74,10 +74,13 @@ final class MenuBarViewModel: ObservableObject {
     /// derived from `(total - used) / total`; rounded to integer so a noisy
     /// reading doesn't visually thrash with decimals.
     static func formattedDiskSpace(_ stats: DiskStats) -> String {
-        let used = SystemStatsFormatters.byteString(stats.usedBytes)
-        let total = SystemStatsFormatters.byteString(stats.totalBytes)
+        let usage = SystemStatsFormatters.diskUsageString(stats)
         let freePercent = freePercentInt(stats)
-        return "\(used) / \(total) · \(freePercent)% free"
+        let format = NSLocalizedString(
+            "%@ · %d%% free",
+            comment: "Format for disk usage and percent free, for example 250 GB / 500 GB · 50% free"
+        )
+        return String(format: format, usage, freePercent)
     }
 
     /// Formats a unit-interval CPU usage to an integer percentage. Inputs

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -67,17 +67,15 @@ final class MenuBarViewModel: ObservableObject {
     /// as "8,000 MB" on a non-en locale and so the popover row width stays
     /// stable across ticks.
     static func formattedRAMUsage(_ stats: MemoryStats) -> String {
-        let used = byteString(stats.usedBytes)
-        let total = byteString(stats.totalBytes)
-        return "\(used) / \(total)"
+        SystemStatsFormatters.memoryUsageString(stats)
     }
 
     /// Formats `DiskStats` to `"used / total · NN% free"`. Free percent is
     /// derived from `(total - used) / total`; rounded to integer so a noisy
     /// reading doesn't visually thrash with decimals.
     static func formattedDiskSpace(_ stats: DiskStats) -> String {
-        let used = byteString(stats.usedBytes)
-        let total = byteString(stats.totalBytes)
+        let used = SystemStatsFormatters.byteString(stats.usedBytes)
+        let total = SystemStatsFormatters.byteString(stats.totalBytes)
         let freePercent = freePercentInt(stats)
         return "\(used) / \(total) · \(freePercent)% free"
     }
@@ -87,39 +85,27 @@ final class MenuBarViewModel: ObservableObject {
     /// `HealthMonitorViewModel.cpuPercentString` so both consumers display
     /// the same value for the same reading.
     static func formattedCPU(_ usage: Double) -> String {
-        let clamped = max(0.0, min(1.0, usage))
-        return "\(Int((clamped * 100).rounded()))%"
+        SystemStatsFormatters.cpuPercentString(usage)
     }
 
     /// Formats a battery's `maxCapacityPercent` (0.0–1.0) as an integer
     /// percent. Returns `nil` when no battery is present so the popover can
     /// hide the row entirely on desktops.
     static func formattedBatteryHealth(_ stats: BatteryStats?) -> String? {
-        guard let stats = stats else { return nil }
-        let clamped = max(0.0, min(1.0, stats.maxCapacityPercent))
-        return "\(Int((clamped * 100).rounded()))%"
+        stats.map(SystemStatsFormatters.batteryCapacityString)
     }
 
     /// Human-readable label for a memory-pressure bucket. Matches the
     /// `HealthMonitorViewModel` vocabulary so the badge in the popover and
     /// the badge in the Health Monitor card always read the same way.
     static func pressureLabel(for level: MemoryPressureLevel) -> String {
-        switch level {
-        case .nominal: return "Nominal"
-        case .fair: return "Fair"
-        case .critical: return "Critical"
-        }
+        SystemStatsFormatters.pressureLabel(for: level)
     }
 
-    /// Color for a memory-pressure bucket. Reuses `StatusColor` from
-    /// `HealthMonitorViewModel` so the menu bar palette and the Health
-    /// Monitor palette can never drift apart.
+    /// Color for a memory-pressure bucket. Uses the shared system-stat
+    /// palette so the menu bar and Health Monitor can never drift apart.
     static func pressureColor(for level: MemoryPressureLevel) -> StatusColor {
-        switch level {
-        case .nominal: return .green
-        case .fair: return .yellow
-        case .critical: return .red
-        }
+        SystemStatsFormatters.pressureColor(for: level)
     }
 
     // MARK: - Compact menu bar label
@@ -145,24 +131,6 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     // MARK: - Helpers
-
-    /// Shared `ByteCountFormatter` configured for GB output. Reused so we
-    /// don't re-allocate one per render on every 2-second tick.
-    ///
-    /// `.useGB` forces the unit even for sub-1 GB inputs ("0.7 GB" rather
-    /// than "700 MB"), keeping popover row width stable as the value
-    /// changes. `countStyle = .file` matches what Finder shows.
-    private static let byteFormatter: ByteCountFormatter = {
-        let f = ByteCountFormatter()
-        f.allowedUnits = [.useGB]
-        f.countStyle = .file
-        f.includesUnit = true
-        return f
-    }()
-
-    private static func byteString(_ bytes: UInt64) -> String {
-        byteFormatter.string(fromByteCount: Int64(min(bytes, UInt64(Int64.max))))
-    }
 
     /// Renders a byte count as compact GB ("12 GB"), capping the integer
     /// component at `compactGBCap` so absurd inputs render as "9999+ GB"

--- a/VaderCleaner/SystemStatsFormatters.swift
+++ b/VaderCleaner/SystemStatsFormatters.swift
@@ -91,8 +91,18 @@ enum SystemStatsFormatters {
     }
 
     private static func percentString(_ value: Double) -> String {
-        unitRatio(value).formatted(.percent.precision(.fractionLength(0)))
+        let clamped = unitRatio(value)
+        return percentFormatter.string(from: NSNumber(value: clamped)) ?? "\(Int((clamped * 100).rounded()))%"
     }
+
+    private static let percentFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .percent
+        f.minimumFractionDigits = 0
+        f.maximumFractionDigits = 0
+        f.roundingMode = .halfUp
+        return f
+    }()
 
     /// Shared `ByteCountFormatter` configured for GB output. Reused so we
     /// don't re-allocate one per card on every telemetry tick.

--- a/VaderCleaner/SystemStatsFormatters.swift
+++ b/VaderCleaner/SystemStatsFormatters.swift
@@ -21,8 +21,7 @@ enum SystemStatsFormatters {
     /// Formats a unit-interval CPU usage to an integer percentage. Inputs
     /// outside `[0, 1]` clamp at the boundary.
     static func cpuPercentString(_ usage: Double) -> String {
-        let clamped = unitRatio(usage)
-        return "\(Int((clamped * 100).rounded()))%"
+        percentString(usage)
     }
 
     /// Returns `value` clamped to `[0, 1]`.
@@ -42,16 +41,27 @@ enum SystemStatsFormatters {
 
     /// Formats `maxCapacityPercent` (0.0-1.0) as an integer percentage.
     static func batteryCapacityString(_ stats: BatteryStats) -> String {
-        let clamped = unitRatio(stats.maxCapacityPercent)
-        return "\(Int((clamped * 100).rounded()))%"
+        percentString(stats.maxCapacityPercent)
     }
 
     /// Human-readable label for a memory-pressure bucket.
     static func pressureLabel(for level: MemoryPressureLevel) -> String {
         switch level {
-        case .nominal: return "Nominal"
-        case .fair: return "Fair"
-        case .critical: return "Critical"
+        case .nominal:
+            return NSLocalizedString(
+                "MemoryPressure.Nominal",
+                comment: "Label for nominal memory pressure"
+            )
+        case .fair:
+            return NSLocalizedString(
+                "MemoryPressure.Fair",
+                comment: "Label for fair memory pressure"
+            )
+        case .critical:
+            return NSLocalizedString(
+                "MemoryPressure.Critical",
+                comment: "Label for critical memory pressure"
+            )
         }
     }
 
@@ -73,7 +83,15 @@ enum SystemStatsFormatters {
     private static func usedTotalString(usedBytes: UInt64, totalBytes: UInt64) -> String {
         let used = byteString(usedBytes)
         let total = byteString(totalBytes)
-        return "\(used) / \(total)"
+        let format = NSLocalizedString(
+            "%@ / %@",
+            comment: "Format for used / total bytes, for example 8 GB / 16 GB"
+        )
+        return String(format: format, used, total)
+    }
+
+    private static func percentString(_ value: Double) -> String {
+        unitRatio(value).formatted(.percent.precision(.fractionLength(0)))
     }
 
     /// Shared `ByteCountFormatter` configured for GB output. Reused so we

--- a/VaderCleaner/SystemStatsFormatters.swift
+++ b/VaderCleaner/SystemStatsFormatters.swift
@@ -1,0 +1,91 @@
+// SystemStatsFormatters.swift
+// Shared display formatting and traffic-light status colors for system telemetry.
+
+import Foundation
+
+/// Traffic-light state system-stat UI surfaces bind to.
+///
+/// We deliberately don't use `SwiftUI.Color` here so view-models and their
+/// tests stay free of SwiftUI imports. The view layer maps `StatusColor` to
+/// `Color` once at the leaf.
+enum StatusColor: Equatable {
+    case green
+    case yellow
+    case red
+    case gray
+}
+
+/// Pure formatting helpers shared by system-stat view-models.
+enum SystemStatsFormatters {
+
+    /// Formats a unit-interval CPU usage to an integer percentage. Inputs
+    /// outside `[0, 1]` clamp at the boundary.
+    static func cpuPercentString(_ usage: Double) -> String {
+        let clamped = unitRatio(usage)
+        return "\(Int((clamped * 100).rounded()))%"
+    }
+
+    /// Returns `value` clamped to `[0, 1]`.
+    static func unitRatio(_ value: Double) -> Double {
+        max(0.0, min(1.0, value))
+    }
+
+    /// Formats memory byte counts as `"used / total"` in GB.
+    static func memoryUsageString(_ stats: MemoryStats) -> String {
+        usedTotalString(usedBytes: stats.usedBytes, totalBytes: stats.totalBytes)
+    }
+
+    /// Formats disk byte counts as `"used / total"` in GB.
+    static func diskUsageString(_ stats: DiskStats) -> String {
+        usedTotalString(usedBytes: stats.usedBytes, totalBytes: stats.totalBytes)
+    }
+
+    /// Formats `maxCapacityPercent` (0.0-1.0) as an integer percentage.
+    static func batteryCapacityString(_ stats: BatteryStats) -> String {
+        let clamped = unitRatio(stats.maxCapacityPercent)
+        return "\(Int((clamped * 100).rounded()))%"
+    }
+
+    /// Human-readable label for a memory-pressure bucket.
+    static func pressureLabel(for level: MemoryPressureLevel) -> String {
+        switch level {
+        case .nominal: return "Nominal"
+        case .fair: return "Fair"
+        case .critical: return "Critical"
+        }
+    }
+
+    /// Color for a memory-pressure bucket.
+    static func pressureColor(for level: MemoryPressureLevel) -> StatusColor {
+        switch level {
+        case .nominal: return .green
+        case .fair: return .yellow
+        case .critical: return .red
+        }
+    }
+
+    /// Formats a byte count in GB with the same Finder-style units across
+    /// Health Monitor and menu bar surfaces.
+    static func byteString(_ bytes: UInt64) -> String {
+        byteFormatter.string(fromByteCount: Int64(min(bytes, UInt64(Int64.max))))
+    }
+
+    private static func usedTotalString(usedBytes: UInt64, totalBytes: UInt64) -> String {
+        let used = byteString(usedBytes)
+        let total = byteString(totalBytes)
+        return "\(used) / \(total)"
+    }
+
+    /// Shared `ByteCountFormatter` configured for GB output. Reused so we
+    /// don't re-allocate one per card on every telemetry tick.
+    ///
+    /// `.useGB` forces the unit even for sub-1 GB inputs ("0.7 GB" rather
+    /// than "700 MB"), which keeps layout stable as values change.
+    private static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = [.useGB]
+        f.countStyle = .file
+        f.includesUnit = true
+        return f
+    }()
+}

--- a/VaderCleaner/en.lproj/Localizable.strings
+++ b/VaderCleaner/en.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 "This permanently removes the selected browser data. Browsers will recreate the storage on next launch but the data won't be recoverable." = "This permanently removes the selected browser data. Browsers will recreate the storage on next launch but the data won't be recoverable.";
 "%@ freed" = "%@ freed";
 "%@ / %@" = "%@ / %@";
+"%@ · %d%% free" = "%@ · %d%% free";
 "%@ will be moved out of these locations. This cannot be undone." = "%@ will be moved out of these locations. This cannot be undone.";
 "MemoryPressure.Critical" = "Critical";
 "MemoryPressure.Fair" = "Fair";

--- a/VaderCleaner/en.lproj/Localizable.strings
+++ b/VaderCleaner/en.lproj/Localizable.strings
@@ -21,4 +21,8 @@
 "This permanently removes the selected browser data and the system Recent Items list. Browsers will recreate the storage on next launch but the data won't be recoverable." = "This permanently removes the selected browser data and the system Recent Items list. Browsers will recreate the storage on next launch but the data won't be recoverable.";
 "This permanently removes the selected browser data. Browsers will recreate the storage on next launch but the data won't be recoverable." = "This permanently removes the selected browser data. Browsers will recreate the storage on next launch but the data won't be recoverable.";
 "%@ freed" = "%@ freed";
+"%@ / %@" = "%@ / %@";
 "%@ will be moved out of these locations. This cannot be undone." = "%@ will be moved out of these locations. This cannot be undone.";
+"MemoryPressure.Critical" = "Critical";
+"MemoryPressure.Fair" = "Fair";
+"MemoryPressure.Nominal" = "Nominal";

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -28,6 +28,13 @@ final class HealthMonitorViewModelTests: XCTestCase {
         XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(1.5), "100%")
     }
 
+    /// Preserve the original `rounded()` tie behavior at x.5 percentage
+    /// boundaries while still using localized percent formatting.
+    func test_cpuPercentString_roundsHalfPercentBoundariesAwayFromZero() {
+        XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(0.005), "1%")
+        XCTAssertEqual(HealthMonitorViewModel.cpuPercentString(0.025), "3%")
+    }
+
     /// `cpuRatio` is what the card's progress bar binds to. Same clamp.
     func test_cpuRatio_clampsToUnitInterval() {
         XCTAssertEqual(HealthMonitorViewModel.cpuRatio(-0.5), 0.0)
@@ -195,6 +202,11 @@ final class HealthMonitorViewModelTests: XCTestCase {
     func test_batteryCapacityString_formatsAsPercent() {
         let stats = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Good")
         XCTAssertEqual(HealthMonitorViewModel.batteryCapacityString(stats), "95%")
+    }
+
+    func test_batteryCapacityString_roundsHalfPercentBoundariesAwayFromZero() {
+        let stats = BatteryStats(cycleCount: 100, maxCapacityPercent: 0.005, condition: "Good")
+        XCTAssertEqual(HealthMonitorViewModel.batteryCapacityString(stats), "1%")
     }
 
     // MARK: - SMART color


### PR DESCRIPTION
## Summary
- Added `SystemStatsFormatters` to hold the shared CPU, battery, pressure, and byte-formatting logic.
- Moved `StatusColor` into the shared module so both view models use the same palette type.
- Updated `HealthMonitorViewModel` and `MenuBarViewModel` to forward through the shared helpers while keeping their public APIs intact.
- Registered the new source file in the Xcode project.
- Closes https://github.com/jayvicsanantonio/VaderCleaner/issues/23

## Testing
- Ran `xcodebuild test` for `VaderCleanerTests/HealthMonitorViewModelTests` and `VaderCleanerTests/MenuBarViewModelTests`.
- Ran the full `VaderCleanerTests` target.
- Result: all tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated system statistics formatting (CPU, memory, disk, battery, memory pressure) into a dedicated internal formatter and updated UI view models to use it, reducing duplication.

* **Localization**
  * Added localized labels for memory-pressure levels and a localized "used / total" format.

* **Tests**
  * Added unit tests covering half-percent rounding behavior for CPU and battery percentage formatting.

* **Chore**
  * Included the new formatting source in the app build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/55)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->