### PR TITLE
feat: App Updater (App Store + Sparkle)

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */; };
 		1947460A68C713844C308694 /* TreemapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
+		218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46943B264F72B3753075A8C /* UpdateInfoTests.swift */; };
 		2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */; };
 		26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */; };
 		26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */; };
@@ -38,14 +39,17 @@
 		3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6697CA6EEE719B2E2D46CE /* AppState.swift */; };
 		35F306676A3412253929EF55 /* TreemapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BDB24525760C96625DD266 /* TreemapView.swift */; };
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
+		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
 		3A0AAEEE22026F9D96D875B2 /* PrivacyCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */; };
 		3A3C0E7B444AE96C4C2D1C8F /* HealthMonitorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */; };
 		3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */; };
 		3B8C348DB1DCBFB89771ADDC /* PrivacyPermissionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */; };
+		3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */; };
 		483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */; };
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
+		4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */; };
 		52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */; };
@@ -70,6 +74,7 @@
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
 		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
+		7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2617BC26104D5196DEDB3589 /* UpdateInfo.swift */; };
 		7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */; };
 		82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */; };
 		823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */; };
@@ -79,6 +84,7 @@
 		83FF16A5DCFB4B225F33236E /* SystemJunkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */; };
 		85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
+		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
 		91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */; };
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
 		99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC50A90E584320709971BCB /* ScanCategoryTests.swift */; };
@@ -91,11 +97,14 @@
 		B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39407E2EA6D045893F1BA4B /* DiskNode.swift */; };
 		B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */; };
 		B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */; };
+		B51203EFD0B1E0734609E427 /* VersionComparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAF96E747AD4C1378B4043D /* VersionComparator.swift */; };
 		B60909E266277B691B876E63 /* NotificationThresholdMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */; };
 		B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */; };
 		B6B4FF9883F54E8F60010ACB /* VaderCleanerHelper in Embed Dependencies */ = {isa = PBXBuildFile; fileRef = 6CBCA8999E04715E502AB892 /* VaderCleanerHelper */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B7DADC9127C373029FC8198A /* AppUninstallerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D62624319B764770F02292 /* AppUninstallerViewModel.swift */; };
+		B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */; };
 		BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2B92863509818189F46CD /* MenuBarContent.swift */; };
+		BABEDA3326E05DC3A8356E3D /* AppStoreUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */; };
 		BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133467A06193C406B027D97C /* NavigationSectionTests.swift */; };
 		BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC391B523110720320AD89 /* SystemPathProviding.swift */; };
 		BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */; };
@@ -115,6 +124,8 @@
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */; };
 		E370FDA389CDFEC249437640 /* AppIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */; };
+		E5E7952A56BA88D9CA86A1B5 /* HTTPFetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */; };
+		E7B7C87B22F9328A45CC6A4B /* AppStoreUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */; };
 		EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */; };
 		EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */; };
 		EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4E92A146A223EA836C156D /* ScanResultTests.swift */; };
@@ -122,6 +133,7 @@
 		F0838C9B10FFB6AD75523D0A /* PrivacyPermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */; };
 		F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */; };
 		F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */; };
+		F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8635D102B895AF349A13D /* AppUpdaterView.swift */; };
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
 		FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */; };
 		FF87A6FAB563AF43345061BB /* PreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */; };
@@ -180,6 +192,7 @@
 		02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicy.swift; sourceTree = "<group>"; };
 		04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerView.swift; sourceTree = "<group>"; };
 		06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocator.swift; sourceTree = "<group>"; };
+		06E8635D102B895AF349A13D /* AppUpdaterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterView.swift; sourceTree = "<group>"; };
 		072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionChecker.swift; sourceTree = "<group>"; };
 		0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManagerTests.swift; sourceTree = "<group>"; };
 		0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyCategory.swift; sourceTree = "<group>"; };
@@ -192,10 +205,13 @@
 		166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorViewModelTests.swift; sourceTree = "<group>"; };
 		16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleter.swift; sourceTree = "<group>"; };
 		1A06928276134E79D8ADFBF5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparatorTests.swift; sourceTree = "<group>"; };
 		1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocatorTests.swift; sourceTree = "<group>"; };
 		1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManagerTests.swift; sourceTree = "<group>"; };
 		22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperRegistration.swift; sourceTree = "<group>"; };
+		22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateCheckerTests.swift; sourceTree = "<group>"; };
 		25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecisionTests.swift; sourceTree = "<group>"; };
+		2617BC26104D5196DEDB3589 /* UpdateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfo.swift; sourceTree = "<group>"; };
 		2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModelTests.swift; sourceTree = "<group>"; };
 		2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModel.swift; sourceTree = "<group>"; };
 		2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManager.swift; sourceTree = "<group>"; };
@@ -207,6 +223,7 @@
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
 		3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerTests.swift; sourceTree = "<group>"; };
 		3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviding.swift; sourceTree = "<group>"; };
+		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
 		46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpersTests.swift; sourceTree = "<group>"; };
@@ -215,6 +232,8 @@
 		4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayout.swift; sourceTree = "<group>"; };
 		4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkUITests.swift; sourceTree = "<group>"; };
 		4D92F45290B56030CBFA83D3 /* Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
+		4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateCheckerTests.swift; sourceTree = "<group>"; };
+		4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPFetching.swift; sourceTree = "<group>"; };
 		50BDB24525760C96625DD266 /* TreemapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapView.swift; sourceTree = "<group>"; };
 		5163E14892EAA1E30C3EFFE5 /* VaderCleanerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VaderCleanerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManager.swift; sourceTree = "<group>"; };
@@ -228,9 +247,11 @@
 		6085B6A39985DFF334821551 /* ExclusionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStore.swift; sourceTree = "<group>"; };
 		6090134A72001DE6262436F3 /* FileIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconCache.swift; sourceTree = "<group>"; };
 		613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModel.swift; sourceTree = "<group>"; };
+		65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateChecker.swift; sourceTree = "<group>"; };
 		6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScannerTests.swift; sourceTree = "<group>"; };
 		67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewSubviews.swift; sourceTree = "<group>"; };
 		673CA7922445475111927C0B /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
+		68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModel.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
 		6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerUITests.swift; sourceTree = "<group>"; };
@@ -266,6 +287,7 @@
 		B2E92F45C5CC0EEA00B12EF5 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		B39407E2EA6D045893F1BA4B /* DiskNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskNode.swift; sourceTree = "<group>"; };
 		B3CD8C98E8253953444DD99F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		B46943B264F72B3753075A8C /* UpdateInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfoTests.swift; sourceTree = "<group>"; };
 		B79E0766E335360E04FC6A53 /* AppDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscovery.swift; sourceTree = "<group>"; };
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
 		BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScanner.swift; sourceTree = "<group>"; };
@@ -278,6 +300,8 @@
 		C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStoreTests.swift; sourceTree = "<group>"; };
 		C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewSubviews.swift; sourceTree = "<group>"; };
 		CAC2037BDF5D632418393BD9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		CEAF96E747AD4C1378B4043D /* VersionComparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparator.swift; sourceTree = "<group>"; };
+		CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateChecker.swift; sourceTree = "<group>"; };
 		CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModelTests.swift; sourceTree = "<group>"; };
 		D1CC391B523110720320AD89 /* SystemPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPathProviding.swift; sourceTree = "<group>"; };
 		D1F6A5DF7364E1886699488B /* BrowserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTests.swift; sourceTree = "<group>"; };
@@ -341,9 +365,12 @@
 				7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */,
 				673CA7922445475111927C0B /* AppInfo.swift */,
 				FE6697CA6EEE719B2E2D46CE /* AppState.swift */,
+				65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */,
 				04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */,
 				49D62624319B764770F02292 /* AppUninstallerViewModel.swift */,
 				C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */,
+				06E8635D102B895AF349A13D /* AppUpdaterView.swift */,
+				68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */,
 				5E978BB01AD677AEDE122B1C /* Assets.xcassets */,
 				57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */,
 				8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */,
@@ -363,6 +390,7 @@
 				FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */,
 				43596249B222D18142F961E2 /* HelperConnectionManager.swift */,
 				22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */,
+				4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */,
 				98D7B18095634307C5D7223D /* Info.plist */,
 				06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */,
 				8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */,
@@ -389,6 +417,7 @@
 				B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */,
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
 				897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */,
+				CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */,
 				16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */,
 				9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */,
 				A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */,
@@ -398,9 +427,11 @@
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
 				4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */,
 				50BDB24525760C96625DD266 /* TreemapView.swift */,
+				2617BC26104D5196DEDB3589 /* UpdateInfo.swift */,
 				9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */,
 				FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */,
 				A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */,
+				CEAF96E747AD4C1378B4043D /* VersionComparator.swift */,
 				46466A1909A880757A7C4B31 /* Localizable.strings */,
 				329FBD86F55918272AF0EF2A /* Localizable.stringsdict */,
 			);
@@ -439,7 +470,9 @@
 				25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */,
 				8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */,
 				9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */,
+				4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */,
 				31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */,
+				42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */,
 				C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */,
 				E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */,
 				A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */,
@@ -472,12 +505,15 @@
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
+				22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */,
 				F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */,
 				2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */,
 				DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */,
 				6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */,
 				46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */,
 				80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */,
+				B46943B264F72B3753075A8C /* UpdateInfoTests.swift */,
+				1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */,
 				E149BD1FE4E65D6589292B84 /* Helpers */,
 			);
 			path = VaderCleanerTests;
@@ -631,7 +667,9 @@
 				6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */,
 				B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */,
 				3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */,
+				E7B7C87B22F9328A45CC6A4B /* AppStoreUpdateCheckerTests.swift in Sources */,
 				11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */,
+				381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */,
 				65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */,
 				F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */,
 				B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */,
@@ -664,6 +702,7 @@
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
+				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,
 				6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */,
 				13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */,
 				0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */,
@@ -671,6 +710,8 @@
 				C26E98922A61A57DB9369C60 /* TestHelpers.swift in Sources */,
 				109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */,
 				BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */,
+				218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */,
+				3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -703,9 +744,12 @@
 				E370FDA389CDFEC249437640 /* AppIconCache.swift in Sources */,
 				2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */,
 				3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */,
+				BABEDA3326E05DC3A8356E3D /* AppStoreUpdateChecker.swift in Sources */,
 				26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */,
 				B7DADC9127C373029FC8198A /* AppUninstallerViewModel.swift in Sources */,
 				D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */,
+				F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */,
+				4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */,
 				9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */,
 				EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */,
 				3328707476CC1411FA1270D0 /* Browser.swift in Sources */,
@@ -720,6 +764,7 @@
 				60DBED2582B50DA009B180C4 /* FileCategory.swift in Sources */,
 				730791446114BB6991798518 /* FileIconCache.swift in Sources */,
 				52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */,
+				E5E7952A56BA88D9CA86A1B5 /* HTTPFetching.swift in Sources */,
 				92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */,
 				3A3C0E7B444AE96C4C2D1C8F /* HealthMonitorViewModel.swift in Sources */,
 				9CA467B702E12F278B7BE6DC /* HelperConnectionManager.swift in Sources */,
@@ -751,6 +796,7 @@
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */,
+				B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */,
 				1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */,
 				DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */,
 				B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */,
@@ -760,8 +806,10 @@
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
 				1947460A68C713844C308694 /* TreemapLayout.swift in Sources */,
 				35F306676A3412253929EF55 /* TreemapView.swift in Sources */,
+				7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */,
 				6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */,
 				BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */,
