### PR TITLE
Add package-aware scanning for Large & Old Files and Space Lens

### DIFF
--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -72,6 +72,7 @@ struct DiskScanner: DiskScanning {
     private static let resourceKeys: [URLResourceKey] = [
         .isRegularFileKey,
         .isDirectoryKey,
+        .isPackageKey,
         .isSymbolicLinkKey,
         .fileSizeKey,
         .nameKey
@@ -178,6 +179,21 @@ struct DiskScanner: DiskScanning {
             let bytes = Int64(resourceValues?.fileSize ?? 0)
             counter.value += 1
             progress(counter.value)
+            return DiskNode(
+                url: url,
+                name: name,
+                size: bytes,
+                isDirectory: false,
+                children: [],
+                isAccessible: true
+            )
+        }
+
+        if resourceValues?.isPackage == true {
+            let bytes = try await PackageDirectorySizer.recursiveSize(of: url) {
+                counter.value += 1
+                progress(counter.value)
+            }
             return DiskNode(
                 url: url,
                 name: name,

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -190,17 +190,20 @@ struct DiskScanner: DiskScanning {
         }
 
         if resourceValues?.isPackage == true {
-            let bytes = try await PackageDirectorySizer.recursiveSize(of: url) {
+            let result = try await PackageDirectorySizer.recursiveSizeResult(of: url) {
                 counter.value += 1
                 progress(counter.value)
+            }
+            if isRoot && !result.isAccessible {
+                throw DiskScanError.rootInaccessible(url)
             }
             return DiskNode(
                 url: url,
                 name: name,
-                size: bytes,
+                size: result.size,
                 isDirectory: false,
                 children: [],
-                isAccessible: true
+                isAccessible: result.isAccessible
             )
         }
 

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -304,22 +304,23 @@ struct FileScanner: FileScanning {
                 // doesn't guarantee canonical-prefixed URLs even when given
                 // a canonical root, so the comparison has to happen on a
                 // resolved path.
-                if hasExclusions {
-                    let canonicalPath = PathExclusionMatcher.canonicalize(url)
-                    if PathExclusionMatcher.isExcluded(path: canonicalPath, by: canonicalExclusions) {
-                        if resourceValues?.isDirectory == true {
-                            enumerator.skipDescendants()
-                        }
-                        continue
+                let canonicalPath = hasExclusions
+                    ? PathExclusionMatcher.canonicalize(url)
+                    : nil
+                if let canonicalPath,
+                   PathExclusionMatcher.isExcluded(path: canonicalPath, by: canonicalExclusions) {
+                    if resourceValues?.isDirectory == true {
+                        enumerator.skipDescendants()
                     }
+                    continue
                 }
 
                 let isDirectory = resourceValues?.isDirectory == true
                 if options.packagesAsFiles,
                    isDirectory,
                    resourceValues?.isPackage == true {
-                    let canonicalPath = PathExclusionMatcher.canonicalize(url)
-                    if PathExclusionMatcher.containsExcludedDescendant(
+                    if let canonicalPath,
+                       PathExclusionMatcher.containsExcludedDescendant(
                         of: canonicalPath,
                         in: canonicalExclusions
                     ) {

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -68,11 +68,36 @@ extension FileScanning {
 }
 
 enum PathExclusionMatcher {
+    struct CanonicalPathMapper {
+        let canonicalRootPath: String
+        private let displayedRootPath: String
+
+        init(canonicalRootPath: String, displayedRootPath: String) {
+            self.canonicalRootPath = canonicalRootPath
+            self.displayedRootPath = displayedRootPath
+        }
+
+        func canonicalPath(for url: URL) -> String {
+            PathExclusionMatcher.project(
+                normalizedPath(url),
+                from: displayedRootPath,
+                to: canonicalRootPath
+            )
+        }
+    }
+
     /// Resolves symlinks and normalises `..`/`.` so exclusion comparisons are
     /// done on canonical paths. Mirrors `ExclusionsStore.canonicalize` so a
     /// path the user excluded matches the same canonical form a scanner sees.
     static func canonicalize(_ url: URL) -> String {
         url.resolvingSymlinksInPath().path
+    }
+
+    static func makeCanonicalPathMapper(for root: URL) -> CanonicalPathMapper {
+        CanonicalPathMapper(
+            canonicalRootPath: canonicalize(root),
+            displayedRootPath: normalizedPath(root)
+        )
     }
 
     /// True when `path` is exactly an excluded path or sits beneath one.
@@ -104,6 +129,28 @@ enum PathExclusionMatcher {
             exclusion.range(of: prefix, options: [.anchored, .caseInsensitive]) != nil
         }
     }
+
+    private static func normalizedPath(_ url: URL) -> String {
+        url.standardizedFileURL.path
+    }
+
+    private static func project(_ path: String, from displayedRootPath: String, to canonicalRootPath: String) -> String {
+        if path.caseInsensitiveCompare(displayedRootPath) == .orderedSame {
+            return canonicalRootPath
+        }
+
+        let displayedPrefix = displayedRootPath.hasSuffix("/") ? displayedRootPath : displayedRootPath + "/"
+        guard path.range(of: displayedPrefix, options: [.anchored, .caseInsensitive]) != nil else {
+            return path
+        }
+
+        let suffix = String(path.dropFirst(displayedPrefix.count))
+        if canonicalRootPath == "/" {
+            return "/" + suffix
+        }
+        let canonicalPrefix = canonicalRootPath.hasSuffix("/") ? canonicalRootPath : canonicalRootPath + "/"
+        return canonicalPrefix + suffix
+    }
 }
 
 /// Shared recursive logical-size calculator for macOS package directories.
@@ -115,6 +162,8 @@ enum PackageDirectorySizer {
     struct Result: Equatable {
         let size: Int64
         let isAccessible: Bool
+        let lastAccessDate: Date?
+        let lastModifiedDate: Date?
     }
 
     private static let cancellationCheckInterval = 512
@@ -128,7 +177,9 @@ enum PackageDirectorySizer {
         .isRegularFileKey,
         .isDirectoryKey,
         .isSymbolicLinkKey,
-        .fileSizeKey
+        .fileSizeKey,
+        .contentAccessDateKey,
+        .contentModificationDateKey
     ]
 
     private static let resourceKeySet = Set(resourceKeys)
@@ -154,6 +205,9 @@ enum PackageDirectorySizer {
         var totalSize: Int64 = 0
         var visitedCount = 0
         var isAccessible = true
+        var newestAccessDate: Date?
+        var newestModifiedDate: Date?
+        let pathMapper = hasExclusions ? PathExclusionMatcher.makeCanonicalPathMapper(for: packageURL) : nil
 
         let enumerator = FileManager.default.enumerator(
             at: packageURL,
@@ -169,7 +223,12 @@ enum PackageDirectorySizer {
         )
 
         guard let enumerator else {
-            return Result(size: 0, isAccessible: false)
+            return Result(
+                size: 0,
+                isAccessible: false,
+                lastAccessDate: nil,
+                lastModifiedDate: nil
+            )
         }
 
         while let url = enumerator.nextObject() as? URL {
@@ -185,8 +244,8 @@ enum PackageDirectorySizer {
                 continue
             }
 
-            if hasExclusions {
-                let canonicalPath = PathExclusionMatcher.canonicalize(url)
+            if let pathMapper {
+                let canonicalPath = pathMapper.canonicalPath(for: url)
                 if PathExclusionMatcher.isExcluded(path: canonicalPath, by: canonicalExclusions) {
                     if resourceValues?.isDirectory == true {
                         enumerator.skipDescendants()
@@ -198,10 +257,28 @@ enum PackageDirectorySizer {
             guard resourceValues?.isRegularFile == true else { continue }
 
             totalSize += Int64(resourceValues?.fileSize ?? 0)
+            newestAccessDate = Self.newer(of: newestAccessDate, and: resourceValues?.contentAccessDate)
+            newestModifiedDate = Self.newer(of: newestModifiedDate, and: resourceValues?.contentModificationDate)
             progress?()
         }
 
-        return Result(size: totalSize, isAccessible: isAccessible)
+        return Result(
+            size: totalSize,
+            isAccessible: isAccessible,
+            lastAccessDate: newestAccessDate,
+            lastModifiedDate: newestModifiedDate
+        )
+    }
+
+    private static func newer(of lhs: Date?, and rhs: Date?) -> Date? {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return nil
+        case (.some(let date), nil), (nil, .some(let date)):
+            return date
+        case (.some(let lhs), .some(let rhs)):
+            return max(lhs, rhs)
+        }
     }
 }
 
@@ -272,9 +349,9 @@ struct FileScanner: FileScanning {
         for root in roots {
             try Task.checkCancellation()
 
-            if hasExclusions {
-                let canonicalRootPath = PathExclusionMatcher.canonicalize(root.url)
-                if PathExclusionMatcher.isExcluded(path: canonicalRootPath, by: canonicalExclusions) {
+            let pathMapper = hasExclusions ? PathExclusionMatcher.makeCanonicalPathMapper(for: root.url) : nil
+            if let pathMapper {
+                if PathExclusionMatcher.isExcluded(path: pathMapper.canonicalRootPath, by: canonicalExclusions) {
                     continue
                 }
             }
@@ -318,16 +395,11 @@ struct FileScanner: FileScanning {
                     continue
                 }
 
-                // Canonicalize per-file *only* when there are exclusions to
-                // compare against — the common case (no exclusions) avoids
-                // the extra symlink-resolution work entirely. We can't lift
-                // this above the loop because `FileManager.enumerator`
-                // doesn't guarantee canonical-prefixed URLs even when given
-                // a canonical root, so the comparison has to happen on a
-                // resolved path.
-                let canonicalPath = hasExclusions
-                    ? PathExclusionMatcher.canonicalize(url)
-                    : nil
+                // Exclusions are canonical, while enumerator URLs keep the
+                // root spelling they were given. Projecting through the root
+                // mapper preserves canonical matching without doing
+                // symlink-resolution I/O for every item.
+                let canonicalPath = pathMapper?.canonicalPath(for: url)
                 if let canonicalPath,
                    PathExclusionMatcher.isExcluded(path: canonicalPath, by: canonicalExclusions) {
                     if resourceValues?.isDirectory == true {
@@ -348,16 +420,16 @@ struct FileScanner: FileScanning {
                         continue
                     }
 
-                    let size = try await PackageDirectorySizer.recursiveSize(
+                    let packageResult = try await PackageDirectorySizer.recursiveSizeResult(
                         of: url,
                         excluding: canonicalExclusions
                     )
                     batch.append(
                         ScannedFile(
                             url: url,
-                            size: size,
-                            lastAccessDate: resourceValues?.contentAccessDate,
-                            lastModifiedDate: resourceValues?.contentModificationDate,
+                            size: packageResult.size,
+                            lastAccessDate: packageResult.lastAccessDate,
+                            lastModifiedDate: packageResult.lastModifiedDate,
                             category: root.category
                         )
                     )

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -21,18 +21,166 @@ protocol FileScanning {
     func scan(
         roots: [ScanRoot],
         excluding: [URL],
+        options: FileScanOptions,
         batchSize: Int,
         onBatch: ([ScannedFile]) async throws -> Void
     ) async throws
 }
 
+struct FileScanOptions: Equatable {
+    static let `default` = FileScanOptions()
+
+    let packagesAsFiles: Bool
+
+    init(packagesAsFiles: Bool = false) {
+        self.packagesAsFiles = packagesAsFiles
+    }
+}
+
 extension FileScanning {
     func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
         var results: [ScannedFile] = []
-        try await scan(roots: roots, excluding: excluding, batchSize: FileScanner.defaultBatchSize) { batch in
+        try await scan(
+            roots: roots,
+            excluding: excluding,
+            options: .default,
+            batchSize: FileScanner.defaultBatchSize
+        ) { batch in
             results.append(contentsOf: batch)
         }
         return results
+    }
+
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        batchSize: Int,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
+        try await scan(
+            roots: roots,
+            excluding: excluding,
+            options: .default,
+            batchSize: batchSize,
+            onBatch: onBatch
+        )
+    }
+}
+
+enum PathExclusionMatcher {
+    /// Resolves symlinks and normalises `..`/`.` so exclusion comparisons are
+    /// done on canonical paths. Mirrors `ExclusionsStore.canonicalize` so a
+    /// path the user excluded matches the same canonical form a scanner sees.
+    static func canonicalize(_ url: URL) -> String {
+        url.resolvingSymlinksInPath().path
+    }
+
+    /// True when `path` is exactly an excluded path or sits beneath one.
+    /// Comparison is at path-component boundaries (not raw prefix) so
+    /// excluding `/tmp/foo` does not also exclude `/tmp/foobar`. macOS's
+    /// default APFS is case-insensitive, hence the case-insensitive compare.
+    /// Uses `range(of:options:)` rather than `lowercased()` so we don't
+    /// allocate a fresh lowercased copy of every enumerated path.
+    static func isExcluded(path: String, by exclusions: [String]) -> Bool {
+        for excluded in exclusions {
+            if path.caseInsensitiveCompare(excluded) == .orderedSame {
+                return true
+            }
+            let prefix = excluded.hasSuffix("/") ? excluded : excluded + "/"
+            if path.range(of: prefix, options: [.anchored, .caseInsensitive]) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// True when one of the excluded paths sits inside `path`, but is not
+    /// equal to `path` itself. Package-as-leaf scans use this to force descent
+    /// when a user excluded something inside a package; otherwise selecting the
+    /// package leaf for deletion would still remove excluded content.
+    static func containsExcludedDescendant(of path: String, in exclusions: [String]) -> Bool {
+        let prefix = path.hasSuffix("/") ? path : path + "/"
+        return exclusions.contains { exclusion in
+            exclusion.range(of: prefix, options: [.anchored, .caseInsensitive]) != nil
+        }
+    }
+}
+
+/// Shared recursive logical-size calculator for macOS package directories.
+/// It intentionally mirrors the scanners' symlink policy: symlinks do not
+/// contribute bytes, so package rollups cannot double-count content or pull in
+/// data outside the scanned tree.
+enum PackageDirectorySizer {
+
+    private static let cancellationCheckInterval = 512
+
+    private static let log = Logger(
+        subsystem: "com.personal.VaderCleaner",
+        category: "PackageDirectorySizer"
+    )
+
+    private static let resourceKeys: [URLResourceKey] = [
+        .isRegularFileKey,
+        .isDirectoryKey,
+        .isSymbolicLinkKey,
+        .fileSizeKey
+    ]
+
+    private static let resourceKeySet = Set(resourceKeys)
+
+    static func recursiveSize(
+        of packageURL: URL,
+        excluding canonicalExclusions: [String] = [],
+        progress: (() -> Void)? = nil
+    ) async throws -> Int64 {
+        let hasExclusions = !canonicalExclusions.isEmpty
+        var totalSize: Int64 = 0
+        var visitedCount = 0
+
+        let enumerator = FileManager.default.enumerator(
+            at: packageURL,
+            includingPropertiesForKeys: resourceKeys,
+            options: [],
+            errorHandler: { url, error in
+                Self.log.debug(
+                    "Skipping unreadable package path \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
+                )
+                return true
+            }
+        )
+
+        guard let enumerator else { return 0 }
+
+        while let url = enumerator.nextObject() as? URL {
+            visitedCount += 1
+            if visitedCount.isMultiple(of: Self.cancellationCheckInterval) {
+                try Task.checkCancellation()
+                await Task.yield()
+            }
+
+            let resourceValues = try? url.resourceValues(forKeys: resourceKeySet)
+
+            if resourceValues?.isSymbolicLink == true {
+                continue
+            }
+
+            if hasExclusions {
+                let canonicalPath = PathExclusionMatcher.canonicalize(url)
+                if PathExclusionMatcher.isExcluded(path: canonicalPath, by: canonicalExclusions) {
+                    if resourceValues?.isDirectory == true {
+                        enumerator.skipDescendants()
+                    }
+                    continue
+                }
+            }
+
+            guard resourceValues?.isRegularFile == true else { continue }
+
+            totalSize += Int64(resourceValues?.fileSize ?? 0)
+            progress?()
+        }
+
+        return totalSize
     }
 }
 
@@ -66,6 +214,7 @@ struct FileScanner: FileScanning {
         .isRegularFileKey,
         .isSymbolicLinkKey,
         .isDirectoryKey,
+        .isPackageKey,
         .fileSizeKey,
         .contentAccessDateKey,
         .contentModificationDateKey
@@ -79,11 +228,12 @@ struct FileScanner: FileScanning {
     func scan(
         roots: [ScanRoot],
         excluding: [URL],
+        options: FileScanOptions = .default,
         batchSize: Int = defaultBatchSize,
         onBatch: ([ScannedFile]) async throws -> Void
     ) async throws {
         let batchLimit = max(1, batchSize)
-        let canonicalExclusions = excluding.map(Self.canonicalize)
+        let canonicalExclusions = excluding.map(PathExclusionMatcher.canonicalize)
         let hasExclusions = !canonicalExclusions.isEmpty
         var batch: [ScannedFile] = []
         batch.reserveCapacity(batchLimit)
@@ -102,20 +252,25 @@ struct FileScanner: FileScanning {
             try Task.checkCancellation()
 
             if hasExclusions {
-                let canonicalRootPath = Self.canonicalize(root.url)
-                if Self.isExcluded(path: canonicalRootPath, by: canonicalExclusions) {
+                let canonicalRootPath = PathExclusionMatcher.canonicalize(root.url)
+                if PathExclusionMatcher.isExcluded(path: canonicalRootPath, by: canonicalExclusions) {
                     continue
                 }
             }
 
-            // `.skipsPackageDescendants` keeps us out of .app bundles and
-            // similar packages. `.skipsHiddenFiles` is intentionally NOT
-            // set: cache and log directories on macOS routinely contain
-            // dot-prefixed files we need to count.
+            // In default mode, `.skipsPackageDescendants` preserves the
+            // historical system-junk behaviour: package internals are not
+            // emitted. Package-as-file mode needs to see the package URL first
+            // so it can emit one rolled-up item and call `skipDescendants()`.
+            // `.skipsHiddenFiles` is intentionally NOT set: cache and log
+            // directories on macOS routinely contain dot-prefixed files we
+            // need to count.
+            let enumerationOptions: FileManager.DirectoryEnumerationOptions =
+                options.packagesAsFiles ? [] : [.skipsPackageDescendants]
             let enumerator = FileManager.default.enumerator(
                 at: root.url,
                 includingPropertiesForKeys: Self.resourceKeys,
-                options: [.skipsPackageDescendants],
+                options: enumerationOptions,
                 errorHandler: { url, error in
                     Self.log.debug(
                         "Skipping unreadable path \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
@@ -150,13 +305,45 @@ struct FileScanner: FileScanning {
                 // a canonical root, so the comparison has to happen on a
                 // resolved path.
                 if hasExclusions {
-                    let canonicalPath = Self.canonicalize(url)
-                    if Self.isExcluded(path: canonicalPath, by: canonicalExclusions) {
+                    let canonicalPath = PathExclusionMatcher.canonicalize(url)
+                    if PathExclusionMatcher.isExcluded(path: canonicalPath, by: canonicalExclusions) {
                         if resourceValues?.isDirectory == true {
                             enumerator.skipDescendants()
                         }
                         continue
                     }
+                }
+
+                let isDirectory = resourceValues?.isDirectory == true
+                if options.packagesAsFiles,
+                   isDirectory,
+                   resourceValues?.isPackage == true {
+                    let canonicalPath = PathExclusionMatcher.canonicalize(url)
+                    if PathExclusionMatcher.containsExcludedDescendant(
+                        of: canonicalPath,
+                        in: canonicalExclusions
+                    ) {
+                        continue
+                    }
+
+                    let size = try await PackageDirectorySizer.recursiveSize(
+                        of: url,
+                        excluding: canonicalExclusions
+                    )
+                    batch.append(
+                        ScannedFile(
+                            url: url,
+                            size: size,
+                            lastAccessDate: resourceValues?.contentAccessDate,
+                            lastModifiedDate: resourceValues?.contentModificationDate,
+                            category: root.category
+                        )
+                    )
+                    enumerator.skipDescendants()
+                    if batch.count >= batchLimit {
+                        try await flushBatch()
+                    }
+                    continue
                 }
 
                 guard resourceValues?.isRegularFile == true else { continue }
@@ -179,33 +366,5 @@ struct FileScanner: FileScanning {
         }
 
         try await flushBatch()
-    }
-
-    // MARK: - Path helpers
-
-    /// Resolves symlinks and normalises `..`/`.` so exclusion comparisons are
-    /// done on canonical paths. Mirrors `ExclusionsStore.canonicalize` so a
-    /// path the user excluded matches the same canonical form a scanner sees.
-    private static func canonicalize(_ url: URL) -> String {
-        url.resolvingSymlinksInPath().path
-    }
-
-    /// True when `path` is exactly an excluded path or sits beneath one.
-    /// Comparison is at path-component boundaries (not raw prefix) so
-    /// excluding `/tmp/foo` does not also exclude `/tmp/foobar`. macOS's
-    /// default APFS is case-insensitive, hence the case-insensitive compare.
-    /// Uses `range(of:options:)` rather than `lowercased()` so we don't
-    /// allocate a fresh lowercased copy of every enumerated path.
-    private static func isExcluded(path: String, by exclusions: [String]) -> Bool {
-        for excluded in exclusions {
-            if path.caseInsensitiveCompare(excluded) == .orderedSame {
-                return true
-            }
-            let prefix = excluded.hasSuffix("/") ? excluded : excluded + "/"
-            if path.range(of: prefix, options: [.anchored, .caseInsensitive]) != nil {
-                return true
-            }
-        }
-        return false
     }
 }

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -112,6 +112,11 @@ enum PathExclusionMatcher {
 /// data outside the scanned tree.
 enum PackageDirectorySizer {
 
+    struct Result: Equatable {
+        let size: Int64
+        let isAccessible: Bool
+    }
+
     private static let cancellationCheckInterval = 512
 
     private static let log = Logger(
@@ -133,15 +138,29 @@ enum PackageDirectorySizer {
         excluding canonicalExclusions: [String] = [],
         progress: (() -> Void)? = nil
     ) async throws -> Int64 {
+        try await recursiveSizeResult(
+            of: packageURL,
+            excluding: canonicalExclusions,
+            progress: progress
+        ).size
+    }
+
+    static func recursiveSizeResult(
+        of packageURL: URL,
+        excluding canonicalExclusions: [String] = [],
+        progress: (() -> Void)? = nil
+    ) async throws -> Result {
         let hasExclusions = !canonicalExclusions.isEmpty
         var totalSize: Int64 = 0
         var visitedCount = 0
+        var isAccessible = true
 
         let enumerator = FileManager.default.enumerator(
             at: packageURL,
             includingPropertiesForKeys: resourceKeys,
             options: [],
             errorHandler: { url, error in
+                isAccessible = false
                 Self.log.debug(
                     "Skipping unreadable package path \(url.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)"
                 )
@@ -149,7 +168,9 @@ enum PackageDirectorySizer {
             }
         )
 
-        guard let enumerator else { return 0 }
+        guard let enumerator else {
+            return Result(size: 0, isAccessible: false)
+        }
 
         while let url = enumerator.nextObject() as? URL {
             visitedCount += 1
@@ -180,7 +201,7 @@ enum PackageDirectorySizer {
             progress?()
         }
 
-        return totalSize
+        return Result(size: totalSize, isAccessible: isAccessible)
     }
 }
 

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -72,6 +72,7 @@ struct LargeOldFilesScanner {
         try await fileScanner.scan(
             roots: roots,
             excluding: excluding,
+            options: FileScanOptions(packagesAsFiles: true),
             batchSize: batchSize
         ) { scannedBatch in
             let matchedBatch = scannedBatch.compactMap { Self.classify($0, cutoff: cutoff) }

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -85,6 +85,35 @@ final class DiskScannerTests: XCTestCase {
         XCTAssertEqual(progressCounts.last, 2, "Progress should still count regular files inside package rollups")
     }
 
+    func test_scan_marksUnreadablePackageAsInaccessibleLeaf() async throws {
+        let package = tempRoot.appendingPathComponent("Protected.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "secret.bin", size: 64, in: contents)
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o000))],
+            ofItemAtPath: package.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o755))],
+                ofItemAtPath: package.path
+            )
+        }
+
+        let canStillRead = (try? FileManager.default.contentsOfDirectory(atPath: package.path)) != nil
+        try XCTSkipIf(canStillRead, "Current process can read chmod 000 packages; cannot exercise the deny path here.")
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(root: tempRoot, progress: { _ in })
+
+        let packageNode = try XCTUnwrap(root.children.first { $0.name == "Protected.app" })
+        XCTAssertFalse(packageNode.isDirectory, "Packages should remain leaf nodes even when inaccessible")
+        XCTAssertFalse(packageNode.isAccessible, "An unreadable package must not be reported as accessible")
+        XCTAssertTrue(packageNode.children.isEmpty)
+    }
+
     // MARK: - Symlink handling
 
     /// A symlink whose target is the scan's own root would cause infinite

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -64,6 +64,27 @@ final class DiskScannerTests: XCTestCase {
         XCTAssertEqual(root.size, 96)
     }
 
+    func test_scan_treatsPackageDirectoryAsLeafWithRolledUpSize() async throws {
+        let package = tempRoot.appendingPathComponent("Photos.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "a.bin", size: 32, in: contents)
+        try TestHelpers.createDummyFile(named: "b.bin", size: 64, in: contents)
+
+        var progressCounts: [Int] = []
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(root: tempRoot, progress: { count in
+            progressCounts.append(count)
+        })
+
+        let packageNode = try XCTUnwrap(root.children.first { $0.name == "Photos.app" })
+        XCTAssertFalse(packageNode.isDirectory, "Packages render as leaf tiles, not drill-down folders")
+        XCTAssertTrue(packageNode.children.isEmpty)
+        XCTAssertEqual(packageNode.size, 96)
+        XCTAssertEqual(root.size, 96)
+        XCTAssertEqual(progressCounts.last, 2, "Progress should still count regular files inside package rollups")
+    }
+
     // MARK: - Symlink handling
 
     /// A symlink whose target is the scan's own root would cause infinite

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -188,6 +188,28 @@ final class FileScannerTests: XCTestCase {
         XCTAssertTrue(files[0].url.path.contains("foobar"))
     }
 
+    func test_canonicalPathMapperProjectsDisplayedRootToCanonicalRoot() {
+        let mapper = PathExclusionMatcher.CanonicalPathMapper(
+            canonicalRootPath: "/private/tmp/root",
+            displayedRootPath: "/tmp/root"
+        )
+
+        let child = URL(fileURLWithPath: "/tmp/root/excluded/file.bin")
+
+        XCTAssertEqual(mapper.canonicalPath(for: child), "/private/tmp/root/excluded/file.bin")
+    }
+
+    func test_canonicalPathMapperPreservesPathBoundary() {
+        let mapper = PathExclusionMatcher.CanonicalPathMapper(
+            canonicalRootPath: "/private/tmp/root",
+            displayedRootPath: "/tmp/root"
+        )
+
+        let sibling = URL(fileURLWithPath: "/tmp/root-sibling/file.bin")
+
+        XCTAssertEqual(mapper.canonicalPath(for: sibling), "/tmp/root-sibling/file.bin")
+    }
+
     // MARK: - Total size
 
     func test_scan_resultTotalSizeMatchesFileSizes() async throws {

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -249,6 +249,81 @@ final class FileScannerTests: XCTestCase {
         )
     }
 
+    // MARK: - Packages
+
+    func test_fileManagerSkipsPackageDescendantsEmitsPackageURLItself() throws {
+        let package = tempRoot.appendingPathComponent("Demo.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        let innerFile = try TestHelpers.createDummyFile(named: "Info.plist", size: 16, in: contents)
+
+        let enumerator = try XCTUnwrap(FileManager.default.enumerator(
+            at: tempRoot,
+            includingPropertiesForKeys: [.isPackageKey],
+            options: [.skipsPackageDescendants]
+        ))
+        let urls = enumerator.compactMap { $0 as? URL }
+        let resolvedPaths = Set(urls.map { $0.resolvingSymlinksInPath().path })
+
+        XCTAssertTrue(
+            resolvedPaths.contains(package.resolvingSymlinksInPath().path),
+            ".skipsPackageDescendants should still surface the package URL so package-as-file mode can emit it"
+        )
+        XCTAssertFalse(
+            resolvedPaths.contains(innerFile.resolvingSymlinksInPath().path),
+            ".skipsPackageDescendants should skip package internals"
+        )
+    }
+
+    func test_scan_packagesAsFilesEmitsPackageDirectoryAsSingleRolledUpItem() async throws {
+        let package = tempRoot.appendingPathComponent("Demo.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "a.bin", size: 32, in: contents)
+        try TestHelpers.createDummyFile(named: "b.bin", size: 64, in: contents)
+
+        let scanner = FileScanner()
+        var files: [ScannedFile] = []
+        try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .largeFile)],
+            excluding: [],
+            options: FileScanOptions(packagesAsFiles: true),
+            batchSize: FileScanner.defaultBatchSize
+        ) { batch in
+            files.append(contentsOf: batch)
+        }
+
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files.first?.url.resolvingSymlinksInPath().path, package.resolvingSymlinksInPath().path)
+        XCTAssertEqual(files.first?.size, 96)
+        XCTAssertEqual(files.first?.category, .largeFile)
+    }
+
+    func test_scan_packagesAsFilesDescendsWhenExclusionTargetsPackageChild() async throws {
+        let package = tempRoot.appendingPathComponent("Demo.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        let kept = try TestHelpers.createDummyFile(named: "kept.bin", size: 32, in: contents)
+        let excluded = try TestHelpers.createDummyFile(named: "excluded.bin", size: 64, in: contents)
+
+        let scanner = FileScanner()
+        var files: [ScannedFile] = []
+        try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .largeFile)],
+            excluding: [excluded],
+            options: FileScanOptions(packagesAsFiles: true),
+            batchSize: FileScanner.defaultBatchSize
+        ) { batch in
+            files.append(contentsOf: batch)
+        }
+
+        XCTAssertEqual(
+            files.map { $0.url.resolvingSymlinksInPath().path },
+            [kept.resolvingSymlinksInPath().path]
+        )
+        XCTAssertEqual(files.map(\.size), [32])
+    }
+
     // MARK: - Permission denied
 
     /// The scanner must surface a clean result rather than throwing when

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -85,6 +85,28 @@ final class LargeOldFilesScannerTests: XCTestCase {
         )
     }
 
+    func test_scan_usesPackageContentAccessDateForAgeClassification() async throws {
+        let root = try makeRoot("pictures")
+        let package = root.appendingPathComponent("PhotoLibrary.photoslibrary", isDirectory: true)
+        let contents = package.appendingPathComponent("database", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        let innerFile = try TestHelpers.createDummyFile(named: "active.sqlite", size: 32, in: contents)
+        try setAccessDate(at: innerFile, to: referenceNow.addingTimeInterval(-3_600))
+        try setAccessDate(
+            at: package,
+            to: referenceNow.addingTimeInterval(-LargeOldFilesScanner.ageThresholdSeconds - 86_400)
+        )
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertTrue(files.isEmpty, "Fresh package contents should keep a small package out of old-file results")
+    }
+
     // MARK: - Age classification
 
     /// A file last accessed before the cutoff must be returned tagged

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -58,6 +58,33 @@ final class LargeOldFilesScannerTests: XCTestCase {
         XCTAssertEqual(files.first?.category, .largeFile)
     }
 
+    func test_scan_emitsLargePackageAsSingleLargeFile() async throws {
+        let root = try makeRoot("applications")
+        let package = root.appendingPathComponent("Archive.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        let innerFile = contents.appendingPathComponent("payload.bin")
+        try createSparseFile(at: innerFile, size: LargeOldFilesScanner.sizeThresholdBytes + 1)
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files.first?.url.resolvingSymlinksInPath().path, package.resolvingSymlinksInPath().path)
+        XCTAssertEqual(files.first?.size, LargeOldFilesScanner.sizeThresholdBytes + 1)
+        XCTAssertEqual(files.first?.category, .largeFile)
+        XCTAssertFalse(
+            files.contains {
+                $0.url.resolvingSymlinksInPath().path == innerFile.resolvingSymlinksInPath().path
+            },
+            "Package internals should not leak as separate large-file rows"
+        )
+    }
+
     // MARK: - Age classification
 
     /// A file last accessed before the cutoff must be returned tagged
@@ -306,6 +333,13 @@ final class LargeOldFilesScannerTests: XCTestCase {
         var mutable = url
         try mutable.setResourceValues(values)
     }
+
+    private func createSparseFile(at url: URL, size: Int64) throws {
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: UInt64(size))
+        try handle.close()
+    }
 }
 
 // MARK: - Stubs
@@ -335,6 +369,7 @@ private struct FakeFileScanner: FileScanning {
     func scan(
         roots: [ScanRoot],
         excluding: [URL],
+        options: FileScanOptions,
         batchSize: Int,
         onBatch: ([ScannedFile]) async throws -> Void
     ) async throws {


### PR DESCRIPTION
## Summary
- Add package-aware scan options so `FileScanner` can emit macOS packages as single rolled-up items when callers opt in
- Keep System Junk on the existing regular-file behavior
- Treat packages as leaf nodes in Space Lens with recursive package size
- Add shared package sizing and exclusion helpers to keep the two scanners aligned
- Cover the new package behavior with unit tests for file scanning, Large & Old Files, and Space Lens
- Closes https://github.com/jayvicsanantonio/VaderCleaner/issues/33

## Testing
- `xcodebuild test -project VaderCleaner.xcodeproj -scheme VaderCleaner -destination 'platform=macOS' -derivedDataPath /private/tmp/VaderCleanerDerivedData -only-testing:VaderCleanerTests`
- Added focused coverage for package enumeration, package-as-file output, exclusion handling inside packages, and Space Lens package leaf rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS application packages and bundle directories (such as .app files) are now scanned as single consolidated items rather than drilling into their contents, displaying aggregated file sizes for each package. This improves disk usage reporting clarity and scanning performance, particularly when analyzing large applications and package-based content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/56)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->