### PR TITLE
feat: add App Uninstaller (#57)

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -10,11 +10,11 @@
 		024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */; };
 		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
-		0AACE024B8504EE78B14CC01 /* SystemStatsFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AACE023B8504EE78B14CC01 /* SystemStatsFormatters.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
 		109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */; };
+		11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */; };
 		11C7DA0D7ECDCBF7DFB3C829 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 329FBD86F55918272AF0EF2A /* Localizable.stringsdict */; };
 		13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */; };
 		1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */; };
@@ -23,6 +23,7 @@
 		1947460A68C713844C308694 /* TreemapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
 		2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */; };
+		26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */; };
 		26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */; };
 		28B2F4C32E608BD283DB2DE5 /* VaderCleanerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */; };
 		2A28D67DA396B3D2B6DB13D5 /* DiskScannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */; };
@@ -32,6 +33,7 @@
 		2BB370554CD9C84ED37C81A0 /* NotificationThresholdMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */; };
 		2CE84E79268B4A59C5B8FACB /* HealthMonitorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */; };
 		2DD748D16E344D435A5C3E24 /* HelperRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */; };
+		2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CA7922445475111927C0B /* AppInfo.swift */; };
 		3328707476CC1411FA1270D0 /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D92F45290B56030CBFA83D3 /* Browser.swift */; };
 		3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6697CA6EEE719B2E2D46CE /* AppState.swift */; };
 		35F306676A3412253929EF55 /* TreemapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BDB24525760C96625DD266 /* TreemapView.swift */; };
@@ -46,7 +48,6 @@
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */; };
-		51688E781C12B6E4622A58F2 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991F5B5938F51D3BC7016E88 /* FileIconCache.swift */; };
 		52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */; };
 		55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
 		567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */; };
@@ -60,11 +61,13 @@
 		63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */; };
 		65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD8C98E8253953444DD99F /* NotificationManager.swift */; };
 		65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
+		65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */; };
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
 		6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */; };
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
 		6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */; };
 		6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */; };
+		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
 		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */; };
@@ -79,14 +82,19 @@
 		91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */; };
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
 		99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC50A90E584320709971BCB /* ScanCategoryTests.swift */; };
+		9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */; };
+		9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */; };
 		9CA467B702E12F278B7BE6DC /* HelperConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43596249B222D18142F961E2 /* HelperConnectionManager.swift */; };
 		A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */; };
+		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
 		AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC67B639248BC5EA1F5473 /* ScanCategory.swift */; };
 		B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39407E2EA6D045893F1BA4B /* DiskNode.swift */; };
+		B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */; };
 		B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */; };
 		B60909E266277B691B876E63 /* NotificationThresholdMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */; };
 		B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */; };
 		B6B4FF9883F54E8F60010ACB /* VaderCleanerHelper in Embed Dependencies */ = {isa = PBXBuildFile; fileRef = 6CBCA8999E04715E502AB892 /* VaderCleanerHelper */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B7DADC9127C373029FC8198A /* AppUninstallerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D62624319B764770F02292 /* AppUninstallerViewModel.swift */; };
 		BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2B92863509818189F46CD /* MenuBarContent.swift */; };
 		BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133467A06193C406B027D97C /* NavigationSectionTests.swift */; };
 		BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC391B523110720320AD89 /* SystemPathProviding.swift */; };
@@ -101,10 +109,12 @@
 		CF68F2891382E3F3D4CA5474 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */; };
 		D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */; };
 		D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */; };
+		D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */; };
 		DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */; };
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */; };
+		EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */; };
 		EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */; };
 		EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4E92A146A223EA836C156D /* ScanResultTests.swift */; };
 		F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */; };
@@ -165,12 +175,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsFormatters.swift; sourceTree = "<group>"; };
 		02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicy.swift; sourceTree = "<group>"; };
+		04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerView.swift; sourceTree = "<group>"; };
 		06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocator.swift; sourceTree = "<group>"; };
 		072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionChecker.swift; sourceTree = "<group>"; };
 		0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManagerTests.swift; sourceTree = "<group>"; };
 		0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyCategory.swift; sourceTree = "<group>"; };
-		0AACE023B8504EE78B14CC01 /* SystemStatsFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsFormatters.swift; sourceTree = "<group>"; };
 		0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitor.swift; sourceTree = "<group>"; };
 		0D4E92A146A223EA836C156D /* ScanResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResultTests.swift; sourceTree = "<group>"; };
 		0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensUITests.swift; sourceTree = "<group>"; };
@@ -190,6 +201,7 @@
 		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
 		2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSection.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
+		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
 		3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerTests.swift; sourceTree = "<group>"; };
@@ -198,6 +210,7 @@
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
 		46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpersTests.swift; sourceTree = "<group>"; };
 		4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsService.swift; sourceTree = "<group>"; };
+		49D62624319B764770F02292 /* AppUninstallerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModel.swift; sourceTree = "<group>"; };
 		4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayout.swift; sourceTree = "<group>"; };
 		4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkUITests.swift; sourceTree = "<group>"; };
 		4D92F45290B56030CBFA83D3 /* Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
@@ -206,14 +219,17 @@
 		5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManager.swift; sourceTree = "<group>"; };
 		5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecision.swift; sourceTree = "<group>"; };
 		55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionCheckerTests.swift; sourceTree = "<group>"; };
+		57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFile.swift; sourceTree = "<group>"; };
 		5CC50A90E584320709971BCB /* ScanCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategoryTests.swift; sourceTree = "<group>"; };
 		5E978BB01AD677AEDE122B1C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScannerTests.swift; sourceTree = "<group>"; };
 		6085B6A39985DFF334821551 /* ExclusionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStore.swift; sourceTree = "<group>"; };
+		6090134A72001DE6262436F3 /* FileIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconCache.swift; sourceTree = "<group>"; };
 		613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModel.swift; sourceTree = "<group>"; };
 		6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScannerTests.swift; sourceTree = "<group>"; };
 		67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewSubviews.swift; sourceTree = "<group>"; };
+		673CA7922445475111927C0B /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
 		6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerUITests.swift; sourceTree = "<group>"; };
@@ -226,6 +242,8 @@
 		897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensView.swift; sourceTree = "<group>"; };
 		8A0F635D79B943130BAB15AE /* VaderCleaner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VaderCleaner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModel.swift; sourceTree = "<group>"; };
+		8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinder.swift; sourceTree = "<group>"; };
+		8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscoveryTests.swift; sourceTree = "<group>"; };
 		8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyCategoryTests.swift; sourceTree = "<group>"; };
 		90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModel.swift; sourceTree = "<group>"; };
 		91C01D5C9DD349049220AFB2 /* VaderCleanerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VaderCleanerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -233,7 +251,6 @@
 		93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesView.swift; sourceTree = "<group>"; };
 		9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearer.swift; sourceTree = "<group>"; };
 		98D7B18095634307C5D7223D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		991F5B5938F51D3BC7016E88 /* FileIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconCache.swift; sourceTree = "<group>"; };
 		9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScanner.swift; sourceTree = "<group>"; };
 		9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFilesPathProviding.swift; sourceTree = "<group>"; };
@@ -247,14 +264,17 @@
 		B2E92F45C5CC0EEA00B12EF5 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		B39407E2EA6D045893F1BA4B /* DiskNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskNode.swift; sourceTree = "<group>"; };
 		B3CD8C98E8253953444DD99F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		B79E0766E335360E04FC6A53 /* AppDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscovery.swift; sourceTree = "<group>"; };
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
 		BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScanner.swift; sourceTree = "<group>"; };
 		BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModelTests.swift; sourceTree = "<group>"; };
 		C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
+		C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinderTests.swift; sourceTree = "<group>"; };
 		C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScanner.swift; sourceTree = "<group>"; };
 		C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C751F5671E4A4657944A7DFC /* PrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyView.swift; sourceTree = "<group>"; };
 		C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStoreTests.swift; sourceTree = "<group>"; };
+		C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewSubviews.swift; sourceTree = "<group>"; };
 		CAC2037BDF5D632418393BD9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModelTests.swift; sourceTree = "<group>"; };
 		D1CC391B523110720320AD89 /* SystemPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPathProviding.swift; sourceTree = "<group>"; };
@@ -315,8 +335,15 @@
 			isa = PBXGroup;
 			children = (
 				5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */,
+				B79E0766E335360E04FC6A53 /* AppDiscovery.swift */,
+				673CA7922445475111927C0B /* AppInfo.swift */,
 				FE6697CA6EEE719B2E2D46CE /* AppState.swift */,
+				04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */,
+				49D62624319B764770F02292 /* AppUninstallerViewModel.swift */,
+				C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */,
 				5E978BB01AD677AEDE122B1C /* Assets.xcassets */,
+				57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */,
+				8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */,
 				4D92F45290B56030CBFA83D3 /* Browser.swift */,
 				9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */,
 				3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */,
@@ -327,7 +354,7 @@
 				613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */,
 				6085B6A39985DFF334821551 /* ExclusionsStore.swift */,
 				F421495C84A41EDEF253EBD6 /* FileCategory.swift */,
-				991F5B5938F51D3BC7016E88 /* FileIconCache.swift */,
+				6090134A72001DE6262436F3 /* FileIconCache.swift */,
 				BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */,
 				AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */,
 				FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */,
@@ -364,7 +391,7 @@
 				A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */,
 				ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */,
 				D1CC391B523110720320AD89 /* SystemPathProviding.swift */,
-				0AACE023B8504EE78B14CC01 /* SystemStatsFormatters.swift */,
+				02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */,
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
 				4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */,
 				50BDB24525760C96625DD266 /* TreemapView.swift */,
@@ -407,7 +434,10 @@
 			isa = PBXGroup;
 			children = (
 				25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */,
+				8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */,
 				9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */,
+				31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */,
+				C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */,
 				E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */,
 				A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */,
 				42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */,
@@ -596,7 +626,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */,
+				B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */,
 				3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */,
+				11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */,
+				65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */,
 				F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */,
 				B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */,
 				7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */,
@@ -663,7 +696,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */,
+				A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */,
+				2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */,
 				3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */,
+				26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */,
+				B7DADC9127C373029FC8198A /* AppUninstallerViewModel.swift in Sources */,
+				D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */,
+				9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */,
+				EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */,
 				3328707476CC1411FA1270D0 /* Browser.swift in Sources */,
 				85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */,
 				2B0438D190A4BDCD9853DC7D /* BrowserDataPathProviding.swift in Sources */,
@@ -674,7 +714,7 @@
 				F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */,
 				C3F9A86A896DAD3A63EB8F9F /* ExclusionsStore.swift in Sources */,
 				60DBED2582B50DA009B180C4 /* FileCategory.swift in Sources */,
-				51688E781C12B6E4622A58F2 /* FileIconCache.swift in Sources */,
+				730791446114BB6991798518 /* FileIconCache.swift in Sources */,
 				52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */,
 				92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */,
 				3A3C0E7B444AE96C4C2D1C8F /* HealthMonitorViewModel.swift in Sources */,
@@ -712,7 +752,7 @@
 				B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */,
 				83FF16A5DCFB4B225F33236E /* SystemJunkViewModel.swift in Sources */,
 				BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */,
-				0AACE024B8504EE78B14CC01 /* SystemStatsFormatters.swift in Sources */,
+				9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */,
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
 				1947460A68C713844C308694 /* TreemapLayout.swift in Sources */,
 				35F306676A3412253929EF55 /* TreemapView.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */; };
+		E370FDA389CDFEC249437640 /* AppIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */; };
 		EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */; };
 		EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */; };
 		EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4E92A146A223EA836C156D /* ScanResultTests.swift */; };