+				B51203EFD0B1E0734609E427 /* VersionComparator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VaderCleaner/AppStoreUpdateChecker.swift
+++ b/VaderCleaner/AppStoreUpdateChecker.swift
@@ -43,11 +43,24 @@ struct DefaultAppStoreUpdateChecker: AppStoreUpdateChecking, Sendable {
         }
         // `URLQueryItem` percent-encodes the value, so a bundle ID
         // containing `+` (rare but legal) round-trips correctly through
-        // the query string.
-        components.queryItems = [URLQueryItem(name: "bundleId", value: bundleID)]
+        // the query string. `entity=macSoftware` constrains the lookup to
+        // Mac App Store titles — a bundle ID can in principle match an
+        // iOS app with the same identifier, and we only ever want the
+        // macOS build's version here.
+        components.queryItems = [
+            URLQueryItem(name: "bundleId", value: bundleID),
+            URLQueryItem(name: "entity", value: "macSoftware")
+        ]
         guard let url = components.url else { return nil }
 
-        let (data, _) = try await httpFetcher.data(from: url)
+        let (data, response) = try await httpFetcher.data(from: url)
+        // A non-200 (rate limiting, 5xx, an HTML error page) would only
+        // surface as an opaque JSON decoding failure further down. Treat
+        // it the same as "no result" — the caller already tolerates a
+        // nil lookup as "no update info available".
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            return nil
+        }
         let payload = try JSONDecoder().decode(LookupResponse.self, from: data)
         guard let first = payload.results.first,
               let storeURL = URL(string: first.trackViewUrl) else {

--- a/VaderCleaner/AppStoreUpdateChecker.swift
+++ b/VaderCleaner/AppStoreUpdateChecker.swift
@@ -1,0 +1,66 @@
+// AppStoreUpdateChecker.swift
+// Mac App Store update lookup via the public iTunes Search API — returns the latest released version and the apps.apple.com URL for an installed App Store bundle ID.
+
+import Foundation
+import os.log
+
+/// Reduced view of the iTunes Search API response that the App Updater
+/// actually consumes — version and the App Store URL we hand to
+/// `NSWorkspace.open`.
+struct AppStoreLookup: Hashable, Sendable {
+    let version: String
+    let appStoreURL: URL
+}
+
+/// Test seam for the iTunes Search API. Production hits
+/// `https://itunes.apple.com/lookup?bundleId=...`; tests inject a stub
+/// HTTP fetcher with pre-baked JSON.
+protocol AppStoreUpdateChecking: Sendable {
+    func latestVersion(forBundleID bundleID: String) async throws -> AppStoreLookup?
+}
+
+/// Production implementation. Returns `nil` on empty result sets rather
+/// than throwing — many MAS apps don't surface in the lookup API and a
+/// missing entry is not an error from the App Updater's perspective.
+struct DefaultAppStoreUpdateChecker: AppStoreUpdateChecking, Sendable {
+
+    private let httpFetcher: HTTPFetching
+    private let baseURL: URL
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "AppStoreUpdateChecker")
+
+    init(
+        httpFetcher: HTTPFetching = URLSession.shared,
+        baseURL: URL = URL(string: "https://itunes.apple.com/lookup")!
+    ) {
+        self.httpFetcher = httpFetcher
+        self.baseURL = baseURL
+    }
+
+    func latestVersion(forBundleID bundleID: String) async throws -> AppStoreLookup? {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        // `URLQueryItem` percent-encodes the value, so a bundle ID
+        // containing `+` (rare but legal) round-trips correctly through
+        // the query string.
+        components.queryItems = [URLQueryItem(name: "bundleId", value: bundleID)]
+        guard let url = components.url else { return nil }
+
+        let (data, _) = try await httpFetcher.data(from: url)
+        let payload = try JSONDecoder().decode(LookupResponse.self, from: data)
+        guard let first = payload.results.first,
+              let storeURL = URL(string: first.trackViewUrl) else {
+            return nil
+        }
+        return AppStoreLookup(version: first.version, appStoreURL: storeURL)
+    }
+
+    private struct LookupResponse: Decodable {
+        let results: [Result]
+        struct Result: Decodable {
+            let version: String
+            let trackViewUrl: String
+        }
+    }
+}

--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -109,6 +109,13 @@ private struct AppUpdaterListState: View {
     let onUpdate: (UpdateInfo) -> Void
     let onUpdateAll: () -> Void
 
+    /// Above this many pending updates, "Update All" asks for
+    /// confirmation first — each entry opens an App Store page or a
+    /// browser download, and firing a dozen-plus external actions at
+    /// once with no warning is a jarring experience.
+    private static let bulkConfirmationThreshold = 10
+    @State private var showBulkConfirmation = false
+
     var body: some View {
         VStack(spacing: 0) {
             List {
@@ -127,7 +134,7 @@ private struct AppUpdaterListState: View {
                 Button(String(
                     localized: "Update All",
                     comment: "Footer button on the App Updater that opens every available update."
-                ), action: onUpdateAll)
+                ), action: updateAllTapped)
                     .controlSize(.large)
                     .keyboardShortcut(.defaultAction)
                     .buttonStyle(.borderedProminent)
@@ -135,6 +142,39 @@ private struct AppUpdaterListState: View {
             }
             .padding(16)
         }
+        .alert(
+            String(
+                localized: "Open all updates?",
+                comment: "Title of the confirmation shown before opening many updates at once."
+            ),
+            isPresented: $showBulkConfirmation
+        ) {
+            Button(String(localized: "Cancel"), role: .cancel) { }
+            Button(String(
+                localized: "Open All",
+                comment: "Confirm button on the App Updater bulk-update confirmation."
+            )) {
+                onUpdateAll()
+            }
+        } message: {
+            Text(bulkConfirmationMessage)
+        }
+    }
+
+    private func updateAllTapped() {
+        if updates.count > Self.bulkConfirmationThreshold {
+            showBulkConfirmation = true
+        } else {
+            onUpdateAll()
+        }
+    }
+
+    private var bulkConfirmationMessage: String {
+        let format = String(
+            localized: "This opens %lld update pages or downloads at once.",
+            comment: "Body of the App Updater bulk-update confirmation."
+        )
+        return String.localizedStringWithFormat(format, Int64(updates.count))
     }
 
     private var updatesCountText: String {

--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -138,8 +138,14 @@ private struct AppUpdaterListState: View {
     }
 
     private var updatesCountText: String {
+        if updates.count == 1 {
+            return String(
+                localized: "1 update available",
+                comment: "Footer label on the App Updater when exactly one update is pending."
+            )
+        }
         let format = String(
-            localized: "%lld available",
+            localized: "%lld updates available",
             comment: "Footer label on the App Updater showing how many updates are pending."
         )
         return String.localizedStringWithFormat(format, Int64(updates.count))

--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -1,0 +1,261 @@
+// AppUpdaterView.swift
+// App Updater feature view — orchestrates the check-for-updates flow, renders the merged App Store + Sparkle update list, and routes per-app and "Update All" actions through the view-model.
+
+import SwiftUI
+
+struct AppUpdaterView: View {
+
+    @ObservedObject private var viewModel: AppUpdaterViewModel
+
+    init(viewModel: AppUpdaterViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(NavigationSection.appUpdater.title)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: { Task { await viewModel.checkForUpdates() } }) {
+                        Label(String(
+                            localized: "Check for Updates",
+                            comment: "Toolbar button on the App Updater that re-checks for updates."
+                        ), systemImage: "arrow.clockwise")
+                    }
+                    .disabled(viewModel.phase == .checking)
+                    .accessibilityIdentifier("appUpdater.check")
+                }
+            }
+            .task {
+                if viewModel.phase == .idle {
+                    await viewModel.checkForUpdates()
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.phase {
+        case .idle, .checking:
+            AppUpdaterProgressState()
+        case .ready:
+            if viewModel.availableUpdates.isEmpty {
+                AppUpdaterUpToDateState()
+            } else {
+                AppUpdaterListState(
+                    updates: viewModel.availableUpdates,
+                    onUpdate: { info in
+                        Task { await viewModel.update(info) }
+                    },
+                    onUpdateAll: { Task { await viewModel.updateAll() } }
+                )
+            }
+        case .failed(let message):
+            AppUpdaterFailedState(
+                message: message,
+                onTryAgain: { Task { await viewModel.checkForUpdates() } }
+            )
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private struct AppUpdaterProgressState: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(String(
+                localized: "Checking for updates…",
+                comment: "Progress label shown while the App Updater is fetching versions."
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("appUpdater.loading")
+    }
+}
+
+private struct AppUpdaterUpToDateState: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text(String(
+                localized: "All apps are up to date",
+                comment: "Empty state shown on the App Updater when no updates are available."
+            ))
+                .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "We didn't find any newer versions for your installed apps.",
+                comment: "Detail shown on the App Updater empty state."
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("appUpdater.upToDate")
+    }
+}
+
+private struct AppUpdaterListState: View {
+    let updates: [UpdateInfo]
+    let onUpdate: (UpdateInfo) -> Void
+    let onUpdateAll: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            List {
+                ForEach(updates) { info in
+                    AppUpdaterRow(info: info, onUpdate: { onUpdate(info) })
+                        .accessibilityIdentifier("appUpdater.row.\(info.bundleID)")
+                }
+            }
+            .listStyle(.inset)
+            Divider()
+            HStack(spacing: 12) {
+                Text(updatesCountText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button(String(
+                    localized: "Update All",
+                    comment: "Footer button on the App Updater that opens every available update."
+                ), action: onUpdateAll)
+                    .controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("appUpdater.updateAll")
+            }
+            .padding(16)
+        }
+    }
+
+    private var updatesCountText: String {
+        let format = String(
+            localized: "%lld available",
+            comment: "Footer label on the App Updater showing how many updates are pending."
+        )
+        return String.localizedStringWithFormat(format, Int64(updates.count))
+    }
+}
+
+private struct AppUpdaterRow: View {
+    let info: UpdateInfo
+    let onUpdate: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: sourceIcon)
+                .font(.system(size: 28))
+                .foregroundStyle(.secondary)
+                .frame(width: 28, height: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(info.appName)
+                    .font(.body.weight(.medium))
+                HStack(spacing: 6) {
+                    Text(versionTransitionText)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Text(sourceBadge)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.secondary.opacity(0.15))
+                        .clipShape(Capsule())
+                }
+            }
+            Spacer()
+            Button(String(
+                localized: "Update",
+                comment: "Per-row action button on the App Updater list."
+            ), action: onUpdate)
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("appUpdater.update.\(info.bundleID)")
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var versionTransitionText: String {
+        let format = String(
+            localized: "%@ → %@",
+            comment: "Version transition label on App Updater rows (installed → latest)."
+        )
+        return String.localizedStringWithFormat(
+            format,
+            info.installedVersion,
+            info.latestVersion
+        )
+    }
+
+    private var sourceBadge: String {
+        switch info.source {
+        case .appStore:
+            return String(
+                localized: "App Store",
+                comment: "Badge text shown on App Updater rows sourced from the Mac App Store."
+            )
+        case .sparkle:
+            return String(
+                localized: "Sparkle",
+                comment: "Badge text shown on App Updater rows sourced from a Sparkle appcast."
+            )
+        }
+    }
+
+    private var sourceIcon: String {
+        switch info.source {
+        case .appStore: return "bag"
+        case .sparkle:  return "sparkles"
+        }
+    }
+}
+
+private struct AppUpdaterFailedState: View {
+    let message: String
+    let onTryAgain: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(String(
+                localized: "Couldn't check for updates",
+                comment: "Title shown on the App Updater failure screen."
+            ))
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("appUpdater.errorMessage")
+            Button(String(
+                localized: "Try Again",
+                comment: "Retry button on the App Updater failure screen."
+            ), action: onTryAgain)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("appUpdater.tryAgain")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+#Preview {
+    AppUpdaterView(viewModel: AppUpdaterViewModel(
+        discover: { _ in [] },
+        checkAppStore: { _ in nil },
+        checkSparkle: { _ in nil },
+        opener: { _ in }
+    ))
+    .frame(width: 900, height: 600)
+}

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -180,6 +180,7 @@ final class AppUpdaterViewModel: ObservableObject {
         return UpdateInfo(
             appName: app.name,
             bundleID: app.bundleID,
+            bundleURL: app.bundleURL,
             installedVersion: installed,
             latestVersion: lookup.version,
             source: .appStore,
@@ -199,6 +200,7 @@ final class AppUpdaterViewModel: ObservableObject {
         return UpdateInfo(
             appName: app.name,
             bundleID: app.bundleID,
+            bundleURL: app.bundleURL,
             installedVersion: installed,
             latestVersion: item.shortVersion,
             source: .sparkle,

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -1,0 +1,215 @@
+// AppUpdaterViewModel.swift
+// State machine and orchestration behind the App Updater feature view — fans installed apps out to App Store and Sparkle checkers concurrently, merges results, suppresses up-to-date apps, and routes user-initiated updates to NSWorkspace.
+
+import AppKit
+import Foundation
+import os.log
+
+/// Drives the App Updater feature view (check → ready → update).
+///
+/// All collaborators are injected as closures so unit tests can drive
+/// every transition without touching real apps or the network. Production
+/// wiring lives in `AppUpdaterViewModel.live()`.
+@MainActor
+final class AppUpdaterViewModel: ObservableObject {
+
+    /// Discrete phases the view binds to.
+    enum Phase: Equatable {
+        case idle
+        case checking
+        case ready
+        case failed(message: String)
+    }
+
+    typealias Discover       = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
+    typealias CheckAppStore  = @Sendable (_ bundleID: String) async -> AppStoreLookup?
+    typealias CheckSparkle   = @Sendable (_ app: AppInfo) async -> SparkleAppcastItem?
+    typealias Opener         = @Sendable (_ url: URL) async -> Void
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var availableUpdates: [UpdateInfo] = []
+
+    private let discover: Discover
+    private let checkAppStore: CheckAppStore
+    private let checkSparkle: CheckSparkle
+    private let opener: Opener
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "AppUpdaterViewModel")
+
+    /// Monotonic counter — a second `checkForUpdates()` invalidates the
+    /// older results so a slow first pass can't overwrite a fresh second
+    /// pass with stale data. Same pattern as `AppUninstallerViewModel`.
+    private var checkGeneration: Int = 0
+
+    init(
+        discover: @escaping Discover,
+        checkAppStore: @escaping CheckAppStore,
+        checkSparkle: @escaping CheckSparkle,
+        opener: @escaping Opener
+    ) {
+        self.discover = discover
+        self.checkAppStore = checkAppStore
+        self.checkSparkle = checkSparkle
+        self.opener = opener
+    }
+
+    // MARK: - Actions
+
+    /// Discovers installed apps and dispatches each to either the App
+    /// Store or the Sparkle checker. The two channels are independent —
+    /// a Sparkle-bundled app uploaded later to the Mac App Store would
+    /// appear in `isAppStore`, so the dispatch is exclusive.
+    func checkForUpdates() async {
+        let generation = beginCheck()
+        phase = .checking
+        do {
+            let apps = try await discover(false)
+            // Bind to locals so the captured values in the TaskGroup
+            // don't accidentally reach back into the actor — closures
+            // are already `@Sendable`, but keeping the capture explicit
+            // makes the data flow obvious.
+            let appStoreCheck = self.checkAppStore
+            let sparkleCheck = self.checkSparkle
+            let updates = await withTaskGroup(of: UpdateInfo?.self) { group -> [UpdateInfo] in
+                for app in apps {
+                    group.addTask { [app] in
+                        if app.isAppStore {
+                            return await Self.checkAppStoreUpdate(
+                                app: app,
+                                check: appStoreCheck
+                            )
+                        } else {
+                            return await Self.checkSparkleUpdate(
+                                app: app,
+                                check: sparkleCheck
+                            )
+                        }
+                    }
+                }
+                var results: [UpdateInfo] = []
+                for await item in group {
+                    if let item { results.append(item) }
+                }
+                return results
+            }
+            guard self.checkGeneration == generation else { return }
+            // Sort case-insensitively by app name so the list order is
+            // deterministic between successive checks.
+            self.availableUpdates = updates.sorted {
+                $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
+            }
+            self.phase = .ready
+        } catch {
+            // Privacy: errors may include user-specific paths.
+            log.error("App Updater discovery failed: \(String(describing: error), privacy: .private)")
+            guard self.checkGeneration == generation else { return }
+            self.availableUpdates = []
+            self.phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    /// Opens the per-app update URL — Mac App Store URL for `appStore`
+    /// entries, the appcast enclosure URL for Sparkle entries. The
+    /// production opener delegates to `NSWorkspace.open`.
+    func update(_ info: UpdateInfo) async {
+        await opener(info.updateURL)
+    }
+
+    /// Opens every available update's URL in sequence. The system
+    /// handles deduplication if multiple URLs point at the same App
+    /// Store entry.
+    func updateAll() async {
+        for info in availableUpdates {
+            await opener(info.updateURL)
+        }
+    }
+
+    // MARK: - Private
+
+    private func beginCheck() -> Int {
+        checkGeneration += 1
+        return checkGeneration
+    }
+
+    /// Runs the App Store lookup and folds the result into an
+    /// `UpdateInfo` if (and only if) the remote version is newer than
+    /// the installed one. A network failure inside the lookup returns
+    /// `nil` — one slow checker must not blank the whole update list.
+    private static func checkAppStoreUpdate(
+        app: AppInfo,
+        check: CheckAppStore
+    ) async -> UpdateInfo? {
+        guard let lookup = await check(app.bundleID) else { return nil }
+        let installed = app.version ?? "0"
+        guard VersionComparator.isNewer(version: lookup.version, than: installed) else {
+            return nil
+        }
+        return UpdateInfo(
+            appName: app.name,
+            bundleID: app.bundleID,
+            installedVersion: installed,
+            latestVersion: lookup.version,
+            source: .appStore,
+            updateURL: lookup.appStoreURL
+        )
+    }
+
+    private static func checkSparkleUpdate(
+        app: AppInfo,
+        check: CheckSparkle
+    ) async -> UpdateInfo? {
+        guard let item = await check(app) else { return nil }
+        let installed = app.version ?? "0"
+        guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else {
+            return nil
+        }
+        return UpdateInfo(
+            appName: app.name,
+            bundleID: app.bundleID,
+            installedVersion: installed,
+            latestVersion: item.shortVersion,
+            source: .sparkle,
+            updateURL: item.downloadURL
+        )
+    }
+}
+
+// MARK: - Production wiring
+
+extension AppUpdaterViewModel {
+
+    /// Build a view-model wired to the real `DefaultAppDiscovery`,
+    /// `DefaultAppStoreUpdateChecker`, `DefaultSparkleUpdateChecker`, and
+    /// `NSWorkspace.open`.
+    @MainActor
+    static func live() -> AppUpdaterViewModel {
+        let discovery = DefaultAppDiscovery()
+        let appStore = DefaultAppStoreUpdateChecker()
+        let sparkle = DefaultSparkleUpdateChecker()
+        return AppUpdaterViewModel(
+            discover: { includingSystemApps in
+                try await discovery.installedApps(includingSystemApps: includingSystemApps)
+            },
+            checkAppStore: { bundleID in
+                do {
+                    return try await appStore.latestVersion(forBundleID: bundleID)
+                } catch {
+                    return nil
+                }
+            },
+            checkSparkle: { app in
+                guard let feedURL = sparkle.feedURL(for: app) else { return nil }
+                do {
+                    return try await sparkle.fetchAppcast(feedURL: feedURL)
+                } catch {
+                    return nil
+                }
+            },
+            opener: { url in
+                await MainActor.run {
+                    _ = NSWorkspace.shared.open(url)
+                }
+            }
+        )
+    }
+}

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -71,24 +71,37 @@ final class AppUpdaterViewModel: ObservableObject {
             let appStoreCheck = self.checkAppStore
             let sparkleCheck = self.checkSparkle
             let updates = await withTaskGroup(of: UpdateInfo?.self) { group -> [UpdateInfo] in
-                for app in apps {
-                    group.addTask { [app] in
-                        if app.isAppStore {
-                            return await Self.checkAppStoreUpdate(
-                                app: app,
-                                check: appStoreCheck
-                            )
-                        } else {
-                            return await Self.checkSparkleUpdate(
-                                app: app,
-                                check: sparkleCheck
-                            )
-                        }
+                // Bounded concurrency: a machine with hundreds of installed
+                // apps would otherwise fire hundreds of simultaneous HTTPS
+                // requests at the iTunes Search API and assorted Sparkle
+                // feeds, inviting rate limiting. A sliding window keeps the
+                // checks parallel but caps in-flight work.
+                var nextIndex = 0
+                while nextIndex < apps.count, nextIndex < Self.maxConcurrentChecks {
+                    let app = apps[nextIndex]
+                    group.addTask {
+                        await Self.checkUpdate(
+                            app: app,
+                            appStoreCheck: appStoreCheck,
+                            sparkleCheck: sparkleCheck
+                        )
                     }
+                    nextIndex += 1
                 }
                 var results: [UpdateInfo] = []
-                for await item in group {
+                while let item = await group.next() {
                     if let item { results.append(item) }
+                    if nextIndex < apps.count {
+                        let app = apps[nextIndex]
+                        group.addTask {
+                            await Self.checkUpdate(
+                                app: app,
+                                appStoreCheck: appStoreCheck,
+                                sparkleCheck: sparkleCheck
+                            )
+                        }
+                        nextIndex += 1
+                    }
                 }
                 return results
             }
@@ -126,9 +139,29 @@ final class AppUpdaterViewModel: ObservableObject {
 
     // MARK: - Private
 
+    /// Maximum number of update checks (HTTPS requests) in flight at once.
+    /// Sized to keep the scan responsive without stampeding the iTunes
+    /// Search API / Sparkle hosts on machines with many installed apps.
+    private static let maxConcurrentChecks = 6
+
     private func beginCheck() -> Int {
         checkGeneration += 1
         return checkGeneration
+    }
+
+    /// Dispatches a single app to the correct update channel. Factored
+    /// out of `checkForUpdates()` so the bounded-concurrency window can
+    /// schedule the same task body in two places without duplication.
+    private static func checkUpdate(
+        app: AppInfo,
+        appStoreCheck: CheckAppStore,
+        sparkleCheck: CheckSparkle
+    ) async -> UpdateInfo? {
+        if app.isAppStore {
+            return await checkAppStoreUpdate(app: app, check: appStoreCheck)
+        } else {
+            return await checkSparkleUpdate(app: app, check: sparkleCheck)
+        }
     }
 
     /// Runs the App Store lookup and folds the result into an

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
     private let spaceLensViewModel: DiskScannerViewModel
     private let privacyViewModel: PrivacyViewModel
     private let appUninstallerViewModel: AppUninstallerViewModel
+    private let appUpdaterViewModel: AppUpdaterViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
@@ -26,13 +27,15 @@ struct ContentView: View {
         largeOldFilesViewModel: LargeOldFilesViewModel,
         spaceLensViewModel: DiskScannerViewModel,
         privacyViewModel: PrivacyViewModel,
-        appUninstallerViewModel: AppUninstallerViewModel
+        appUninstallerViewModel: AppUninstallerViewModel,
+        appUpdaterViewModel: AppUpdaterViewModel
     ) {
         self.systemJunkViewModel = systemJunkViewModel
         self.largeOldFilesViewModel = largeOldFilesViewModel
         self.spaceLensViewModel = spaceLensViewModel
         self.privacyViewModel = privacyViewModel
         self.appUninstallerViewModel = appUninstallerViewModel
+        self.appUpdaterViewModel = appUpdaterViewModel
     }
 
     var body: some View {
@@ -102,6 +105,8 @@ struct ContentView: View {
             PrivacyView(viewModel: privacyViewModel)
         case .appUninstaller:
             AppUninstallerView(viewModel: appUninstallerViewModel)
+        case .appUpdater:
+            AppUpdaterView(viewModel: appUpdaterViewModel)
         default:
             PlaceholderDetailView(section: section)
         }
@@ -150,7 +155,8 @@ private struct PlaceholderDetailView: View {
         largeOldFilesViewModel: LargeOldFilesViewModel.live(exclusions: exclusions),
         spaceLensViewModel: DiskScannerViewModel.live(),
         privacyViewModel: PrivacyViewModel.live(),
-        appUninstallerViewModel: AppUninstallerViewModel.live()
+        appUninstallerViewModel: AppUninstallerViewModel.live(),
+        appUpdaterViewModel: AppUpdaterViewModel.live()
     )
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())

--- a/VaderCleaner/HTTPFetching.swift
+++ b/VaderCleaner/HTTPFetching.swift
@@ -1,0 +1,16 @@
+// HTTPFetching.swift
+// Minimal HTTP fetch seam used by the App Updater so the Sparkle and App Store checkers can be unit-tested without hitting the real network.
+
+import Foundation
+
+/// Tiny protocol shaped like the part of `URLSession` we actually use. The
+/// production conformance is `URLSession`; unit tests inject a stub that
+/// returns fixture bytes.
+///
+/// `Sendable` so the App Updater view-model can hand the fetcher into a
+/// `TaskGroup` and have it called concurrently from multiple tasks.
+protocol HTTPFetching: Sendable {
+    func data(from url: URL) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPFetching {}

--- a/VaderCleaner/SparkleUpdateChecker.swift
+++ b/VaderCleaner/SparkleUpdateChecker.swift
@@ -35,27 +35,20 @@ protocol SparkleUpdateChecking: Sendable {
 struct DefaultSparkleUpdateChecker: SparkleUpdateChecking, Sendable {
 
     private let httpFetcher: HTTPFetching
-    private let fileManager: FileManager
     private let log = Logger(subsystem: "com.personal.VaderCleaner",
                              category: "SparkleUpdateChecker")
 
-    init(httpFetcher: HTTPFetching = URLSession.shared,
-         fileManager: FileManager = .default) {
+    init(httpFetcher: HTTPFetching = URLSession.shared) {
         self.httpFetcher = httpFetcher
-        self.fileManager = fileManager
     }
 
     func feedURL(for app: AppInfo) -> URL? {
-        let infoPlist = app.bundleURL
-            .appendingPathComponent("Contents", isDirectory: true)
-            .appendingPathComponent("Info.plist")
-        guard let data = try? Data(contentsOf: infoPlist),
-              let plist = try? PropertyListSerialization.propertyList(
-                from: data,
-                options: [],
-                format: nil
-              ) as? [String: Any],
-              let raw = plist["SUFeedURL"] as? String,
+        // `Bundle(url:)` + `object(forInfoDictionaryKey:)` transparently
+        // handles binary vs. XML plists and leverages the system bundle
+        // cache, rather than us re-reading and re-parsing Info.plist by
+        // hand.
+        guard let bundle = Bundle(url: app.bundleURL),
+              let raw = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String,
               !raw.isEmpty else {
             return nil
         }
@@ -75,14 +68,33 @@ struct DefaultSparkleUpdateChecker: SparkleUpdateChecking, Sendable {
 
     /// Parses appcast XML and returns the newest `<item>` (by
     /// `shortVersionString`, with `version` as a tiebreaker) that has a
-    /// downloadable `<enclosure>`. Items without an enclosure are
-    /// skipped — release-notes-only entries aren't actionable updates.
-    static func parseAppcast(xml: Data) -> SparkleAppcastItem? {
+    /// downloadable `<enclosure>` **and** whose
+    /// `sparkle:minimumSystemVersion` (if any) the running macOS
+    /// satisfies. Items without an enclosure are skipped — release-notes-
+    /// only entries aren't actionable updates — and items that require a
+    /// newer macOS than the user is on are filtered out so we never offer
+    /// a download Sparkle itself would refuse to install.
+    ///
+    /// - Parameter currentSystemVersion: the running macOS product
+    ///   version ("14.5.0"). Defaults to the live value; injected by
+    ///   tests so the OS-compatibility filter is deterministic.
+    static func parseAppcast(
+        xml: Data,
+        currentSystemVersion: String = DefaultSparkleUpdateChecker.currentSystemVersionString()
+    ) -> SparkleAppcastItem? {
         let parser = AppcastXMLParser()
         let xmlParser = XMLParser(data: xml)
         xmlParser.delegate = parser
         guard xmlParser.parse() else { return nil }
-        return parser.bestItem()
+        return parser.bestItem(currentSystemVersion: currentSystemVersion)
+    }
+
+    /// The running macOS product version as a dotted string. Kept here
+    /// (rather than read inline) so the OS-compatibility filter has a
+    /// single, injectable source of truth.
+    static func currentSystemVersionString() -> String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
     }
 }
 
@@ -90,14 +102,26 @@ struct DefaultSparkleUpdateChecker: SparkleUpdateChecking, Sendable {
 /// appcast and picks the newest enclosure-bearing one.
 private final class AppcastXMLParser: NSObject, XMLParserDelegate {
 
-    private var items: [SparkleAppcastItem] = []
+    /// Each parsed item paired with its `sparkle:minimumSystemVersion`
+    /// (nil when the feed doesn't constrain the OS for that item).
+    private var collected: [(item: SparkleAppcastItem, minimumSystemVersion: String?)] = []
     private var currentEnclosureURL: URL?
     private var currentShortVersion: String?
     private var currentVersion: String?
+    private var currentMinimumSystemVersion: String?
+    private var minimumSystemVersionBuffer: String?
     private var inItem = false
 
-    func bestItem() -> SparkleAppcastItem? {
-        return items.max { lhs, rhs in
+    func bestItem(currentSystemVersion: String) -> SparkleAppcastItem? {
+        let compatible = collected.filter { entry in
+            guard let minimum = entry.minimumSystemVersion, !minimum.isEmpty else {
+                return true
+            }
+            // Keep the item only when the running OS is at least the
+            // required minimum (current >= minimum).
+            return VersionComparator.compare(currentSystemVersion, minimum) != .orderedAscending
+        }
+        return compatible.map(\.item).max { lhs, rhs in
             let shortComparison = VersionComparator.compare(
                 lhs.shortVersion,
                 rhs.shortVersion
@@ -126,6 +150,7 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
         if local == "item" {
             inItem = true
             currentEnclosureURL = nil
+            currentMinimumSystemVersion = nil
             // Seed from any version attributes carried on the `<item>`
             // itself — older feeds place `sparkle:shortVersionString` /
             // `sparkle:version` here rather than on the enclosure. The
@@ -135,6 +160,13 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
                 ?? attributeDict["shortVersionString"]
             currentVersion = attributeDict["sparkle:version"]
                 ?? attributeDict["version"]
+            return
+        }
+        if inItem, local == "minimumSystemVersion" {
+            // `<sparkle:minimumSystemVersion>` carries its value as
+            // element text, so start buffering character data until the
+            // matching end tag.
+            minimumSystemVersionBuffer = ""
             return
         }
         if inItem, local == "enclosure" {
@@ -162,6 +194,12 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
         qualifiedName qName: String?
     ) {
         let local = localName(for: elementName)
+        if local == "minimumSystemVersion", let buffer = minimumSystemVersionBuffer {
+            let trimmed = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+            currentMinimumSystemVersion = trimmed.isEmpty ? nil : trimmed
+            minimumSystemVersionBuffer = nil
+            return
+        }
         guard local == "item", inItem else {
             return
         }
@@ -171,11 +209,22 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
         guard let downloadURL = currentEnclosureURL else { return }
         let shortVersion = currentShortVersion ?? currentVersion ?? ""
         guard !shortVersion.isEmpty else { return }
-        items.append(SparkleAppcastItem(
-            shortVersion: shortVersion,
-            version: currentVersion,
-            downloadURL: downloadURL
+        collected.append((
+            item: SparkleAppcastItem(
+                shortVersion: shortVersion,
+                version: currentVersion,
+                downloadURL: downloadURL
+            ),
+            minimumSystemVersion: currentMinimumSystemVersion
         ))
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        // Only accumulate while inside a `<sparkle:minimumSystemVersion>`
+        // element — we don't care about any other text nodes.
+        if minimumSystemVersionBuffer != nil {
+            minimumSystemVersionBuffer?.append(string)
+        }
     }
 
     /// XMLParser delivers the qualified name ("sparkle:enclosure") rather

--- a/VaderCleaner/SparkleUpdateChecker.swift
+++ b/VaderCleaner/SparkleUpdateChecker.swift
@@ -109,8 +109,16 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
     private var currentShortVersion: String?
     private var currentVersion: String?
     private var currentMinimumSystemVersion: String?
-    private var minimumSystemVersionBuffer: String?
     private var inItem = false
+    /// True while inside a `<sparkle:deltas>` block. Delta enclosures are
+    /// binary patches keyed to a specific installed build and are useless
+    /// as a user-facing download, so we ignore everything nested there.
+    private var inDeltas = false
+    /// Local name of the element whose text we're currently accumulating
+    /// (`minimumSystemVersion`, `shortVersionString`, or `version`), or
+    /// nil when not inside one of those.
+    private var bufferingElement: String?
+    private var textBuffer = ""
 
     func bestItem(currentSystemVersion: String) -> SparkleAppcastItem? {
         let compatible = collected.filter { entry in
@@ -149,6 +157,7 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
         let local = localName(for: elementName)
         if local == "item" {
             inItem = true
+            inDeltas = false
             currentEnclosureURL = nil
             currentMinimumSystemVersion = nil
             // Seed from any version attributes carried on the `<item>`
@@ -162,14 +171,32 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
                 ?? attributeDict["version"]
             return
         }
-        if inItem, local == "minimumSystemVersion" {
-            // `<sparkle:minimumSystemVersion>` carries its value as
-            // element text, so start buffering character data until the
-            // matching end tag.
-            minimumSystemVersionBuffer = ""
+        guard inItem else { return }
+        if local == "deltas" {
+            inDeltas = true
             return
         }
-        if inItem, local == "enclosure" {
+        if !inDeltas,
+           local == "minimumSystemVersion"
+            || local == "shortVersionString"
+            || local == "version" {
+            // These can appear as child elements carrying their value as
+            // text (Sparkle's element form) rather than as enclosure
+            // attributes — buffer the character data until the end tag.
+            bufferingElement = local
+            textBuffer = ""
+            return
+        }
+        if local == "enclosure" {
+            // Skip delta enclosures: those nested in `<sparkle:deltas>`
+            // and any carrying `sparkle:deltaFrom`. They're patches Sparkle
+            // applies to one specific installed build — opening one as a
+            // manual download gives the user a broken link.
+            if inDeltas
+                || attributeDict["sparkle:deltaFrom"] != nil
+                || attributeDict["deltaFrom"] != nil {
+                return
+            }
             // The enclosure attributes are where Sparkle places the
             // version in most modern feeds; prefer them over any
             // item-level seed but keep the seed as a fallback.
@@ -194,16 +221,34 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
         qualifiedName qName: String?
     ) {
         let local = localName(for: elementName)
-        if local == "minimumSystemVersion", let buffer = minimumSystemVersionBuffer {
-            let trimmed = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
-            currentMinimumSystemVersion = trimmed.isEmpty ? nil : trimmed
-            minimumSystemVersionBuffer = nil
+        if local == "deltas" {
+            inDeltas = false
+            return
+        }
+        if let buffering = bufferingElement, local == buffering {
+            let trimmed = textBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = trimmed.isEmpty ? nil : trimmed
+            switch buffering {
+            case "minimumSystemVersion":
+                currentMinimumSystemVersion = value
+            case "shortVersionString":
+                // Element form is the lowest-precedence source — only use
+                // it when neither an item nor enclosure attribute set it.
+                if currentShortVersion == nil { currentShortVersion = value }
+            case "version":
+                if currentVersion == nil { currentVersion = value }
+            default:
+                break
+            }
+            bufferingElement = nil
+            textBuffer = ""
             return
         }
         guard local == "item", inItem else {
             return
         }
         inItem = false
+        inDeltas = false
         // Only emit items that actually point at something the user can
         // download — a release-notes-only item isn't an update.
         guard let downloadURL = currentEnclosureURL else { return }
@@ -220,10 +265,10 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
     }
 
     func parser(_ parser: XMLParser, foundCharacters string: String) {
-        // Only accumulate while inside a `<sparkle:minimumSystemVersion>`
-        // element — we don't care about any other text nodes.
-        if minimumSystemVersionBuffer != nil {
-            minimumSystemVersionBuffer?.append(string)
+        // Only accumulate while inside one of the buffered version
+        // elements — we don't care about any other text nodes.
+        if bufferingElement != nil {
+            textBuffer.append(string)
         }
     }
 

--- a/VaderCleaner/SparkleUpdateChecker.swift
+++ b/VaderCleaner/SparkleUpdateChecker.swift
@@ -1,0 +1,167 @@
+// SparkleUpdateChecker.swift
+// Sparkle appcast pipeline — reads SUFeedURL from an .app bundle, fetches the appcast XML, and parses out the newest <item> with a downloadable enclosure.
+
+import Foundation
+import os.log
+
+/// Single appcast `<item>` reduced to the fields the App Updater consumes.
+/// `shortVersion` is the user-facing version string ("2.0.0"); `version`
+/// is the build number Sparkle uses for ordering ("2000"). The view-model
+/// presents `shortVersion` and stores `downloadURL` for the "Update"
+/// action.
+struct SparkleAppcastItem: Hashable, Sendable {
+    let shortVersion: String
+    let version: String?
+    let downloadURL: URL
+}
+
+/// Test seam between the App Updater and a live Sparkle feed. Production
+/// implementation reads `SUFeedURL` from the bundle and fetches the
+/// appcast over HTTPS; tests inject a stub that returns fixture bytes.
+protocol SparkleUpdateChecking: Sendable {
+    /// Returns the appcast URL for an app, or `nil` when the bundle's
+    /// `Info.plist` doesn't carry `SUFeedURL` (i.e. not a Sparkle app).
+    func feedURL(for app: AppInfo) -> URL?
+
+    /// Fetches and parses the appcast at `feedURL`, returning the newest
+    /// `<item>` with a downloadable enclosure, or `nil` if the feed has
+    /// no usable items.
+    func fetchAppcast(feedURL: URL) async throws -> SparkleAppcastItem?
+}
+
+/// Production implementation. The Info.plist read happens synchronously
+/// — it's a single small file — but the appcast fetch is async because
+/// it crosses the network.
+struct DefaultSparkleUpdateChecker: SparkleUpdateChecking, Sendable {
+
+    private let httpFetcher: HTTPFetching
+    private let fileManager: FileManager
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "SparkleUpdateChecker")
+
+    init(httpFetcher: HTTPFetching = URLSession.shared,
+         fileManager: FileManager = .default) {
+        self.httpFetcher = httpFetcher
+        self.fileManager = fileManager
+    }
+
+    func feedURL(for app: AppInfo) -> URL? {
+        let infoPlist = app.bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: infoPlist),
+              let plist = try? PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+              ) as? [String: Any],
+              let raw = plist["SUFeedURL"] as? String,
+              !raw.isEmpty else {
+            return nil
+        }
+        return URL(string: raw)
+    }
+
+    func fetchAppcast(feedURL: URL) async throws -> SparkleAppcastItem? {
+        let (data, _) = try await httpFetcher.data(from: feedURL)
+        return Self.parseAppcast(xml: data)
+    }
+
+    /// Parses appcast XML and returns the newest `<item>` (by
+    /// `shortVersionString`, with `version` as a tiebreaker) that has a
+    /// downloadable `<enclosure>`. Items without an enclosure are
+    /// skipped — release-notes-only entries aren't actionable updates.
+    static func parseAppcast(xml: Data) -> SparkleAppcastItem? {
+        let parser = AppcastXMLParser()
+        let xmlParser = XMLParser(data: xml)
+        xmlParser.delegate = parser
+        guard xmlParser.parse() else { return nil }
+        return parser.bestItem()
+    }
+}
+
+/// Streaming `XMLParser` delegate that collects `<item>` entries from an
+/// appcast and picks the newest enclosure-bearing one.
+private final class AppcastXMLParser: NSObject, XMLParserDelegate {
+
+    private var items: [SparkleAppcastItem] = []
+    private var currentEnclosureURL: URL?
+    private var currentShortVersion: String?
+    private var currentVersion: String?
+    private var inItem = false
+
+    func bestItem() -> SparkleAppcastItem? {
+        return items.max { lhs, rhs in
+            let lhsVer = lhs.shortVersion
+            let rhsVer = rhs.shortVersion
+            return VersionComparator.compare(lhsVer, rhsVer) == .orderedAscending
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        let local = localName(for: elementName)
+        if local == "item" {
+            inItem = true
+            currentEnclosureURL = nil
+            currentShortVersion = nil
+            currentVersion = nil
+            return
+        }
+        if inItem, local == "enclosure" {
+            // Pull shortVersionString / version from the enclosure
+            // attributes — that's where Sparkle places them in most feeds.
+            // Some older feeds put `sparkle:shortVersionString` on the
+            // `<item>` itself, but the enclosure variant is dominant.
+            if let urlString = attributeDict["url"], let url = URL(string: urlString) {
+                currentEnclosureURL = url
+            }
+            if currentShortVersion == nil {
+                currentShortVersion = attributeDict["sparkle:shortVersionString"]
+                    ?? attributeDict["shortVersionString"]
+            }
+            if currentVersion == nil {
+                currentVersion = attributeDict["sparkle:version"]
+                    ?? attributeDict["version"]
+            }
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        let local = localName(for: elementName)
+        guard local == "item", inItem else {
+            return
+        }
+        inItem = false
+        // Only emit items that actually point at something the user can
+        // download — a release-notes-only item isn't an update.
+        guard let downloadURL = currentEnclosureURL else { return }
+        let shortVersion = currentShortVersion ?? currentVersion ?? ""
+        guard !shortVersion.isEmpty else { return }
+        items.append(SparkleAppcastItem(
+            shortVersion: shortVersion,
+            version: currentVersion,
+            downloadURL: downloadURL
+        ))
+    }
+
+    /// XMLParser delivers the qualified name ("sparkle:enclosure") rather
+    /// than the local name ("enclosure") when namespace processing is off.
+    /// Strip the prefix here so the dispatcher above stays simple.
+    private func localName(for elementName: String) -> String {
+        if let colonIndex = elementName.firstIndex(of: ":") {
+            return String(elementName[elementName.index(after: colonIndex)...])
+        }
+        return elementName
+    }
+}

--- a/VaderCleaner/SparkleUpdateChecker.swift
+++ b/VaderCleaner/SparkleUpdateChecker.swift
@@ -197,6 +197,16 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
                 || attributeDict["deltaFrom"] != nil {
                 return
             }
+            // Skip enclosures explicitly tagged for another platform.
+            // Sparkle treats a missing `sparkle:os` as macOS; an explicit
+            // value other than macos/osx (e.g. "windows") means this
+            // enclosure isn't a macOS build, so accepting its URL could
+            // hand the user a Windows installer.
+            if let os = (attributeDict["sparkle:os"] ?? attributeDict["os"])?
+                .lowercased(),
+               os != "macos", os != "osx", os != "mac" {
+                return
+            }
             // The enclosure attributes are where Sparkle places the
             // version in most modern feeds; prefer them over any
             // item-level seed but keep the seed as a fallback.

--- a/VaderCleaner/SparkleUpdateChecker.swift
+++ b/VaderCleaner/SparkleUpdateChecker.swift
@@ -63,7 +63,13 @@ struct DefaultSparkleUpdateChecker: SparkleUpdateChecking, Sendable {
     }
 
     func fetchAppcast(feedURL: URL) async throws -> SparkleAppcastItem? {
-        let (data, _) = try await httpFetcher.data(from: feedURL)
+        let (data, response) = try await httpFetcher.data(from: feedURL)
+        // Only parse a successful response — a 404/5xx body is usually an
+        // HTML error page that would either parse to nothing or, worse,
+        // yield a bogus item. Treat it as "no appcast available".
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            return nil
+        }
         return Self.parseAppcast(xml: data)
     }
 
@@ -92,9 +98,20 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
 
     func bestItem() -> SparkleAppcastItem? {
         return items.max { lhs, rhs in
-            let lhsVer = lhs.shortVersion
-            let rhsVer = rhs.shortVersion
-            return VersionComparator.compare(lhsVer, rhsVer) == .orderedAscending
+            let shortComparison = VersionComparator.compare(
+                lhs.shortVersion,
+                rhs.shortVersion
+            )
+            // When two items advertise the same marketing version, fall
+            // back to the build (`sparkle:version`) so a same-short-string
+            // hotfix isn't passed over for an older artifact.
+            if shortComparison == .orderedSame {
+                return VersionComparator.compare(
+                    lhs.version ?? "0",
+                    rhs.version ?? "0"
+                ) == .orderedAscending
+            }
+            return shortComparison == .orderedAscending
         }
     }
 
@@ -109,25 +126,31 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
         if local == "item" {
             inItem = true
             currentEnclosureURL = nil
-            currentShortVersion = nil
-            currentVersion = nil
+            // Seed from any version attributes carried on the `<item>`
+            // itself — older feeds place `sparkle:shortVersionString` /
+            // `sparkle:version` here rather than on the enclosure. The
+            // enclosure handler below still overrides these when the
+            // (dominant) enclosure-attribute form is present.
+            currentShortVersion = attributeDict["sparkle:shortVersionString"]
+                ?? attributeDict["shortVersionString"]
+            currentVersion = attributeDict["sparkle:version"]
+                ?? attributeDict["version"]
             return
         }
         if inItem, local == "enclosure" {
-            // Pull shortVersionString / version from the enclosure
-            // attributes — that's where Sparkle places them in most feeds.
-            // Some older feeds put `sparkle:shortVersionString` on the
-            // `<item>` itself, but the enclosure variant is dominant.
+            // The enclosure attributes are where Sparkle places the
+            // version in most modern feeds; prefer them over any
+            // item-level seed but keep the seed as a fallback.
             if let urlString = attributeDict["url"], let url = URL(string: urlString) {
                 currentEnclosureURL = url
             }
-            if currentShortVersion == nil {
-                currentShortVersion = attributeDict["sparkle:shortVersionString"]
-                    ?? attributeDict["shortVersionString"]
+            if let short = attributeDict["sparkle:shortVersionString"]
+                ?? attributeDict["shortVersionString"] {
+                currentShortVersion = short
             }
-            if currentVersion == nil {
-                currentVersion = attributeDict["sparkle:version"]
-                    ?? attributeDict["version"]
+            if let version = attributeDict["sparkle:version"]
+                ?? attributeDict["version"] {
+                currentVersion = version
             }
         }
     }

--- a/VaderCleaner/UpdateInfo.swift
+++ b/VaderCleaner/UpdateInfo.swift
@@ -1,0 +1,29 @@
+// UpdateInfo.swift
+// Value type describing a single available update — installed vs. latest version, which channel surfaced it, and the URL to send the user to in order to install it.
+
+import Foundation
+
+/// Which channel surfaced an `UpdateInfo`. The App Updater UI renders a
+/// badge per row using this; the view-model also routes the click target
+/// (Mac App Store URL vs. Sparkle download URL) off this distinction.
+enum UpdateSource: String, Hashable, Sendable {
+    case appStore
+    case sparkle
+}
+
+/// A single update available for an installed app.
+///
+/// `id` is keyed off the bundle ID rather than the version pair so SwiftUI
+/// lists stay stable across successive "Check for Updates" passes — the
+/// version strings will flip from one check to the next, but the row
+/// identity should not.
+struct UpdateInfo: Identifiable, Hashable, Sendable {
+    let appName: String
+    let bundleID: String
+    let installedVersion: String
+    let latestVersion: String
+    let source: UpdateSource
+    let updateURL: URL
+
+    var id: String { bundleID }
+}

--- a/VaderCleaner/UpdateInfo.swift
+++ b/VaderCleaner/UpdateInfo.swift
@@ -13,17 +13,22 @@ enum UpdateSource: String, Hashable, Sendable {
 
 /// A single update available for an installed app.
 ///
-/// `id` is keyed off the bundle ID rather than the version pair so SwiftUI
-/// lists stay stable across successive "Check for Updates" passes — the
-/// version strings will flip from one check to the next, but the row
-/// identity should not.
+/// `id` keys off the installed bundle's path rather than the bundle ID or
+/// the version pair. Versions flip between successive "Check for Updates"
+/// passes, so the row identity must not depend on them — but the bundle
+/// ID alone isn't unique either: the same app can be installed in two
+/// locations (e.g. `/Applications` and `~/Applications`), which `AppInfo`
+/// explicitly supports by keying *its* id off `bundleURL.path`. Mirroring
+/// that here keeps each installed copy a distinct SwiftUI row instead of
+/// colliding into one identity and dropping/reusing the wrong row.
 struct UpdateInfo: Identifiable, Hashable, Sendable {
     let appName: String
     let bundleID: String
+    let bundleURL: URL
     let installedVersion: String
     let latestVersion: String
     let source: UpdateSource
     let updateURL: URL
 
-    var id: String { bundleID }
+    var id: String { bundleURL.path }
 }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -31,6 +31,7 @@ struct VaderCleanerApp: App {
     @StateObject private var spaceLensViewModel: DiskScannerViewModel
     @StateObject private var privacyViewModel: PrivacyViewModel
     @StateObject private var appUninstallerViewModel: AppUninstallerViewModel
+    @StateObject private var appUpdaterViewModel: AppUpdaterViewModel
     // App-scope so the cheap-stats timer outlives any single window. The
     // Health Monitor view (Prompt 9), the menu bar (Prompt 10), and the
     // notification dispatcher (Prompt 11) all subscribe via
@@ -71,6 +72,7 @@ struct VaderCleanerApp: App {
         _spaceLensViewModel = StateObject(wrappedValue: DiskScannerViewModel.live())
         _privacyViewModel = StateObject(wrappedValue: PrivacyViewModel.live())
         _appUninstallerViewModel = StateObject(wrappedValue: AppUninstallerViewModel.live())
+        _appUpdaterViewModel = StateObject(wrappedValue: AppUpdaterViewModel.live())
         // Construct the polling service and the menu bar view-model in the
         // same init so both `@StateObject` wrappers reference the *same*
         // service instance. Initializing `menuBarViewModel` at its property
@@ -129,7 +131,8 @@ struct VaderCleanerApp: App {
                 largeOldFilesViewModel: largeOldFilesViewModel,
                 spaceLensViewModel: spaceLensViewModel,
                 privacyViewModel: privacyViewModel,
-                appUninstallerViewModel: appUninstallerViewModel
+                appUninstallerViewModel: appUninstallerViewModel,
+                appUpdaterViewModel: appUpdaterViewModel
             )
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)

--- a/VaderCleaner/VersionComparator.swift
+++ b/VaderCleaner/VersionComparator.swift
@@ -34,14 +34,27 @@ enum VersionComparator {
         return .orderedSame
     }
 
-    /// Extracts the leading numeric prefix from `token`. "12-beta" → 12.
-    /// "beta" → 0. Values that overflow `UInt64` fall back to 0 so we never
+    /// Extracts the numeric value of `token`, skipping any leading
+    /// non-digit characters first. "v12" → 12, "12-beta" → 12, "beta" → 0.
+    /// The leading-skip matters because Sparkle feeds (and some Mac apps)
+    /// commonly tag releases as "v1.2.3"; without it every component would
+    /// parse to 0 and a real update would look identical to the installed
+    /// build. Values that overflow `UInt64` fall back to 0 so we never
     /// trap on malformed input — the caller treats those as equal-or-older.
     private static func leadingNumber(in token: String) -> UInt64 {
         var digits = ""
+        var seenDigit = false
         for character in token {
-            guard character.isASCII, character.isNumber else { break }
-            digits.append(character)
+            let isDigit = character.isASCII && character.isNumber
+            if isDigit {
+                digits.append(character)
+                seenDigit = true
+            } else if seenDigit {
+                // Stop at the first non-digit *after* the numeric run so
+                // "1-beta" stays 1 rather than swallowing later digits.
+                break
+            }
+            // Leading non-digits (the "v" in "v1.2") are skipped.
         }
         return UInt64(digits) ?? 0
     }

--- a/VaderCleaner/VersionComparator.swift
+++ b/VaderCleaner/VersionComparator.swift
@@ -1,0 +1,48 @@
+// VersionComparator.swift
+// Semantic version comparison used by the App Updater to decide whether a remote version is newer than the locally-installed one.
+
+import Foundation
+
+/// Pure helpers for comparing dotted version strings ("1.0.0", "1.2.3-beta",
+/// "1.2"). The implementation deliberately does NOT pull in a full SemVer
+/// parser — Mac apps emit a variety of version strings that don't conform
+/// strictly to SemVer, and the App Updater only ever needs to answer "is A
+/// newer than B?" not "what is the pre-release identifier?".
+enum VersionComparator {
+
+    /// Whether `version` represents a release strictly newer than `other`.
+    /// Equal versions return `false`.
+    static func isNewer(version: String, than other: String) -> Bool {
+        compare(version, other) == .orderedDescending
+    }
+
+    /// Component-wise numeric comparison with zero-padding for differing
+    /// lengths. A non-zero trailing component beats a shorter version
+    /// ("1.0.0.1" > "1.0.0"). Components are parsed with their leading
+    /// digits only, so "4-beta" maps to 4 — enough to keep us correct on
+    /// the common cases without committing to a full pre-release grammar.
+    static func compare(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let leftTokens = lhs.split(separator: ".")
+        let rightTokens = rhs.split(separator: ".")
+        let maxCount = max(leftTokens.count, rightTokens.count)
+        for index in 0..<maxCount {
+            let left = index < leftTokens.count ? leadingNumber(in: String(leftTokens[index])) : 0
+            let right = index < rightTokens.count ? leadingNumber(in: String(rightTokens[index])) : 0
+            if left < right { return .orderedAscending }
+            if left > right { return .orderedDescending }
+        }
+        return .orderedSame
+    }
+
+    /// Extracts the leading numeric prefix from `token`. "12-beta" → 12.
+    /// "beta" → 0. Values that overflow `UInt64` fall back to 0 so we never
+    /// trap on malformed input — the caller treats those as equal-or-older.
+    private static func leadingNumber(in token: String) -> UInt64 {
+        var digits = ""
+        for character in token {
+            guard character.isASCII, character.isNumber else { break }
+            digits.append(character)
+        }
+        return UInt64(digits) ?? 0
+    }
+}

--- a/VaderCleanerTests/AppStoreUpdateCheckerTests.swift
+++ b/VaderCleanerTests/AppStoreUpdateCheckerTests.swift
@@ -1,0 +1,68 @@
+// AppStoreUpdateCheckerTests.swift
+// Tests the iTunes Search API integration — JSON parsing for version and trackViewUrl, and graceful handling of empty result sets.
+
+import XCTest
+@testable import VaderCleaner
+
+final class AppStoreUpdateCheckerTests: XCTestCase {
+
+    /// On a successful lookup the checker returns the latest version and
+    /// the App Store URL — both extracted from the iTunes Search response.
+    func test_latestVersion_extractsVersionAndTrackViewURL() async throws {
+        let payload = """
+        {
+          "resultCount": 1,
+          "results": [
+            {
+              "version": "5.4.1",
+              "trackViewUrl": "https://apps.apple.com/us/app/helio/id12345?mt=12",
+              "bundleId": "com.acme.helio"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let fetcher = StubHTTPFetcher()
+        await fetcher.set(
+            response: payload,
+            for: URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio")!
+        )
+        let checker = DefaultAppStoreUpdateChecker(httpFetcher: fetcher)
+        let lookup = try await checker.latestVersion(forBundleID: "com.acme.helio")
+        XCTAssertEqual(lookup?.version, "5.4.1")
+        XCTAssertEqual(lookup?.appStoreURL,
+                       URL(string: "https://apps.apple.com/us/app/helio/id12345?mt=12"))
+    }
+
+    /// An empty `results` array means the bundle ID isn't present in the
+    /// store and the checker must return `nil` — not throw.
+    func test_latestVersion_returnsNilForEmptyResults() async throws {
+        let payload = #"{"resultCount":0,"results":[]}"#.data(using: .utf8)!
+        let fetcher = StubHTTPFetcher()
+        await fetcher.set(
+            response: payload,
+            for: URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio")!
+        )
+        let checker = DefaultAppStoreUpdateChecker(httpFetcher: fetcher)
+        let lookup = try await checker.latestVersion(forBundleID: "com.acme.helio")
+        XCTAssertNil(lookup)
+    }
+
+    /// The bundle ID is sent as a query item — verifies the URL layout
+    /// the iTunes Search API expects (`?bundleId=<id>`). Bundle IDs in
+    /// practice are reverse-DNS strings and don't carry characters that
+    /// need percent-encoding, so we don't add a heavier escape pass on
+    /// top of `URLQueryItem`.
+    func test_latestVersion_buildsExpectedQueryURL() async throws {
+        let fetcher = StubHTTPFetcher()
+        let expected = URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio")!
+        await fetcher.set(
+            response: #"{"resultCount":0,"results":[]}"#.data(using: .utf8)!,
+            for: expected
+        )
+        let checker = DefaultAppStoreUpdateChecker(httpFetcher: fetcher)
+        _ = try await checker.latestVersion(forBundleID: "com.acme.helio")
+        let requested = await fetcher.requestedURLs
+        XCTAssertEqual(requested.first, expected)
+    }
+}

--- a/VaderCleanerTests/AppStoreUpdateCheckerTests.swift
+++ b/VaderCleanerTests/AppStoreUpdateCheckerTests.swift
@@ -25,7 +25,7 @@ final class AppStoreUpdateCheckerTests: XCTestCase {
         let fetcher = StubHTTPFetcher()
         await fetcher.set(
             response: payload,
-            for: URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio")!
+            for: URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio&entity=macSoftware")!
         )
         let checker = DefaultAppStoreUpdateChecker(httpFetcher: fetcher)
         let lookup = try await checker.latestVersion(forBundleID: "com.acme.helio")
@@ -41,21 +41,36 @@ final class AppStoreUpdateCheckerTests: XCTestCase {
         let fetcher = StubHTTPFetcher()
         await fetcher.set(
             response: payload,
-            for: URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio")!
+            for: URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio&entity=macSoftware")!
         )
         let checker = DefaultAppStoreUpdateChecker(httpFetcher: fetcher)
         let lookup = try await checker.latestVersion(forBundleID: "com.acme.helio")
         XCTAssertNil(lookup)
     }
 
-    /// The bundle ID is sent as a query item — verifies the URL layout
-    /// the iTunes Search API expects (`?bundleId=<id>`). Bundle IDs in
-    /// practice are reverse-DNS strings and don't carry characters that
-    /// need percent-encoding, so we don't add a heavier escape pass on
-    /// top of `URLQueryItem`.
+    /// A non-200 response (rate limiting, 5xx, HTML error page) returns
+    /// `nil` instead of surfacing as an opaque JSON decode failure.
+    func test_latestVersion_nonOKStatusReturnsNil() async throws {
+        let fetcher = StubHTTPFetcher()
+        await fetcher.set(
+            response: Data("Too Many Requests".utf8),
+            for: URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio&entity=macSoftware")!,
+            statusCode: 429
+        )
+        let checker = DefaultAppStoreUpdateChecker(httpFetcher: fetcher)
+        let lookup = try await checker.latestVersion(forBundleID: "com.acme.helio")
+        XCTAssertNil(lookup)
+    }
+
+    /// The lookup URL carries both `bundleId` and `entity=macSoftware`,
+    /// the latter constraining results to Mac App Store titles so a
+    /// same-bundle-ID iOS app can't shadow the macOS version. Bundle IDs
+    /// in practice are reverse-DNS strings and don't carry characters
+    /// that need percent-encoding, so we don't add a heavier escape pass
+    /// on top of `URLQueryItem`.
     func test_latestVersion_buildsExpectedQueryURL() async throws {
         let fetcher = StubHTTPFetcher()
-        let expected = URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio")!
+        let expected = URL(string: "https://itunes.apple.com/lookup?bundleId=com.acme.helio&entity=macSoftware")!
         await fetcher.set(
             response: #"{"resultCount":0,"results":[]}"#.data(using: .utf8)!,
             for: expected

--- a/VaderCleanerTests/AppUpdaterViewModelTests.swift
+++ b/VaderCleanerTests/AppUpdaterViewModelTests.swift
@@ -152,6 +152,7 @@ final class AppUpdaterViewModelTests: XCTestCase {
         let info = UpdateInfo(
             appName: "Helio",
             bundleID: "com.acme.helio",
+            bundleURL: URL(fileURLWithPath: "/Applications/Helio.app"),
             installedVersion: "1.0",
             latestVersion: "2.0",
             source: .appStore,

--- a/VaderCleanerTests/AppUpdaterViewModelTests.swift
+++ b/VaderCleanerTests/AppUpdaterViewModelTests.swift
@@ -1,0 +1,230 @@
+// AppUpdaterViewModelTests.swift
+// Drives the AppUpdaterViewModel state machine — check-for-updates dispatch, App Store + Sparkle result merging, version-equal suppression, opener routing, and failure paths — using injected fakes so no real apps or network are touched.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class AppUpdaterViewModelTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertTrue(vm.availableUpdates.isEmpty)
+    }
+
+    // MARK: - Discovery
+
+    /// `checkForUpdates()` lands `.ready` with a merged list of App Store +
+    /// Sparkle results, suppressing any app whose installed version already
+    /// matches the latest.
+    func test_checkForUpdates_mergesAppStoreAndSparkleResults() async {
+        let masApp = makeApp(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            version: "5.0.0",
+            isAppStore: true
+        )
+        let sparkleApp = makeApp(
+            name: "Mango",
+            bundleID: "com.acme.mango",
+            version: "1.0.0",
+            isAppStore: false
+        )
+        let upToDateApp = makeApp(
+            name: "Solar",
+            bundleID: "com.unrelated.solar",
+            version: "2.0.0",
+            isAppStore: true
+        )
+
+        let vm = makeViewModel(
+            discover: { _ in [masApp, sparkleApp, upToDateApp] },
+            checkAppStore: { bundleID in
+                switch bundleID {
+                case "com.acme.helio":
+                    return AppStoreLookup(
+                        version: "5.4.1",
+                        appStoreURL: URL(string: "https://apps.apple.com/app/id123")!
+                    )
+                case "com.unrelated.solar":
+                    return AppStoreLookup(
+                        version: "2.0.0",
+                        appStoreURL: URL(string: "https://apps.apple.com/app/id999")!
+                    )
+                default:
+                    return nil
+                }
+            },
+            checkSparkle: { app in
+                guard app.bundleID == "com.acme.mango" else { return nil }
+                return SparkleAppcastItem(
+                    shortVersion: "2.0.0",
+                    version: "2000",
+                    downloadURL: URL(string: "https://example.com/mango-2.dmg")!
+                )
+            }
+        )
+
+        await vm.checkForUpdates()
+
+        XCTAssertEqual(vm.phase, .ready)
+        let bundleIDs = vm.availableUpdates.map(\.bundleID).sorted()
+        XCTAssertEqual(bundleIDs, ["com.acme.helio", "com.acme.mango"])
+
+        let helio = vm.availableUpdates.first(where: { $0.bundleID == "com.acme.helio" })
+        XCTAssertEqual(helio?.source, .appStore)
+        XCTAssertEqual(helio?.latestVersion, "5.4.1")
+
+        let mango = vm.availableUpdates.first(where: { $0.bundleID == "com.acme.mango" })
+        XCTAssertEqual(mango?.source, .sparkle)
+        XCTAssertEqual(mango?.latestVersion, "2.0.0")
+    }
+
+    /// Apps whose installed version already matches the latest must NOT
+    /// appear in `availableUpdates`. Without this filter, the UI would show
+    /// "Update" rows for up-to-date apps and the user would be misled.
+    func test_checkForUpdates_suppressesUpToDateApps() async {
+        let app = makeApp(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            checkAppStore: { _ in
+                AppStoreLookup(
+                    version: "1.0.0",
+                    appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
+                )
+            }
+        )
+        await vm.checkForUpdates()
+        XCTAssertTrue(vm.availableUpdates.isEmpty)
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    /// An empty installed-apps list short-circuits to `.ready` with no
+    /// updates — no checker calls.
+    func test_checkForUpdates_noAppsLandsReady() async {
+        let appStoreCalls = ActorBox(0)
+        let sparkleCalls = ActorBox(0)
+        let vm = makeViewModel(
+            discover: { _ in [] },
+            checkAppStore: { _ in await appStoreCalls.increment(); return nil },
+            checkSparkle: { _ in await sparkleCalls.increment(); return nil }
+        )
+        await vm.checkForUpdates()
+        XCTAssertEqual(vm.phase, .ready)
+        let appStore = await appStoreCalls.value
+        let sparkle = await sparkleCalls.value
+        XCTAssertEqual(appStore, 0)
+        XCTAssertEqual(sparkle, 0)
+    }
+
+    /// A throwing discovery surfaces `.failed` so the view can render its
+    /// "Try again" state.
+    func test_checkForUpdates_discoveryFailureTransitionsToFailed() async {
+        struct BoomError: Error {}
+        let vm = makeViewModel(
+            discover: { _ in throw BoomError() }
+        )
+        await vm.checkForUpdates()
+        if case .failed = vm.phase {
+            // expected
+        } else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Update routing
+
+    /// `update(_:)` opens the update URL via the injected opener. The
+    /// production opener delegates to `NSWorkspace.open`.
+    func test_update_invokesOpenerWithUpdateURL() async {
+        let opened = ActorBox<[URL]>([])
+        let vm = makeViewModel(
+            opener: { url in await opened.set(opened.value + [url]) }
+        )
+        let info = UpdateInfo(
+            appName: "Helio",
+            bundleID: "com.acme.helio",
+            installedVersion: "1.0",
+            latestVersion: "2.0",
+            source: .appStore,
+            updateURL: URL(string: "https://apps.apple.com/app/id1")!
+        )
+        await vm.update(info)
+        let urls = await opened.value
+        XCTAssertEqual(urls, [URL(string: "https://apps.apple.com/app/id1")!])
+    }
+
+    /// `updateAll()` opens every available update's URL.
+    func test_updateAll_opensEveryURL() async {
+        let opened = ActorBox<[URL]>([])
+        let app = makeApp(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            checkAppStore: { _ in
+                AppStoreLookup(
+                    version: "2.0.0",
+                    appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
+                )
+            },
+            opener: { url in await opened.set(opened.value + [url]) }
+        )
+        await vm.checkForUpdates()
+        await vm.updateAll()
+        let urls = await opened.value
+        XCTAssertEqual(urls, [URL(string: "https://apps.apple.com/app/id1")!])
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        discover: @escaping AppUpdaterViewModel.Discover = { _ in [] },
+        checkAppStore: @escaping AppUpdaterViewModel.CheckAppStore = { _ in nil },
+        checkSparkle: @escaping AppUpdaterViewModel.CheckSparkle = { _ in nil },
+        opener: @escaping AppUpdaterViewModel.Opener = { _ in }
+    ) -> AppUpdaterViewModel {
+        AppUpdaterViewModel(
+            discover: discover,
+            checkAppStore: checkAppStore,
+            checkSparkle: checkSparkle,
+            opener: opener
+        )
+    }
+
+    private func makeApp(
+        name: String,
+        bundleID: String,
+        version: String,
+        isAppStore: Bool
+    ) -> AppInfo {
+        AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: version,
+            bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+            isAppStore: isAppStore
+        )
+    }
+}
+
+private actor ActorBox<Value: Sendable> {
+    private(set) var value: Value
+    init(_ initial: Value) { self.value = initial }
+    func set(_ newValue: Value) { value = newValue }
+}
+
+private extension ActorBox where Value == Int {
+    func increment() { value += 1 }
+}

--- a/VaderCleanerTests/SparkleUpdateCheckerTests.swift
+++ b/VaderCleanerTests/SparkleUpdateCheckerTests.swift
@@ -94,11 +94,60 @@ final class SparkleUpdateCheckerTests: XCTestCase {
         XCTAssertNil(DefaultSparkleUpdateChecker.parseAppcast(xml: xml))
     }
 
-    // MARK: - fetchUpdate
+    /// When two items share the same `shortVersionString`, the one with
+    /// the newer `sparkle:version` (build) must win so a same-marketing-
+    /// version hotfix isn't passed over for an older artifact.
+    func test_parseAppcast_tieBreaksOnBuildVersion() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <enclosure url="https://example.com/Helio-2.0.0-100.dmg"
+                         sparkle:version="100"
+                         sparkle:shortVersionString="2.0.0" />
+            </item>
+            <item>
+              <enclosure url="https://example.com/Helio-2.0.0-105.dmg"
+                         sparkle:version="105"
+                         sparkle:shortVersionString="2.0.0" />
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
 
-    /// `fetchUpdate` runs feed bytes through the injected HTTP fetcher and
-    /// returns the newest item — no live network access.
-    func test_fetchUpdate_routesThroughInjectedFetcher() async throws {
+        let item = DefaultSparkleUpdateChecker.parseAppcast(xml: xml)
+        XCTAssertEqual(item?.version, "105")
+        XCTAssertEqual(item?.downloadURL,
+                       URL(string: "https://example.com/Helio-2.0.0-105.dmg"))
+    }
+
+    /// Older feeds carry `sparkle:shortVersionString` / `sparkle:version`
+    /// on the `<item>` element itself rather than the enclosure. The
+    /// parser must still surface those rather than dropping the item.
+    func test_parseAppcast_readsVersionAttributesOnItemElement() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item sparkle:shortVersionString="4.2.0" sparkle:version="4200">
+              <enclosure url="https://example.com/Helio-4.2.0.dmg" />
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let item = DefaultSparkleUpdateChecker.parseAppcast(xml: xml)
+        XCTAssertEqual(item?.shortVersion, "4.2.0")
+        XCTAssertEqual(item?.downloadURL,
+                       URL(string: "https://example.com/Helio-4.2.0.dmg"))
+    }
+
+    // MARK: - fetchAppcast
+
+    /// `fetchAppcast` runs feed bytes through the injected HTTP fetcher
+    /// and returns the newest item — no live network access.
+    func test_fetchAppcast_routesThroughInjectedFetcher() async throws {
         let xml = """
         <?xml version="1.0"?>
         <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
@@ -115,6 +164,22 @@ final class SparkleUpdateCheckerTests: XCTestCase {
         let checker = DefaultSparkleUpdateChecker(httpFetcher: stub)
         let item = try await checker.fetchAppcast(feedURL: URL(string: "https://example.com/appcast.xml")!)
         XCTAssertEqual(item?.shortVersion, "3.0.0")
+    }
+
+    /// A non-200 feed response (404/5xx/HTML error page) yields `nil`
+    /// rather than attempting to parse an error body into a bogus item.
+    func test_fetchAppcast_nonOKStatusReturnsNil() async throws {
+        let stub = StubHTTPFetcher()
+        await stub.set(
+            response: Data("<html>not found</html>".utf8),
+            for: URL(string: "https://example.com/appcast.xml")!,
+            statusCode: 404
+        )
+        let checker = DefaultSparkleUpdateChecker(httpFetcher: stub)
+        let item = try await checker.fetchAppcast(
+            feedURL: URL(string: "https://example.com/appcast.xml")!
+        )
+        XCTAssertNil(item)
     }
 
     // MARK: - Helpers

--- a/VaderCleanerTests/SparkleUpdateCheckerTests.swift
+++ b/VaderCleanerTests/SparkleUpdateCheckerTests.swift
@@ -143,6 +143,60 @@ final class SparkleUpdateCheckerTests: XCTestCase {
                        URL(string: "https://example.com/Helio-4.2.0.dmg"))
     }
 
+    /// The newest item requires a macOS the user isn't running, so the
+    /// parser must fall back to the newest *compatible* item rather than
+    /// offering a build Sparkle itself would refuse to install.
+    func test_parseAppcast_skipsItemsRequiringNewerMacOS() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <sparkle:minimumSystemVersion>99.0.0</sparkle:minimumSystemVersion>
+              <enclosure url="https://example.com/Helio-3.0.0.dmg"
+                         sparkle:shortVersionString="3.0.0" sparkle:version="3000" />
+            </item>
+            <item>
+              <sparkle:minimumSystemVersion>12.0.0</sparkle:minimumSystemVersion>
+              <enclosure url="https://example.com/Helio-2.0.0.dmg"
+                         sparkle:shortVersionString="2.0.0" sparkle:version="2000" />
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let item = DefaultSparkleUpdateChecker.parseAppcast(
+            xml: xml,
+            currentSystemVersion: "14.5.0"
+        )
+        XCTAssertEqual(item?.shortVersion, "2.0.0")
+        XCTAssertEqual(item?.downloadURL,
+                       URL(string: "https://example.com/Helio-2.0.0.dmg"))
+    }
+
+    /// An item is eligible exactly when the running OS meets its
+    /// `minimumSystemVersion`; equal versions are eligible.
+    func test_parseAppcast_includesItemWhenOSMeetsMinimum() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <sparkle:minimumSystemVersion>14.5.0</sparkle:minimumSystemVersion>
+              <enclosure url="https://example.com/Helio-5.0.0.dmg"
+                         sparkle:shortVersionString="5.0.0" sparkle:version="5000" />
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let item = DefaultSparkleUpdateChecker.parseAppcast(
+            xml: xml,
+            currentSystemVersion: "14.5.0"
+        )
+        XCTAssertEqual(item?.shortVersion, "5.0.0")
+    }
+
     // MARK: - fetchAppcast
 
     /// `fetchAppcast` runs feed bytes through the injected HTTP fetcher

--- a/VaderCleanerTests/SparkleUpdateCheckerTests.swift
+++ b/VaderCleanerTests/SparkleUpdateCheckerTests.swift
@@ -254,6 +254,38 @@ final class SparkleUpdateCheckerTests: XCTestCase {
                        URL(string: "https://example.com/Helio-3.0.0.dmg"))
     }
 
+    /// Cross-platform feeds tag enclosures with `sparkle:os`. An
+    /// enclosure marked for a non-macOS platform must be skipped so the
+    /// updater falls back to the newest macOS build instead of offering
+    /// a Windows installer.
+    func test_parseAppcast_skipsNonMacOSEnclosures() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <enclosure url="https://example.com/Helio-3.0.0.exe"
+                         sparkle:os="windows"
+                         sparkle:shortVersionString="3.0.0" sparkle:version="3000" />
+            </item>
+            <item>
+              <enclosure url="https://example.com/Helio-2.0.0.dmg"
+                         sparkle:os="macos"
+                         sparkle:shortVersionString="2.0.0" sparkle:version="2000" />
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let item = DefaultSparkleUpdateChecker.parseAppcast(
+            xml: xml,
+            currentSystemVersion: "14.5.0"
+        )
+        XCTAssertEqual(item?.shortVersion, "2.0.0")
+        XCTAssertEqual(item?.downloadURL,
+                       URL(string: "https://example.com/Helio-2.0.0.dmg"))
+    }
+
     // MARK: - fetchAppcast
 
     /// `fetchAppcast` runs feed bytes through the injected HTTP fetcher

--- a/VaderCleanerTests/SparkleUpdateCheckerTests.swift
+++ b/VaderCleanerTests/SparkleUpdateCheckerTests.swift
@@ -197,6 +197,63 @@ final class SparkleUpdateCheckerTests: XCTestCase {
         XCTAssertEqual(item?.shortVersion, "5.0.0")
     }
 
+    /// Some feeds publish version metadata as child *elements*
+    /// (`<sparkle:version>` / `<sparkle:shortVersionString>`) with the
+    /// enclosure carrying only the download URL. Those must still surface
+    /// rather than being dropped for an empty version.
+    func test_parseAppcast_readsElementFormVersionMetadata() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <sparkle:version>1248</sparkle:version>
+              <sparkle:shortVersionString>1.5.1</sparkle:shortVersionString>
+              <enclosure url="https://example.com/Helio-1.5.1.dmg" />
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let item = DefaultSparkleUpdateChecker.parseAppcast(
+            xml: xml,
+            currentSystemVersion: "14.5.0"
+        )
+        XCTAssertEqual(item?.shortVersion, "1.5.1")
+        XCTAssertEqual(item?.version, "1248")
+        XCTAssertEqual(item?.downloadURL,
+                       URL(string: "https://example.com/Helio-1.5.1.dmg"))
+    }
+
+    /// Delta updates appear as a nested `<sparkle:deltas>` block of
+    /// patch enclosures after the full enclosure. The parser must keep
+    /// the full archive URL and never let a `.delta` patch overwrite it.
+    func test_parseAppcast_ignoresDeltaEnclosures() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <enclosure url="https://example.com/Helio-3.0.0.dmg"
+                         sparkle:shortVersionString="3.0.0" sparkle:version="3000" />
+              <sparkle:deltas>
+                <enclosure url="https://example.com/Helio-2.9.0-3.0.0.delta"
+                           sparkle:deltaFrom="2900"
+                           sparkle:shortVersionString="3.0.0" sparkle:version="3000" />
+              </sparkle:deltas>
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let item = DefaultSparkleUpdateChecker.parseAppcast(
+            xml: xml,
+            currentSystemVersion: "14.5.0"
+        )
+        XCTAssertEqual(item?.downloadURL,
+                       URL(string: "https://example.com/Helio-3.0.0.dmg"))
+    }
+
     // MARK: - fetchAppcast
 
     /// `fetchAppcast` runs feed bytes through the injected HTTP fetcher

--- a/VaderCleanerTests/SparkleUpdateCheckerTests.swift
+++ b/VaderCleanerTests/SparkleUpdateCheckerTests.swift
@@ -1,0 +1,178 @@
+// SparkleUpdateCheckerTests.swift
+// Tests the Sparkle appcast pipeline — reading SUFeedURL from a fixture .app bundle, parsing appcast XML for the newest item, and routing the fetched bytes through the injected HTTPFetching seam.
+
+import XCTest
+@testable import VaderCleaner
+
+final class SparkleUpdateCheckerTests: XCTestCase {
+
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        tempDirectory = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        TestHelpers.tearDownTempDirectory(tempDirectory)
+        tempDirectory = nil
+    }
+
+    // MARK: - feedURL
+
+    /// `feedURL(for:)` reads the `SUFeedURL` value from the bundle's
+    /// `Info.plist` — the standard Sparkle integration key.
+    func test_feedURL_readsSUFeedURLFromInfoPlist() throws {
+        let feed = "https://example.com/appcast.xml"
+        let app = try makeAppBundle(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            extraInfoPlist: ["SUFeedURL": feed]
+        )
+        let checker = DefaultSparkleUpdateChecker(httpFetcher: StubHTTPFetcher())
+        XCTAssertEqual(checker.feedURL(for: app), URL(string: feed))
+    }
+
+    /// A bundle without `SUFeedURL` returns `nil`. The view-model uses this
+    /// to skip Sparkle entirely for non-Sparkle apps.
+    func test_feedURL_isNilWhenSUFeedURLMissing() throws {
+        let app = try makeAppBundle(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            extraInfoPlist: [:]
+        )
+        let checker = DefaultSparkleUpdateChecker(httpFetcher: StubHTTPFetcher())
+        XCTAssertNil(checker.feedURL(for: app))
+    }
+
+    // MARK: - parseAppcast
+
+    /// `parseAppcast(xml:)` picks the *newest* item by version, not by
+    /// document order — real Sparkle appcasts emit items in non-monotonic
+    /// order and our checker must not regress users by reporting a stale
+    /// version as "the update".
+    func test_parseAppcast_returnsNewestItemEvenWhenOutOfOrder() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <title>2.0.0</title>
+              <enclosure url="https://example.com/Helio-2.0.0.dmg"
+                         sparkle:version="2.0.0"
+                         sparkle:shortVersionString="2.0.0" />
+            </item>
+            <item>
+              <title>1.5.0</title>
+              <enclosure url="https://example.com/Helio-1.5.0.dmg"
+                         sparkle:version="1.5.0"
+                         sparkle:shortVersionString="1.5.0" />
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let item = DefaultSparkleUpdateChecker.parseAppcast(xml: xml)
+        XCTAssertEqual(item?.shortVersion, "2.0.0")
+        XCTAssertEqual(item?.downloadURL, URL(string: "https://example.com/Helio-2.0.0.dmg"))
+    }
+
+    /// Items without an enclosure are skipped; release notes-only items are
+    /// not actionable as an update target.
+    func test_parseAppcast_skipsItemsWithoutEnclosure() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <title>2.0.0 notes</title>
+              <sparkle:releaseNotesLink>https://example.com/notes.html</sparkle:releaseNotesLink>
+            </item>
+          </channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        XCTAssertNil(DefaultSparkleUpdateChecker.parseAppcast(xml: xml))
+    }
+
+    // MARK: - fetchUpdate
+
+    /// `fetchUpdate` runs feed bytes through the injected HTTP fetcher and
+    /// returns the newest item — no live network access.
+    func test_fetchUpdate_routesThroughInjectedFetcher() async throws {
+        let xml = """
+        <?xml version="1.0"?>
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel><item>
+            <enclosure url="https://example.com/x.dmg"
+                       sparkle:shortVersionString="3.0.0"
+                       sparkle:version="3000" />
+          </item></channel>
+        </rss>
+        """.data(using: .utf8)!
+
+        let stub = StubHTTPFetcher()
+        await stub.set(response: xml, for: URL(string: "https://example.com/appcast.xml")!)
+        let checker = DefaultSparkleUpdateChecker(httpFetcher: stub)
+        let item = try await checker.fetchAppcast(feedURL: URL(string: "https://example.com/appcast.xml")!)
+        XCTAssertEqual(item?.shortVersion, "3.0.0")
+    }
+
+    // MARK: - Helpers
+
+    private func makeAppBundle(
+        name: String,
+        bundleID: String,
+        extraInfoPlist: [String: Any]
+    ) throws -> AppInfo {
+        let appURL = tempDirectory
+            .appendingPathComponent("\(name).app", isDirectory: true)
+        let contents = appURL.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        var plist: [String: Any] = [
+            "CFBundleIdentifier": bundleID,
+            "CFBundleName": name,
+            "CFBundleShortVersionString": "1.0"
+        ]
+        for (key, value) in extraInfoPlist {
+            plist[key] = value
+        }
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: contents.appendingPathComponent("Info.plist"))
+        return AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: "1.0",
+            bundleURL: appURL,
+            isAppStore: false
+        )
+    }
+}
+
+/// In-memory stand-in for `URLSession` used by both the Sparkle and App
+/// Store checker tests so unit tests never touch the network.
+actor StubHTTPFetcher: HTTPFetching {
+    private var responses: [URL: (Data, URLResponse)] = [:]
+    private(set) var requestedURLs: [URL] = []
+
+    func set(response: Data, for url: URL, statusCode: Int = 200) {
+        let httpResponse = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        responses[url] = (response, httpResponse)
+    }
+
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        requestedURLs.append(url)
+        if let pair = responses[url] {
+            return pair
+        }
+        throw URLError(.fileDoesNotExist)
+    }
+}

--- a/VaderCleanerTests/UpdateInfoTests.swift
+++ b/VaderCleanerTests/UpdateInfoTests.swift
@@ -1,18 +1,20 @@
 // UpdateInfoTests.swift
-// Tests the UpdateInfo value type — identifier stability, equality, and the source enum used to pick which update channel a row was discovered through.
+// Tests the UpdateInfo value type — identifier stability, per-install uniqueness, and the source enum used to pick which update channel a row was discovered through.
 
 import XCTest
 @testable import VaderCleaner
 
 final class UpdateInfoTests: XCTestCase {
 
-    /// `id` keys off the bundle ID so SwiftUI lists stay stable when the
-    /// version strings change between successive checks.
+    /// `id` keys off the installed bundle path, so it stays stable when
+    /// only the version strings change between successive checks.
     func test_id_isStableAcrossVersionChanges() {
         let url = URL(string: "https://apps.apple.com/app/id123")!
+        let bundle = URL(fileURLWithPath: "/Applications/Helio.app")
         let a = UpdateInfo(
             appName: "Helio",
             bundleID: "com.acme.helio",
+            bundleURL: bundle,
             installedVersion: "1.0.0",
             latestVersion: "1.0.1",
             source: .appStore,
@@ -21,12 +23,39 @@ final class UpdateInfoTests: XCTestCase {
         let b = UpdateInfo(
             appName: "Helio",
             bundleID: "com.acme.helio",
+            bundleURL: bundle,
             installedVersion: "1.0.1",
             latestVersion: "1.0.2",
             source: .appStore,
             updateURL: url
         )
         XCTAssertEqual(a.id, b.id)
+    }
+
+    /// The same bundle ID installed in two locations must produce two
+    /// distinct identities so SwiftUI renders both rows instead of
+    /// collapsing them and dropping/reusing the wrong one.
+    func test_id_isUniquePerInstalledBundlePath() {
+        let url = URL(string: "https://apps.apple.com/app/id123")!
+        let primary = UpdateInfo(
+            appName: "Helio",
+            bundleID: "com.acme.helio",
+            bundleURL: URL(fileURLWithPath: "/Applications/Helio.app"),
+            installedVersion: "1.0.0",
+            latestVersion: "2.0.0",
+            source: .appStore,
+            updateURL: url
+        )
+        let secondary = UpdateInfo(
+            appName: "Helio",
+            bundleID: "com.acme.helio",
+            bundleURL: URL(fileURLWithPath: "/Users/me/Applications/Helio.app"),
+            installedVersion: "1.5.0",
+            latestVersion: "2.0.0",
+            source: .appStore,
+            updateURL: url
+        )
+        XCTAssertNotEqual(primary.id, secondary.id)
     }
 
     /// `source` carries the channel; the App Updater UI uses it to render a
@@ -36,6 +65,7 @@ final class UpdateInfoTests: XCTestCase {
         let info = UpdateInfo(
             appName: "Helio",
             bundleID: "com.acme.helio",
+            bundleURL: URL(fileURLWithPath: "/Applications/Helio.app"),
             installedVersion: "1.0",
             latestVersion: "2.0",
             source: .sparkle,

--- a/VaderCleanerTests/UpdateInfoTests.swift
+++ b/VaderCleanerTests/UpdateInfoTests.swift
@@ -1,0 +1,47 @@
+// UpdateInfoTests.swift
+// Tests the UpdateInfo value type — identifier stability, equality, and the source enum used to pick which update channel a row was discovered through.
+
+import XCTest
+@testable import VaderCleaner
+
+final class UpdateInfoTests: XCTestCase {
+
+    /// `id` keys off the bundle ID so SwiftUI lists stay stable when the
+    /// version strings change between successive checks.
+    func test_id_isStableAcrossVersionChanges() {
+        let url = URL(string: "https://apps.apple.com/app/id123")!
+        let a = UpdateInfo(
+            appName: "Helio",
+            bundleID: "com.acme.helio",
+            installedVersion: "1.0.0",
+            latestVersion: "1.0.1",
+            source: .appStore,
+            updateURL: url
+        )
+        let b = UpdateInfo(
+            appName: "Helio",
+            bundleID: "com.acme.helio",
+            installedVersion: "1.0.1",
+            latestVersion: "1.0.2",
+            source: .appStore,
+            updateURL: url
+        )
+        XCTAssertEqual(a.id, b.id)
+    }
+
+    /// `source` carries the channel; the App Updater UI uses it to render a
+    /// per-row badge ("App Store" vs "Sparkle").
+    func test_sourceIsCarriedThroughInit() {
+        let url = URL(string: "https://example.com/x.dmg")!
+        let info = UpdateInfo(
+            appName: "Helio",
+            bundleID: "com.acme.helio",
+            installedVersion: "1.0",
+            latestVersion: "2.0",
+            source: .sparkle,
+            updateURL: url
+        )
+        XCTAssertEqual(info.source, .sparkle)
+        XCTAssertEqual(info.updateURL, url)
+    }
+}

--- a/VaderCleanerTests/VersionComparatorTests.swift
+++ b/VaderCleanerTests/VersionComparatorTests.swift
@@ -48,6 +48,16 @@ final class VersionComparatorTests: XCTestCase {
         XCTAssertFalse(VersionComparator.isNewer(version: "1.2.3-beta", than: "1.2.3"))
     }
 
+    /// Sparkle feeds (and some Mac apps) tag releases as "v1.2.3". The
+    /// leading "v" must be skipped so the numeric components still compare
+    /// — otherwise every component parses to 0 and a real update looks
+    /// identical to the installed build.
+    func test_isNewer_skipsLeadingVPrefix() {
+        XCTAssertTrue(VersionComparator.isNewer(version: "v1.2.4", than: "v1.2.3"))
+        XCTAssertTrue(VersionComparator.isNewer(version: "v2.0.0", than: "1.9.9"))
+        XCTAssertFalse(VersionComparator.isNewer(version: "v1.0.0", than: "1.0.0"))
+    }
+
     /// Numeric components larger than `Int.max` would crash a naive Int
     /// parse; the comparator falls back to lexicographic compare in that case
     /// without crashing.

--- a/VaderCleanerTests/VersionComparatorTests.swift
+++ b/VaderCleanerTests/VersionComparatorTests.swift
@@ -58,9 +58,10 @@ final class VersionComparatorTests: XCTestCase {
         XCTAssertFalse(VersionComparator.isNewer(version: "v1.0.0", than: "1.0.0"))
     }
 
-    /// Numeric components larger than `Int.max` would crash a naive Int
-    /// parse; the comparator falls back to lexicographic compare in that case
-    /// without crashing.
+    /// Numeric components larger than `UInt64.max` would crash a naive
+    /// parse; `leadingNumber` returns `UInt64(digits) ?? 0`, so overflow
+    /// is treated as 0 (the version compares as equal-or-older) without
+    /// crashing.
     func test_isNewer_doesNotCrashOnHugeComponents() {
         XCTAssertNoThrow(VersionComparator.isNewer(
             version: "99999999999999999999.0",

--- a/VaderCleanerTests/VersionComparatorTests.swift
+++ b/VaderCleanerTests/VersionComparatorTests.swift
@@ -1,0 +1,60 @@
+// VersionComparatorTests.swift
+// Tests semantic version comparison helpers used by the App Updater to decide whether a remotely-discovered version is newer than the locally-installed one.
+
+import XCTest
+@testable import VaderCleaner
+
+final class VersionComparatorTests: XCTestCase {
+
+    // MARK: - isNewer
+
+    func test_isNewer_returnsTrueForPatchBump() {
+        XCTAssertTrue(VersionComparator.isNewer(version: "1.0.1", than: "1.0.0"))
+    }
+
+    func test_isNewer_returnsTrueForMinorBump() {
+        XCTAssertTrue(VersionComparator.isNewer(version: "1.1.0", than: "1.0.9"))
+    }
+
+    func test_isNewer_returnsTrueForMajorBump() {
+        XCTAssertTrue(VersionComparator.isNewer(version: "2.0.0", than: "1.99.99"))
+    }
+
+    func test_isNewer_returnsFalseForSameVersion() {
+        XCTAssertFalse(VersionComparator.isNewer(version: "1.2.3", than: "1.2.3"))
+    }
+
+    func test_isNewer_returnsFalseForOlderVersion() {
+        XCTAssertFalse(VersionComparator.isNewer(version: "1.0.0", than: "1.0.1"))
+    }
+
+    /// "1.0" should compare equal to "1.0.0" — the shorter version pads with
+    /// implicit zero components.
+    func test_isNewer_padsShorterVersionWithZeros() {
+        XCTAssertFalse(VersionComparator.isNewer(version: "1.0", than: "1.0.0"))
+        XCTAssertFalse(VersionComparator.isNewer(version: "1.0.0", than: "1.0"))
+    }
+
+    /// A longer version with a non-zero extra component must compare newer.
+    func test_isNewer_treatsExtraNonZeroComponentAsNewer() {
+        XCTAssertTrue(VersionComparator.isNewer(version: "1.0.0.1", than: "1.0.0"))
+    }
+
+    /// Build suffixes ("1.2.3-beta", "1.2.3+456") are tolerated — we strip
+    /// non-digit trailing characters from each numeric component so the
+    /// numeric prefix governs the comparison.
+    func test_isNewer_tolerantOfNonDigitSuffixes() {
+        XCTAssertTrue(VersionComparator.isNewer(version: "1.2.4-beta", than: "1.2.3"))
+        XCTAssertFalse(VersionComparator.isNewer(version: "1.2.3-beta", than: "1.2.3"))
+    }
+
+    /// Numeric components larger than `Int.max` would crash a naive Int
+    /// parse; the comparator falls back to lexicographic compare in that case
+    /// without crashing.
+    func test_isNewer_doesNotCrashOnHugeComponents() {
+        XCTAssertNoThrow(VersionComparator.isNewer(
+            version: "99999999999999999999.0",
+            than: "1.0"
+        ))
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -37,7 +37,7 @@
 
 - [x] **Prompt 18** — Privacy feature (browser detection + data clearing + recent files)
 - [x] **Prompt 19** — App Uninstaller (discovery + associated files + deletion)
-- [ ] **Prompt 20** — App Updater (App Store + Sparkle)
+- [x] **Prompt 20** — App Updater (App Store + Sparkle)
 - [ ] **Prompt 21** — Extensions Manager (Safari, browser, Mail, internet plugins, login items)
 
 ## Phase 4 — Optimization & Security


### PR DESCRIPTION
## Summary

Implements Prompt 20 from `plan.md` — the **App Updater** feature.

- Discovers installed apps and dispatches each to either the Mac App Store lookup (iTunes Search API) or its Sparkle appcast, concurrently via `withTaskGroup`.
- Merges and sorts the results, suppressing apps already on the latest version.
- New sidebar route `NavigationSection.appUpdater` renders a list of available updates with source badges and per-row + "Update All" actions, routed through `NSWorkspace.open`.

### Files

**Production**
- [UpdateInfo.swift](VaderCleaner/UpdateInfo.swift) — value type + `UpdateSource` enum
- [VersionComparator.swift](VaderCleaner/VersionComparator.swift) — semantic version comparison
- [HTTPFetching.swift](VaderCleaner/HTTPFetching.swift) — URLSession-shaped test seam
- [SparkleUpdateChecker.swift](VaderCleaner/SparkleUpdateChecker.swift) — `SUFeedURL` lookup, appcast XML parsing (picks newest by `shortVersionString`, not document order)
- [AppStoreUpdateChecker.swift](VaderCleaner/AppStoreUpdateChecker.swift) — iTunes Search API
- [AppUpdaterViewModel.swift](VaderCleaner/AppUpdaterViewModel.swift) — closure-injected collaborators, `TaskGroup`-based dispatch, generation-counter cancellation
- [AppUpdaterView.swift](VaderCleaner/AppUpdaterView.swift) — idle / checking / ready / up-to-date / failed screens
- Wiring in [ContentView.swift](VaderCleaner/ContentView.swift) and [VaderCleanerApp.swift](VaderCleaner/VaderCleanerApp.swift)

**Tests (all in `VaderCleanerTests/`)** — 5 new files, 26 new tests, total suite 442 passing.

### Test plan

- [x] `xcodebuild build-for-testing` passes
- [x] `xcodebuild test` — 442 tests passing, 0 failures (`VaderCleanerTests` target)
- [ ] Manual: open the app, click **App Updater** in the sidebar, confirm a check runs against your installed apps (network access required)
- [ ] Manual: click **Update** on an entry; confirm it opens the App Store / Sparkle download URL in the default handler

### Out of scope / follow-ups

- Auto-update / silent install — VaderCleaner only surfaces and links out.
- Sparkle signature verification — not needed because the user opens the download URL in their browser; macOS Gatekeeper handles the rest.
- Bundle URL on `UpdateInfo` so the list can show per-app icons (currently uses an SF Symbol per source; revisit if it feels too generic).

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App Updater UI and view model to discover updates (App Store + Sparkle), show source badges, compare versions, and trigger single or bulk updates (with confirmation for large batches).
* **New Utilities**
  * Added networking and version-comparison support and a stable update metadata model to power checks and display.
* **Tests**
  * Added unit coverage for update checkers, appcast parsing, view model behavior, version comparison, and update metadata.
* **Documentation**
  * Marked App Updater task complete in project notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/60)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->