@@ -236,6 +237,7 @@
 		6CBCA8999E04715E502AB892 /* VaderCleanerHelper */ = {isa = PBXFileReference; includeInIndex = 0; path = VaderCleanerHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingView.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
+		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
 		80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayoutTests.swift; sourceTree = "<group>"; };
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 			children = (
 				5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */,
 				B79E0766E335360E04FC6A53 /* AppDiscovery.swift */,
+				7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */,
 				673CA7922445475111927C0B /* AppInfo.swift */,
 				FE6697CA6EEE719B2E2D46CE /* AppState.swift */,
 				04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */,
@@ -697,6 +700,7 @@
 			files = (
 				6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */,
 				A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */,
+				E370FDA389CDFEC249437640 /* AppIconCache.swift in Sources */,
 				2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */,
 				3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */,
 				26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */,

--- a/VaderCleaner/AppDiscovery.swift
+++ b/VaderCleaner/AppDiscovery.swift
@@ -15,6 +15,12 @@ protocol AppDiscovering: Sendable {
     ///   Defaults to `false` at the view-model layer; the Preferences
     ///   toggle (future work) can flip it on.
     func installedApps(includingSystemApps: Bool) async throws -> [AppInfo]
+
+    /// Recursive byte size of the `.app` directory tree. Runs lazily
+    /// when the user selects a row in the App Uninstaller — folding
+    /// this into `installedApps` would pin launch on multi-second
+    /// directory walks for users with many installed apps.
+    func bundleSize(at url: URL) async -> Int64
 }
 
 /// Production discovery — walks the three canonical macOS app roots and
@@ -69,7 +75,9 @@ struct DefaultAppDiscovery: AppDiscovering, Sendable {
                         options: [.skipsHiddenFiles]
                     )
                 } catch {
-                    log.debug("AppDiscovery skipping unreadable root \(root.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    // Privacy: paths and raw error text can leak user-
+                    // identifying info into Console; redact both.
+                    log.debug("AppDiscovery skipping unreadable root \(root.path, privacy: .private(mask: .hash)): \(String(describing: error), privacy: .private)")
                     continue
                 }
                 for entry in entries {
@@ -130,23 +138,30 @@ struct DefaultAppDiscovery: AppDiscovering, Sendable {
             .appendingPathComponent("receipt")
         let isAppStore = fileManager.fileExists(atPath: receipt.path)
 
-        let size = bundleSize(at: url, fileManager: fileManager)
-
         return AppInfo(
             name: name,
             bundleID: bundleID,
             version: version,
             bundleURL: url,
-            bundleSizeBytes: size,
             isAppStore: isAppStore
         )
+    }
+
+    /// Recursive byte size of the `.app` directory tree. Hops to a
+    /// background queue so the view-model can `await` it without pinning
+    /// the main actor while the directory walk runs.
+    func bundleSize(at url: URL) async -> Int64 {
+        let fileManager = fileManager
+        return await Task.detached(priority: .userInitiated) {
+            Self.bundleSize(at: url, fileManager: fileManager)
+        }.value
     }
 
     /// Recursive byte size of the `.app` directory tree. Errors are
     /// tolerated — a permission failure inside a single nested resource
     /// (e.g. a sandboxed `XPCService` we can't stat) must not zero out
     /// the whole row.
-    private static func bundleSize(at url: URL, fileManager: FileManager) -> Int64 {
+    static func bundleSize(at url: URL, fileManager: FileManager) -> Int64 {
         guard let enumerator = fileManager.enumerator(
             at: url,
             includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],

--- a/VaderCleaner/AppDiscovery.swift
+++ b/VaderCleaner/AppDiscovery.swift
@@ -77,20 +77,28 @@ struct DefaultAppDiscovery: AppDiscovering, Sendable {
             var apps: [AppInfo] = []
             for root in roots {
                 guard fileManager.fileExists(atPath: root.path) else { continue }
-                let entries: [URL]
-                do {
-                    entries = try fileManager.contentsOfDirectory(
-                        at: root,
-                        includingPropertiesForKeys: [.isDirectoryKey],
-                        options: [.skipsHiddenFiles]
-                    )
-                } catch {
-                    // Privacy: paths and raw error text can leak user-
-                    // identifying info into Console; redact both.
-                    log.debug("AppDiscovery skipping unreadable root \(root.path, privacy: .private(mask: .hash)): \(String(describing: error), privacy: .private)")
-                    continue
-                }
-                for entry in entries {
+                // `.skipsPackageDescendants` keeps the enumerator from
+                // walking *inside* `.app` bundles (Contents/MacOS, etc.) —
+                // we want to find the bundle itself, not its frameworks
+                // or XPC services. Without recursion we'd miss apps
+                // installed in vendor subfolders like
+                // `/Applications/Adobe/.../*.app` or `/Applications/Setapp/*.app`.
+                guard let enumerator = fileManager.enumerator(
+                    at: root,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles, .skipsPackageDescendants],
+                    errorHandler: { url, error in
+                        // Privacy: paths and raw error text can leak user-
+                        // identifying info into Console; redact both. Keep
+                        // walking the rest of the tree — a single
+                        // unreadable subfolder must not blank the whole
+                        // app list.
+                        log.debug("AppDiscovery skipping unreadable entry \(url.path, privacy: .private(mask: .hash)): \(String(describing: error), privacy: .private)")
+                        return true
+                    }
+                ) else { continue }
+
+                for case let entry as URL in enumerator {
                     guard entry.pathExtension.caseInsensitiveCompare("app") == .orderedSame else {
                         continue
                     }

--- a/VaderCleaner/AppDiscovery.swift
+++ b/VaderCleaner/AppDiscovery.swift
@@ -1,0 +1,165 @@
+// AppDiscovery.swift
+// Locates installed .app bundles under /Applications, /Applications/Utilities, and ~/Applications and returns their parsed metadata for the App Uninstaller list.
+
+import Foundation
+import os.log
+
+/// Test seam between `AppUninstallerViewModel` and the real macOS
+/// application directories. The protocol returns ready-to-display
+/// `AppInfo` records so the view-model never has to walk the filesystem
+/// directly — every call site can be exercised with an in-memory stub
+/// in tests.
+protocol AppDiscovering: Sendable {
+    /// - Parameter includingSystemApps: when `false`, bundles whose
+    ///   `CFBundleIdentifier` begins with `com.apple.` are filtered out.
+    ///   Defaults to `false` at the view-model layer; the Preferences
+    ///   toggle (future work) can flip it on.
+    func installedApps(includingSystemApps: Bool) async throws -> [AppInfo]
+}
+
+/// Production discovery — walks the three canonical macOS app roots and
+/// reads `Info.plist` for each `.app` bundle it finds.
+struct DefaultAppDiscovery: AppDiscovering, Sendable {
+
+    private let fileManager: FileManager
+    private let roots: [URL]
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "AppDiscovery")
+
+    /// - Parameter homeDirectory: the user's home, used to resolve
+    ///   `~/Applications`. Defaults to the real home; tests inject a
+    ///   temp dir so the fixture is fully hermetic.
+    /// - Parameter additionalRoots: extra roots to scan in addition to
+    ///   the macOS defaults. Tests use this to point discovery at a
+    ///   fixture tree and bypass the real `/Applications`.
+    init(
+        fileManager: FileManager = .default,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        additionalRoots: [URL] = [],
+        useDefaultRoots: Bool = true
+    ) {
+        self.fileManager = fileManager
+        var roots: [URL] = []
+        if useDefaultRoots {
+            roots.append(URL(fileURLWithPath: "/Applications", isDirectory: true))
+            roots.append(URL(fileURLWithPath: "/Applications/Utilities", isDirectory: true))
+            roots.append(homeDirectory.appendingPathComponent("Applications", isDirectory: true))
+        }
+        roots.append(contentsOf: additionalRoots)
+        self.roots = roots
+    }
+
+    func installedApps(includingSystemApps: Bool) async throws -> [AppInfo] {
+        // Hop off the calling actor so the directory walk and `Info.plist`
+        // reads don't pin the main thread for hundreds of milliseconds on
+        // machines with many installed apps.
+        let fileManager = fileManager
+        let roots = roots
+        let log = log
+        return await Task.detached(priority: .userInitiated) {
+            var seen = Set<String>()
+            var apps: [AppInfo] = []
+            for root in roots {
+                guard fileManager.fileExists(atPath: root.path) else { continue }
+                let entries: [URL]
+                do {
+                    entries = try fileManager.contentsOfDirectory(
+                        at: root,
+                        includingPropertiesForKeys: [.isDirectoryKey],
+                        options: [.skipsHiddenFiles]
+                    )
+                } catch {
+                    log.debug("AppDiscovery skipping unreadable root \(root.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    continue
+                }
+                for entry in entries {
+                    guard entry.pathExtension.caseInsensitiveCompare("app") == .orderedSame else {
+                        continue
+                    }
+                    guard let info = Self.parseBundle(at: entry, fileManager: fileManager) else {
+                        continue
+                    }
+                    if !includingSystemApps, info.bundleID.hasPrefix("com.apple.") {
+                        continue
+                    }
+                    // Dedup by bundle URL path — two roots may surface the
+                    // same `.app` (e.g. `/Applications` and a fixture root
+                    // pointing at the same tree in tests).
+                    guard seen.insert(info.bundleURL.path).inserted else { continue }
+                    apps.append(info)
+                }
+            }
+            apps.sort { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+            return apps
+        }.value
+    }
+
+    /// Parses `Info.plist` for a single `.app` bundle. Returns `nil` when
+    /// `CFBundleIdentifier` is missing — without a bundle ID we can't find
+    /// associated files later, so the row would be useless to the user.
+    static func parseBundle(at url: URL, fileManager: FileManager) -> AppInfo? {
+        let infoPlistURL = url
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: infoPlistURL) else { return nil }
+        guard let plist = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+        ) as? [String: Any] else { return nil }
+        guard let bundleID = plist["CFBundleIdentifier"] as? String,
+              !bundleID.isEmpty else { return nil }
+
+        let displayName = (plist["CFBundleDisplayName"] as? String).flatMap {
+            $0.isEmpty ? nil : $0
+        }
+        let bundleName = (plist["CFBundleName"] as? String).flatMap {
+            $0.isEmpty ? nil : $0
+        }
+        let filenameWithoutExtension = url.deletingPathExtension().lastPathComponent
+        let name = displayName ?? bundleName ?? filenameWithoutExtension
+
+        let version = (plist["CFBundleShortVersionString"] as? String)
+            ?? (plist["CFBundleVersion"] as? String)
+
+        let receipt = url
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("_MASReceipt", isDirectory: true)
+            .appendingPathComponent("receipt")
+        let isAppStore = fileManager.fileExists(atPath: receipt.path)
+
+        let size = bundleSize(at: url, fileManager: fileManager)
+
+        return AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: version,
+            bundleURL: url,
+            bundleSizeBytes: size,
+            isAppStore: isAppStore
+        )
+    }
+
+    /// Recursive byte size of the `.app` directory tree. Errors are
+    /// tolerated — a permission failure inside a single nested resource
+    /// (e.g. a sandboxed `XPCService` we can't stat) must not zero out
+    /// the whole row.
+    private static func bundleSize(at url: URL, fileManager: FileManager) -> Int64 {
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in true }
+        ) else { return 0 }
+        var total: Int64 = 0
+        for case let item as URL in enumerator {
+            let values = try? item.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            if values?.isRegularFile == true, let fileSize = values?.fileSize {
+                total += Int64(fileSize)
+            }
+        }
+        return total
+    }
+}

--- a/VaderCleaner/AppDiscovery.swift
+++ b/VaderCleaner/AppDiscovery.swift
@@ -50,6 +50,16 @@ struct DefaultAppDiscovery: AppDiscovering, Sendable {
             roots.append(URL(fileURLWithPath: "/Applications", isDirectory: true))
             roots.append(URL(fileURLWithPath: "/Applications/Utilities", isDirectory: true))
             roots.append(homeDirectory.appendingPathComponent("Applications", isDirectory: true))
+            // On modern macOS most Apple system apps (Finder, Notes,
+            // Calendar, etc.) live under `/System/Applications` on the
+            // read-only Signed System Volume, not `/Applications`. Without
+            // these roots the "Show system apps" toggle would silently
+            // fail to surface most system apps even after the
+            // `com.apple.*` filter is disabled. Trashing them is blocked
+            // by SSV — the workspace recycler reports failure for those
+            // bundles, which the view-model already routes to `.failed`.
+            roots.append(URL(fileURLWithPath: "/System/Applications", isDirectory: true))
+            roots.append(URL(fileURLWithPath: "/System/Applications/Utilities", isDirectory: true))
         }
         roots.append(contentsOf: additionalRoots)
         self.roots = roots

--- a/VaderCleaner/AppIconCache.swift
+++ b/VaderCleaner/AppIconCache.swift
@@ -1,0 +1,78 @@
+// AppIconCache.swift
+// Per-bundle NSImage cache for the App Uninstaller list so rendering rows doesn't call NSWorkspace.shared.icon(forFile:) synchronously inside SwiftUI body.
+
+import AppKit
+import Combine
+
+/// Caches `NSWorkspace.shared.icon(forFile:)` results keyed by the
+/// `.app` bundle URL. The App Uninstaller list pre-loads icons on a
+/// background queue when the discovery results land, then views read
+/// synchronously from the cache during `body`. Bundles that haven't
+/// been pre-loaded yet fall back to the generic application icon so
+/// the row still renders something — the real icon swaps in once the
+/// pre-load publishes its `revision` bump.
+///
+/// Cache is keyed by bundle URL path rather than file extension (the
+/// strategy `FileIconCache` uses) because each `.app` has its own
+/// asset-catalog icon — there's no shared "kind" key the way `.png`
+/// or `.txt` share one.
+@MainActor
+final class AppIconCache: ObservableObject {
+    /// Bumped after every batch of pre-loaded icons so SwiftUI views
+    /// observing the cache re-render and pick up the freshly cached
+    /// images.
+    @Published private(set) var revision: Int = 0
+
+    private var icons: [String: NSImage] = [:]
+    private let placeholderIcon: NSImage
+    private let loader: (URL) -> NSImage
+    private let workQueue = DispatchQueue(label: "com.personal.VaderCleaner.app-icon-cache",
+                                          qos: .userInitiated)
+
+    /// `nonisolated` so SwiftUI views (which initialize at non-isolated
+    /// scope) can construct the cache inline as a `@StateObject` default.
+    /// All published mutation flows through `preloadIcons(for:)`, which
+    /// remains main-actor isolated.
+    nonisolated init(
+        placeholderIcon: NSImage = NSWorkspace.shared.icon(for: .application),
+        loader: @escaping (URL) -> NSImage = { url in
+            NSWorkspace.shared.icon(forFile: url.path)
+        }
+    ) {
+        self.placeholderIcon = placeholderIcon
+        self.loader = loader
+    }
+
+    /// Returns the cached icon for `bundleURL`, or the generic
+    /// application placeholder if the icon hasn't been pre-loaded yet.
+    /// Safe to call from inside a SwiftUI `body`.
+    func icon(for bundleURL: URL) -> NSImage {
+        icons[bundleURL.path] ?? placeholderIcon
+    }
+
+    /// Pre-load icons for `urls` on a background queue. Idempotent —
+    /// URLs already in the cache are skipped. Publishes a `revision`
+    /// bump once new icons land so observing views re-render.
+    func preloadIcons(for urls: [URL]) async {
+        let missing = urls.filter { icons[$0.path] == nil }
+        guard !missing.isEmpty else { return }
+
+        let loader = self.loader
+        let workQueue = self.workQueue
+        let loaded: [(String, NSImage)] = await withCheckedContinuation { continuation in
+            workQueue.async {
+                let pairs = missing.map { ($0.path, loader($0)) }
+                continuation.resume(returning: pairs)
+            }
+        }
+
+        var added = 0
+        for (path, image) in loaded where icons[path] == nil {
+            icons[path] = image
+            added += 1
+        }
+        if added > 0 {
+            revision += 1
+        }
+    }
+}

--- a/VaderCleaner/AppInfo.swift
+++ b/VaderCleaner/AppInfo.swift
@@ -1,0 +1,34 @@
+// AppInfo.swift
+// Value type describing a single installed macOS application discovered by AppDiscovery and surfaced in the App Uninstaller list.
+
+import Foundation
+
+/// A single installed `.app` bundle plus the metadata the App Uninstaller
+/// needs to display it and decide what to remove.
+///
+/// `bundleSizeBytes` is computed lazily by `AppDiscovery` (size of the
+/// `.app` directory tree); a value of `0` is acceptable when sizing
+/// failed — the row still renders, just with no size label. `iconPath`
+/// is intentionally a `URL?` rather than an `NSImage` so the value type
+/// stays cleanly `Sendable`; the view layer resolves the icon via
+/// `NSWorkspace.shared.icon(forFile:)` at render time so it picks up
+/// the asset-catalog (`.car`) icons that modern apps use without us
+/// having to parse `CFBundleIconFile` ourselves.
+///
+/// `isAppStore` reflects the presence of `Contents/_MASReceipt/receipt`
+/// inside the bundle — the canonical Mac App Store install marker —
+/// and is reserved for future "show App Store apps separately" filters
+/// and for App Updater (Prompt 20).
+struct AppInfo: Identifiable, Hashable, Sendable {
+    let name: String
+    let bundleID: String
+    let version: String?
+    let bundleURL: URL
+    let bundleSizeBytes: Int64
+    let isAppStore: Bool
+
+    /// `id` keys off the bundle URL path so SwiftUI lists stay stable across
+    /// repeated discovery passes — bundleID is not unique (two copies of the
+    /// same app under `/Applications` and `~/Applications` would collide).
+    var id: String { bundleURL.path }
+}

--- a/VaderCleaner/AppInfo.swift
+++ b/VaderCleaner/AppInfo.swift
@@ -6,14 +6,17 @@ import Foundation
 /// A single installed `.app` bundle plus the metadata the App Uninstaller
 /// needs to display it and decide what to remove.
 ///
-/// `bundleSizeBytes` is computed lazily by `AppDiscovery` (size of the
-/// `.app` directory tree); a value of `0` is acceptable when sizing
-/// failed — the row still renders, just with no size label. `iconPath`
-/// is intentionally a `URL?` rather than an `NSImage` so the value type
-/// stays cleanly `Sendable`; the view layer resolves the icon via
-/// `NSWorkspace.shared.icon(forFile:)` at render time so it picks up
-/// the asset-catalog (`.car`) icons that modern apps use without us
-/// having to parse `CFBundleIconFile` ourselves.
+/// Bundle size is **not** part of this value — recursively summing every
+/// regular file in every installed `.app` during the initial discovery
+/// pass is expensive (multi-second on machines with many apps) and
+/// pinning that work to launch makes the entire feature feel slow.
+/// `AppUninstallerViewModel.bundleSize(for:)` computes the size lazily
+/// when the user selects a row, in parallel with the associated-files
+/// scan.
+///
+/// Icons are similarly resolved through a dedicated `@MainActor`
+/// `AppIconCache` rather than carried on `AppInfo`, so the value type
+/// stays cleanly `Sendable`.
 ///
 /// `isAppStore` reflects the presence of `Contents/_MASReceipt/receipt`
 /// inside the bundle — the canonical Mac App Store install marker —
@@ -24,7 +27,6 @@ struct AppInfo: Identifiable, Hashable, Sendable {
     let bundleID: String
     let version: String?
     let bundleURL: URL
-    let bundleSizeBytes: Int64
     let isAppStore: Bool
 
     /// `id` keys off the bundle URL path so SwiftUI lists stay stable across

--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -10,10 +10,12 @@ import SwiftUI
 struct AppUninstallerView: View {
 
     @ObservedObject private var viewModel: AppUninstallerViewModel
+    @StateObject private var iconCache: AppIconCache
     @State private var showUninstallConfirmation = false
 
-    init(viewModel: AppUninstallerViewModel) {
+    init(viewModel: AppUninstallerViewModel, iconCache: AppIconCache = AppIconCache()) {
         self.viewModel = viewModel
+        _iconCache = StateObject(wrappedValue: iconCache)
     }
 
     var body: some View {
@@ -62,6 +64,7 @@ struct AppUninstallerView: View {
             AppUninstallerListPane(
                 apps: viewModel.filteredApps,
                 selectedAppID: viewModel.selectedAppID,
+                bundleSize: viewModel.bundleSize(for:),
                 searchQuery: Binding(
                     get: { viewModel.searchQuery },
                     set: { viewModel.searchQuery = $0 }
@@ -74,17 +77,27 @@ struct AppUninstallerView: View {
                         Task { await viewModel.reloadApps() }
                     }
                 ),
-                onSelect: viewModel.select
+                onSelect: viewModel.select,
+                iconCache: iconCache
             )
             .frame(minWidth: 260, idealWidth: 300, maxWidth: 360)
             Divider()
             AppUninstallerDetailPane(
                 app: viewModel.selectedApp,
+                bundleSize: viewModel.selectedAppBundleSize,
                 isLoadingAssociatedFiles: viewModel.isLoadingAssociatedFiles,
                 groupedFiles: viewModel.associatedFilesByCategory,
                 totalReclaimableSize: viewModel.totalReclaimableSize,
-                onUninstall: { showUninstallConfirmation = true }
+                canUninstall: viewModel.canUninstallSelectedApp,
+                onUninstall: { showUninstallConfirmation = true },
+                iconCache: iconCache
             )
+        }
+        .onChange(of: viewModel.filteredApps.map(\.id)) { _, _ in
+            Task { await iconCache.preloadIcons(for: viewModel.filteredApps.map(\.bundleURL)) }
+        }
+        .task(id: viewModel.apps.map(\.id)) {
+            await iconCache.preloadIcons(for: viewModel.apps.map(\.bundleURL))
         }
     }
 

--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -28,8 +28,14 @@ struct AppUninstallerView: View {
                 }
             }
             .alert(uninstallConfirmationTitle, isPresented: $showUninstallConfirmation) {
-                Button("Cancel", role: .cancel) { }
-                Button("Move to Trash", role: .destructive) {
+                Button(String(
+                    localized: "Cancel",
+                    comment: "Cancel button on the App Uninstaller confirmation alert."
+                ), role: .cancel) { }
+                Button(String(
+                    localized: "Move to Trash",
+                    comment: "Confirm-uninstall button on the App Uninstaller confirmation alert."
+                ), role: .destructive) {
                     Task { await viewModel.uninstall() }
                 }
             } message: {
@@ -41,12 +47,18 @@ struct AppUninstallerView: View {
     private var content: some View {
         switch viewModel.phase {
         case .idle, .loading:
-            AppUninstallerProgressState(label: "Discovering installed apps…",
+            AppUninstallerProgressState(label: String(
+                                            localized: "Discovering installed apps…",
+                                            comment: "Progress label while the App Uninstaller scans for installed apps."
+                                        ),
                                          identifier: "appUninstaller.loading")
         case .ready:
             readyContent
         case .uninstalling:
-            AppUninstallerProgressState(label: "Moving to Trash…",
+            AppUninstallerProgressState(label: String(
+                                            localized: "Moving to Trash…",
+                                            comment: "Progress label while the App Uninstaller is moving items to Trash."
+                                        ),
                                          identifier: "appUninstaller.uninstalling")
         case .complete(let bytes):
             AppUninstallerCompleteState(bytesFreed: bytes,

--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -1,0 +1,120 @@
+// AppUninstallerView.swift
+// App Uninstaller feature view — orchestrates app discovery, selection, associated-files inspection, and destructive uninstall.
+
+import SwiftUI
+
+/// Detail view shown when the user selects "App Uninstaller" in the sidebar.
+/// Two-pane layout: searchable installed-app list on the left, associated-
+/// files inspector + uninstall control on the right. The view-model owns
+/// the state machine and the actual side-effects.
+struct AppUninstallerView: View {
+
+    @ObservedObject private var viewModel: AppUninstallerViewModel
+    @State private var showUninstallConfirmation = false
+
+    init(viewModel: AppUninstallerViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(NavigationSection.appUninstaller.title)
+            .task {
+                if viewModel.phase == .idle {
+                    await viewModel.loadApps()
+                }
+            }
+            .alert(uninstallConfirmationTitle, isPresented: $showUninstallConfirmation) {
+                Button("Cancel", role: .cancel) { }
+                Button("Move to Trash", role: .destructive) {
+                    Task { await viewModel.uninstall() }
+                }
+            } message: {
+                Text(uninstallConfirmationMessage)
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.phase {
+        case .idle, .loading:
+            AppUninstallerProgressState(label: "Discovering installed apps…",
+                                         identifier: "appUninstaller.loading")
+        case .ready:
+            readyContent
+        case .uninstalling:
+            AppUninstallerProgressState(label: "Moving to Trash…",
+                                         identifier: "appUninstaller.uninstalling")
+        case .complete(let bytes):
+            AppUninstallerCompleteState(bytesFreed: bytes,
+                                        onContinue: viewModel.dismissResult)
+        case .failed(let stage, let message):
+            AppUninstallerFailedState(stage: stage,
+                                     message: message,
+                                     onTryAgain: { Task { await viewModel.loadApps() } })
+        }
+    }
+
+    @ViewBuilder
+    private var readyContent: some View {
+        HStack(spacing: 0) {
+            AppUninstallerListPane(
+                apps: viewModel.filteredApps,
+                selectedAppID: viewModel.selectedAppID,
+                searchQuery: Binding(
+                    get: { viewModel.searchQuery },
+                    set: { viewModel.searchQuery = $0 }
+                ),
+                includesSystemApps: Binding(
+                    get: { viewModel.includesSystemApps },
+                    set: { newValue in
+                        guard newValue != viewModel.includesSystemApps else { return }
+                        viewModel.includesSystemApps = newValue
+                        Task { await viewModel.reloadApps() }
+                    }
+                ),
+                onSelect: viewModel.select
+            )
+            .frame(minWidth: 260, idealWidth: 300, maxWidth: 360)
+            Divider()
+            AppUninstallerDetailPane(
+                app: viewModel.selectedApp,
+                isLoadingAssociatedFiles: viewModel.isLoadingAssociatedFiles,
+                groupedFiles: viewModel.associatedFilesByCategory,
+                totalReclaimableSize: viewModel.totalReclaimableSize,
+                onUninstall: { showUninstallConfirmation = true }
+            )
+        }
+    }
+
+    private var uninstallConfirmationTitle: String {
+        String(
+            localized: "Move app and its data to Trash?",
+            comment: "Alert title asking the user to confirm uninstalling an app."
+        )
+    }
+
+    private var uninstallConfirmationMessage: String {
+        if let app = viewModel.selectedApp {
+            let format = String(
+                localized: "%@ and its associated files will be moved to the Trash. You can restore them from the Trash until you empty it.",
+                comment: "Alert message confirming an app uninstall."
+            )
+            return String.localizedStringWithFormat(format, app.name)
+        }
+        return String(
+            localized: "The selected app and its associated files will be moved to the Trash.",
+            comment: "Fallback alert message confirming an app uninstall when the app name is unavailable."
+        )
+    }
+}
+
+#Preview {
+    AppUninstallerView(viewModel: AppUninstallerViewModel(
+        discover: { _ in [] },
+        findFiles: { _ in [] },
+        recycle: { _ in 0 }
+    ))
+    .frame(width: 900, height: 600)
+}

--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -127,7 +127,7 @@ struct AppUninstallerView: View {
     AppUninstallerView(viewModel: AppUninstallerViewModel(
         discover: { _ in [] },
         findFiles: { _ in [] },
-        recycle: { _ in 0 }
+        recycle: { _, _ in 0 }
     ))
     .frame(width: 900, height: 600)
 }

--- a/VaderCleaner/AppUninstallerViewModel.swift
+++ b/VaderCleaner/AppUninstallerViewModel.swift
@@ -34,7 +34,11 @@ final class AppUninstallerViewModel: ObservableObject {
     typealias Discover     = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
     typealias FindFiles    = @Sendable (_ bundleID: String) async -> [AssociatedFile]
     typealias MeasureSize  = @Sendable (_ bundleURL: URL) async -> Int64
-    typealias Recycle      = @Sendable (_ urls: [URL]) async throws -> Int64
+    /// Recycler contract: takes the `.app` bundle URL and the associated
+    /// file URLs separately so the production implementation can verify
+    /// the bundle itself was moved (and not just the user-writable
+    /// residue). Returns the byte-count actually freed.
+    typealias Recycle      = @Sendable (_ bundleURL: URL, _ associatedURLs: [URL]) async throws -> Int64
 
     @Published private(set) var phase: Phase = .idle
     @Published private(set) var apps: [AppInfo] = []
@@ -253,11 +257,10 @@ final class AppUninstallerViewModel: ObservableObject {
     /// and leave residual user data behind.
     func uninstall() async {
         guard let app = selectedApp, !isLoadingAssociatedFiles else { return }
-        let urls = [app.bundleURL] + associatedFiles.map { $0.url }
-        guard !urls.isEmpty else { return }
+        let associatedURLs = associatedFiles.map { $0.url }
         phase = .uninstalling
         do {
-            let bytesFreed = try await recycle(urls)
+            let bytesFreed = try await recycle(app.bundleURL, associatedURLs)
             // Drop the app from the cached list and reset selection so the
             // user sees the result without a stale row pointing at a now-
             // Trashed bundle. `bytesFreed` is the recycler's authoritative
@@ -318,8 +321,11 @@ extension AppUninstallerViewModel {
             measureSize: { url in
                 await discovery.bundleSize(at: url)
             },
-            recycle: { urls in
-                try await Self.recycleViaWorkspace(urls: urls)
+            recycle: { bundleURL, associatedURLs in
+                try await Self.recycleViaWorkspace(
+                    bundleURL: bundleURL,
+                    associatedURLs: associatedURLs
+                )
             }
         )
     }
@@ -330,23 +336,37 @@ extension AppUninstallerViewModel {
     ///
     /// `NSWorkspace.recycle` does NOT throw on partial failure — it returns
     /// the items it managed to Trash and reports an error only when the
-    /// entire batch failed. We sum sizes for items the system confirmed
-    /// were moved.
-    private static func recycleViaWorkspace(urls: [URL]) async throws -> Int64 {
+    /// entire batch failed. The `.app` bundle is the must-succeed item:
+    /// if user-writable residue gets Trashed but the root-owned bundle
+    /// itself is denied, the app is still installed and showing
+    /// "Complete" would mislead the user (and leave a stale row in the
+    /// list). We therefore throw whenever the bundle URL is missing from
+    /// `newURLs`, even if some associated files succeeded. Associated-
+    /// file partial failures are tolerated — they're best-effort
+    /// cleanup, and "we Trashed the app and most of its data" is a
+    /// useful outcome.
+    private static func recycleViaWorkspace(
+        bundleURL: URL,
+        associatedURLs: [URL]
+    ) async throws -> Int64 {
+        let allURLs = [bundleURL] + associatedURLs
         // Capture sizes before recycle — once the path is in Trash, the
         // original URL doesn't stat anymore. We need this to credit
         // bytes-freed for the items the workspace successfully moved.
-        let sizesByPath = sizes(for: urls)
+        let sizesByPath = sizes(for: allURLs)
         return try await withCheckedThrowingContinuation { continuation in
-            NSWorkspace.shared.recycle(urls) { newURLs, error in
-                if let error {
-                    // Only fail when nothing was Trashed. A partial failure
-                    // (some items missing from `newURLs`) still credits the
-                    // ones that succeeded.
-                    if newURLs.isEmpty {
-                        continuation.resume(throwing: error)
-                        return
-                    }
+            NSWorkspace.shared.recycle(allURLs) { newURLs, error in
+                let bundleMoved = newURLs.keys.contains(where: { $0.path == bundleURL.path })
+                if !bundleMoved {
+                    let resolvedError = error ?? NSError(
+                        domain: "com.personal.VaderCleaner.AppUninstaller",
+                        code: -1,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: "The application bundle could not be moved to the Trash."
+                        ]
+                    )
+                    continuation.resume(throwing: resolvedError)
+                    return
                 }
                 var bytesFreed: Int64 = 0
                 for original in newURLs.keys {

--- a/VaderCleaner/AppUninstallerViewModel.swift
+++ b/VaderCleaner/AppUninstallerViewModel.swift
@@ -1,0 +1,331 @@
+// AppUninstallerViewModel.swift
+// State machine and selection logic behind the App Uninstaller feature view — drives idle/loading/ready/uninstalling/complete transitions and routes the uninstall through an injected recycler.
+
+import AppKit
+import Foundation
+import os.log
+
+/// Drives the App Uninstaller feature view (load apps → select → uninstall → done).
+///
+/// Like `PrivacyViewModel` and `SystemJunkViewModel`, all collaborators are
+/// injected as closures so unit tests can drive every transition without
+/// touching real disk state. Production wiring lives in
+/// `AppUninstallerViewModel.live()` below.
+@MainActor
+final class AppUninstallerViewModel: ObservableObject {
+
+    /// Which step of the flow generated a `.failed` phase, so the view can
+    /// pick the right heading.
+    enum FailureStage: Equatable {
+        case loading
+        case uninstalling
+    }
+
+    /// Discrete phases the view binds to.
+    enum Phase: Equatable {
+        case idle
+        case loading
+        case ready
+        case uninstalling
+        case complete(bytesFreed: Int64)
+        case failed(stage: FailureStage, message: String)
+    }
+
+    typealias Discover     = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
+    typealias FindFiles    = @Sendable (_ bundleID: String) async -> [AssociatedFile]
+    typealias Recycle      = @Sendable (_ urls: [URL]) async throws -> Int64
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var apps: [AppInfo] = []
+    @Published private(set) var selectedAppID: AppInfo.ID?
+    @Published private(set) var associatedFiles: [AssociatedFile] = []
+    @Published private(set) var isLoadingAssociatedFiles: Bool = false
+    @Published var includesSystemApps: Bool = false
+    @Published var searchQuery: String = ""
+
+    private let discover: Discover
+    private let findFiles: FindFiles
+    private let recycle: Recycle
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "AppUninstallerViewModel")
+
+    /// Cached associated-files results keyed by bundle URL path. Selecting
+    /// the same app twice in a session doesn't re-walk the filesystem.
+    private var associatedFilesCache: [AppInfo.ID: [AssociatedFile]] = [:]
+
+    /// Monotonically increasing token for in-flight operations — see the
+    /// same pattern in `PrivacyViewModel` for the rationale.
+    private var loadGeneration: Int = 0
+    private var selectGeneration: Int = 0
+
+    init(
+        discover: @escaping Discover,
+        findFiles: @escaping FindFiles,
+        recycle: @escaping Recycle
+    ) {
+        self.discover = discover
+        self.findFiles = findFiles
+        self.recycle = recycle
+    }
+
+    // MARK: - Public surface
+
+    /// Convenience for the view layer — the currently selected `AppInfo`.
+    var selectedApp: AppInfo? {
+        guard let id = selectedAppID else { return nil }
+        return apps.first(where: { $0.id == id })
+    }
+
+    /// Apps filtered by the current search query. Case-insensitive,
+    /// substring match on name OR bundle ID. An empty query returns
+    /// the full list.
+    var filteredApps: [AppInfo] {
+        let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return apps }
+        return apps.filter { app in
+            app.name.localizedCaseInsensitiveContains(trimmed)
+                || app.bundleID.localizedCaseInsensitiveContains(trimmed)
+        }
+    }
+
+    /// Sum of bundle size + all associated file sizes for the selected app.
+    /// Returns 0 when nothing is selected — the footer renders "0 bytes" in
+    /// that case, which is correct (nothing will be Trashed).
+    var totalReclaimableSize: Int64 {
+        guard let app = selectedApp else { return 0 }
+        let associated = associatedFiles.reduce(Int64(0)) { $0 + $1.sizeBytes }
+        return app.bundleSizeBytes + associated
+    }
+
+    /// Associated files for the selected app grouped by category, in the
+    /// stable declaration order of `AssociatedFileCategory.allCases`. The
+    /// view renders one section per category.
+    var associatedFilesByCategory: [(AssociatedFileCategory, [AssociatedFile])] {
+        var bucketed: [AssociatedFileCategory: [AssociatedFile]] = [:]
+        for file in associatedFiles {
+            bucketed[file.category, default: []].append(file)
+        }
+        return AssociatedFileCategory.allCases.compactMap { category in
+            guard let entries = bucketed[category], !entries.isEmpty else { return nil }
+            return (category, entries)
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Initial load — populates `apps` and lands in `.ready` (or `.failed`).
+    func loadApps() async {
+        let generation = beginLoad()
+        phase = .loading
+        let includes = includesSystemApps
+        do {
+            let result = try await discover(includes)
+            guard self.loadGeneration == generation else { return }
+            self.apps = result
+            // Restore selection if the previously-selected app still exists,
+            // otherwise drop it so the right-hand panel collapses to its
+            // empty state.
+            if let id = self.selectedAppID,
+               result.contains(where: { $0.id == id }) {
+                // keep current selection
+            } else {
+                self.selectedAppID = nil
+                self.associatedFiles = []
+            }
+            self.phase = .ready
+        } catch {
+            log.error("App discovery failed: \(String(describing: error), privacy: .public)")
+            guard self.loadGeneration == generation else { return }
+            self.apps = []
+            self.selectedAppID = nil
+            self.associatedFiles = []
+            self.phase = .failed(stage: .loading, message: error.localizedDescription)
+        }
+    }
+
+    /// Reloads the app list with the current `includesSystemApps` setting.
+    /// Called by the view when the user flips the toggle so the visible
+    /// list reflects the new filter immediately.
+    func reloadApps() async {
+        await loadApps()
+    }
+
+    /// Select an app by ID. Drives an async associated-files lookup,
+    /// publishing `associatedFiles` once the finder returns. A second
+    /// `select(...)` before the first finishes cancels the older lookup
+    /// so the right-hand panel can't flash stale rows from a previous
+    /// selection.
+    func select(_ appID: AppInfo.ID?) {
+        selectedAppID = appID
+        guard let appID, let app = apps.first(where: { $0.id == appID }) else {
+            associatedFiles = []
+            isLoadingAssociatedFiles = false
+            return
+        }
+        if let cached = associatedFilesCache[appID] {
+            associatedFiles = cached
+            isLoadingAssociatedFiles = false
+            return
+        }
+        associatedFiles = []
+        isLoadingAssociatedFiles = true
+        let generation = beginSelect()
+        let bundleID = app.bundleID
+        let findFiles = findFiles
+        Task { [weak self] in
+            let found = await findFiles(bundleID)
+            await MainActor.run { [weak self] in
+                guard let self, self.selectGeneration == generation else { return }
+                self.associatedFilesCache[appID] = found
+                if self.selectedAppID == appID {
+                    self.associatedFiles = found
+                    self.isLoadingAssociatedFiles = false
+                }
+            }
+        }
+    }
+
+    /// Uninstall the currently-selected app. Routes the bundle URL plus
+    /// every associated file URL through the injected recycler. A no-op
+    /// when nothing is selected.
+    func uninstall() async {
+        guard let app = selectedApp else { return }
+        let urls = [app.bundleURL] + associatedFiles.map { $0.url }
+        guard !urls.isEmpty else { return }
+        let plannedBytes = totalReclaimableSize
+        phase = .uninstalling
+        do {
+            let bytesFreed = try await recycle(urls)
+            // Drop the app from the cached list and reset selection so the
+            // user sees the result without a stale row pointing at a now-
+            // Trashed bundle. We use the optimistic `plannedBytes` when the
+            // recycler reports `0` only as a degenerate fallback — the
+            // recycler is the source of truth.
+            apps.removeAll(where: { $0.id == app.id })
+            selectedAppID = nil
+            associatedFiles = []
+            associatedFilesCache.removeValue(forKey: app.id)
+            phase = .complete(bytesFreed: bytesFreed > 0 ? bytesFreed : plannedBytes)
+        } catch {
+            log.error("App uninstall failed: \(String(describing: error), privacy: .public)")
+            phase = .failed(stage: .uninstalling, message: error.localizedDescription)
+        }
+    }
+
+    /// Returns the VM to `.ready` after a complete / failed phase so the
+    /// user can pick another app to uninstall without restarting the
+    /// discovery scan.
+    func dismissResult() {
+        phase = .ready
+    }
+
+    // MARK: - Generations
+
+    private func beginLoad() -> Int {
+        loadGeneration += 1
+        return loadGeneration
+    }
+
+    private func beginSelect() -> Int {
+        selectGeneration += 1
+        return selectGeneration
+    }
+}
+
+// MARK: - Production wiring
+
+extension AppUninstallerViewModel {
+
+    /// Build a view-model wired to the real `DefaultAppDiscovery`,
+    /// `DefaultAssociatedFileFinder`, and `NSWorkspace.recycle(...)`.
+    @MainActor
+    static func live() -> AppUninstallerViewModel {
+        let discovery = DefaultAppDiscovery()
+        let finder = DefaultAssociatedFileFinder()
+        return AppUninstallerViewModel(
+            discover: { includingSystemApps in
+                try await discovery.installedApps(includingSystemApps: includingSystemApps)
+            },
+            findFiles: { bundleID in
+                await finder.find(forBundleID: bundleID)
+            },
+            recycle: { urls in
+                try await Self.recycleViaWorkspace(urls: urls)
+            }
+        )
+    }
+
+    /// Bridges `NSWorkspace.recycle(_:completionHandler:)` (callback-based,
+    /// returns a `[URL: URL]` map of original → Trash URLs) to an async
+    /// throwing call that reports total bytes successfully Trashed.
+    ///
+    /// `NSWorkspace.recycle` does NOT throw on partial failure — it returns
+    /// the items it managed to Trash and reports an error only when the
+    /// entire batch failed. We sum sizes for items the system confirmed
+    /// were moved.
+    private static func recycleViaWorkspace(urls: [URL]) async throws -> Int64 {
+        // Capture sizes before recycle — once the path is in Trash, the
+        // original URL doesn't stat anymore. We need this to credit
+        // bytes-freed for the items the workspace successfully moved.
+        let sizesByPath = sizes(for: urls)
+        return try await withCheckedThrowingContinuation { continuation in
+            NSWorkspace.shared.recycle(urls) { newURLs, error in
+                if let error {
+                    // Only fail when nothing was Trashed. A partial failure
+                    // (some items missing from `newURLs`) still credits the
+                    // ones that succeeded.
+                    if newURLs.isEmpty {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                }
+                var bytesFreed: Int64 = 0
+                for original in newURLs.keys {
+                    bytesFreed += sizesByPath[original.path] ?? 0
+                }
+                continuation.resume(returning: bytesFreed)
+            }
+        }
+    }
+
+    /// Pre-recycle size snapshot keyed by absolute path. Directories sum
+    /// their regular-file children; missing items contribute 0.
+    private static func sizes(for urls: [URL]) -> [String: Int64] {
+        var result: [String: Int64] = [:]
+        let fileManager = FileManager.default
+        for url in urls {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+                result[url.path] = 0
+                continue
+            }
+            if !isDirectory.boolValue {
+                if let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+                   let size = attrs[.size] as? NSNumber {
+                    result[url.path] = size.int64Value
+                } else {
+                    result[url.path] = 0
+                }
+                continue
+            }
+            guard let enumerator = fileManager.enumerator(
+                at: url,
+                includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+                options: [.skipsHiddenFiles],
+                errorHandler: { _, _ in true }
+            ) else {
+                result[url.path] = 0
+                continue
+            }
+            var total: Int64 = 0
+            for case let item as URL in enumerator {
+                let values = try? item.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+                if values?.isRegularFile == true, let fileSize = values?.fileSize {
+                    total += Int64(fileSize)
+                }
+            }
+            result[url.path] = total
+        }
+        return result
+    }
+}

--- a/VaderCleaner/AppUninstallerViewModel.swift
+++ b/VaderCleaner/AppUninstallerViewModel.swift
@@ -33,6 +33,7 @@ final class AppUninstallerViewModel: ObservableObject {
 
     typealias Discover     = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
     typealias FindFiles    = @Sendable (_ bundleID: String) async -> [AssociatedFile]
+    typealias MeasureSize  = @Sendable (_ bundleURL: URL) async -> Int64
     typealias Recycle      = @Sendable (_ urls: [URL]) async throws -> Int64
 
     @Published private(set) var phase: Phase = .idle
@@ -40,11 +41,15 @@ final class AppUninstallerViewModel: ObservableObject {
     @Published private(set) var selectedAppID: AppInfo.ID?
     @Published private(set) var associatedFiles: [AssociatedFile] = []
     @Published private(set) var isLoadingAssociatedFiles: Bool = false
+    /// Bundle size of the currently selected app, computed lazily on
+    /// selection. `nil` until the per-app size measurement returns.
+    @Published private(set) var selectedAppBundleSize: Int64?
     @Published var includesSystemApps: Bool = false
     @Published var searchQuery: String = ""
 
     private let discover: Discover
     private let findFiles: FindFiles
+    private let measureSize: MeasureSize
     private let recycle: Recycle
     private let log = Logger(subsystem: "com.personal.VaderCleaner",
                              category: "AppUninstallerViewModel")
@@ -52,6 +57,11 @@ final class AppUninstallerViewModel: ObservableObject {
     /// Cached associated-files results keyed by bundle URL path. Selecting
     /// the same app twice in a session doesn't re-walk the filesystem.
     private var associatedFilesCache: [AppInfo.ID: [AssociatedFile]] = [:]
+
+    /// Cached bundle sizes keyed by bundle URL path. The size walk is
+    /// expensive on apps with many bundled frameworks, so we avoid
+    /// repeating it after the first selection.
+    private var bundleSizeCache: [AppInfo.ID: Int64] = [:]
 
     /// Monotonically increasing token for in-flight operations — see the
     /// same pattern in `PrivacyViewModel` for the rationale.
@@ -61,10 +71,12 @@ final class AppUninstallerViewModel: ObservableObject {
     init(
         discover: @escaping Discover,
         findFiles: @escaping FindFiles,
+        measureSize: @escaping MeasureSize = { _ in 0 },
         recycle: @escaping Recycle
     ) {
         self.discover = discover
         self.findFiles = findFiles
+        self.measureSize = measureSize
         self.recycle = recycle
     }
 
@@ -90,11 +102,13 @@ final class AppUninstallerViewModel: ObservableObject {
 
     /// Sum of bundle size + all associated file sizes for the selected app.
     /// Returns 0 when nothing is selected — the footer renders "0 bytes" in
-    /// that case, which is correct (nothing will be Trashed).
+    /// that case, which is correct (nothing will be Trashed). The bundle
+    /// size component is `nil` until the per-app size measurement
+    /// returns; the footer reflects the partial total in the meantime.
     var totalReclaimableSize: Int64 {
-        guard let app = selectedApp else { return 0 }
+        guard selectedApp != nil else { return 0 }
         let associated = associatedFiles.reduce(Int64(0)) { $0 + $1.sizeBytes }
-        return app.bundleSizeBytes + associated
+        return (selectedAppBundleSize ?? 0) + associated
     }
 
     /// Associated files for the selected app grouped by category, in the
@@ -134,7 +148,8 @@ final class AppUninstallerViewModel: ObservableObject {
             }
             self.phase = .ready
         } catch {
-            log.error("App discovery failed: \(String(describing: error), privacy: .public)")
+            // Privacy: errors may include user-specific paths.
+            log.error("App discovery failed: \(String(describing: error), privacy: .private)")
             guard self.loadGeneration == generation else { return }
             self.apps = []
             self.selectedAppID = nil
@@ -150,64 +165,115 @@ final class AppUninstallerViewModel: ObservableObject {
         await loadApps()
     }
 
-    /// Select an app by ID. Drives an async associated-files lookup,
-    /// publishing `associatedFiles` once the finder returns. A second
-    /// `select(...)` before the first finishes cancels the older lookup
-    /// so the right-hand panel can't flash stale rows from a previous
-    /// selection.
+    /// Select an app by ID. Drives an async associated-files lookup AND
+    /// a deferred bundle-size measurement in parallel, publishing
+    /// `associatedFiles` and `selectedAppBundleSize` independently as
+    /// each one finishes. A second `select(...)` before the first
+    /// finishes cancels the older lookups so the right-hand panel can't
+    /// flash stale rows from a previous selection.
     func select(_ appID: AppInfo.ID?) {
         selectedAppID = appID
         guard let appID, let app = apps.first(where: { $0.id == appID }) else {
             associatedFiles = []
+            selectedAppBundleSize = nil
             isLoadingAssociatedFiles = false
             return
         }
-        if let cached = associatedFilesCache[appID] {
-            associatedFiles = cached
+
+        // Hydrate cached results synchronously so the UI doesn't flash
+        // back to "loading" for an app the user has already inspected.
+        selectedAppBundleSize = bundleSizeCache[appID]
+
+        if let cachedFiles = associatedFilesCache[appID] {
+            associatedFiles = cachedFiles
             isLoadingAssociatedFiles = false
-            return
+            // Bundle-size measurement may still be outstanding even when
+            // associated files were cached (e.g. an error path skipped it
+            // last time); fall through to schedule it if needed.
+        } else {
+            associatedFiles = []
+            isLoadingAssociatedFiles = true
         }
-        associatedFiles = []
-        isLoadingAssociatedFiles = true
+
         let generation = beginSelect()
         let bundleID = app.bundleID
+        let bundleURL = app.bundleURL
         let findFiles = findFiles
-        Task { [weak self] in
-            let found = await findFiles(bundleID)
-            await MainActor.run { [weak self] in
-                guard let self, self.selectGeneration == generation else { return }
-                self.associatedFilesCache[appID] = found
-                if self.selectedAppID == appID {
-                    self.associatedFiles = found
-                    self.isLoadingAssociatedFiles = false
+        let measureSize = measureSize
+        let needsFiles = associatedFilesCache[appID] == nil
+        let needsSize = bundleSizeCache[appID] == nil
+
+        if needsFiles {
+            Task { [weak self] in
+                let found = await findFiles(bundleID)
+                await MainActor.run { [weak self] in
+                    guard let self, self.selectGeneration == generation else { return }
+                    self.associatedFilesCache[appID] = found
+                    if self.selectedAppID == appID {
+                        self.associatedFiles = found
+                        self.isLoadingAssociatedFiles = false
+                    }
+                }
+            }
+        }
+
+        if needsSize {
+            Task { [weak self] in
+                let size = await measureSize(bundleURL)
+                await MainActor.run { [weak self] in
+                    guard let self, self.selectGeneration == generation else { return }
+                    self.bundleSizeCache[appID] = size
+                    if self.selectedAppID == appID {
+                        self.selectedAppBundleSize = size
+                    }
                 }
             }
         }
     }
 
+    /// Bundle size for an app, if it has been measured. Used by the list
+    /// row to show "— MB" only after the size lands rather than during
+    /// the initial discovery pass.
+    func bundleSize(for appID: AppInfo.ID) -> Int64? {
+        bundleSizeCache[appID]
+    }
+
+    /// Whether the destructive uninstall button should be enabled for
+    /// the currently selected app. False while the associated-files
+    /// scan is in flight — confirming early would only Trash the bundle
+    /// and leave residual user data behind.
+    var canUninstallSelectedApp: Bool {
+        selectedApp != nil && !isLoadingAssociatedFiles
+    }
+
     /// Uninstall the currently-selected app. Routes the bundle URL plus
     /// every associated file URL through the injected recycler. A no-op
-    /// when nothing is selected.
+    /// when nothing is selected or when the associated-files scan is
+    /// still in flight — confirming early would Trash only the bundle
+    /// and leave residual user data behind.
     func uninstall() async {
-        guard let app = selectedApp else { return }
+        guard let app = selectedApp, !isLoadingAssociatedFiles else { return }
         let urls = [app.bundleURL] + associatedFiles.map { $0.url }
         guard !urls.isEmpty else { return }
-        let plannedBytes = totalReclaimableSize
         phase = .uninstalling
         do {
             let bytesFreed = try await recycle(urls)
             // Drop the app from the cached list and reset selection so the
             // user sees the result without a stale row pointing at a now-
-            // Trashed bundle. We use the optimistic `plannedBytes` when the
-            // recycler reports `0` only as a degenerate fallback — the
-            // recycler is the source of truth.
+            // Trashed bundle. `bytesFreed` is the recycler's authoritative
+            // sum of what it actually moved to Trash — we do NOT fall back
+            // to a planned/optimistic total, since that would claim
+            // "X MB freed" when the recycler reports 0.
             apps.removeAll(where: { $0.id == app.id })
             selectedAppID = nil
             associatedFiles = []
+            selectedAppBundleSize = nil
             associatedFilesCache.removeValue(forKey: app.id)
-            phase = .complete(bytesFreed: bytesFreed > 0 ? bytesFreed : plannedBytes)
+            bundleSizeCache.removeValue(forKey: app.id)
+            phase = .complete(bytesFreed: bytesFreed)
         } catch {
-            log.error("App uninstall failed: \(String(describing: error), privacy: .public)")
+            // Privacy: errors may include user-specific paths.
+            log.error("App uninstall failed: \(String(describing: error), privacy: .private)")
             phase = .failed(stage: .uninstalling, message: error.localizedDescription)
         }
     }
@@ -248,6 +314,9 @@ extension AppUninstallerViewModel {
             },
             findFiles: { bundleID in
                 await finder.find(forBundleID: bundleID)
+            },
+            measureSize: { url in
+                await discovery.bundleSize(at: url)
             },
             recycle: { urls in
                 try await Self.recycleViaWorkspace(urls: urls)

--- a/VaderCleaner/AppUninstallerViewSubviews.swift
+++ b/VaderCleaner/AppUninstallerViewSubviews.swift
@@ -33,9 +33,11 @@ struct AppUninstallerProgressState: View {
 struct AppUninstallerListPane: View {
     let apps: [AppInfo]
     let selectedAppID: AppInfo.ID?
+    let bundleSize: (AppInfo.ID) -> Int64?
     @Binding var searchQuery: String
     @Binding var includesSystemApps: Bool
     let onSelect: (AppInfo.ID?) -> Void
+    @ObservedObject var iconCache: AppIconCache
 
     var body: some View {
         VStack(spacing: 0) {
@@ -50,7 +52,9 @@ struct AppUninstallerListPane: View {
                     set: { onSelect($0) }
                 )) {
                     ForEach(apps) { app in
-                        AppUninstallerListRow(app: app)
+                        AppUninstallerListRow(app: app,
+                                              size: bundleSize(app.id),
+                                              iconCache: iconCache)
                             .tag(Optional(app.id))
                             .accessibilityIdentifier("appUninstaller.row.\(app.bundleID)")
                     }
@@ -95,10 +99,16 @@ struct AppUninstallerSearchField: View {
 
 struct AppUninstallerListRow: View {
     let app: AppInfo
+    let size: Int64?
+    @ObservedObject var iconCache: AppIconCache
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(nsImage: NSWorkspace.shared.icon(forFile: app.bundleURL.path))
+            // Cached icon — falls back to the generic application icon
+            // until the background pre-load lands. `iconCache` is an
+            // ObservedObject so its `revision` bump re-renders this row
+            // once the real icon is available.
+            Image(nsImage: iconCache.icon(for: app.bundleURL))
                 .resizable()
                 .frame(width: 28, height: 28)
             VStack(alignment: .leading, spacing: 2) {
@@ -111,9 +121,9 @@ struct AppUninstallerListRow: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    if app.bundleSizeBytes > 0 {
+                    if let size, size > 0 {
                         Text(AppUninstallerFormatting.byteFormatter
-                            .string(fromByteCount: app.bundleSizeBytes))
+                            .string(fromByteCount: size))
                             .font(.caption.monospacedDigit())
                             .foregroundStyle(.secondary)
                     }
@@ -144,15 +154,18 @@ struct AppUninstallerEmptyListState: View {
 
 struct AppUninstallerDetailPane: View {
     let app: AppInfo?
+    let bundleSize: Int64?
     let isLoadingAssociatedFiles: Bool
     let groupedFiles: [(AssociatedFileCategory, [AssociatedFile])]
     let totalReclaimableSize: Int64
+    let canUninstall: Bool
     let onUninstall: () -> Void
+    @ObservedObject var iconCache: AppIconCache
 
     var body: some View {
         if let app {
             VStack(spacing: 0) {
-                AppUninstallerDetailHeader(app: app)
+                AppUninstallerDetailHeader(app: app, bundleSize: bundleSize, iconCache: iconCache)
                 Divider()
                 if isLoadingAssociatedFiles {
                     VStack(spacing: 12) {
@@ -173,6 +186,7 @@ struct AppUninstallerDetailPane: View {
                 Divider()
                 AppUninstallerDetailFooter(
                     totalReclaimableSize: totalReclaimableSize,
+                    canUninstall: canUninstall,
                     onUninstall: onUninstall
                 )
             }
@@ -184,10 +198,14 @@ struct AppUninstallerDetailPane: View {
 
 struct AppUninstallerDetailHeader: View {
     let app: AppInfo
+    let bundleSize: Int64?
+    @ObservedObject var iconCache: AppIconCache
 
     var body: some View {
         HStack(spacing: 14) {
-            Image(nsImage: NSWorkspace.shared.icon(forFile: app.bundleURL.path))
+            // Cached icon — see `AppUninstallerListRow` for why the
+            // cache is observed.
+            Image(nsImage: iconCache.icon(for: app.bundleURL))
                 .resizable()
                 .frame(width: 56, height: 56)
             VStack(alignment: .leading, spacing: 4) {
@@ -210,10 +228,12 @@ struct AppUninstallerDetailHeader: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    Text(AppUninstallerFormatting.byteFormatter
-                        .string(fromByteCount: app.bundleSizeBytes))
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
+                    if let bundleSize {
+                        Text(AppUninstallerFormatting.byteFormatter
+                            .string(fromByteCount: bundleSize))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             Spacer()
@@ -316,6 +336,7 @@ struct AppUninstallerFileRow: View {
 
 struct AppUninstallerDetailFooter: View {
     let totalReclaimableSize: Int64
+    let canUninstall: Bool
     let onUninstall: () -> Void
 
     var body: some View {
@@ -333,6 +354,10 @@ struct AppUninstallerDetailFooter: View {
                     .accessibilityIdentifier("appUninstaller.totalReclaimable")
             }
             Spacer()
+            // Disabled while the associated-files scan is in flight so a
+            // user who confirms early can't ship the bundle to Trash and
+            // leave caches / preferences behind — the confirmation alert
+            // promises "app and its associated files" will be moved.
             Button(String(
                 localized: "Uninstall",
                 comment: "Primary action button on the App Uninstaller detail pane."
@@ -340,6 +365,7 @@ struct AppUninstallerDetailFooter: View {
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
                 .buttonStyle(.borderedProminent)
+                .disabled(!canUninstall)
                 .accessibilityIdentifier("appUninstaller.uninstall")
         }
         .padding(16)
@@ -410,7 +436,10 @@ struct AppUninstallerFailedState: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 460)
                 .accessibilityIdentifier("appUninstaller.errorMessage")
-            Button("Try Again", action: onTryAgain)
+            Button(String(
+                localized: "Try Again",
+                comment: "Retry action on the App Uninstaller failure screen."
+            ), action: onTryAgain)
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("appUninstaller.tryAgain")

--- a/VaderCleaner/AppUninstallerViewSubviews.swift
+++ b/VaderCleaner/AppUninstallerViewSubviews.swift
@@ -1,0 +1,421 @@
+// AppUninstallerViewSubviews.swift
+// Dedicated subviews for App Uninstaller list pane, detail pane, file rows, and state screens.
+
+import AppKit
+import SwiftUI
+
+enum AppUninstallerFormatting {
+    static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+}
+
+struct AppUninstallerProgressState: View {
+    let label: String
+    let identifier: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+struct AppUninstallerListPane: View {
+    let apps: [AppInfo]
+    let selectedAppID: AppInfo.ID?
+    @Binding var searchQuery: String
+    @Binding var includesSystemApps: Bool
+    let onSelect: (AppInfo.ID?) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            AppUninstallerSearchField(query: $searchQuery)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            if apps.isEmpty {
+                AppUninstallerEmptyListState()
+            } else {
+                List(selection: Binding(
+                    get: { selectedAppID },
+                    set: { onSelect($0) }
+                )) {
+                    ForEach(apps) { app in
+                        AppUninstallerListRow(app: app)
+                            .tag(Optional(app.id))
+                            .accessibilityIdentifier("appUninstaller.row.\(app.bundleID)")
+                    }
+                }
+                .listStyle(.sidebar)
+            }
+            Divider()
+            Toggle(isOn: $includesSystemApps) {
+                Text(String(
+                    localized: "Show system apps",
+                    comment: "Toggle that includes com.apple.* apps in the App Uninstaller list."
+                ))
+                .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .accessibilityIdentifier("appUninstaller.showSystemApps")
+        }
+    }
+}
+
+struct AppUninstallerSearchField: View {
+    @Binding var query: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField(String(
+                localized: "Search apps",
+                comment: "Placeholder for the App Uninstaller search field."
+            ), text: $query)
+                .textFieldStyle(.plain)
+                .accessibilityIdentifier("appUninstaller.search")
+        }
+        .padding(6)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+}
+
+struct AppUninstallerListRow: View {
+    let app: AppInfo
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(nsImage: NSWorkspace.shared.icon(forFile: app.bundleURL.path))
+                .resizable()
+                .frame(width: 28, height: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(app.name)
+                    .font(.body)
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    if let version = app.version {
+                        Text(version)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if app.bundleSizeBytes > 0 {
+                        Text(AppUninstallerFormatting.byteFormatter
+                            .string(fromByteCount: app.bundleSizeBytes))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct AppUninstallerEmptyListState: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text(String(
+                localized: "No matching apps",
+                comment: "Empty state shown when the App Uninstaller search returns no apps."
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct AppUninstallerDetailPane: View {
+    let app: AppInfo?
+    let isLoadingAssociatedFiles: Bool
+    let groupedFiles: [(AssociatedFileCategory, [AssociatedFile])]
+    let totalReclaimableSize: Int64
+    let onUninstall: () -> Void
+
+    var body: some View {
+        if let app {
+            VStack(spacing: 0) {
+                AppUninstallerDetailHeader(app: app)
+                Divider()
+                if isLoadingAssociatedFiles {
+                    VStack(spacing: 12) {
+                        ProgressView()
+                        Text(String(
+                            localized: "Scanning associated files…",
+                            comment: "Status text shown while the App Uninstaller scans for associated files."
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if groupedFiles.isEmpty {
+                    AppUninstallerNoAssociatedFiles()
+                } else {
+                    AppUninstallerAssociatedFilesList(groupedFiles: groupedFiles)
+                }
+                Divider()
+                AppUninstallerDetailFooter(
+                    totalReclaimableSize: totalReclaimableSize,
+                    onUninstall: onUninstall
+                )
+            }
+        } else {
+            AppUninstallerNoSelectionState()
+        }
+    }
+}
+
+struct AppUninstallerDetailHeader: View {
+    let app: AppInfo
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(nsImage: NSWorkspace.shared.icon(forFile: app.bundleURL.path))
+                .resizable()
+                .frame(width: 56, height: 56)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(app.name)
+                    .font(.title3.weight(.semibold))
+                Text(app.bundleID)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 8) {
+                    if let version = app.version {
+                        Label(version, systemImage: "tag")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if app.isAppStore {
+                        Label(String(
+                            localized: "App Store",
+                            comment: "Badge shown next to apps installed via the Mac App Store."
+                        ), systemImage: "bag")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(AppUninstallerFormatting.byteFormatter
+                        .string(fromByteCount: app.bundleSizeBytes))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(16)
+    }
+}
+
+struct AppUninstallerNoSelectionState: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "xmark.app")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(String(
+                localized: "Select an app",
+                comment: "Detail-pane heading shown when no app is selected in the App Uninstaller."
+            ))
+                .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "Pick an app from the list to see its associated files and uninstall it.",
+                comment: "Detail-pane description shown when no app is selected in the App Uninstaller."
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct AppUninstallerNoAssociatedFiles: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "tray")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text(String(
+                localized: "No associated files found",
+                comment: "Empty state shown when an app has no associated files."
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Text(String(
+                localized: "Only the app bundle will be moved to Trash.",
+                comment: "Detail shown when an app has no associated files."
+            ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct AppUninstallerAssociatedFilesList: View {
+    let groupedFiles: [(AssociatedFileCategory, [AssociatedFile])]
+
+    var body: some View {
+        List {
+            ForEach(groupedFiles, id: \.0) { pair in
+                Section {
+                    ForEach(pair.1) { file in
+                        AppUninstallerFileRow(file: file)
+                            .accessibilityIdentifier("appUninstaller.file.\(pair.0.rawValue).\(file.url.lastPathComponent)")
+                    }
+                } header: {
+                    Text(pair.0.displayName)
+                        .font(.callout.weight(.semibold))
+                }
+            }
+        }
+    }
+}
+
+struct AppUninstallerFileRow: View {
+    let file: AssociatedFile
+
+    var body: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(file.url.lastPathComponent)
+                    .font(.body)
+                    .lineLimit(1)
+                Text(file.url.deletingLastPathComponent().path)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Text(AppUninstallerFormatting.byteFormatter
+                .string(fromByteCount: file.sizeBytes))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct AppUninstallerDetailFooter: View {
+    let totalReclaimableSize: Int64
+    let onUninstall: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(
+                    localized: "Total reclaimable",
+                    comment: "Footer label showing the total size that will be reclaimed when an app is uninstalled."
+                ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(AppUninstallerFormatting.byteFormatter
+                    .string(fromByteCount: totalReclaimableSize))
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("appUninstaller.totalReclaimable")
+            }
+            Spacer()
+            Button(String(
+                localized: "Uninstall",
+                comment: "Primary action button on the App Uninstaller detail pane."
+            ), action: onUninstall)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("appUninstaller.uninstall")
+        }
+        .padding(16)
+    }
+}
+
+struct AppUninstallerCompleteState: View {
+    let bytesFreed: Int64
+    let onContinue: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text(bytesFreedText)
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("appUninstaller.bytesFreed")
+            Text(String(
+                localized: "Items were moved to the Trash. Empty the Trash to reclaim the space.",
+                comment: "Detail shown on the App Uninstaller complete screen."
+            ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+            Button(String(
+                localized: "Continue",
+                comment: "Button on the App Uninstaller complete screen to return to the list."
+            ), action: onContinue)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("appUninstaller.continue")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private var bytesFreedText: String {
+        let format = String(
+            localized: "%@ moved to Trash",
+            comment: "Summary of disk space that will be reclaimed after emptying the Trash."
+        )
+        return String.localizedStringWithFormat(
+            format,
+            AppUninstallerFormatting.byteFormatter.string(fromByteCount: bytesFreed)
+        )
+    }
+}
+
+struct AppUninstallerFailedState: View {
+    let stage: AppUninstallerViewModel.FailureStage
+    let message: String
+    let onTryAgain: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(stage == .loading
+                 ? String(localized: "Couldn't load installed apps")
+                 : String(localized: "Couldn't uninstall the app"))
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("appUninstaller.errorMessage")
+            Button("Try Again", action: onTryAgain)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("appUninstaller.tryAgain")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/VaderCleaner/AssociatedFile.swift
+++ b/VaderCleaner/AssociatedFile.swift
@@ -17,6 +17,7 @@ enum AssociatedFileCategory: String, CaseIterable, Codable, Hashable, Identifiab
     case groupContainers
     case savedState
     case launchAgents
+    case launchDaemons
 
     var id: String { rawValue }
 
@@ -33,6 +34,7 @@ enum AssociatedFileCategory: String, CaseIterable, Codable, Hashable, Identifiab
         case .groupContainers:    return "Group Containers"
         case .savedState:         return "Saved Application State"
         case .launchAgents:       return "Launch Agents"
+        case .launchDaemons:      return "Launch Daemons"
         }
     }
 }

--- a/VaderCleaner/AssociatedFile.swift
+++ b/VaderCleaner/AssociatedFile.swift
@@ -1,0 +1,53 @@
+// AssociatedFile.swift
+// Value type representing a single on-disk artifact belonging to an installed app — preferences, caches, logs, container, etc. — that the App Uninstaller surfaces for review and bulk removal.
+
+import Foundation
+
+/// Categories the App Uninstaller groups associated files under in the UI.
+///
+/// Raw values are stable identifiers used by the view layer for sectioning
+/// and accessibility identifiers; do not reorder existing cases or rename
+/// raw values without bumping callers.
+enum AssociatedFileCategory: String, CaseIterable, Codable, Hashable, Identifiable, Sendable {
+    case preferences
+    case applicationSupport
+    case cache
+    case logs
+    case containers
+    case groupContainers
+    case savedState
+    case launchAgents
+
+    var id: String { rawValue }
+
+    /// Human-readable section heading. Localised at the call site (the view
+    /// layer wraps this through `String(localized:)`) so the stable raw value
+    /// remains separate from display copy.
+    var displayName: String {
+        switch self {
+        case .preferences:        return "Preferences"
+        case .applicationSupport: return "Application Support"
+        case .cache:              return "Caches"
+        case .logs:               return "Logs"
+        case .containers:         return "Containers"
+        case .groupContainers:    return "Group Containers"
+        case .savedState:         return "Saved Application State"
+        case .launchAgents:       return "Launch Agents"
+        }
+    }
+}
+
+/// A single on-disk artifact owned by an installed app. The App Uninstaller
+/// surfaces these grouped by `category` so the user can review what's about
+/// to be moved to Trash alongside the `.app` bundle.
+///
+/// `Identifiable` by `url` so SwiftUI lists stay stable as a finder pass
+/// re-emits the same item — `Hashable` so selection sets and dedup work
+/// without needing to introduce a separate identifier strategy.
+struct AssociatedFile: Identifiable, Hashable, Sendable {
+    let url: URL
+    let sizeBytes: Int64
+    let category: AssociatedFileCategory
+
+    var id: URL { url }
+}

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -56,6 +56,7 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
             results.append(contentsOf: matches(
                 inDirectory: preferencesDir,
                 nameStartsWith: bundleID,
+                requiredSuffix: ".plist",
                 category: .preferences,
                 fileManager: fileManager
             ))
@@ -63,6 +64,7 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
             results.append(contentsOf: matches(
                 inDirectory: byHostDir,
                 nameStartsWith: bundleID,
+                requiredSuffix: ".plist",
                 category: .preferences,
                 fileManager: fileManager
             ))
@@ -104,6 +106,7 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
             results.append(contentsOf: matches(
                 inDirectory: savedStateDir,
                 nameStartsWith: bundleID,
+                requiredSuffix: ".savedState",
                 category: .savedState,
                 fileManager: fileManager
             ))
@@ -143,15 +146,19 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
         }.value
     }
 
-    /// Returns every entry in `directory` whose name is the bundle ID or
-    /// starts with the bundle ID *followed by a dot* — required so a
-    /// search for `com.acme.helio` doesn't sweep in `com.acme.helio2.plist`
-    /// or `com.acme.helioworld.plist`. Sized and tagged with `category`.
+    /// Returns every entry in `directory` whose name matches the bundle ID
+    /// on a dot-boundary — exactly `<bundleID>` (with optional `requiredSuffix`)
+    /// or `<bundleID>.<anything>` (also subject to `requiredSuffix`). Required
+    /// so a search for `com.acme.helio` doesn't sweep in `com.acme.helio2`.
+    /// When `requiredSuffix` is non-nil the entry name must also end with it
+    /// (case-insensitive), so a Preferences scan can be locked to `.plist`
+    /// files and Saved Application State to `.savedState` directories.
     /// Missing or unreadable directories are tolerated — they're the common
     /// case (most apps don't write to most of these locations).
     private func matches(
         inDirectory directory: URL,
         nameStartsWith prefix: String,
+        requiredSuffix: String? = nil,
         category: AssociatedFileCategory,
         fileManager: FileManager
     ) -> [AssociatedFile] {
@@ -164,13 +171,20 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
         return entries.compactMap { entry in
             let name = entry.lastPathComponent
             guard name == prefix || name.hasPrefix(dottedPrefix) else { return nil }
+            if let requiredSuffix,
+               name.range(of: requiredSuffix, options: [.caseInsensitive, .anchored, .backwards]) == nil {
+                return nil
+            }
             return makeAssociatedFile(at: entry, category: category, fileManager: fileManager)
         }
     }
 
-    /// Same as `nameStartsWith` but uses substring matching — required
-    /// for Group Containers (team-ID prefix) and Launch Agents (vendor
-    /// suffixes).
+    /// Returns every entry whose name contains the bundle ID on a
+    /// dot-boundary — required for Group Containers (`<TEAMID>.<bundleID>`)
+    /// and Launch Agents (`<bundleID>.helper.plist`, `<bundleID>.updater.plist`),
+    /// while still rejecting siblings like `com.acme.helio2.plist` for a
+    /// search of `com.acme.helio`. The bundle ID must be surrounded by
+    /// dots, or anchored at the start / end of the filename.
     private func matches(
         inDirectory directory: URL,
         nameContains needle: String,
@@ -183,9 +197,25 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
             options: [.skipsHiddenFiles]
         )) ?? []
         return entries.compactMap { entry in
-            guard entry.lastPathComponent.contains(needle) else { return nil }
+            let name = entry.lastPathComponent
+            guard Self.nameContainsBundleID(name, bundleID: needle) else { return nil }
             return makeAssociatedFile(at: entry, category: category, fileManager: fileManager)
         }
+    }
+
+    /// True when `bundleID` appears in `name` on a dot-boundary at either
+    /// end or both — `<bundleID>`, `<bundleID>.suffix`, `<prefix>.<bundleID>`,
+    /// or `<prefix>.<bundleID>.suffix`. Pure substring matching would mark
+    /// `com.acme.helio2.plist` as a match for `com.acme.helio`, which the
+    /// recycler would then Trash unsolicited.
+    static func nameContainsBundleID(_ name: String, bundleID: String) -> Bool {
+        guard !bundleID.isEmpty else { return false }
+        guard let range = name.range(of: bundleID) else { return false }
+        let hasLeftBoundary = range.lowerBound == name.startIndex
+            || name[name.index(before: range.lowerBound)] == "."
+        let hasRightBoundary = range.upperBound == name.endIndex
+            || name[range.upperBound] == "."
+        return hasLeftBoundary && hasRightBoundary
     }
 
     /// Stat + size for a candidate path. Returns `nil` when the path

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -1,0 +1,238 @@
+// AssociatedFileFinder.swift
+// Locates on-disk artifacts (preferences, caches, logs, containers, launch agents, …) that belong to a given app bundle so the App Uninstaller can review and Trash them alongside the .app bundle.
+
+import Foundation
+import os.log
+
+/// Test seam between `AppUninstallerViewModel` and the on-disk associated-
+/// file lookup. The protocol is async so production implementations can hop
+/// to a background actor for the directory traversal without blocking the
+/// view-model's main-actor isolation.
+protocol AssociatedFileFinding: Sendable {
+    func find(forBundleID bundleID: String) async -> [AssociatedFile]
+}
+
+/// Production finder — looks under `~/Library/...` and `/Library/...`
+/// for files and directories whose names match the given bundle ID.
+///
+/// All locations under the user's home are user-writable, so removal via
+/// `NSWorkspace.recycle` succeeds without privilege escalation.
+/// `/Library/LaunchAgents/*<bundleID>*.plist` is also surfaced; the
+/// recycler will prompt the user for authorization when moving root-owned
+/// items, which is the standard macOS Finder behavior for Trashing system
+/// files.
+struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
+
+    private let fileManager: FileManager
+    private let homeDirectory: URL
+    private let systemLibraryDirectory: URL
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "AssociatedFileFinder")
+
+    init(
+        fileManager: FileManager = .default,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        systemLibraryDirectory: URL = URL(fileURLWithPath: "/Library", isDirectory: true)
+    ) {
+        self.fileManager = fileManager
+        self.homeDirectory = homeDirectory
+        self.systemLibraryDirectory = systemLibraryDirectory
+    }
+
+    func find(forBundleID bundleID: String) async -> [AssociatedFile] {
+        let fileManager = fileManager
+        let userLibrary = homeDirectory.appendingPathComponent("Library", isDirectory: true)
+        let systemLibrary = systemLibraryDirectory
+
+        return await Task.detached(priority: .userInitiated) {
+            var results: [AssociatedFile] = []
+
+            // ── Preferences ─────────────────────────────────────────
+            // Three valid spellings on disk:
+            //   ~/Library/Preferences/<bundleID>.plist
+            //   ~/Library/Preferences/<bundleID>.*.plist (per-host LSSharedFileList variants)
+            //   ~/Library/Preferences/ByHost/<bundleID>.*.plist
+            let preferencesDir = userLibrary.appendingPathComponent("Preferences", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: preferencesDir,
+                nameStartsWith: bundleID,
+                category: .preferences,
+                fileManager: fileManager
+            ))
+            let byHostDir = preferencesDir.appendingPathComponent("ByHost", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: byHostDir,
+                nameStartsWith: bundleID,
+                category: .preferences,
+                fileManager: fileManager
+            ))
+
+            // ── Single-name lookups under ~/Library ─────────────────
+            let singleNameLocations: [(String, AssociatedFileCategory)] = [
+                ("Application Support", .applicationSupport),
+                ("Caches", .cache),
+                ("Logs", .logs),
+                ("Containers", .containers),
+                ("HTTPStorages", .containers)
+            ]
+            for (subpath, category) in singleNameLocations {
+                let candidate = userLibrary
+                    .appendingPathComponent(subpath, isDirectory: true)
+                    .appendingPathComponent(bundleID, isDirectory: false)
+                if let file = makeAssociatedFile(at: candidate, category: category, fileManager: fileManager) {
+                    results.append(file)
+                }
+            }
+
+            // ── Group Containers ────────────────────────────────────
+            // Vendors prefix the directory with a Team ID:
+            //   ~/Library/Group Containers/<TEAMID>.<bundleID>
+            // so a "contains bundleID" match is required.
+            let groupContainersDir = userLibrary
+                .appendingPathComponent("Group Containers", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: groupContainersDir,
+                nameContains: bundleID,
+                category: .groupContainers,
+                fileManager: fileManager
+            ))
+
+            // ── Saved Application State ─────────────────────────────
+            //   ~/Library/Saved Application State/<bundleID>.savedState
+            let savedStateDir = userLibrary
+                .appendingPathComponent("Saved Application State", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: savedStateDir,
+                nameStartsWith: bundleID,
+                category: .savedState,
+                fileManager: fileManager
+            ))
+
+            // ── Launch Agents ───────────────────────────────────────
+            // User-domain (no privilege required) and system-domain
+            // (recycle will prompt for authorization). Match a contains
+            // pattern because vendors sometimes append " .plist" or
+            // ".plist.helper" suffixes to the bundle ID.
+            let userLaunchAgentsDir = userLibrary
+                .appendingPathComponent("LaunchAgents", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: userLaunchAgentsDir,
+                nameContains: bundleID,
+                category: .launchAgents,
+                fileManager: fileManager
+            ))
+            let systemLaunchAgentsDir = systemLibrary
+                .appendingPathComponent("LaunchAgents", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: systemLaunchAgentsDir,
+                nameContains: bundleID,
+                category: .launchAgents,
+                fileManager: fileManager
+            ))
+
+            // Stable order: category (in declaration order), then URL path —
+            // makes the rendered list deterministic across runs and makes
+            // test fixtures easier to reason about.
+            results.sort { lhs, rhs in
+                if lhs.category != rhs.category {
+                    return Self.categoryOrder(lhs.category) < Self.categoryOrder(rhs.category)
+                }
+                return lhs.url.path < rhs.url.path
+            }
+            return results
+        }.value
+    }
+
+    /// Returns every entry in `directory` whose name is the bundle ID or
+    /// starts with the bundle ID *followed by a dot* — required so a
+    /// search for `com.acme.helio` doesn't sweep in `com.acme.helio2.plist`
+    /// or `com.acme.helioworld.plist`. Sized and tagged with `category`.
+    /// Missing or unreadable directories are tolerated — they're the common
+    /// case (most apps don't write to most of these locations).
+    private func matches(
+        inDirectory directory: URL,
+        nameStartsWith prefix: String,
+        category: AssociatedFileCategory,
+        fileManager: FileManager
+    ) -> [AssociatedFile] {
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        let dottedPrefix = prefix + "."
+        return entries.compactMap { entry in
+            let name = entry.lastPathComponent
+            guard name == prefix || name.hasPrefix(dottedPrefix) else { return nil }
+            return makeAssociatedFile(at: entry, category: category, fileManager: fileManager)
+        }
+    }
+
+    /// Same as `nameStartsWith` but uses substring matching — required
+    /// for Group Containers (team-ID prefix) and Launch Agents (vendor
+    /// suffixes).
+    private func matches(
+        inDirectory directory: URL,
+        nameContains needle: String,
+        category: AssociatedFileCategory,
+        fileManager: FileManager
+    ) -> [AssociatedFile] {
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return entries.compactMap { entry in
+            guard entry.lastPathComponent.contains(needle) else { return nil }
+            return makeAssociatedFile(at: entry, category: category, fileManager: fileManager)
+        }
+    }
+
+    /// Stat + size for a candidate path. Returns `nil` when the path
+    /// doesn't exist, so callers can probe a fixed list of candidates
+    /// without checking existence themselves.
+    private func makeAssociatedFile(
+        at url: URL,
+        category: AssociatedFileCategory,
+        fileManager: FileManager
+    ) -> AssociatedFile? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        let size = pathSize(at: url, fileManager: fileManager)
+        return AssociatedFile(url: url, sizeBytes: size, category: category)
+    }
+
+    /// Recursive byte size for a single path. Directories sum their
+    /// regular-file children; regular files return their own size.
+    private func pathSize(at url: URL, fileManager: FileManager) -> Int64 {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return 0
+        }
+        if !isDirectory.boolValue {
+            if let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+               let size = attrs[.size] as? NSNumber {
+                return size.int64Value
+            }
+            return 0
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in true }
+        ) else { return 0 }
+        var total: Int64 = 0
+        for case let item as URL in enumerator {
+            let values = try? item.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            if values?.isRegularFile == true, let fileSize = values?.fileSize {
+                total += Int64(fileSize)
+            }
+        }
+        return total
+    }
+
+    /// Stable category sort key — declaration order in `allCases`.
+    private static func categoryOrder(_ category: AssociatedFileCategory) -> Int {
+        AssociatedFileCategory.allCases.firstIndex(of: category) ?? Int.max
+    }
+}

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -86,6 +86,32 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
                 }
             }
 
+            // ── System-wide /Library counterparts ───────────────────
+            // Installers that drop machine-wide data (typically through
+            // pkg installers) leave their residue under `/Library/...`,
+            // not the user's home. Without these lookups uninstalling
+            // the app would leave system-wide caches / app support /
+            // preferences orphaned on disk. These paths are usually
+            // root-owned; the recycler prompts for authorization the
+            // same way Finder does when Trashing system files.
+            let systemPreferencesDir = systemLibrary
+                .appendingPathComponent("Preferences", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: systemPreferencesDir,
+                nameStartsWith: bundleID,
+                requiredSuffix: ".plist",
+                category: .preferences,
+                fileManager: fileManager
+            ))
+            for (subpath, category) in singleNameLocations {
+                let candidate = systemLibrary
+                    .appendingPathComponent(subpath, isDirectory: true)
+                    .appendingPathComponent(bundleID, isDirectory: false)
+                if let file = makeAssociatedFile(at: candidate, category: category, fileManager: fileManager) {
+                    results.append(file)
+                }
+            }
+
             // ── Group Containers ────────────────────────────────────
             // Vendors prefix the directory with a Team ID:
             //   ~/Library/Group Containers/<TEAMID>.<bundleID>

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -121,6 +121,7 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
             results.append(contentsOf: matches(
                 inDirectory: userLaunchAgentsDir,
                 nameContains: bundleID,
+                requiredSuffix: ".plist",
                 category: .launchAgents,
                 fileManager: fileManager
             ))
@@ -129,6 +130,7 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
             results.append(contentsOf: matches(
                 inDirectory: systemLaunchAgentsDir,
                 nameContains: bundleID,
+                requiredSuffix: ".plist",
                 category: .launchAgents,
                 fileManager: fileManager
             ))
@@ -185,9 +187,13 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
     /// while still rejecting siblings like `com.acme.helio2.plist` for a
     /// search of `com.acme.helio`. The bundle ID must be surrounded by
     /// dots, or anchored at the start / end of the filename.
+    /// `requiredSuffix` is enforced (case-insensitive) so LaunchAgents
+    /// can be locked to `.plist` files and stray binaries / unrelated
+    /// resources never enter the uninstall plan.
     private func matches(
         inDirectory directory: URL,
         nameContains needle: String,
+        requiredSuffix: String? = nil,
         category: AssociatedFileCategory,
         fileManager: FileManager
     ) -> [AssociatedFile] {
@@ -199,6 +205,10 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
         return entries.compactMap { entry in
             let name = entry.lastPathComponent
             guard Self.nameContainsBundleID(name, bundleID: needle) else { return nil }
+            if let requiredSuffix,
+               name.range(of: requiredSuffix, options: [.caseInsensitive, .anchored, .backwards]) == nil {
+                return nil
+            }
             return makeAssociatedFile(at: entry, category: category, fileManager: fileManager)
         }
     }

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -135,6 +135,22 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
                 fileManager: fileManager
             ))
 
+            // ── Launch Daemons (root background services) ───────────
+            // Apps that install a privileged helper register it under
+            // `/Library/LaunchDaemons/<bundleID>*.plist`. Without this
+            // lookup the daemon stays registered after uninstall and
+            // can keep running on the next boot. The recycler prompts
+            // for authorization since the directory is root-owned.
+            let systemLaunchDaemonsDir = systemLibrary
+                .appendingPathComponent("LaunchDaemons", isDirectory: true)
+            results.append(contentsOf: matches(
+                inDirectory: systemLaunchDaemonsDir,
+                nameContains: bundleID,
+                requiredSuffix: ".plist",
+                category: .launchDaemons,
+                fileManager: fileManager
+            ))
+
             // Stable order: category (in declaration order), then URL path —
             // makes the rendered list deterministic across runs and makes
             // test fixtures easier to reason about.

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     private let largeOldFilesViewModel: LargeOldFilesViewModel
     private let spaceLensViewModel: DiskScannerViewModel
     private let privacyViewModel: PrivacyViewModel
+    private let appUninstallerViewModel: AppUninstallerViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
@@ -24,12 +25,14 @@ struct ContentView: View {
         systemJunkViewModel: SystemJunkViewModel,
         largeOldFilesViewModel: LargeOldFilesViewModel,
         spaceLensViewModel: DiskScannerViewModel,
-        privacyViewModel: PrivacyViewModel
+        privacyViewModel: PrivacyViewModel,
+        appUninstallerViewModel: AppUninstallerViewModel
     ) {
         self.systemJunkViewModel = systemJunkViewModel
         self.largeOldFilesViewModel = largeOldFilesViewModel
         self.spaceLensViewModel = spaceLensViewModel
         self.privacyViewModel = privacyViewModel
+        self.appUninstallerViewModel = appUninstallerViewModel
     }
 
     var body: some View {
@@ -97,6 +100,8 @@ struct ContentView: View {
             SpaceLensView(viewModel: spaceLensViewModel)
         case .privacy:
             PrivacyView(viewModel: privacyViewModel)
+        case .appUninstaller:
+            AppUninstallerView(viewModel: appUninstallerViewModel)
         default:
             PlaceholderDetailView(section: section)
         }
@@ -144,7 +149,8 @@ private struct PlaceholderDetailView: View {
         systemJunkViewModel: SystemJunkViewModel.live(exclusions: exclusions),
         largeOldFilesViewModel: LargeOldFilesViewModel.live(exclusions: exclusions),
         spaceLensViewModel: DiskScannerViewModel.live(),
-        privacyViewModel: PrivacyViewModel.live()
+        privacyViewModel: PrivacyViewModel.live(),
+        appUninstallerViewModel: AppUninstallerViewModel.live()
     )
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -30,6 +30,7 @@ struct VaderCleanerApp: App {
     @StateObject private var largeOldFilesViewModel: LargeOldFilesViewModel
     @StateObject private var spaceLensViewModel: DiskScannerViewModel
     @StateObject private var privacyViewModel: PrivacyViewModel
+    @StateObject private var appUninstallerViewModel: AppUninstallerViewModel
     // App-scope so the cheap-stats timer outlives any single window. The
     // Health Monitor view (Prompt 9), the menu bar (Prompt 10), and the
     // notification dispatcher (Prompt 11) all subscribe via
@@ -69,6 +70,7 @@ struct VaderCleanerApp: App {
         )
         _spaceLensViewModel = StateObject(wrappedValue: DiskScannerViewModel.live())
         _privacyViewModel = StateObject(wrappedValue: PrivacyViewModel.live())
+        _appUninstallerViewModel = StateObject(wrappedValue: AppUninstallerViewModel.live())
         // Construct the polling service and the menu bar view-model in the
         // same init so both `@StateObject` wrappers reference the *same*
         // service instance. Initializing `menuBarViewModel` at its property
@@ -126,7 +128,8 @@ struct VaderCleanerApp: App {
                 systemJunkViewModel: systemJunkViewModel,
                 largeOldFilesViewModel: largeOldFilesViewModel,
                 spaceLensViewModel: spaceLensViewModel,
-                privacyViewModel: privacyViewModel
+                privacyViewModel: privacyViewModel,
+                appUninstallerViewModel: appUninstallerViewModel
             )
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)

--- a/VaderCleanerTests/AppDiscoveryTests.swift
+++ b/VaderCleanerTests/AppDiscoveryTests.swift
@@ -42,6 +42,64 @@ final class AppDiscoveryTests: XCTestCase {
         XCTAssertEqual(apps.first?.bundleURL.lastPathComponent, "Helio.app")
     }
 
+    /// Apps installed inside vendor subfolders such as
+    /// `/Applications/Adobe/.../*.app` or `/Applications/Setapp/*.app`
+    /// must surface in the list; the enumerator walks recursively but
+    /// `.skipsPackageDescendants` keeps it out of `.app` internals.
+    /// Codex P2 on PR #58.
+    func test_installedApps_findsAppsInsideVendorSubfolders() async throws {
+        try makeAppBundle(named: "TopLevel", bundleID: "com.acme.toplevel")
+        let vendorDir = tempRoot.appendingPathComponent("Adobe", isDirectory: true)
+        try FileManager.default.createDirectory(at: vendorDir, withIntermediateDirectories: true)
+        try makeAppBundle(named: "Vendor", bundleID: "com.acme.vendor", inDirectory: vendorDir)
+        let deeperDir = vendorDir.appendingPathComponent("Suite", isDirectory: true)
+        try FileManager.default.createDirectory(at: deeperDir, withIntermediateDirectories: true)
+        try makeAppBundle(named: "Deeper", bundleID: "com.acme.deeper", inDirectory: deeperDir)
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+        let apps = try await discovery.installedApps(includingSystemApps: true)
+        XCTAssertEqual(
+            Set(apps.map(\.bundleID)),
+            ["com.acme.toplevel", "com.acme.vendor", "com.acme.deeper"]
+        )
+    }
+
+    /// The enumerator must NOT descend into `.app` bundle internals —
+    /// XPC services and helper apps nested in `Contents/MacOS` /
+    /// `Contents/XPCServices` should never appear in the App Uninstaller
+    /// list (they're sub-components of their parent app).
+    func test_installedApps_doesNotDescendIntoAppBundles() async throws {
+        let parent = try makeAppBundle(named: "Parent", bundleID: "com.acme.parent")
+        let nestedDir = parent
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("XPCServices", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedDir, withIntermediateDirectories: true)
+        // Write a fully-formed nested `.app` with its own Info.plist.
+        let nested = nestedDir.appendingPathComponent("Helper.app", isDirectory: true)
+        let nestedContents = nested.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedContents, withIntermediateDirectories: true)
+        let nestedPlist: [String: Any] = [
+            "CFBundleIdentifier": "com.acme.parent.helper",
+            "CFBundleName": "Helper"
+        ]
+        let nestedData = try PropertyListSerialization.data(
+            fromPropertyList: nestedPlist, format: .xml, options: 0
+        )
+        try nestedData.write(to: nestedContents.appendingPathComponent("Info.plist"))
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+        let apps = try await discovery.installedApps(includingSystemApps: true)
+        XCTAssertEqual(apps.map(\.bundleID), ["com.acme.parent"])
+    }
+
     /// Multiple apps must come back sorted by case-insensitive name so
     /// the rendered list is deterministic and human-friendly.
     func test_installedApps_sortsResultsAlphabetically() async throws {
@@ -159,9 +217,11 @@ final class AppDiscoveryTests: XCTestCase {
         named name: String,
         bundleID: String,
         version: String? = "1.0",
-        appStore: Bool = false
+        appStore: Bool = false,
+        inDirectory directory: URL? = nil
     ) throws -> URL {
-        let bundle = tempRoot.appendingPathComponent("\(name).app", isDirectory: true)
+        let parent: URL = directory ?? tempRoot
+        let bundle = parent.appendingPathComponent("\(name).app", isDirectory: true)
         let contents = bundle.appendingPathComponent("Contents", isDirectory: true)
         try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
         var plist: [String: Any] = [

--- a/VaderCleanerTests/AppDiscoveryTests.swift
+++ b/VaderCleanerTests/AppDiscoveryTests.swift
@@ -1,0 +1,166 @@
+// AppDiscoveryTests.swift
+// Verifies that DefaultAppDiscovery surfaces installed .app bundles, parses Info.plist metadata, filters Apple system apps, and tolerates malformed bundles.
+
+import XCTest
+@testable import VaderCleaner
+
+final class AppDiscoveryTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Discovery basics
+
+    /// A bundle laid out under the fixture root must surface in
+    /// `installedApps(includingSystemApps:)` with parsed metadata.
+    func test_installedApps_returnsBundlesUnderRoot() async throws {
+        try makeAppBundle(named: "Helio", bundleID: "com.acme.helio", version: "1.2.3")
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+
+        let apps = try await discovery.installedApps(includingSystemApps: true)
+        XCTAssertEqual(apps.count, 1)
+        XCTAssertEqual(apps.first?.name, "Helio")
+        XCTAssertEqual(apps.first?.bundleID, "com.acme.helio")
+        XCTAssertEqual(apps.first?.version, "1.2.3")
+        XCTAssertEqual(apps.first?.bundleURL.lastPathComponent, "Helio.app")
+    }
+
+    /// Multiple apps must come back sorted by case-insensitive name so
+    /// the rendered list is deterministic and human-friendly.
+    func test_installedApps_sortsResultsAlphabetically() async throws {
+        try makeAppBundle(named: "Zeppelin", bundleID: "com.acme.zeppelin")
+        try makeAppBundle(named: "Aria", bundleID: "com.acme.aria")
+        try makeAppBundle(named: "mango", bundleID: "com.acme.mango")
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+        let apps = try await discovery.installedApps(includingSystemApps: true)
+        XCTAssertEqual(apps.map(\.name), ["Aria", "mango", "Zeppelin"])
+    }
+
+    /// `com.apple.*` bundles must be filtered out unless the toggle is on.
+    func test_installedApps_excludesAppleBundlesByDefault() async throws {
+        try makeAppBundle(named: "Finder", bundleID: "com.apple.finder")
+        try makeAppBundle(named: "ThirdParty", bundleID: "com.acme.thirdparty")
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+
+        let withoutSystem = try await discovery.installedApps(includingSystemApps: false)
+        XCTAssertEqual(withoutSystem.map(\.bundleID), ["com.acme.thirdparty"])
+
+        let withSystem = try await discovery.installedApps(includingSystemApps: true)
+        XCTAssertEqual(withSystem.map(\.bundleID).sorted(),
+                       ["com.acme.thirdparty", "com.apple.finder"])
+    }
+
+    /// Bundles without a parseable `Info.plist` must be skipped without
+    /// derailing discovery for the remaining apps.
+    func test_installedApps_skipsBundlesWithoutInfoPlist() async throws {
+        try makeAppBundle(named: "Good", bundleID: "com.acme.good")
+        // Make a malformed bundle with no Info.plist at all.
+        let badBundle = tempRoot.appendingPathComponent("Bad.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: badBundle, withIntermediateDirectories: true)
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+        let apps = try await discovery.installedApps(includingSystemApps: true)
+        XCTAssertEqual(apps.map(\.bundleID), ["com.acme.good"])
+    }
+
+    /// `_MASReceipt/receipt` presence flips `isAppStore` to `true`.
+    func test_installedApps_detectsAppStoreInstall() async throws {
+        try makeAppBundle(named: "Premium", bundleID: "com.acme.premium", appStore: true)
+        try makeAppBundle(named: "Sideloaded", bundleID: "com.acme.sideloaded", appStore: false)
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+        let apps = try await discovery.installedApps(includingSystemApps: true)
+        let byID = Dictionary(uniqueKeysWithValues: apps.map { ($0.bundleID, $0) })
+        XCTAssertTrue(byID["com.acme.premium"]?.isAppStore == true)
+        XCTAssertTrue(byID["com.acme.sideloaded"]?.isAppStore == false)
+    }
+
+    /// Bundle size is summed from regular-file children inside the `.app`.
+    func test_installedApps_sumsBundleSize() async throws {
+        let bundle = try makeAppBundle(named: "Sized", bundleID: "com.acme.sized")
+        let executableDir = bundle
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: executableDir, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 2, size: 4_096, in: executableDir)
+
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: tempRoot.appendingPathComponent("home", isDirectory: true),
+            additionalRoots: [tempRoot],
+            useDefaultRoots: false
+        )
+        let apps = try await discovery.installedApps(includingSystemApps: true)
+        XCTAssertEqual(apps.count, 1)
+        // Two files × 4096 bytes + the Info.plist contributes its own size.
+        XCTAssertGreaterThanOrEqual(apps.first?.bundleSizeBytes ?? 0, 8_192)
+    }
+
+    // MARK: - Fixture helpers
+
+    @discardableResult
+    private func makeAppBundle(
+        named name: String,
+        bundleID: String,
+        version: String? = "1.0",
+        appStore: Bool = false
+    ) throws -> URL {
+        let bundle = tempRoot.appendingPathComponent("\(name).app", isDirectory: true)
+        let contents = bundle.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        var plist: [String: Any] = [
+            "CFBundleIdentifier": bundleID,
+            "CFBundleName": name
+        ]
+        if let version {
+            plist["CFBundleShortVersionString"] = version
+        }
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: contents.appendingPathComponent("Info.plist"))
+
+        if appStore {
+            let receiptDir = contents.appendingPathComponent("_MASReceipt", isDirectory: true)
+            try FileManager.default.createDirectory(at: receiptDir, withIntermediateDirectories: true)
+            try Data([0x00, 0x01]).write(to: receiptDir.appendingPathComponent("receipt"))
+        }
+        return bundle
+    }
+}

--- a/VaderCleanerTests/AppDiscoveryTests.swift
+++ b/VaderCleanerTests/AppDiscoveryTests.swift
@@ -110,8 +110,11 @@ final class AppDiscoveryTests: XCTestCase {
         XCTAssertTrue(byID["com.acme.sideloaded"]?.isAppStore == false)
     }
 
-    /// Bundle size is summed from regular-file children inside the `.app`.
-    func test_installedApps_sumsBundleSize() async throws {
+    /// Bundle size is computed on demand by `bundleSize(at:)`, not
+    /// during the initial discovery pass — folding the directory walk
+    /// into `installedApps` would pin launch on multi-second I/O for
+    /// users with many installed apps.
+    func test_bundleSize_sumsRegularFiles() async throws {
         let bundle = try makeAppBundle(named: "Sized", bundleID: "com.acme.sized")
         let executableDir = bundle
             .appendingPathComponent("Contents", isDirectory: true)
@@ -124,10 +127,9 @@ final class AppDiscoveryTests: XCTestCase {
             additionalRoots: [tempRoot],
             useDefaultRoots: false
         )
-        let apps = try await discovery.installedApps(includingSystemApps: true)
-        XCTAssertEqual(apps.count, 1)
+        let size = await discovery.bundleSize(at: bundle)
         // Two files × 4096 bytes + the Info.plist contributes its own size.
-        XCTAssertGreaterThanOrEqual(apps.first?.bundleSizeBytes ?? 0, 8_192)
+        XCTAssertGreaterThanOrEqual(size, 8_192)
     }
 
     // MARK: - Fixture helpers

--- a/VaderCleanerTests/AppDiscoveryTests.swift
+++ b/VaderCleanerTests/AppDiscoveryTests.swift
@@ -94,6 +94,26 @@ final class AppDiscoveryTests: XCTestCase {
         XCTAssertEqual(apps.map(\.bundleID), ["com.acme.good"])
     }
 
+    /// `useDefaultRoots: true` must include `/System/Applications` and
+    /// its `Utilities` subfolder. Many Apple system apps live there on
+    /// modern macOS; without these roots the "Show system apps" toggle
+    /// would silently fail to surface most system apps even after the
+    /// `com.apple.*` filter is disabled. Codex P2 on PR #58.
+    func test_init_defaultRootsIncludeSystemApplications() {
+        let discovery = DefaultAppDiscovery(
+            homeDirectory: URL(fileURLWithPath: "/Users/test"),
+            useDefaultRoots: true
+        )
+        let mirror = Mirror(reflecting: discovery)
+        let roots = mirror.children.first(where: { $0.label == "roots" })?.value as? [URL] ?? []
+        let rootPaths = roots.map(\.path)
+        XCTAssertTrue(rootPaths.contains("/Applications"))
+        XCTAssertTrue(rootPaths.contains("/Applications/Utilities"))
+        XCTAssertTrue(rootPaths.contains("/Users/test/Applications"))
+        XCTAssertTrue(rootPaths.contains("/System/Applications"))
+        XCTAssertTrue(rootPaths.contains("/System/Applications/Utilities"))
+    }
+
     /// `_MASReceipt/receipt` presence flips `isAppStore` to `true`.
     func test_installedApps_detectsAppStoreInstall() async throws {
         try makeAppBundle(named: "Premium", bundleID: "com.acme.premium", appStore: true)

--- a/VaderCleanerTests/AppUninstallerViewModelTests.swift
+++ b/VaderCleanerTests/AppUninstallerViewModelTests.swift
@@ -1,0 +1,329 @@
+// AppUninstallerViewModelTests.swift
+// Tests the AppUninstallerViewModel state machine — load, selection, associated files lookup, total reclaimable, uninstall, failure paths — driving every transition through injected fakes so no real apps are touched.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class AppUninstallerViewModelTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    /// On construction the VM is `.idle` so the view shows its loading state
+    /// after `task { loadApps() }` rather than a stale list from a prior
+    /// session.
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertTrue(vm.apps.isEmpty)
+        XCTAssertNil(vm.selectedAppID)
+    }
+
+    // MARK: - Load
+
+    /// `loadApps()` populates the app list and lands in `.ready`.
+    func test_loadApps_transitionsToReadyWithSortedApps() async {
+        let apps = [
+            makeApp(name: "Zephyr", bundleID: "com.acme.zephyr"),
+            makeApp(name: "Alpha", bundleID: "com.acme.alpha")
+        ]
+        let vm = makeViewModel(
+            discover: { _ in apps }
+        )
+        await vm.loadApps()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.apps.map(\.bundleID), ["com.acme.zephyr", "com.acme.alpha"])
+    }
+
+    /// A throwing discovery surfaces `.failed(stage: .loading, ...)`.
+    func test_loadApps_failureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let vm = makeViewModel(discover: { _ in throw BoomError() })
+        await vm.loadApps()
+
+        if case .failed(let stage, _) = vm.phase {
+            XCTAssertEqual(stage, .loading)
+        } else {
+            XCTFail("Expected .failed(.loading), got \(vm.phase)")
+        }
+        XCTAssertTrue(vm.apps.isEmpty)
+    }
+
+    /// Toggling `includesSystemApps` and reloading must forward the flag
+    /// to the discovery layer.
+    func test_reloadApps_forwardsIncludesSystemAppsFlag() async {
+        var receivedFlag: Bool?
+        let vm = makeViewModel(discover: { includes in
+            receivedFlag = includes
+            return []
+        })
+        vm.includesSystemApps = true
+        await vm.reloadApps()
+        XCTAssertEqual(receivedFlag, true)
+    }
+
+    // MARK: - Filtering
+
+    /// `filteredApps` matches case-insensitively on name and bundle ID.
+    func test_filteredApps_matchesNameAndBundleID() async {
+        let apps = [
+            makeApp(name: "Helio", bundleID: "com.acme.helio"),
+            makeApp(name: "Mango", bundleID: "com.acme.mango"),
+            makeApp(name: "Solar", bundleID: "com.unrelated.solar")
+        ]
+        let vm = makeViewModel(discover: { _ in apps })
+        await vm.loadApps()
+
+        vm.searchQuery = "helio"
+        XCTAssertEqual(vm.filteredApps.map(\.bundleID), ["com.acme.helio"])
+
+        vm.searchQuery = "ACME"
+        XCTAssertEqual(vm.filteredApps.map(\.bundleID).sorted(),
+                       ["com.acme.helio", "com.acme.mango"])
+
+        vm.searchQuery = ""
+        XCTAssertEqual(vm.filteredApps.count, 3)
+    }
+
+    // MARK: - Selection
+
+    /// Selecting an app populates `associatedFiles` from the injected finder.
+    func test_select_populatesAssociatedFiles() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let stubFiles = [
+            AssociatedFile(
+                url: URL(fileURLWithPath: "/tmp/p.plist"),
+                sizeBytes: 10,
+                category: .preferences
+            ),
+            AssociatedFile(
+                url: URL(fileURLWithPath: "/tmp/c.bin"),
+                sizeBytes: 50,
+                category: .cache
+            )
+        ]
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in stubFiles }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { vm.associatedFiles.count == stubFiles.count }
+        XCTAssertEqual(vm.associatedFiles.map(\.sizeBytes), [10, 50])
+        XCTAssertFalse(vm.isLoadingAssociatedFiles)
+    }
+
+    /// Deselecting (passing `nil`) clears the associated files panel.
+    func test_select_nilClearsAssociatedFiles() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [
+                AssociatedFile(url: URL(fileURLWithPath: "/tmp/p"), sizeBytes: 1, category: .preferences)
+            ] }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { !vm.associatedFiles.isEmpty }
+        vm.select(nil)
+        XCTAssertNil(vm.selectedAppID)
+        XCTAssertTrue(vm.associatedFiles.isEmpty)
+    }
+
+    /// Re-selecting the same app reuses the cached associated files and
+    /// does not invoke the finder again.
+    func test_select_secondTimeUsesCache() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        var finderCalls = 0
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in
+                finderCalls += 1
+                return [AssociatedFile(url: URL(fileURLWithPath: "/tmp/p"), sizeBytes: 1, category: .preferences)]
+            }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { !vm.associatedFiles.isEmpty }
+        vm.select(nil)
+        vm.select(app.id)
+        await waitFor { !vm.associatedFiles.isEmpty }
+        XCTAssertEqual(finderCalls, 1)
+    }
+
+    // MARK: - Totals
+
+    /// `totalReclaimableSize` is bundle size + sum of associated files.
+    func test_totalReclaimableSize_isBundleSizePlusAssociated() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio", bundleSize: 1_000)
+        let stubFiles = [
+            AssociatedFile(url: URL(fileURLWithPath: "/tmp/a"), sizeBytes: 50, category: .cache),
+            AssociatedFile(url: URL(fileURLWithPath: "/tmp/b"), sizeBytes: 200, category: .logs)
+        ]
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in stubFiles }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { !vm.associatedFiles.isEmpty }
+        XCTAssertEqual(vm.totalReclaimableSize, 1_250)
+    }
+
+    /// Files are exposed grouped by category in declaration order.
+    func test_associatedFilesByCategory_groupsAndSortsByDeclarationOrder() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let stubFiles = [
+            AssociatedFile(url: URL(fileURLWithPath: "/tmp/a"), sizeBytes: 1, category: .logs),
+            AssociatedFile(url: URL(fileURLWithPath: "/tmp/b"), sizeBytes: 1, category: .preferences),
+            AssociatedFile(url: URL(fileURLWithPath: "/tmp/c"), sizeBytes: 1, category: .cache)
+        ]
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in stubFiles }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { !vm.associatedFiles.isEmpty }
+        let groups = vm.associatedFilesByCategory
+        XCTAssertEqual(groups.map(\.0), [.preferences, .cache, .logs])
+    }
+
+    // MARK: - Uninstall
+
+    /// `uninstall()` hands the bundle URL + every associated URL to the
+    /// recycler, drops the app from `apps`, and lands in `.complete`.
+    func test_uninstall_invokesRecyclerWithBundleAndAssociatedURLs() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let stubFiles = [
+            AssociatedFile(url: URL(fileURLWithPath: "/tmp/p"), sizeBytes: 10, category: .preferences),
+            AssociatedFile(url: URL(fileURLWithPath: "/tmp/c"), sizeBytes: 50, category: .cache)
+        ]
+        let received = ActorBox<[URL]>([])
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in stubFiles },
+            recycle: { urls in
+                await received.set(urls)
+                return 60
+            }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { !vm.associatedFiles.isEmpty }
+
+        await vm.uninstall()
+
+        let urls = await received.value
+        XCTAssertEqual(urls.first, app.bundleURL)
+        XCTAssertEqual(Set(urls), Set([app.bundleURL] + stubFiles.map(\.url)))
+        XCTAssertEqual(vm.phase, .complete(bytesFreed: 60))
+        XCTAssertFalse(vm.apps.contains(where: { $0.id == app.id }))
+        XCTAssertNil(vm.selectedAppID)
+    }
+
+    /// A throwing recycler surfaces `.failed(stage: .uninstalling, ...)`.
+    func test_uninstall_failureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            recycle: { _ in throw BoomError() }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { vm.selectedApp != nil }
+        await vm.uninstall()
+        if case .failed(let stage, _) = vm.phase {
+            XCTAssertEqual(stage, .uninstalling)
+        } else {
+            XCTFail("Expected .failed(.uninstalling), got \(vm.phase)")
+        }
+    }
+
+    /// `uninstall()` is a no-op when nothing is selected.
+    func test_uninstall_isNoOpWithoutSelection() async {
+        let calls = ActorBox(0)
+        let vm = makeViewModel(
+            discover: { _ in [] },
+            recycle: { _ in await calls.increment(); return 0 }
+        )
+        await vm.loadApps()
+        await vm.uninstall()
+        let count = await calls.value
+        XCTAssertEqual(count, 0)
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    /// `dismissResult()` brings the VM back to `.ready` after a complete
+    /// or failed phase.
+    func test_dismissResult_returnsToReady() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            recycle: { _ in 0 }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { vm.selectedApp != nil }
+        await vm.uninstall()
+        vm.dismissResult()
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        discover: @escaping AppUninstallerViewModel.Discover = { _ in [] },
+        findFiles: @escaping AppUninstallerViewModel.FindFiles = { _ in [] },
+        recycle: @escaping AppUninstallerViewModel.Recycle = { _ in 0 }
+    ) -> AppUninstallerViewModel {
+        AppUninstallerViewModel(
+            discover: discover,
+            findFiles: findFiles,
+            recycle: recycle
+        )
+    }
+
+    private func makeApp(
+        name: String,
+        bundleID: String,
+        bundleSize: Int64 = 0
+    ) -> AppInfo {
+        AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: "1.0",
+            bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+            bundleSizeBytes: bundleSize,
+            isAppStore: false
+        )
+    }
+
+    /// Polls `condition` on the main actor until it becomes true or the
+    /// timeout elapses. Used because `select(...)` kicks off an async
+    /// associated-files lookup whose result lands on the main actor after
+    /// the awaiting `Task` resumes.
+    private func waitFor(
+        timeout: TimeInterval = 1.0,
+        _ condition: () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() > deadline { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+}
+
+private actor ActorBox<Value: Sendable> {
+    private(set) var value: Value
+    init(_ initial: Value) { self.value = initial }
+    func set(_ newValue: Value) { value = newValue }
+}
+
+private extension ActorBox where Value == Int {
+    func increment() { value += 1 }
+}

--- a/VaderCleanerTests/AppUninstallerViewModelTests.swift
+++ b/VaderCleanerTests/AppUninstallerViewModelTests.swift
@@ -234,7 +234,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
                 }
                 return []
             },
-            recycle: { _ in await recycleCalls.increment(); return 1 }
+            recycle: { _, _ in await recycleCalls.increment(); return 1 }
         )
         await vm.loadApps()
         vm.select(app.id)
@@ -276,12 +276,14 @@ final class AppUninstallerViewModelTests: XCTestCase {
             AssociatedFile(url: URL(fileURLWithPath: "/tmp/p"), sizeBytes: 10, category: .preferences),
             AssociatedFile(url: URL(fileURLWithPath: "/tmp/c"), sizeBytes: 50, category: .cache)
         ]
-        let received = ActorBox<[URL]>([])
+        let receivedBundle = ActorBox<URL?>(nil)
+        let receivedAssociated = ActorBox<[URL]>([])
         let vm = makeViewModel(
             discover: { _ in [app] },
             findFiles: { _ in stubFiles },
-            recycle: { urls in
-                await received.set(urls)
+            recycle: { bundleURL, associatedURLs in
+                await receivedBundle.set(bundleURL)
+                await receivedAssociated.set(associatedURLs)
                 return 60
             }
         )
@@ -291,12 +293,42 @@ final class AppUninstallerViewModelTests: XCTestCase {
 
         await vm.uninstall()
 
-        let urls = await received.value
-        XCTAssertEqual(urls.first, app.bundleURL)
-        XCTAssertEqual(Set(urls), Set([app.bundleURL] + stubFiles.map(\.url)))
+        let bundle = await receivedBundle.value
+        let associated = await receivedAssociated.value
+        XCTAssertEqual(bundle, app.bundleURL)
+        XCTAssertEqual(Set(associated), Set(stubFiles.map(\.url)))
         XCTAssertEqual(vm.phase, .complete(bytesFreed: 60))
         XCTAssertFalse(vm.apps.contains(where: { $0.id == app.id }))
         XCTAssertNil(vm.selectedAppID)
+    }
+
+    /// If the recycler reports that the bundle could not be moved
+    /// (e.g. root-owned `/Applications/*.app` denied while user-domain
+    /// associated files succeeded), the view-model must surface
+    /// `.failed(.uninstalling)` rather than showing "complete" — the
+    /// app is still installed, leaving a stale row in the list would
+    /// mislead the user. Codex P2 on PR #58.
+    func test_uninstall_recyclerBundleFailureSurfacesAsFailed() async {
+        struct BundleNotMovedError: Error {}
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            recycle: { _, _ in throw BundleNotMovedError() }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { vm.canUninstallSelectedApp }
+        await vm.uninstall()
+
+        if case .failed(let stage, _) = vm.phase {
+            XCTAssertEqual(stage, .uninstalling)
+        } else {
+            XCTFail("Expected .failed(.uninstalling), got \(vm.phase)")
+        }
+        // App row must still be present so the user can retry.
+        XCTAssertTrue(vm.apps.contains(where: { $0.id == app.id }),
+                      "App must stay in the list when its bundle was not Trashed")
     }
 
     /// A throwing recycler surfaces `.failed(stage: .uninstalling, ...)`.
@@ -306,7 +338,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         let vm = makeViewModel(
             discover: { _ in [app] },
             findFiles: { _ in [] },
-            recycle: { _ in throw BoomError() }
+            recycle: { _, _ in throw BoomError() }
         )
         await vm.loadApps()
         vm.select(app.id)
@@ -327,7 +359,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         let calls = ActorBox(0)
         let vm = makeViewModel(
             discover: { _ in [] },
-            recycle: { _ in await calls.increment(); return 0 }
+            recycle: { _, _ in await calls.increment(); return 0 }
         )
         await vm.loadApps()
         await vm.uninstall()
@@ -343,7 +375,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         let vm = makeViewModel(
             discover: { _ in [app] },
             findFiles: { _ in [] },
-            recycle: { _ in 0 }
+            recycle: { _, _ in 0 }
         )
         await vm.loadApps()
         vm.select(app.id)
@@ -359,7 +391,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         discover: @escaping AppUninstallerViewModel.Discover = { _ in [] },
         findFiles: @escaping AppUninstallerViewModel.FindFiles = { _ in [] },
         measureSize: @escaping AppUninstallerViewModel.MeasureSize = { _ in 0 },
-        recycle: @escaping AppUninstallerViewModel.Recycle = { _ in 0 }
+        recycle: @escaping AppUninstallerViewModel.Recycle = { _, _ in 0 }
     ) -> AppUninstallerViewModel {
         AppUninstallerViewModel(
             discover: discover,

--- a/VaderCleanerTests/AppUninstallerViewModelTests.swift
+++ b/VaderCleanerTests/AppUninstallerViewModelTests.swift
@@ -153,21 +153,98 @@ final class AppUninstallerViewModelTests: XCTestCase {
 
     // MARK: - Totals
 
-    /// `totalReclaimableSize` is bundle size + sum of associated files.
+    /// `totalReclaimableSize` is bundle size + sum of associated files
+    /// once both async lookups have landed.
     func test_totalReclaimableSize_isBundleSizePlusAssociated() async {
-        let app = makeApp(name: "Helio", bundleID: "com.acme.helio", bundleSize: 1_000)
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
         let stubFiles = [
             AssociatedFile(url: URL(fileURLWithPath: "/tmp/a"), sizeBytes: 50, category: .cache),
             AssociatedFile(url: URL(fileURLWithPath: "/tmp/b"), sizeBytes: 200, category: .logs)
         ]
         let vm = makeViewModel(
             discover: { _ in [app] },
-            findFiles: { _ in stubFiles }
+            findFiles: { _ in stubFiles },
+            measureSize: { _ in 1_000 }
         )
         await vm.loadApps()
         vm.select(app.id)
-        await waitFor { !vm.associatedFiles.isEmpty }
+        await waitFor { !vm.associatedFiles.isEmpty && vm.selectedAppBundleSize != nil }
         XCTAssertEqual(vm.totalReclaimableSize, 1_250)
+    }
+
+    /// `bundleSize(for:)` returns `nil` until the per-app size
+    /// measurement lands, then the measured value. The list row uses
+    /// this to defer rendering the size label.
+    func test_bundleSize_returnsNilUntilMeasured() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            measureSize: { _ in 4_096 }
+        )
+        await vm.loadApps()
+        XCTAssertNil(vm.bundleSize(for: app.id),
+                     "Bundle size must not be computed during discovery")
+        vm.select(app.id)
+        await waitFor { vm.bundleSize(for: app.id) != nil }
+        XCTAssertEqual(vm.bundleSize(for: app.id), 4_096)
+    }
+
+    /// `canUninstallSelectedApp` is false while the associated-files
+    /// scan is in flight so the destructive button is disabled — see
+    /// the Codex review comment on the uninstall flow.
+    func test_canUninstallSelectedApp_isFalseWhileAssociatedFilesLoading() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let releaseFinder = ActorBox<CheckedContinuation<Void, Never>?>(nil)
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in
+                await withCheckedContinuation { continuation in
+                    Task { await releaseFinder.set(continuation) }
+                }
+                return []
+            }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitForActor { await releaseFinder.value != nil }
+        XCTAssertTrue(vm.isLoadingAssociatedFiles)
+        XCTAssertFalse(vm.canUninstallSelectedApp,
+                       "Uninstall must be gated while associated files are still being scanned")
+
+        // Release the finder and confirm canUninstall flips true.
+        let continuation: CheckedContinuation<Void, Never>? = await releaseFinder.value
+        continuation?.resume()
+        await waitFor { !vm.isLoadingAssociatedFiles }
+        XCTAssertTrue(vm.canUninstallSelectedApp)
+    }
+
+    /// `uninstall()` must be a no-op while the associated-files scan is
+    /// in flight — confirming early would otherwise Trash only the
+    /// bundle and leave caches/preferences behind.
+    func test_uninstall_isNoOpWhileAssociatedFilesLoading() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let recycleCalls = ActorBox(0)
+        let releaseFinder = ActorBox<CheckedContinuation<Void, Never>?>(nil)
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in
+                await withCheckedContinuation { continuation in
+                    Task { await releaseFinder.set(continuation) }
+                }
+                return []
+            },
+            recycle: { _ in await recycleCalls.increment(); return 1 }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitForActor { await releaseFinder.value != nil }
+        XCTAssertTrue(vm.isLoadingAssociatedFiles)
+        await vm.uninstall()
+        let count = await recycleCalls.value
+        XCTAssertEqual(count, 0, "uninstall must not run while scan is in flight")
+        let continuation: CheckedContinuation<Void, Never>? = await releaseFinder.value
+        continuation?.resume()
     }
 
     /// Files are exposed grouped by category in declaration order.
@@ -233,7 +310,10 @@ final class AppUninstallerViewModelTests: XCTestCase {
         )
         await vm.loadApps()
         vm.select(app.id)
-        await waitFor { vm.selectedApp != nil }
+        // Wait for the associated-files scan to finish — `uninstall()`
+        // is a no-op while the scan is still in flight, so an early call
+        // would never reach the recycler.
+        await waitFor { vm.canUninstallSelectedApp }
         await vm.uninstall()
         if case .failed(let stage, _) = vm.phase {
             XCTAssertEqual(stage, .uninstalling)
@@ -267,7 +347,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         )
         await vm.loadApps()
         vm.select(app.id)
-        await waitFor { vm.selectedApp != nil }
+        await waitFor { vm.canUninstallSelectedApp }
         await vm.uninstall()
         vm.dismissResult()
         XCTAssertEqual(vm.phase, .ready)
@@ -278,26 +358,26 @@ final class AppUninstallerViewModelTests: XCTestCase {
     private func makeViewModel(
         discover: @escaping AppUninstallerViewModel.Discover = { _ in [] },
         findFiles: @escaping AppUninstallerViewModel.FindFiles = { _ in [] },
+        measureSize: @escaping AppUninstallerViewModel.MeasureSize = { _ in 0 },
         recycle: @escaping AppUninstallerViewModel.Recycle = { _ in 0 }
     ) -> AppUninstallerViewModel {
         AppUninstallerViewModel(
             discover: discover,
             findFiles: findFiles,
+            measureSize: measureSize,
             recycle: recycle
         )
     }
 
     private func makeApp(
         name: String,
-        bundleID: String,
-        bundleSize: Int64 = 0
+        bundleID: String
     ) -> AppInfo {
         AppInfo(
             name: name,
             bundleID: bundleID,
             version: "1.0",
             bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
-            bundleSizeBytes: bundleSize,
             isAppStore: false
         )
     }
@@ -312,6 +392,19 @@ final class AppUninstallerViewModelTests: XCTestCase {
     ) async {
         let deadline = Date().addingTimeInterval(timeout)
         while !condition() {
+            if Date() > deadline { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+
+    /// Same as `waitFor` but for predicates that need to `await` an
+    /// actor (e.g. reading from an `ActorBox`).
+    private func waitForActor(
+        timeout: TimeInterval = 2.0,
+        _ condition: @Sendable () async -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while await !condition() {
             if Date() > deadline { return }
             try? await Task.sleep(nanoseconds: 5_000_000)
         }

--- a/VaderCleanerTests/AssociatedFileFinderTests.swift
+++ b/VaderCleanerTests/AssociatedFileFinderTests.swift
@@ -223,8 +223,77 @@ final class AssociatedFileFinderTests: XCTestCase {
         let finder = makeFinder()
         let result = await finder.find(forBundleID: "com.acme.helio")
         let launchAgents = result.filter { $0.category == .launchAgents }
-        XCTAssertEqual(launchAgents.count, 2)
-        XCTAssertEqual(launchAgents.reduce(0) { $0 + $1.sizeBytes }, 144)
+        XCTAssertEqual(
+            Set(launchAgents.map { $0.url.lastPathComponent }),
+            ["com.acme.helio.updater.plist", "com.acme.helio.helper.plist"]
+        )
+        let sizesByName = Dictionary(
+            uniqueKeysWithValues: launchAgents.map { ($0.url.lastPathComponent, $0.sizeBytes) }
+        )
+        XCTAssertEqual(sizesByName["com.acme.helio.updater.plist"], 64)
+        XCTAssertEqual(sizesByName["com.acme.helio.helper.plist"], 80)
+    }
+
+    // MARK: - System-wide /Library coverage
+
+    /// Pkg-installer-style apps drop machine-wide data under
+    /// `/Library/...`, not the user's home. Without scanning those
+    /// roots, residue would survive uninstall. Codex P2 on PR #58.
+    func test_find_includesSystemWideLibraryResidue() async throws {
+        let systemPrefs = systemLibrary
+            .appendingPathComponent("Preferences", isDirectory: true)
+            .appendingPathComponent("com.acme.helio.plist")
+        let systemAppSupport = systemLibrary
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("com.acme.helio", isDirectory: true)
+            .appendingPathComponent("data.bin")
+        let systemCache = systemLibrary
+            .appendingPathComponent("Caches", isDirectory: true)
+            .appendingPathComponent("com.acme.helio", isDirectory: true)
+            .appendingPathComponent("blob.bin")
+        let systemLogs = systemLibrary
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent("com.acme.helio", isDirectory: true)
+            .appendingPathComponent("daemon.log")
+        for url in [systemPrefs, systemAppSupport, systemCache, systemLogs] {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data(repeating: 0xCD, count: 16).write(to: url)
+        }
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        // Compare via standardized paths so `/var/...` vs `/private/var/...`
+        // differences from `contentsOfDirectory(at:)` don't flake the test.
+        let standardizedPaths = Set(result.map { $0.url.standardizedFileURL.path })
+        func expect(_ url: URL, _ label: String) {
+            XCTAssertTrue(
+                standardizedPaths.contains(url.standardizedFileURL.path),
+                "\(label) must be surfaced (got \(standardizedPaths))"
+            )
+        }
+        expect(systemPrefs, "system Preferences plist")
+        expect(systemAppSupport.deletingLastPathComponent(), "system Application Support directory")
+        expect(systemCache.deletingLastPathComponent(), "system Caches directory")
+        expect(systemLogs.deletingLastPathComponent(), "system Logs directory")
+    }
+
+    /// The system /Library Preferences scan must require the .plist
+    /// extension — same constraint as the user-domain scan so stray
+    /// `.db` / `.lock` files don't enter the uninstall plan.
+    func test_find_systemPreferencesRequireDotPlistSuffix() async throws {
+        let prefsDir = systemLibrary.appendingPathComponent("Preferences", isDirectory: true)
+        try FileManager.default.createDirectory(at: prefsDir, withIntermediateDirectories: true)
+        try Data().write(to: prefsDir.appendingPathComponent("com.acme.helio.plist"))
+        try Data().write(to: prefsDir.appendingPathComponent("com.acme.helio.db"))
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let names = result.filter { $0.category == .preferences }.map { $0.url.lastPathComponent }
+        XCTAssertTrue(names.contains("com.acme.helio.plist"))
+        XCTAssertFalse(names.contains("com.acme.helio.db"))
     }
 
     // MARK: - Empty / missing
@@ -239,17 +308,31 @@ final class AssociatedFileFinderTests: XCTestCase {
     // MARK: - Ordering
 
     /// Results are stably ordered by category in declaration order, then
-    /// by URL path — so SwiftUI list diffing is predictable.
+    /// by URL path within a category — so SwiftUI list diffing is
+    /// predictable and unit tests on the order don't flake.
     func test_find_resultsAreStableOrderedByCategoryThenPath() async throws {
         try makeFile(under: "Library/Logs/com.acme.helio/app.log", size: 1)
         try makeFile(under: "Library/Preferences/com.acme.helio.plist", size: 1)
-        try makeFile(under: "Library/Caches/com.acme.helio/blob.bin", size: 1)
+        // Two LaunchAgents in the user domain so we can pin path ordering
+        // within a single category — `zeta` should sort after `alpha`.
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio.zeta.plist", size: 1)
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio.alpha.plist", size: 1)
 
         let finder = makeFinder()
         let result = await finder.find(forBundleID: "com.acme.helio")
+
         let categories = result.map(\.category)
         let categoryRanks = categories.map { AssociatedFileCategory.allCases.firstIndex(of: $0)! }
         XCTAssertEqual(categoryRanks, categoryRanks.sorted())
+
+        // Within-category path ordering — assert for every category
+        // present in the result so a regression on any single category
+        // is caught.
+        for category in Set(result.map(\.category)) {
+            let paths = result.filter { $0.category == category }.map { $0.url.path }
+            XCTAssertEqual(paths, paths.sorted(),
+                           "Items in \(category) must be path-sorted")
+        }
     }
 
     // MARK: - Helpers

--- a/VaderCleanerTests/AssociatedFileFinderTests.swift
+++ b/VaderCleanerTests/AssociatedFileFinderTests.swift
@@ -1,0 +1,178 @@
+// AssociatedFileFinderTests.swift
+// Verifies that DefaultAssociatedFileFinder locates preferences, caches, logs, containers, group containers, saved state, and launch agents that belong to a given bundle ID.
+
+import XCTest
+@testable import VaderCleaner
+
+final class AssociatedFileFinderTests: XCTestCase {
+
+    private var tempRoot: URL!
+    private var home: URL!
+    private var systemLibrary: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+        home = tempRoot.appendingPathComponent("home", isDirectory: true)
+        systemLibrary = tempRoot.appendingPathComponent("system_library", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: systemLibrary, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        home = nil
+        systemLibrary = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Preferences
+
+    func test_find_returnsPreferencesPlistByExactName() async throws {
+        try makeFile(under: "Library/Preferences/com.acme.helio.plist", size: 128)
+        try makeFile(under: "Library/Preferences/com.unrelated.plist", size: 64)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.category, .preferences)
+        XCTAssertEqual(result.first?.sizeBytes, 128)
+        XCTAssertEqual(result.first?.url.lastPathComponent, "com.acme.helio.plist")
+    }
+
+    /// A search for `com.acme.helio` must NOT also match
+    /// `com.acme.helio2.plist` or `com.acme.helioworld.savedState` —
+    /// the bundle ID has to be followed by a dot (or end-of-name).
+    func test_find_doesNotMatchBundleIDPrefixOnOtherBundles() async throws {
+        try makeFile(under: "Library/Preferences/com.acme.helio.plist", size: 16)
+        try makeFile(under: "Library/Preferences/com.acme.helio2.plist", size: 32)
+        try makeFile(under: "Library/Saved Application State/com.acme.helioworld.savedState/keep", size: 64)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let names = result.map { $0.url.lastPathComponent }
+        XCTAssertTrue(names.contains("com.acme.helio.plist"))
+        XCTAssertFalse(names.contains("com.acme.helio2.plist"),
+                       "Prefix match must not pull in sibling bundles")
+        XCTAssertFalse(names.contains("com.acme.helioworld.savedState"),
+                       "Prefix match must require a dot separator")
+    }
+
+    func test_find_returnsByHostPreferences() async throws {
+        try makeFile(under: "Library/Preferences/ByHost/com.acme.helio.ABCDEF.plist", size: 32)
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+
+        XCTAssertTrue(result.contains(where: { $0.url.lastPathComponent.contains("com.acme.helio") }))
+        XCTAssertTrue(result.allSatisfy { $0.category == .preferences })
+    }
+
+    // MARK: - Standard ~/Library locations
+
+    func test_find_includesApplicationSupportAndCachesAndLogsAndContainers() async throws {
+        try makeFile(under: "Library/Application Support/com.acme.helio/notes.dat", size: 1_000)
+        try makeFile(under: "Library/Caches/com.acme.helio/blob.bin", size: 2_000)
+        try makeFile(under: "Library/Logs/com.acme.helio/app.log", size: 500)
+        try makeFile(under: "Library/Containers/com.acme.helio/Data/keep.txt", size: 250)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let byCategory = Dictionary(grouping: result, by: \.category)
+
+        XCTAssertEqual(byCategory[.applicationSupport]?.count, 1)
+        XCTAssertEqual(byCategory[.applicationSupport]?.first?.sizeBytes, 1_000)
+        XCTAssertEqual(byCategory[.cache]?.count, 1)
+        XCTAssertEqual(byCategory[.cache]?.first?.sizeBytes, 2_000)
+        XCTAssertEqual(byCategory[.logs]?.count, 1)
+        XCTAssertEqual(byCategory[.logs]?.first?.sizeBytes, 500)
+        XCTAssertEqual(byCategory[.containers]?.count, 1)
+        XCTAssertEqual(byCategory[.containers]?.first?.sizeBytes, 250)
+    }
+
+    /// Vendors prefix Group Containers with their Team ID, so substring
+    /// matching is required.
+    func test_find_includesGroupContainersWithTeamIDPrefix() async throws {
+        try makeFile(under: "Library/Group Containers/TEAM1234.com.acme.helio/shared.bin", size: 999)
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        XCTAssertEqual(result.filter { $0.category == .groupContainers }.count, 1)
+        XCTAssertEqual(result.first(where: { $0.category == .groupContainers })?.sizeBytes, 999)
+    }
+
+    func test_find_includesSavedApplicationState() async throws {
+        try makeFile(under: "Library/Saved Application State/com.acme.helio.savedState/keep", size: 12)
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let savedState = result.first(where: { $0.category == .savedState })
+        XCTAssertNotNil(savedState)
+        XCTAssertEqual(savedState?.sizeBytes, 12)
+    }
+
+    func test_find_includesUserAndSystemLaunchAgents() async throws {
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio.updater.plist", size: 64)
+        let systemAgentURL = systemLibrary
+            .appendingPathComponent("LaunchAgents", isDirectory: true)
+            .appendingPathComponent("com.acme.helio.helper.plist")
+        try FileManager.default.createDirectory(
+            at: systemAgentURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(repeating: 0xAB, count: 80).write(to: systemAgentURL)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let launchAgents = result.filter { $0.category == .launchAgents }
+        XCTAssertEqual(launchAgents.count, 2)
+        XCTAssertEqual(launchAgents.reduce(0) { $0 + $1.sizeBytes }, 144)
+    }
+
+    // MARK: - Empty / missing
+
+    /// A bundle ID with nothing on disk returns an empty array.
+    func test_find_returnsEmptyArrayForUnknownBundleID() async {
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.unknown.ghost")
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Ordering
+
+    /// Results are stably ordered by category in declaration order, then
+    /// by URL path — so SwiftUI list diffing is predictable.
+    func test_find_resultsAreStableOrderedByCategoryThenPath() async throws {
+        try makeFile(under: "Library/Logs/com.acme.helio/app.log", size: 1)
+        try makeFile(under: "Library/Preferences/com.acme.helio.plist", size: 1)
+        try makeFile(under: "Library/Caches/com.acme.helio/blob.bin", size: 1)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let categories = result.map(\.category)
+        let categoryRanks = categories.map { AssociatedFileCategory.allCases.firstIndex(of: $0)! }
+        XCTAssertEqual(categoryRanks, categoryRanks.sorted())
+    }
+
+    // MARK: - Helpers
+
+    private func makeFinder() -> DefaultAssociatedFileFinder {
+        DefaultAssociatedFileFinder(
+            fileManager: .default,
+            homeDirectory: home,
+            systemLibraryDirectory: systemLibrary
+        )
+    }
+
+    @discardableResult
+    private func makeFile(under relativePath: String, size: Int) throws -> URL {
+        let url = home.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(repeating: 0xCD, count: size).write(to: url)
+        return url
+    }
+}

--- a/VaderCleanerTests/AssociatedFileFinderTests.swift
+++ b/VaderCleanerTests/AssociatedFileFinderTests.swift
@@ -173,6 +173,42 @@ final class AssociatedFileFinderTests: XCTestCase {
         XCTAssertEqual(names, ["com.acme.helio.updater.plist"])
     }
 
+    /// Apps that install a privileged helper register it under
+    /// `/Library/LaunchDaemons/<bundleID>*.plist`. The scan must
+    /// include those so the daemon doesn't survive uninstall and
+    /// keep running on the next boot. Codex P2 on PR #58.
+    func test_find_includesSystemLaunchDaemons() async throws {
+        let systemDaemonURL = systemLibrary
+            .appendingPathComponent("LaunchDaemons", isDirectory: true)
+            .appendingPathComponent("com.acme.helio.daemon.plist")
+        try FileManager.default.createDirectory(
+            at: systemDaemonURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(repeating: 0xCD, count: 128).write(to: systemDaemonURL)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let daemons = result.filter { $0.category == .launchDaemons }
+        XCTAssertEqual(daemons.count, 1)
+        XCTAssertEqual(daemons.first?.url.lastPathComponent, "com.acme.helio.daemon.plist")
+        XCTAssertEqual(daemons.first?.sizeBytes, 128)
+    }
+
+    /// LaunchDaemons lookup must require the `.plist` extension —
+    /// same rationale as LaunchAgents.
+    func test_find_launchDaemonsRequireDotPlistSuffix() async throws {
+        let dir = systemLibrary.appendingPathComponent("LaunchDaemons", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data().write(to: dir.appendingPathComponent("com.acme.helio.daemon.plist"))
+        try Data().write(to: dir.appendingPathComponent("com.acme.helio.daemon.binary"))
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let names = result.filter { $0.category == .launchDaemons }.map { $0.url.lastPathComponent }
+        XCTAssertEqual(names, ["com.acme.helio.daemon.plist"])
+    }
+
     func test_find_includesUserAndSystemLaunchAgents() async throws {
         try makeFile(under: "Library/LaunchAgents/com.acme.helio.updater.plist", size: 64)
         let systemAgentURL = systemLibrary

--- a/VaderCleanerTests/AssociatedFileFinderTests.swift
+++ b/VaderCleanerTests/AssociatedFileFinderTests.swift
@@ -44,6 +44,52 @@ final class AssociatedFileFinderTests: XCTestCase {
         XCTAssertEqual(result.first?.url.lastPathComponent, "com.acme.helio.plist")
     }
 
+    /// A Preferences scan must reject non-`.plist` entries that happen
+    /// to share the bundle-ID prefix — without the extension filter, a
+    /// stray `com.acme.helio.db` would be Trashed during uninstall.
+    func test_find_excludesNonPlistEntriesUnderPreferences() async throws {
+        try makeFile(under: "Library/Preferences/com.acme.helio.plist", size: 16)
+        try makeFile(under: "Library/Preferences/com.acme.helio.db", size: 64)
+        try makeFile(under: "Library/Preferences/com.acme.helio.lock", size: 8)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let names = result.map { $0.url.lastPathComponent }
+        XCTAssertTrue(names.contains("com.acme.helio.plist"))
+        XCTAssertFalse(names.contains("com.acme.helio.db"),
+                       "Preferences scan must require the .plist suffix")
+        XCTAssertFalse(names.contains("com.acme.helio.lock"),
+                       "Preferences scan must require the .plist suffix")
+    }
+
+    /// A Group Containers / LaunchAgents scan must reject siblings that
+    /// share the bundle-ID prefix but lack a dot boundary on the
+    /// matched substring (`com.acme.helio2`, `com.acme.helioworld`).
+    /// The finder emits the matched directory itself (Group Containers
+    /// are directories the user wants Trashed wholesale), so the
+    /// assertions match on the last path component.
+    func test_find_groupContainersAndLaunchAgentsRejectNonBoundaryMatches() async throws {
+        // Wanted hits.
+        try makeFile(under: "Library/Group Containers/TEAM1234.com.acme.helio/shared.bin", size: 1)
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio.helper.plist", size: 1)
+        // Sibling apps — must be excluded.
+        try makeFile(under: "Library/Group Containers/TEAM5678.com.acme.helio2/shared.bin", size: 1)
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio2.helper.plist", size: 1)
+        try makeFile(under: "Library/LaunchAgents/com.acme.helioworld.plist", size: 1)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let names = result.map { $0.url.lastPathComponent }
+        XCTAssertTrue(names.contains("TEAM1234.com.acme.helio"))
+        XCTAssertTrue(names.contains("com.acme.helio.helper.plist"))
+        XCTAssertFalse(names.contains("TEAM5678.com.acme.helio2"),
+                       "Substring match must not pull in helio2 sibling app")
+        XCTAssertFalse(names.contains("com.acme.helio2.helper.plist"),
+                       "Substring match must not pull in helio2 sibling app")
+        XCTAssertFalse(names.contains("com.acme.helioworld.plist"),
+                       "Substring match must require a dot boundary")
+    }
+
     /// A search for `com.acme.helio` must NOT also match
     /// `com.acme.helio2.plist` or `com.acme.helioworld.savedState` —
     /// the bundle ID has to be followed by a dot (or end-of-name).

--- a/VaderCleanerTests/AssociatedFileFinderTests.swift
+++ b/VaderCleanerTests/AssociatedFileFinderTests.swift
@@ -158,6 +158,21 @@ final class AssociatedFileFinderTests: XCTestCase {
         XCTAssertEqual(savedState?.sizeBytes, 12)
     }
 
+    /// LaunchAgents lookup must require the `.plist` extension —
+    /// vendors occasionally drop unrelated companion files (binaries,
+    /// scripts, sockets) into LaunchAgents directories and a too-broad
+    /// substring match would Trash them during uninstall.
+    func test_find_launchAgentsRequireDotPlistSuffix() async throws {
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio.updater.plist", size: 16)
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio.helper.binary", size: 8_192)
+        try makeFile(under: "Library/LaunchAgents/com.acme.helio.socket", size: 0)
+
+        let finder = makeFinder()
+        let result = await finder.find(forBundleID: "com.acme.helio")
+        let names = result.filter { $0.category == .launchAgents }.map { $0.url.lastPathComponent }
+        XCTAssertEqual(names, ["com.acme.helio.updater.plist"])
+    }
+
     func test_find_includesUserAndSystemLaunchAgents() async throws {
         try makeFile(under: "Library/LaunchAgents/com.acme.helio.updater.plist", size: 64)
         let systemAgentURL = systemLibrary

--- a/todo.md
+++ b/todo.md
@@ -36,7 +36,7 @@
 ## Phase 3 — Privacy & Apps
 
 - [x] **Prompt 18** — Privacy feature (browser detection + data clearing + recent files)
-- [ ] **Prompt 19** — App Uninstaller (discovery + associated files + deletion)
+- [x] **Prompt 19** — App Uninstaller (discovery + associated files + deletion)
 - [ ] **Prompt 20** — App Updater (App Store + Sparkle)
 - [ ] **Prompt 21** — Extensions Manager (Safari, browser, Mail, internet plugins, login items)
 


### PR DESCRIPTION
## Summary

- Implements Prompt 19 (issue #57): App Uninstaller feature — discovers installed apps, surfaces their on-disk associated files grouped by category, and moves the bundle plus residue to the Trash via `NSWorkspace.recycle`.
- Adds `AppInfo`, `AssociatedFile(Category)`, `AppDiscovery`, `AssociatedFileFinder`, `AppUninstallerViewModel`, and split-pane `AppUninstallerView` with searchable app list, associated-files inspector, destructive confirmation, and idle / loading / complete / failed states.
- Wires `NavigationSection.appUninstaller` through `ContentView` and `VaderCleanerApp` — Privacy and other sections are untouched.

### Deletion strategy
`/Applications/*.app` is typically root-owned; the privileged helper allowlist deliberately does **not** cover app bundles or `~/Library/Preferences/*`. Using `NSWorkspace.recycle` for everything:
- Reversible — user can restore from Trash.
- Handles authorization via the standard Finder prompt for root-owned items.
- Avoids broadening the privileged surface (kept narrow per issue #41).

User confirmed this approach over extending the helper allowlist before implementation.

### Tests
- `AppDiscoveryTests` (6) — discovery, sorting, Apple-bundle filter, malformed-bundle tolerance, App Store detection, bundle sizing.
- `AssociatedFileFinderTests` (9) — every category, ByHost preferences, Group Containers with team-ID prefix, system + user launch agents, stable ordering, **and a negative test confirming `com.acme.helio` does not match `com.acme.helio2`**.
- `AppUninstallerViewModelTests` (14) — every phase transition, search filter, selection caching, totals, uninstall success/failure, dismiss.

All 401 unit tests pass. Build clean.

### Notes
- I could not click through the UI from this session (no GUI), so the SwiftUI flow is verified by unit tests and `xcodebuild build` only. Recommend a manual smoke pass before merging: select an app, inspect associated files, confirm the Trash prompt fires for a root-owned bundle.
- `xcodegen generate` was run; `project.pbxproj` is committed alongside the new sources.

## Test plan

- [ ] Run the full unit test suite locally (`xcodebuild test`)
- [ ] Smoke: open App Uninstaller, select a sideloaded app, confirm associated files render grouped by category
- [ ] Smoke: select a system-owned app (e.g. one installed under `/Applications`), tap Uninstall, confirm the Finder authorization prompt appears
- [ ] Smoke: toggle "Show system apps" and confirm the list reloads with `com.apple.*` entries
- [ ] Smoke: type in the search field and confirm filtering on name + bundle ID

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App Uninstaller: discover installed apps, view details and associated files, measure reclaimable space, and uninstall apps to Trash.
  * New UI: full App Uninstaller screen with list/detail panes, search, system-app toggle, confirmations, and result states.

* **New Types**
  * AppInfo and AssociatedFile (with categorized groups) for representing apps and their artifacts.

* **Performance**
  * Asynchronous app icon caching and preloading for smoother rendering.

* **Tests**
  * Comprehensive tests for app discovery, associated-file finding, and uninstaller view-model flows.

* **Chore**
  * Project configuration updated; todo list item for App Uninstaller marked complete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/58)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->