### PR TITLE
feat: Extensions Manager (Safari, browser, Mail, internet plugins, login items)

### DIFF
--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -29,7 +29,13 @@ struct HelperDeletionPolicy {
         allowedDescendantRoots: [
             URL(fileURLWithPath: "/Library/Caches", isDirectory: true),
             URL(fileURLWithPath: "/Library/Logs", isDirectory: true),
-            URL(fileURLWithPath: "/private/var/folders", isDirectory: true)
+            URL(fileURLWithPath: "/private/var/folders", isDirectory: true),
+            // System-wide Mail plugins and internet plug-ins removed by the
+            // Extensions Manager. Narrowly scoped to these two product
+            // directories — the helper still refuses anything else under
+            // /Library.
+            URL(fileURLWithPath: "/Library/Mail/Bundles", isDirectory: true),
+            URL(fileURLWithPath: "/Library/Internet Plug-Ins", isDirectory: true)
         ],
         allowedLaunchPlistRoots: [
             URL(fileURLWithPath: "/Library/LaunchAgents", isDirectory: true),

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
 		4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */; };
+		4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */; };
 		52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */; };
@@ -62,6 +63,7 @@
 		5FCAAC81ED67F40178636235 /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
 		60DBED2582B50DA009B180C4 /* FileCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F421495C84A41EDEF253EBD6 /* FileCategory.swift */; };
 		62A51901AE4CA4CE8FB58349 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 46466A1909A880757A7C4B31 /* Localizable.strings */; };
+		6370C48606EABFE1E9343565 /* ExtensionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */; };
 		63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */; };
 		65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD8C98E8253953444DD99F /* NotificationManager.swift */; };
 		65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
@@ -74,6 +76,7 @@
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
 		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
+		7BB62CCBF7BE84455A11531C /* ExtensionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */; };
 		7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2617BC26104D5196DEDB3589 /* UpdateInfo.swift */; };
 		7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */; };
 		82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */; };
@@ -83,6 +86,7 @@
 		834DC89A0BA1ED2A0B5B33CB /* PermissionOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */; };
 		83FF16A5DCFB4B225F33236E /* SystemJunkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */; };
 		85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */; };
+		892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
 		91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */; };
@@ -94,6 +98,7 @@
 		A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
 		AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC67B639248BC5EA1F5473 /* ScanCategory.swift */; };
+		B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */; };
 		B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39407E2EA6D045893F1BA4B /* DiskNode.swift */; };
 		B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */; };
 		B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */; };
@@ -110,6 +115,7 @@
 		BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */; };
 		BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */; };
 		C2542EE3974C2F9232EE74D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5E978BB01AD677AEDE122B1C /* Assets.xcassets */; };
+		C254D02B4C1C10021EF0E62D /* ExtensionsManagerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */; };
 		C26E98922A61A57DB9369C60 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E92F45C5CC0EEA00B12EF5 /* TestHelpers.swift */; };
 		C2F35144C0139C8829C4BB8A /* MenuBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */; };
 		C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */; };
@@ -121,6 +127,7 @@
 		D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */; };
 		DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */; };
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
+		E0420FF267A637AD7F530407 /* ExtensionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */; };
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */; };
 		E370FDA389CDFEC249437640 /* AppIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */; };
@@ -134,6 +141,7 @@
 		F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */; };
 		F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */; };
 		F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8635D102B895AF349A13D /* AppUpdaterView.swift */; };
+		F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */; };
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
 		FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */; };
 		FF87A6FAB563AF43345061BB /* PreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */; };
@@ -202,6 +210,7 @@
 		1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewSubviews.swift; sourceTree = "<group>"; };
 		133467A06193C406B027D97C /* NavigationSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSectionTests.swift; sourceTree = "<group>"; };
 		13A5713F5928025F9FE34A43 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDiscovery.swift; sourceTree = "<group>"; };
 		166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorViewModelTests.swift; sourceTree = "<group>"; };
 		16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleter.swift; sourceTree = "<group>"; };
 		1A06928276134E79D8ADFBF5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -225,6 +234,7 @@
 		3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviding.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
+		42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewSubviews.swift; sourceTree = "<group>"; };
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
 		46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpersTests.swift; sourceTree = "<group>"; };
 		4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsService.swift; sourceTree = "<group>"; };
@@ -247,6 +257,7 @@
 		6085B6A39985DFF334821551 /* ExclusionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStore.swift; sourceTree = "<group>"; };
 		6090134A72001DE6262436F3 /* FileIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconCache.swift; sourceTree = "<group>"; };
 		613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModel.swift; sourceTree = "<group>"; };
+		63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModel.swift; sourceTree = "<group>"; };
 		65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateChecker.swift; sourceTree = "<group>"; };
 		6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScannerTests.swift; sourceTree = "<group>"; };
 		67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewSubviews.swift; sourceTree = "<group>"; };
@@ -266,6 +277,8 @@
 		8A0F635D79B943130BAB15AE /* VaderCleaner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VaderCleaner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModel.swift; sourceTree = "<group>"; };
 		8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinder.swift; sourceTree = "<group>"; };
+		8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDiscoveryTests.swift; sourceTree = "<group>"; };
+		8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerView.swift; sourceTree = "<group>"; };
 		8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscoveryTests.swift; sourceTree = "<group>"; };
 		8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyCategoryTests.swift; sourceTree = "<group>"; };
 		90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModel.swift; sourceTree = "<group>"; };
@@ -275,6 +288,7 @@
 		9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearer.swift; sourceTree = "<group>"; };
 		98D7B18095634307C5D7223D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
+		9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItem.swift; sourceTree = "<group>"; };
 		9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScanner.swift; sourceTree = "<group>"; };
 		9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFilesPathProviding.swift; sourceTree = "<group>"; };
 		A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategoryTests.swift; sourceTree = "<group>"; };
@@ -292,6 +306,7 @@
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
 		BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScanner.swift; sourceTree = "<group>"; };
 		BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModelTests.swift; sourceTree = "<group>"; };
+		BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModelTests.swift; sourceTree = "<group>"; };
 		C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
 		C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinderTests.swift; sourceTree = "<group>"; };
 		C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScanner.swift; sourceTree = "<group>"; };
@@ -308,6 +323,7 @@
 		D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetector.swift; sourceTree = "<group>"; };
 		D2C2B92863509818189F46CD /* MenuBarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContent.swift; sourceTree = "<group>"; };
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
+		DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItemTests.swift; sourceTree = "<group>"; };
 		DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitorTests.swift; sourceTree = "<group>"; };
 		E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStore.swift; sourceTree = "<group>"; };
 		E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModel.swift; sourceTree = "<group>"; };
@@ -383,6 +399,11 @@
 				C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */,
 				613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */,
 				6085B6A39985DFF334821551 /* ExclusionsStore.swift */,
+				13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */,
+				9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */,
+				8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */,
+				63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */,
+				42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */,
 				F421495C84A41EDEF253EBD6 /* FileCategory.swift */,
 				6090134A72001DE6262436F3 /* FileIconCache.swift */,
 				BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */,
@@ -483,6 +504,9 @@
 				3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */,
 				BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */,
 				C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */,
+				8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */,
+				DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */,
+				BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */,
 				A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */,
 				6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */,
 				166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */,
@@ -680,6 +704,9 @@
 				82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */,
 				2A28D67DA396B3D2B6DB13D5 /* DiskScannerViewModelTests.swift in Sources */,
 				A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */,
+				F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */,
+				7BB62CCBF7BE84455A11531C /* ExtensionItemTests.swift in Sources */,
+				B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */,
 				1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */,
 				823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */,
 				2CE84E79268B4A59C5B8FACB /* HealthMonitorViewModelTests.swift in Sources */,
@@ -761,6 +788,11 @@
 				D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */,
 				F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */,
 				C3F9A86A896DAD3A63EB8F9F /* ExclusionsStore.swift in Sources */,
+				E0420FF267A637AD7F530407 /* ExtensionDiscovery.swift in Sources */,
+				6370C48606EABFE1E9343565 /* ExtensionItem.swift in Sources */,
+				4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */,
+				892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */,
+				C254D02B4C1C10021EF0E62D /* ExtensionsManagerViewSubviews.swift in Sources */,
 				60DBED2582B50DA009B180C4 /* FileCategory.swift in Sources */,
 				730791446114BB6991798518 /* FileIconCache.swift in Sources */,
 				52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -15,6 +15,7 @@ struct ContentView: View {
     private let privacyViewModel: PrivacyViewModel
     private let appUninstallerViewModel: AppUninstallerViewModel
     private let appUpdaterViewModel: AppUpdaterViewModel
+    private let extensionsManagerViewModel: ExtensionsManagerViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
@@ -28,7 +29,8 @@ struct ContentView: View {
         spaceLensViewModel: DiskScannerViewModel,
         privacyViewModel: PrivacyViewModel,
         appUninstallerViewModel: AppUninstallerViewModel,
-        appUpdaterViewModel: AppUpdaterViewModel
+        appUpdaterViewModel: AppUpdaterViewModel,
+        extensionsManagerViewModel: ExtensionsManagerViewModel
     ) {
         self.systemJunkViewModel = systemJunkViewModel
         self.largeOldFilesViewModel = largeOldFilesViewModel
@@ -36,6 +38,7 @@ struct ContentView: View {
         self.privacyViewModel = privacyViewModel
         self.appUninstallerViewModel = appUninstallerViewModel
         self.appUpdaterViewModel = appUpdaterViewModel
+        self.extensionsManagerViewModel = extensionsManagerViewModel
     }
 
     var body: some View {
@@ -107,6 +110,8 @@ struct ContentView: View {
             AppUninstallerView(viewModel: appUninstallerViewModel)
         case .appUpdater:
             AppUpdaterView(viewModel: appUpdaterViewModel)
+        case .extensions:
+            ExtensionsManagerView(viewModel: extensionsManagerViewModel)
         default:
             PlaceholderDetailView(section: section)
         }
@@ -156,7 +161,8 @@ private struct PlaceholderDetailView: View {
         spaceLensViewModel: DiskScannerViewModel.live(),
         privacyViewModel: PrivacyViewModel.live(),
         appUninstallerViewModel: AppUninstallerViewModel.live(),
-        appUpdaterViewModel: AppUpdaterViewModel.live()
+        appUpdaterViewModel: AppUpdaterViewModel.live(),
+        extensionsManagerViewModel: ExtensionsManagerViewModel.live()
     )
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())

--- a/VaderCleaner/ExtensionDiscovery.swift
+++ b/VaderCleaner/ExtensionDiscovery.swift
@@ -2,7 +2,6 @@
 // The five Extensions Manager discovery types — Safari, browser, Mail-plugin, internet-plug-in, and launch-agent scanners — plus the shared protocol and sizing helper they emit ExtensionItems through.
 
 import Foundation
-import os.log
 
 /// Test seam between `ExtensionsManagerViewModel` and the real on-disk
 /// extension locations. Each concrete discoverer scans one surface and
@@ -59,11 +58,6 @@ enum ExtensionArtifactSizer {
     }
 }
 
-private let extensionDiscoveryLog = Logger(
-    subsystem: "com.personal.VaderCleaner",
-    category: "ExtensionDiscovery"
-)
-
 // MARK: - Safari
 
 /// Scans the legacy `~/Library/Safari/Extensions/` directory.
@@ -111,9 +105,10 @@ struct SafariExtensionDiscovery: ExtensionDiscovering {
                     size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
                 ))
             }
-            return items.sorted {
-                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-            }
+            // Not sorted here: ExtensionsManagerViewModel.groupedByType
+            // sorts each bucket by name before display, so ordering the
+            // raw discovery output would be redundant work.
+            return items
         }.value
     }
 }
@@ -160,9 +155,10 @@ struct BrowserExtensionDiscovery: ExtensionDiscovering {
                 in: support.appendingPathComponent("Firefox/Profiles", isDirectory: true),
                 fileManager: fileManager
             ))
-            return items.sorted {
-                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-            }
+            // Not sorted here: ExtensionsManagerViewModel.groupedByType
+            // sorts each bucket by name before display, so ordering the
+            // raw discovery output would be redundant work.
+            return items
         }.value
     }
 
@@ -321,9 +317,9 @@ struct MailPluginDiscovery: ExtensionDiscovering {
                 ))
             }
         }
-        return items.sorted {
-            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-        }
+        // Not sorted here: ExtensionsManagerViewModel.groupedByType sorts
+        // each bucket by name before display.
+        return items
     }
 }
 
@@ -425,9 +421,10 @@ struct LaunchAgentDiscovery: ExtensionDiscovering {
                     ))
                 }
             }
-            return items.sorted {
-                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-            }
+            // Not sorted here: ExtensionsManagerViewModel.groupedByType
+            // sorts each bucket by name before display, so ordering the
+            // raw discovery output would be redundant work.
+            return items
         }.value
     }
 

--- a/VaderCleaner/ExtensionDiscovery.swift
+++ b/VaderCleaner/ExtensionDiscovery.swift
@@ -1,0 +1,424 @@
+// ExtensionDiscovery.swift
+// The five Extensions Manager discovery types — Safari, browser, Mail-plugin, internet-plug-in, and launch-agent scanners — plus the shared protocol and sizing helper they emit ExtensionItems through.
+
+import Foundation
+import os.log
+
+/// Test seam between `ExtensionsManagerViewModel` and the real on-disk
+/// extension locations. Each concrete discoverer scans one surface and
+/// returns ready-to-display `ExtensionItem`s so the view-model never walks
+/// the filesystem directly — every call site is exercisable with a temp
+/// fixture in tests.
+protocol ExtensionDiscovering: Sendable {
+    func extensions() async -> [ExtensionItem]
+}
+
+// MARK: - Shared sizing
+
+/// Recursive byte size of an artifact. A bare file contributes its own
+/// size; a bundle/directory sums its regular-file descendants. Errors are
+/// tolerated — an unreadable nested resource must not zero the row.
+enum ExtensionArtifactSizer {
+    static func size(at url: URL, fileManager: FileManager) -> Int64 {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return 0
+        }
+        if !isDirectory.boolValue {
+            let attrs = try? fileManager.attributesOfItem(atPath: url.path)
+            return (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in true }
+        ) else { return 0 }
+        var total: Int64 = 0
+        for case let item as URL in enumerator {
+            let values = try? item.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            if values?.isRegularFile == true, let fileSize = values?.fileSize {
+                total += Int64(fileSize)
+            }
+        }
+        return total
+    }
+
+    /// `CFBundleIdentifier` from a bundle's `Contents/Info.plist`, or `nil`.
+    static func bundleID(at bundleURL: URL) -> String? {
+        let infoPlist = bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: infoPlist),
+              let plist = try? PropertyListSerialization.propertyList(
+                from: data, options: [], format: nil
+              ) as? [String: Any],
+              let id = plist["CFBundleIdentifier"] as? String,
+              !id.isEmpty else { return nil }
+        return id
+    }
+}
+
+private let extensionDiscoveryLog = Logger(
+    subsystem: "com.personal.VaderCleaner",
+    category: "ExtensionDiscovery"
+)
+
+// MARK: - Safari
+
+/// Scans the legacy `~/Library/Safari/Extensions/` directory.
+///
+/// On macOS 14+ most Safari extensions ship as `.appex` inside a parent app
+/// via PluginKit and `SFSafariExtensionManager` cannot enumerate
+/// third-party extensions — so this directory is frequently absent and the
+/// honest result is `[]`. Legacy `.safariextz` archives and any `.appex`
+/// still living here are surfaced.
+struct SafariExtensionDiscovery: ExtensionDiscovering {
+
+    private let homeDirectory: URL
+    private let fileManager: FileManager
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) {
+        self.homeDirectory = homeDirectory
+        self.fileManager = fileManager
+    }
+
+    func extensions() async -> [ExtensionItem] {
+        let dir = homeDirectory
+            .appendingPathComponent("Library/Safari/Extensions", isDirectory: true)
+        let fileManager = fileManager
+        return await Task.detached(priority: .userInitiated) {
+            guard fileManager.fileExists(atPath: dir.path) else { return [] }
+            let entries = (try? fileManager.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            var items: [ExtensionItem] = []
+            for entry in entries {
+                let ext = entry.pathExtension.lowercased()
+                guard ext == "safariextz" || ext == "appex" else { continue }
+                items.append(ExtensionItem(
+                    name: entry.deletingPathExtension().lastPathComponent,
+                    path: entry,
+                    bundleID: ext == "appex"
+                        ? ExtensionArtifactSizer.bundleID(at: entry) : nil,
+                    type: .safariExtension,
+                    isEnabled: true,
+                    size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
+                ))
+            }
+            return items.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+        }.value
+    }
+}
+
+// MARK: - Browser
+
+/// Enumerates Chromium-family and Firefox profile extension directories.
+struct BrowserExtensionDiscovery: ExtensionDiscovering {
+
+    /// Chromium-family product directories under `Application Support`. All
+    /// surface as `.chromeExtension` — the enum has no per-vendor case and
+    /// the on-disk layout is identical across them.
+    private static let chromiumRoots = [
+        "Google/Chrome",
+        "Chromium",
+        "BraveSoftware/Brave-Browser",
+        "Microsoft Edge"
+    ]
+
+    private let homeDirectory: URL
+    private let fileManager: FileManager
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) {
+        self.homeDirectory = homeDirectory
+        self.fileManager = fileManager
+    }
+
+    func extensions() async -> [ExtensionItem] {
+        let support = homeDirectory
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        let fileManager = fileManager
+        return await Task.detached(priority: .userInitiated) {
+            var items: [ExtensionItem] = []
+            for root in Self.chromiumRoots {
+                let productDir = support.appendingPathComponent(root, isDirectory: true)
+                items.append(contentsOf: Self.chromiumExtensions(
+                    in: productDir, fileManager: fileManager
+                ))
+            }
+            items.append(contentsOf: Self.firefoxExtensions(
+                in: support.appendingPathComponent("Firefox/Profiles", isDirectory: true),
+                fileManager: fileManager
+            ))
+            return items.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+        }.value
+    }
+
+    /// Walks `<product>/<profile>/Extensions/<id>/<version>/manifest.json`.
+    private static func chromiumExtensions(
+        in productDir: URL,
+        fileManager: FileManager
+    ) -> [ExtensionItem] {
+        guard fileManager.fileExists(atPath: productDir.path) else { return [] }
+        let profiles = (try? fileManager.contentsOfDirectory(
+            at: productDir, includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        var items: [ExtensionItem] = []
+        for profile in profiles {
+            let extensionsDir = profile
+                .appendingPathComponent("Extensions", isDirectory: true)
+            guard fileManager.fileExists(atPath: extensionsDir.path) else { continue }
+            let extIDs = (try? fileManager.contentsOfDirectory(
+                at: extensionsDir, includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            for extDir in extIDs {
+                let versionDirs = (try? fileManager.contentsOfDirectory(
+                    at: extDir, includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles]
+                )) ?? []
+                guard let latest = versionDirs.sorted(by: {
+                    $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending
+                }).last else { continue }
+                let manifestName = Self.chromeManifestName(
+                    at: latest.appendingPathComponent("manifest.json")
+                )
+                items.append(ExtensionItem(
+                    name: manifestName ?? extDir.lastPathComponent,
+                    path: extDir,
+                    bundleID: extDir.lastPathComponent,
+                    type: .chromeExtension,
+                    isEnabled: true,
+                    size: ExtensionArtifactSizer.size(at: extDir, fileManager: fileManager)
+                ))
+            }
+        }
+        return items
+    }
+
+    /// Reads the `name` field from a Chrome `manifest.json`. Localised
+    /// manifests use a `__MSG_*__` placeholder we can't resolve without the
+    /// `_locales` lookup — callers fall back to the extension id in that
+    /// case.
+    private static func chromeManifestName(at url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let name = json["name"] as? String,
+              !name.isEmpty,
+              !name.hasPrefix("__MSG_") else { return nil }
+        return name
+    }
+
+    /// `<profile>/extensions/*.xpi` (or unpacked dirs) under every Firefox
+    /// profile.
+    private static func firefoxExtensions(
+        in profilesDir: URL,
+        fileManager: FileManager
+    ) -> [ExtensionItem] {
+        guard fileManager.fileExists(atPath: profilesDir.path) else { return [] }
+        let profiles = (try? fileManager.contentsOfDirectory(
+            at: profilesDir, includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        var items: [ExtensionItem] = []
+        for profile in profiles {
+            let extensionsDir = profile
+                .appendingPathComponent("extensions", isDirectory: true)
+            guard fileManager.fileExists(atPath: extensionsDir.path) else { continue }
+            let entries = (try? fileManager.contentsOfDirectory(
+                at: extensionsDir, includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            for entry in entries {
+                let isXPI = entry.pathExtension.lowercased() == "xpi"
+                var isDir: ObjCBool = false
+                fileManager.fileExists(atPath: entry.path, isDirectory: &isDir)
+                guard isXPI || isDir.boolValue else { continue }
+                items.append(ExtensionItem(
+                    name: entry.deletingPathExtension().lastPathComponent,
+                    path: entry,
+                    bundleID: entry.deletingPathExtension().lastPathComponent,
+                    type: .firefoxExtension,
+                    isEnabled: true,
+                    size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
+                ))
+            }
+        }
+        return items
+    }
+}
+
+// MARK: - Mail plugins
+
+/// Scans the user and system `Mail/Bundles/` directories for `.mailbundle`s.
+struct MailPluginDiscovery: ExtensionDiscovering {
+
+    private let userBundlesDirectory: URL
+    private let systemBundlesDirectory: URL?
+    private let fileManager: FileManager
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        systemBundlesDirectory: URL? = URL(fileURLWithPath: "/Library/Mail/Bundles", isDirectory: true),
+        fileManager: FileManager = .default
+    ) {
+        self.userBundlesDirectory = homeDirectory
+            .appendingPathComponent("Library/Mail/Bundles", isDirectory: true)
+        self.systemBundlesDirectory = systemBundlesDirectory
+        self.fileManager = fileManager
+    }
+
+    func extensions() async -> [ExtensionItem] {
+        let roots = [userBundlesDirectory, systemBundlesDirectory].compactMap { $0 }
+        let fileManager = fileManager
+        return await Task.detached(priority: .userInitiated) {
+            Self.bundles(
+                in: roots,
+                extensions: ["mailbundle"],
+                type: .mailPlugin,
+                fileManager: fileManager
+            )
+        }.value
+    }
+
+    static func bundles(
+        in roots: [URL],
+        extensions: Set<String>,
+        type: ExtensionType,
+        fileManager: FileManager
+    ) -> [ExtensionItem] {
+        var seen = Set<String>()
+        var items: [ExtensionItem] = []
+        for root in roots {
+            guard fileManager.fileExists(atPath: root.path) else { continue }
+            let entries = (try? fileManager.contentsOfDirectory(
+                at: root, includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            for entry in entries {
+                guard extensions.contains(entry.pathExtension.lowercased()) else { continue }
+                guard seen.insert(entry.path).inserted else { continue }
+                items.append(ExtensionItem(
+                    name: entry.deletingPathExtension().lastPathComponent,
+                    path: entry,
+                    bundleID: ExtensionArtifactSizer.bundleID(at: entry),
+                    type: type,
+                    isEnabled: true,
+                    size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
+                ))
+            }
+        }
+        return items.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+}
+
+// MARK: - Internet plug-ins
+
+/// Scans the user and system `Internet Plug-Ins/` directories.
+struct InternetPluginDiscovery: ExtensionDiscovering {
+
+    private let userPluginsDirectory: URL
+    private let systemPluginsDirectory: URL?
+    private let fileManager: FileManager
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        systemPluginsDirectory: URL? = URL(fileURLWithPath: "/Library/Internet Plug-Ins", isDirectory: true),
+        fileManager: FileManager = .default
+    ) {
+        self.userPluginsDirectory = homeDirectory
+            .appendingPathComponent("Library/Internet Plug-Ins", isDirectory: true)
+        self.systemPluginsDirectory = systemPluginsDirectory
+        self.fileManager = fileManager
+    }
+
+    func extensions() async -> [ExtensionItem] {
+        let roots = [userPluginsDirectory, systemPluginsDirectory].compactMap { $0 }
+        let fileManager = fileManager
+        return await Task.detached(priority: .userInitiated) {
+            MailPluginDiscovery.bundles(
+                in: roots,
+                extensions: ["plugin", "webplugin", "bundle"],
+                type: .internetPlugin,
+                fileManager: fileManager
+            )
+        }.value
+    }
+}
+
+// MARK: - Launch agents / login items
+
+/// Reads `~/Library/LaunchAgents` plists. These are the discoverable
+/// surface for third-party login items — `SMAppService` cannot enumerate
+/// items registered by other apps.
+struct LaunchAgentDiscovery: ExtensionDiscovering {
+
+    private let agentsDirectory: URL
+    private let fileManager: FileManager
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) {
+        self.agentsDirectory = homeDirectory
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        self.fileManager = fileManager
+    }
+
+    /// Every `*.plist` under `~/Library/LaunchAgents`. `name` comes from the
+    /// `Label` key (falling back to the filename); `isEnabled` is the
+    /// inverse of the `Disabled` key — launchd's authoritative source.
+    func userAgents() async -> [ExtensionItem] {
+        let dir = agentsDirectory
+        let fileManager = fileManager
+        return await Task.detached(priority: .userInitiated) {
+            guard fileManager.fileExists(atPath: dir.path) else { return [] }
+            let entries = (try? fileManager.contentsOfDirectory(
+                at: dir, includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            var items: [ExtensionItem] = []
+            for entry in entries where entry.pathExtension.lowercased() == "plist" {
+                let plist = (try? Data(contentsOf: entry)).flatMap {
+                    try? PropertyListSerialization.propertyList(
+                        from: $0, options: [], format: nil
+                    ) as? [String: Any]
+                } ?? [:]
+                let label = (plist["Label"] as? String).flatMap {
+                    $0.isEmpty ? nil : $0
+                }
+                let disabled = (plist["Disabled"] as? Bool) ?? false
+                items.append(ExtensionItem(
+                    name: label ?? entry.deletingPathExtension().lastPathComponent,
+                    path: entry,
+                    bundleID: nil,
+                    type: .loginItemFromApp,
+                    isEnabled: !disabled,
+                    size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
+                ))
+            }
+            return items.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+        }.value
+    }
+
+    func extensions() async -> [ExtensionItem] {
+        await userAgents()
+    }
+}

--- a/VaderCleaner/ExtensionDiscovery.swift
+++ b/VaderCleaner/ExtensionDiscovery.swift
@@ -368,49 +368,62 @@ struct InternetPluginDiscovery: ExtensionDiscovering {
 /// items registered by other apps.
 struct LaunchAgentDiscovery: ExtensionDiscovering {
 
-    private let agentsDirectory: URL
+    private let roots: [URL]
     private let fileManager: FileManager
 
     init(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        systemRoots: [URL] = [
+            URL(fileURLWithPath: "/Library/LaunchAgents", isDirectory: true),
+            URL(fileURLWithPath: "/Library/LaunchDaemons", isDirectory: true)
+        ],
         fileManager: FileManager = .default
     ) {
-        self.agentsDirectory = homeDirectory
-            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        self.roots = [
+            homeDirectory.appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        ] + systemRoots
         self.fileManager = fileManager
     }
 
-    /// Every `*.plist` under `~/Library/LaunchAgents`. `name` comes from the
-    /// `Label` key (falling back to the filename); `isEnabled` is the
-    /// inverse of the `Disabled` key — launchd's authoritative source.
+    /// Every `*.plist` under the user's `~/Library/LaunchAgents` plus the
+    /// system `/Library/LaunchAgents` and `/Library/LaunchDaemons` roots,
+    /// deduped by path. `name` comes from the `Label` key (falling back to
+    /// the filename); `isEnabled` is the inverse of the `Disabled` key —
+    /// launchd's authoritative source. The system roots are removable: the
+    /// privileged helper's allowlist permits direct-child plists under both,
+    /// and `requiresHelper` routes those paths through it.
     func userAgents() async -> [ExtensionItem] {
-        let dir = agentsDirectory
+        let roots = roots
         let fileManager = fileManager
         return await Task.detached(priority: .userInitiated) {
-            guard fileManager.fileExists(atPath: dir.path) else { return [] }
-            let entries = (try? fileManager.contentsOfDirectory(
-                at: dir, includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            )) ?? []
+            var seen = Set<String>()
             var items: [ExtensionItem] = []
-            for entry in entries where entry.pathExtension.lowercased() == "plist" {
-                let plist = (try? Data(contentsOf: entry)).flatMap {
-                    try? PropertyListSerialization.propertyList(
-                        from: $0, options: [], format: nil
-                    ) as? [String: Any]
-                } ?? [:]
-                let label = (plist["Label"] as? String).flatMap {
-                    $0.isEmpty ? nil : $0
+            for dir in roots {
+                guard fileManager.fileExists(atPath: dir.path) else { continue }
+                let entries = (try? fileManager.contentsOfDirectory(
+                    at: dir, includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles]
+                )) ?? []
+                for entry in entries where entry.pathExtension.lowercased() == "plist" {
+                    guard seen.insert(entry.path).inserted else { continue }
+                    let plist = (try? Data(contentsOf: entry)).flatMap {
+                        try? PropertyListSerialization.propertyList(
+                            from: $0, options: [], format: nil
+                        ) as? [String: Any]
+                    } ?? [:]
+                    let label = (plist["Label"] as? String).flatMap {
+                        $0.isEmpty ? nil : $0
+                    }
+                    let disabled = (plist["Disabled"] as? Bool) ?? false
+                    items.append(ExtensionItem(
+                        name: label ?? entry.deletingPathExtension().lastPathComponent,
+                        path: entry,
+                        bundleID: nil,
+                        type: .loginItemFromApp,
+                        isEnabled: !disabled,
+                        size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
+                    ))
                 }
-                let disabled = (plist["Disabled"] as? Bool) ?? false
-                items.append(ExtensionItem(
-                    name: label ?? entry.deletingPathExtension().lastPathComponent,
-                    path: entry,
-                    bundleID: nil,
-                    type: .loginItemFromApp,
-                    isEnabled: !disabled,
-                    size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
-                ))
             }
             return items.sorted {
                 $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending

--- a/VaderCleaner/ExtensionItem.swift
+++ b/VaderCleaner/ExtensionItem.swift
@@ -1,0 +1,61 @@
+// ExtensionItem.swift
+// Value type for a single discovered extension / plugin / login-item launch agent, plus the ExtensionType enum the Extensions Manager groups them under.
+
+import Foundation
+
+/// The categories the Extensions Manager groups discovered items under.
+///
+/// Raw values are stable identifiers used by the view layer for section
+/// identity and accessibility — do not reorder cases or rename raw values
+/// without bumping callers.
+enum ExtensionType: String, CaseIterable, Identifiable, Sendable {
+    case safariExtension
+    case chromeExtension
+    case firefoxExtension
+    case mailPlugin
+    case internetPlugin
+    case loginItemFromApp
+
+    var id: String { rawValue }
+
+    /// Human-readable section heading. Localised at the call site (the view
+    /// wraps this through `String(localized:)`) so the stable raw value stays
+    /// separate from display copy.
+    var displayName: String {
+        switch self {
+        case .safariExtension:  return "Safari Extensions"
+        case .chromeExtension:  return "Chrome Extensions"
+        case .firefoxExtension: return "Firefox Extensions"
+        case .mailPlugin:       return "Mail Plugins"
+        case .internetPlugin:   return "Internet Plug-ins"
+        case .loginItemFromApp: return "Login Items & Launch Agents"
+        }
+    }
+}
+
+/// A single discovered extension artifact: a Safari/browser extension, a Mail
+/// plugin, an internet plug-in, or a login-item launch agent.
+///
+/// `Identifiable` by `path` so SwiftUI list identity stays stable across
+/// re-discovery passes that re-emit the same item; `Hashable` so the
+/// view-model can diff item sets without a separate identifier strategy.
+struct ExtensionItem: Identifiable, Hashable, Sendable {
+    /// Display name — manifest/`Label`/`CFBundleName` derived, falling back
+    /// to the filename when no richer source exists.
+    let name: String
+    /// Absolute on-disk location that removal acts on.
+    let path: URL
+    /// Owning bundle identifier when one is available (Mail plugins,
+    /// internet plug-ins). `nil` for bare launch agents and legacy
+    /// `.safariextz` archives.
+    let bundleID: String?
+    let type: ExtensionType
+    /// Best-effort enabled state. Authoritative only for launch agents
+    /// (inverse of the plist `Disabled` key); other sources default to
+    /// `true` because macOS exposes no queryable per-extension state.
+    let isEnabled: Bool
+    /// Recursive byte size of the artifact, used for the row's size label.
+    let size: Int64
+
+    var id: URL { path }
+}

--- a/VaderCleaner/ExtensionsManagerView.swift
+++ b/VaderCleaner/ExtensionsManagerView.swift
@@ -1,0 +1,155 @@
+// ExtensionsManagerView.swift
+// Extensions Manager feature view — discovers Safari/browser extensions, Mail plugins, internet plug-ins, and login-item launch agents, groups them by type, and removes the selected one after confirmation.
+
+import SwiftUI
+
+/// Detail view shown when the user selects "Extensions" in the sidebar.
+/// A single grouped list (one section per `ExtensionType`) with a per-row
+/// Remove control; the view-model owns the state machine and side-effects.
+struct ExtensionsManagerView: View {
+
+    @ObservedObject private var viewModel: ExtensionsManagerViewModel
+    @State private var pendingRemoval: ExtensionItem?
+
+    init(viewModel: ExtensionsManagerViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(NavigationSection.extensions.title)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        Task { await viewModel.refresh() }
+                    } label: {
+                        Label(String(
+                            localized: "Refresh",
+                            comment: "Toolbar button that re-runs Extensions Manager discovery."
+                        ), systemImage: "arrow.clockwise")
+                    }
+                    .disabled(viewModel.phase == .loading || viewModel.phase == .removing)
+                    .accessibilityIdentifier("extensions.refresh")
+                }
+            }
+            .task {
+                if viewModel.phase == .idle {
+                    await viewModel.refresh()
+                }
+            }
+            .alert(
+                removalConfirmationTitle,
+                isPresented: Binding(
+                    get: { pendingRemoval != nil },
+                    set: { if !$0 { pendingRemoval = nil } }
+                )
+            ) {
+                Button(String(
+                    localized: "Cancel",
+                    comment: "Cancel button on the Extensions Manager removal confirmation alert."
+                ), role: .cancel) {
+                    pendingRemoval = nil
+                }
+                Button(String(
+                    localized: "Remove",
+                    comment: "Confirm-removal button on the Extensions Manager removal confirmation alert."
+                ), role: .destructive) {
+                    if let item = pendingRemoval {
+                        pendingRemoval = nil
+                        Task { await viewModel.remove(item) }
+                    }
+                }
+            } message: {
+                Text(removalConfirmationMessage)
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.phase {
+        case .idle, .loading:
+            ExtensionsManagerProgressState(
+                label: String(
+                    localized: "Scanning for extensions…",
+                    comment: "Progress label while the Extensions Manager runs discovery."
+                ),
+                identifier: "extensions.loading"
+            )
+        case .removing:
+            ExtensionsManagerProgressState(
+                label: String(
+                    localized: "Removing…",
+                    comment: "Progress label while the Extensions Manager removes an item."
+                ),
+                identifier: "extensions.removing"
+            )
+        case .ready:
+            if viewModel.groupedByType.isEmpty {
+                ExtensionsManagerEmptyState()
+            } else {
+                ExtensionsManagerList(
+                    groups: viewModel.groupedByType,
+                    onRemove: { pendingRemoval = $0 }
+                )
+            }
+        case .failed(let stage, let message):
+            ExtensionsManagerFailedState(
+                stage: stage,
+                message: message,
+                onPrimary: {
+                    switch stage {
+                    case .loading:
+                        Task { await viewModel.refresh() }
+                    case .removing:
+                        viewModel.dismissResult()
+                    }
+                }
+            )
+        }
+    }
+
+    private var removalConfirmationTitle: String {
+        String(
+            localized: "Remove this extension?",
+            comment: "Alert title asking the user to confirm removing an extension."
+        )
+    }
+
+    private var removalConfirmationMessage: String {
+        if let item = pendingRemoval {
+            let format = String(
+                localized: "%@ will be permanently deleted from disk. This cannot be undone.",
+                comment: "Alert message confirming an extension removal."
+            )
+            return String.localizedStringWithFormat(format, item.name)
+        }
+        return String(
+            localized: "The selected extension will be permanently deleted from disk.",
+            comment: "Fallback alert message confirming an extension removal."
+        )
+    }
+}
+
+#Preview {
+    ExtensionsManagerView(viewModel: ExtensionsManagerViewModel(
+        discover: {
+            [
+                ExtensionItem(name: "uBlock Origin",
+                              path: URL(fileURLWithPath: "/tmp/ublock"),
+                              bundleID: "org.ublock",
+                              type: .chromeExtension,
+                              isEnabled: true,
+                              size: 5_242_880),
+                ExtensionItem(name: "com.acme.updater",
+                              path: URL(fileURLWithPath: "/tmp/com.acme.updater.plist"),
+                              bundleID: nil,
+                              type: .loginItemFromApp,
+                              isEnabled: false,
+                              size: 2_048)
+            ]
+        },
+        remove: { _ in }
+    ))
+    .frame(width: 900, height: 600)
+}

--- a/VaderCleaner/ExtensionsManagerViewModel.swift
+++ b/VaderCleaner/ExtensionsManagerViewModel.swift
@@ -1,0 +1,221 @@
+// ExtensionsManagerViewModel.swift
+// State machine behind the Extensions Manager view — runs the five discoverers concurrently, groups results by ExtensionType, and routes removal between FileManager (user paths) and the privileged helper (/Library paths).
+
+import Foundation
+import os.log
+
+/// Drives the Extensions Manager feature view (discover → group → remove).
+///
+/// Collaborators are injected as closures so unit tests can drive every
+/// transition without touching real extension state. Production wiring lives
+/// in `ExtensionsManagerViewModel.live()` below.
+@MainActor
+final class ExtensionsManagerViewModel: ObservableObject {
+
+    /// Which step produced a `.failed` phase, so the view can pick the
+    /// right heading and recovery affordance.
+    enum FailureStage: Equatable {
+        case loading
+        case removing
+    }
+
+    /// Discrete phases the view binds to.
+    enum Phase: Equatable {
+        case idle
+        case loading
+        case ready
+        case removing
+        case failed(stage: FailureStage, message: String)
+    }
+
+    typealias Discover = () async throws -> [ExtensionItem]
+    typealias Remove   = (ExtensionItem) async throws -> Void
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var items: [ExtensionItem] = []
+
+    private let discover: Discover
+    private let removal: Remove
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "ExtensionsManagerViewModel")
+
+    /// Monotonically increasing token so a stale discovery pass that
+    /// resolves after a newer `refresh()` can't clobber fresh state — same
+    /// pattern as the other feature view-models.
+    private var loadGeneration = 0
+
+    init(
+        discover: @escaping Discover,
+        remove: @escaping Remove
+    ) {
+        self.discover = discover
+        self.removal = remove
+    }
+
+    // MARK: - Public surface
+
+    /// Discovered items bucketed by `ExtensionType`, emitted in
+    /// `ExtensionType.allCases` declaration order with empty buckets
+    /// skipped. The view renders one section per tuple.
+    var groupedByType: [(ExtensionType, [ExtensionItem])] {
+        var bucket: [ExtensionType: [ExtensionItem]] = [:]
+        for item in items {
+            bucket[item.type, default: []].append(item)
+        }
+        return ExtensionType.allCases.compactMap { type in
+            guard let entries = bucket[type], !entries.isEmpty else { return nil }
+            let sorted = entries.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            return (type, sorted)
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Runs discovery and lands `.ready` (or `.failed(.loading)`).
+    func refresh() async {
+        let generation = beginLoad()
+        phase = .loading
+        do {
+            let result = try await discover()
+            guard loadGeneration == generation else { return }
+            items = result
+            phase = .ready
+        } catch {
+            // Privacy: discovery errors may include user-specific paths.
+            log.error("Extension discovery failed: \(String(describing: error), privacy: .private)")
+            guard loadGeneration == generation else { return }
+            items = []
+            phase = .failed(stage: .loading, message: error.localizedDescription)
+        }
+    }
+
+    /// Removes a single item. On success the row is dropped and the VM
+    /// returns to `.ready`; on failure the list is left intact so the user
+    /// can retry.
+    func remove(_ item: ExtensionItem) async {
+        phase = .removing
+        do {
+            try await removal(item)
+            items.removeAll { $0.id == item.id }
+            phase = .ready
+        } catch {
+            // Privacy: removal errors may include user-specific paths.
+            log.error("Extension removal failed: \(String(describing: error), privacy: .private)")
+            phase = .failed(stage: .removing, message: error.localizedDescription)
+        }
+    }
+
+    /// Returns the VM to `.ready` after a `.failed` phase so the user can
+    /// retry without re-running discovery.
+    func dismissResult() {
+        phase = .ready
+    }
+
+    // MARK: - Generations
+
+    private func beginLoad() -> Int {
+        loadGeneration += 1
+        return loadGeneration
+    }
+}
+
+// MARK: - Production wiring
+
+extension ExtensionsManagerViewModel {
+
+    /// Builds a view-model wired to the five real discoverers (run
+    /// concurrently) and the path-routed removal pipeline.
+    @MainActor
+    static func live() -> ExtensionsManagerViewModel {
+        ExtensionsManagerViewModel(
+            discover: {
+                async let safari   = SafariExtensionDiscovery().extensions()
+                async let browser  = BrowserExtensionDiscovery().extensions()
+                async let mail     = MailPluginDiscovery().extensions()
+                async let internet = InternetPluginDiscovery().extensions()
+                async let agents   = LaunchAgentDiscovery().extensions()
+                let merged = await safari + browser + mail + internet + agents
+                return merged.sorted {
+                    $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                }
+            },
+            remove: { item in
+                try await Self.removeItem(item)
+            }
+        )
+    }
+
+    /// Routes removal by privilege need. User-writable paths (`~/Library/…`,
+    /// including `~/Library/LaunchAgents`) are removed in-process. Paths
+    /// under `/Library` or `/System` (system Mail bundles, system internet
+    /// plug-ins) go through the privileged helper — launch-agent plists via
+    /// the dedicated `removeLaunchAgent(path:)`, everything else via the
+    /// batched `deleteFiles(_:)`.
+    private static func removeItem(_ item: ExtensionItem) async throws {
+        let path = item.path.path
+        guard SystemJunkDeleter.requiresHelper(path: path) else {
+            try FileManager.default.removeItem(at: item.path)
+            return
+        }
+        if item.type == .loginItemFromApp {
+            try await helperCall { helper, done in
+                helper.removeLaunchAgent(path: path, reply: done)
+            }
+        } else {
+            try await helperCall { helper, done in
+                helper.deleteFiles([path], reply: done)
+            }
+        }
+    }
+
+    /// Bridges a reply-block helper call to async/throwing. Installs both
+    /// the per-call XPC error handler and the reply block; whichever fires
+    /// first resumes the continuation (the other becomes a no-op via the
+    /// once-only guard) so a dropped connection can't freeze removal.
+    private static func helperCall(
+        _ body: @escaping (VaderCleanerHelperProtocol, @escaping (Error?) -> Void) -> Void
+    ) async throws {
+        let error: Error? = await withCheckedContinuation { continuation in
+            let resumer = OnceResumer(continuation)
+            let helper = HelperConnectionManager.shared.helper { connectionError in
+                resumer.resume(with: connectionError)
+            }
+            guard let helper else {
+                resumer.resume(with: NSError(
+                    domain: "com.personal.VaderCleaner.ExtensionsManager",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Helper unavailable"]
+                ))
+                return
+            }
+            body(helper) { replyError in
+                resumer.resume(with: replyError)
+            }
+        }
+        if let error { throw error }
+    }
+}
+
+/// Once-only continuation resume. The XPC reply block and the
+/// connection-level error handler may both fire; `CheckedContinuation`
+/// traps on a second resume, so the first wins and later attempts are
+/// dropped. A class because multiple closures reference it; `NSLock`
+/// covers the "two callbacks on different threads" race.
+private final class OnceResumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(_ continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let cont = continuation
+        continuation = nil
+        lock.unlock()
+        cont?.resume(returning: error)
+    }
+}

--- a/VaderCleaner/ExtensionsManagerViewModel.swift
+++ b/VaderCleaner/ExtensionsManagerViewModel.swift
@@ -153,7 +153,7 @@ extension ExtensionsManagerViewModel {
     /// plug-ins) go through the privileged helper — launch-agent plists via
     /// the dedicated `removeLaunchAgent(path:)`, everything else via the
     /// batched `deleteFiles(_:)`.
-    private static func removeItem(_ item: ExtensionItem) async throws {
+    private nonisolated static func removeItem(_ item: ExtensionItem) async throws {
         let path = item.path.path
         guard SystemJunkDeleter.requiresHelper(path: path) else {
             try FileManager.default.removeItem(at: item.path)
@@ -174,7 +174,7 @@ extension ExtensionsManagerViewModel {
     /// the per-call XPC error handler and the reply block; whichever fires
     /// first resumes the continuation (the other becomes a no-op via the
     /// once-only guard) so a dropped connection can't freeze removal.
-    private static func helperCall(
+    private nonisolated static func helperCall(
         _ body: @escaping (VaderCleanerHelperProtocol, @escaping (Error?) -> Void) -> Void
     ) async throws {
         let error: Error? = await withCheckedContinuation { continuation in

--- a/VaderCleaner/ExtensionsManagerViewModel.swift
+++ b/VaderCleaner/ExtensionsManagerViewModel.swift
@@ -136,10 +136,9 @@ extension ExtensionsManagerViewModel {
                 async let mail     = MailPluginDiscovery().extensions()
                 async let internet = InternetPluginDiscovery().extensions()
                 async let agents   = LaunchAgentDiscovery().extensions()
-                let merged = await safari + browser + mail + internet + agents
-                return merged.sorted {
-                    $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-                }
+                // Not sorted here: `groupedByType` sorts each bucket by
+                // name before the data reaches the UI.
+                return await safari + browser + mail + internet + agents
             },
             remove: { item in
                 try await Self.removeItem(item)

--- a/VaderCleaner/ExtensionsManagerViewSubviews.swift
+++ b/VaderCleaner/ExtensionsManagerViewSubviews.swift
@@ -1,0 +1,163 @@
+// ExtensionsManagerViewSubviews.swift
+// Dedicated subviews for the Extensions Manager grouped list, rows, and progress / empty / failed state screens.
+
+import SwiftUI
+
+enum ExtensionsManagerFormatting {
+    static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+}
+
+struct ExtensionsManagerProgressState: View {
+    let label: String
+    let identifier: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+struct ExtensionsManagerEmptyState: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "puzzlepiece.extension")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(String(
+                localized: "No extensions found",
+                comment: "Empty state heading shown when the Extensions Manager finds nothing."
+            ))
+                .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "VaderCleaner didn't find any browser extensions, Mail plugins, internet plug-ins, or login-item launch agents.",
+                comment: "Empty state description for the Extensions Manager."
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("extensions.empty")
+    }
+}
+
+struct ExtensionsManagerList: View {
+    let groups: [(ExtensionType, [ExtensionItem])]
+    let onRemove: (ExtensionItem) -> Void
+
+    var body: some View {
+        List {
+            ForEach(groups, id: \.0) { pair in
+                Section {
+                    ForEach(pair.1) { item in
+                        ExtensionsManagerRow(item: item) { onRemove(item) }
+                            .accessibilityIdentifier("extensions.row.\(pair.0.rawValue).\(item.path.lastPathComponent)")
+                    }
+                } header: {
+                    Text(LocalizedStringKey(pair.0.displayName))
+                        .font(.callout.weight(.semibold))
+                }
+            }
+        }
+        .listStyle(.inset)
+    }
+}
+
+struct ExtensionsManagerRow: View {
+    let item: ExtensionItem
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(item.name)
+                        .font(.body)
+                        .lineLimit(1)
+                    if !item.isEnabled {
+                        Text(String(
+                            localized: "Disabled",
+                            comment: "Badge shown next to a disabled launch agent / extension."
+                        ))
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.18))
+                            .clipShape(Capsule())
+                    }
+                }
+                Text(item.bundleID ?? item.path.deletingLastPathComponent().path)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            if item.size > 0 {
+                Text(ExtensionsManagerFormatting.byteFormatter
+                    .string(fromByteCount: item.size))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            Button(role: .destructive, action: onRemove) {
+                Text(String(
+                    localized: "Remove",
+                    comment: "Per-row remove button in the Extensions Manager."
+                ))
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("extensions.remove.\(item.path.lastPathComponent)")
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct ExtensionsManagerFailedState: View {
+    let stage: ExtensionsManagerViewModel.FailureStage
+    let message: String
+    let onPrimary: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(stage == .loading
+                 ? String(localized: "Couldn't scan for extensions",
+                          comment: "Heading on the Extensions Manager failure screen when discovery failed.")
+                 : String(localized: "Couldn't remove the extension",
+                          comment: "Heading on the Extensions Manager failure screen when removal failed."))
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("extensions.errorMessage")
+            Button(stage == .loading
+                   ? String(localized: "Try Again",
+                            comment: "Retry discovery on the Extensions Manager failure screen.")
+                   : String(localized: "Back to Extensions",
+                            comment: "Return to the list after a failed Extensions Manager removal."),
+                   action: onPrimary)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("extensions.failurePrimary")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -32,6 +32,7 @@ struct VaderCleanerApp: App {
     @StateObject private var privacyViewModel: PrivacyViewModel
     @StateObject private var appUninstallerViewModel: AppUninstallerViewModel
     @StateObject private var appUpdaterViewModel: AppUpdaterViewModel
+    @StateObject private var extensionsManagerViewModel: ExtensionsManagerViewModel
     // App-scope so the cheap-stats timer outlives any single window. The
     // Health Monitor view (Prompt 9), the menu bar (Prompt 10), and the
     // notification dispatcher (Prompt 11) all subscribe via
@@ -73,6 +74,7 @@ struct VaderCleanerApp: App {
         _privacyViewModel = StateObject(wrappedValue: PrivacyViewModel.live())
         _appUninstallerViewModel = StateObject(wrappedValue: AppUninstallerViewModel.live())
         _appUpdaterViewModel = StateObject(wrappedValue: AppUpdaterViewModel.live())
+        _extensionsManagerViewModel = StateObject(wrappedValue: ExtensionsManagerViewModel.live())
         // Construct the polling service and the menu bar view-model in the
         // same init so both `@StateObject` wrappers reference the *same*
         // service instance. Initializing `menuBarViewModel` at its property
@@ -132,7 +134,8 @@ struct VaderCleanerApp: App {
                 spaceLensViewModel: spaceLensViewModel,
                 privacyViewModel: privacyViewModel,
                 appUninstallerViewModel: appUninstallerViewModel,
-                appUpdaterViewModel: appUpdaterViewModel
+                appUpdaterViewModel: appUpdaterViewModel,
+                extensionsManagerViewModel: extensionsManagerViewModel
             )
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)

--- a/VaderCleanerTests/ExtensionDiscoveryTests.swift
+++ b/VaderCleanerTests/ExtensionDiscoveryTests.swift
@@ -69,7 +69,7 @@ final class ExtensionDiscoveryTests: XCTestCase {
             to: agentsDir.appendingPathComponent("com.acme.updater.plist")
         )
 
-        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome)
+        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome, systemRoots: [])
         let agents = await discovery.userAgents()
 
         XCTAssertEqual(agents.count, 1)
@@ -99,7 +99,7 @@ final class ExtensionDiscoveryTests: XCTestCase {
             to: agentsDir.appendingPathComponent("com.acme.disabled.plist")
         )
 
-        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome)
+        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome, systemRoots: [])
         let byName = Dictionary(
             uniqueKeysWithValues: await discovery.userAgents().map { ($0.name, $0) }
         )
@@ -121,10 +121,59 @@ final class ExtensionDiscoveryTests: XCTestCase {
             to: agentsDir.appendingPathComponent("com.acme.one.plist")
         )
 
-        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome)
+        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome, systemRoots: [])
         let viaProtocol = await discovery.extensions()
         let viaUserAgents = await discovery.userAgents()
         XCTAssertEqual(viaProtocol, viaUserAgents)
+    }
+
+    /// System-wide launch agents and daemons under `/Library/LaunchAgents`
+    /// and `/Library/LaunchDaemons` are surfaced alongside the user's, so
+    /// the "Login Items & Launch Agents" section doesn't miss common
+    /// third-party background items.
+    func test_launchAgents_surfacesSystemAgentsAndDaemons() async throws {
+        let userDir = tempHome
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        let sysAgents = tempSystem.appendingPathComponent("LaunchAgents", isDirectory: true)
+        let sysDaemons = tempSystem.appendingPathComponent("LaunchDaemons", isDirectory: true)
+        for dir in [userDir, sysAgents, sysDaemons] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        try writePlist(
+            ["Label": "com.user.agent"],
+            to: userDir.appendingPathComponent("com.user.agent.plist")
+        )
+        try writePlist(
+            ["Label": "com.system.agent"],
+            to: sysAgents.appendingPathComponent("com.system.agent.plist")
+        )
+        try writePlist(
+            ["Label": "com.system.daemon", "Disabled": true],
+            to: sysDaemons.appendingPathComponent("com.system.daemon.plist")
+        )
+
+        let discovery = LaunchAgentDiscovery(
+            homeDirectory: tempHome,
+            systemRoots: [sysAgents, sysDaemons]
+        )
+        let byName = Dictionary(
+            uniqueKeysWithValues: await discovery.userAgents().map { ($0.name, $0) }
+        )
+
+        XCTAssertEqual(
+            Set(byName.keys),
+            ["com.user.agent", "com.system.agent", "com.system.daemon"]
+        )
+        XCTAssertEqual(byName["com.system.agent"]?.type, .loginItemFromApp)
+        XCTAssertEqual(byName["com.system.daemon"]?.isEnabled, false)
+        XCTAssertEqual(
+            byName["com.system.agent"]?.path.lastPathComponent,
+            "com.system.agent.plist"
+        )
+        XCTAssertEqual(
+            byName["com.system.agent"]?.path.deletingLastPathComponent().lastPathComponent,
+            "LaunchAgents"
+        )
     }
 
     // MARK: - Mail plugins

--- a/VaderCleanerTests/ExtensionDiscoveryTests.swift
+++ b/VaderCleanerTests/ExtensionDiscoveryTests.swift
@@ -1,0 +1,231 @@
+// ExtensionDiscoveryTests.swift
+// Exercises the five Extensions Manager discovery types against hermetic temp-directory fixtures so no real Safari/Mail/launch-agent state is touched.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ExtensionDiscoveryTests: XCTestCase {
+
+    private var tempHome: URL!
+    private var tempSystem: URL!
+
+    override func setUpWithError() throws {
+        tempHome = try TestHelpers.createTempDirectory()
+        tempSystem = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        TestHelpers.tearDownTempDirectory(tempHome)
+        TestHelpers.tearDownTempDirectory(tempSystem)
+    }
+
+    // MARK: - Safari
+
+    /// Contract from the plan: `extensions()` returns an array (possibly
+    /// empty). A home with no `Safari/Extensions` directory — the common
+    /// case on modern macOS where extensions ship as `.appex` via
+    /// PluginKit — must yield `[]`, never a crash.
+    func test_safari_returnsEmptyArrayWhenDirectoryAbsent() async {
+        let discovery = SafariExtensionDiscovery(homeDirectory: tempHome)
+        let result = await discovery.extensions()
+        XCTAssertEqual(result, [])
+    }
+
+    /// A planted legacy `.safariextz` archive is surfaced as a
+    /// `.safariExtension` item.
+    func test_safari_surfacesLegacyArchive() async throws {
+        let extensionsDir = tempHome
+            .appendingPathComponent("Library/Safari/Extensions", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: extensionsDir, withIntermediateDirectories: true
+        )
+        try TestHelpers.createDummyFile(
+            named: "AdBlock.safariextz", size: 2048, in: extensionsDir
+        )
+
+        let discovery = SafariExtensionDiscovery(homeDirectory: tempHome)
+        let result = await discovery.extensions()
+
+        XCTAssertEqual(result.count, 1)
+        let item = try XCTUnwrap(result.first)
+        XCTAssertEqual(item.name, "AdBlock")
+        XCTAssertEqual(item.type, .safariExtension)
+        XCTAssertEqual(item.size, 2048)
+    }
+
+    // MARK: - Launch agents
+
+    /// `userAgents()` reads every plist under `~/Library/LaunchAgents` and
+    /// derives `name` from the `Label` key.
+    func test_launchAgents_userAgentsReadsLabelAndPath() async throws {
+        let agentsDir = tempHome
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: agentsDir, withIntermediateDirectories: true
+        )
+        try writePlist(
+            ["Label": "com.acme.updater",
+             "ProgramArguments": ["/usr/local/bin/acme"]],
+            to: agentsDir.appendingPathComponent("com.acme.updater.plist")
+        )
+
+        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome)
+        let agents = await discovery.userAgents()
+
+        XCTAssertEqual(agents.count, 1)
+        let agent = try XCTUnwrap(agents.first)
+        XCTAssertEqual(agent.name, "com.acme.updater")
+        XCTAssertEqual(agent.type, .loginItemFromApp)
+        XCTAssertTrue(agent.isEnabled)
+        XCTAssertEqual(
+            agent.path.lastPathComponent, "com.acme.updater.plist"
+        )
+    }
+
+    /// `Disabled = true` in the plist flips `isEnabled` to `false` — that
+    /// key is the authoritative launchd source.
+    func test_launchAgents_disabledKeyFlipsIsEnabled() async throws {
+        let agentsDir = tempHome
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: agentsDir, withIntermediateDirectories: true
+        )
+        try writePlist(
+            ["Label": "com.acme.enabled"],
+            to: agentsDir.appendingPathComponent("com.acme.enabled.plist")
+        )
+        try writePlist(
+            ["Label": "com.acme.disabled", "Disabled": true],
+            to: agentsDir.appendingPathComponent("com.acme.disabled.plist")
+        )
+
+        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome)
+        let byName = Dictionary(
+            uniqueKeysWithValues: await discovery.userAgents().map { ($0.name, $0) }
+        )
+
+        XCTAssertEqual(byName["com.acme.enabled"]?.isEnabled, true)
+        XCTAssertEqual(byName["com.acme.disabled"]?.isEnabled, false)
+    }
+
+    /// `extensions()` is the protocol surface; for launch agents it must
+    /// return the same set as `userAgents()`.
+    func test_launchAgents_extensionsMirrorsUserAgents() async throws {
+        let agentsDir = tempHome
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: agentsDir, withIntermediateDirectories: true
+        )
+        try writePlist(
+            ["Label": "com.acme.one"],
+            to: agentsDir.appendingPathComponent("com.acme.one.plist")
+        )
+
+        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome)
+        let viaProtocol = await discovery.extensions()
+        let viaUserAgents = await discovery.userAgents()
+        XCTAssertEqual(viaProtocol, viaUserAgents)
+    }
+
+    // MARK: - Mail plugins
+
+    /// `.mailbundle` directories under both the user and system Bundles
+    /// roots are surfaced as `.mailPlugin` items.
+    func test_mailPlugins_surfacesUserAndSystemBundles() async throws {
+        let userBundles = tempHome
+            .appendingPathComponent("Library/Mail/Bundles", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: userBundles, withIntermediateDirectories: true
+        )
+        try makeBundle(named: "GPGMail.mailbundle", in: userBundles)
+        try makeBundle(named: "SystemMailPlugin.mailbundle", in: tempSystem)
+
+        let discovery = MailPluginDiscovery(
+            homeDirectory: tempHome,
+            systemBundlesDirectory: tempSystem
+        )
+        let names = Set(await discovery.extensions().map(\.name))
+
+        XCTAssertTrue(names.contains("GPGMail"))
+        XCTAssertTrue(names.contains("SystemMailPlugin"))
+        for item in await discovery.extensions() {
+            XCTAssertEqual(item.type, .mailPlugin)
+        }
+    }
+
+    // MARK: - Internet plug-ins
+
+    /// `.plugin` bundles under the user/system Internet Plug-Ins roots are
+    /// surfaced as `.internetPlugin` items.
+    func test_internetPlugins_surfacesUserAndSystemPlugins() async throws {
+        let userPlugins = tempHome
+            .appendingPathComponent("Library/Internet Plug-Ins", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: userPlugins, withIntermediateDirectories: true
+        )
+        try makeBundle(named: "Flash Player.plugin", in: userPlugins)
+        try makeBundle(named: "QuickTime.plugin", in: tempSystem)
+
+        let discovery = InternetPluginDiscovery(
+            homeDirectory: tempHome,
+            systemPluginsDirectory: tempSystem
+        )
+        let names = Set(await discovery.extensions().map(\.name))
+
+        XCTAssertTrue(names.contains("Flash Player"))
+        XCTAssertTrue(names.contains("QuickTime"))
+    }
+
+    // MARK: - Browser extensions
+
+    /// A planted unpacked Chrome extension (manifest.json under
+    /// `Extensions/<id>/<version>/`) is surfaced with the manifest name.
+    func test_browser_surfacesChromeExtension() async throws {
+        let versionDir = tempHome.appendingPathComponent(
+            "Library/Application Support/Google/Chrome/Default/Extensions/abcdef/1.2.0",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: versionDir, withIntermediateDirectories: true
+        )
+        let manifest = #"{"name":"Tab Manager","version":"1.2.0"}"#
+        try manifest.write(
+            to: versionDir.appendingPathComponent("manifest.json"),
+            atomically: true, encoding: .utf8
+        )
+
+        let discovery = BrowserExtensionDiscovery(homeDirectory: tempHome)
+        let chrome = await discovery.extensions()
+            .filter { $0.type == .chromeExtension }
+
+        XCTAssertEqual(chrome.count, 1)
+        XCTAssertEqual(chrome.first?.name, "Tab Manager")
+    }
+
+    /// No browser profile directories → empty, not a crash.
+    func test_browser_returnsEmptyWhenNoProfiles() async {
+        let discovery = BrowserExtensionDiscovery(homeDirectory: tempHome)
+        let result = await discovery.extensions()
+        XCTAssertEqual(result, [])
+    }
+
+    // MARK: - Fixture helpers
+
+    private func writePlist(_ dict: [String: Any], to url: URL) throws {
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: dict, format: .xml, options: 0
+        )
+        try data.write(to: url)
+    }
+
+    /// Creates a minimal `.bundle`-style directory with a Contents/ child so
+    /// the size walk has something to sum.
+    private func makeBundle(named name: String, in directory: URL) throws {
+        let bundle = directory.appendingPathComponent(name, isDirectory: true)
+        let contents = bundle.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: contents, withIntermediateDirectories: true
+        )
+        try TestHelpers.createDummyFile(named: "Info.plist", size: 128, in: contents)
+    }
+}

--- a/VaderCleanerTests/ExtensionItemTests.swift
+++ b/VaderCleanerTests/ExtensionItemTests.swift
@@ -1,0 +1,98 @@
+// ExtensionItemTests.swift
+// Pins the ExtensionItem value type and the ExtensionType enum — required properties, stable raw values, and display names the Extensions Manager UI sections on.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ExtensionItemTests: XCTestCase {
+
+    // MARK: - ExtensionItem
+
+    /// The struct must expose the properties the discovery layer and UI bind
+    /// to: name, path, type, isEnabled (plus optional bundleID and size).
+    func test_extensionItem_exposesRequiredProperties() {
+        let url = URL(fileURLWithPath: "/Users/x/Library/LaunchAgents/com.acme.agent.plist")
+        let item = ExtensionItem(
+            name: "Acme Agent",
+            path: url,
+            bundleID: "com.acme.agent",
+            type: .loginItemFromApp,
+            isEnabled: true,
+            size: 4096
+        )
+
+        XCTAssertEqual(item.name, "Acme Agent")
+        XCTAssertEqual(item.path, url)
+        XCTAssertEqual(item.bundleID, "com.acme.agent")
+        XCTAssertEqual(item.type, .loginItemFromApp)
+        XCTAssertTrue(item.isEnabled)
+        XCTAssertEqual(item.size, 4096)
+    }
+
+    /// `id` is the on-disk path so SwiftUI list identity stays stable across
+    /// re-discovery passes that re-emit the same item.
+    func test_extensionItem_idIsPath() {
+        let url = URL(fileURLWithPath: "/Library/Mail/Bundles/Foo.mailbundle")
+        let item = ExtensionItem(
+            name: "Foo",
+            path: url,
+            bundleID: nil,
+            type: .mailPlugin,
+            isEnabled: false,
+            size: 0
+        )
+        XCTAssertEqual(item.id, url)
+    }
+
+    /// bundleID is optional — Safari `.safariextz` archives and bare launch
+    /// agents don't always carry one.
+    func test_extensionItem_bundleIDIsOptional() {
+        let item = ExtensionItem(
+            name: "Legacy",
+            path: URL(fileURLWithPath: "/tmp/Legacy.safariextz"),
+            bundleID: nil,
+            type: .safariExtension,
+            isEnabled: true,
+            size: 10
+        )
+        XCTAssertNil(item.bundleID)
+    }
+
+    // MARK: - ExtensionType
+
+    /// All six categories the plan enumerates must be present.
+    func test_extensionType_hasAllSixCases() {
+        XCTAssertEqual(ExtensionType.allCases.count, 6)
+        XCTAssertEqual(
+            Set(ExtensionType.allCases),
+            [.safariExtension, .chromeExtension, .firefoxExtension,
+             .mailPlugin, .internetPlugin, .loginItemFromApp]
+        )
+    }
+
+    /// Raw values are stable identifiers used for section identity /
+    /// accessibility — a rename would silently break the UI grouping.
+    func test_extensionType_rawValuesAreStable() {
+        XCTAssertEqual(ExtensionType.safariExtension.rawValue, "safariExtension")
+        XCTAssertEqual(ExtensionType.chromeExtension.rawValue, "chromeExtension")
+        XCTAssertEqual(ExtensionType.firefoxExtension.rawValue, "firefoxExtension")
+        XCTAssertEqual(ExtensionType.mailPlugin.rawValue, "mailPlugin")
+        XCTAssertEqual(ExtensionType.internetPlugin.rawValue, "internetPlugin")
+        XCTAssertEqual(ExtensionType.loginItemFromApp.rawValue, "loginItemFromApp")
+    }
+
+    /// `id` mirrors the raw value so `ForEach` over `allCases` is stable.
+    func test_extensionType_idIsRawValue() {
+        for type in ExtensionType.allCases {
+            XCTAssertEqual(type.id, type.rawValue)
+        }
+    }
+
+    /// Every case has a non-empty, human-readable section heading.
+    func test_extensionType_displayNamesAreNonEmpty() {
+        for type in ExtensionType.allCases {
+            XCTAssertFalse(type.displayName.isEmpty,
+                           "\(type.rawValue) must have a display name")
+        }
+    }
+}

--- a/VaderCleanerTests/ExtensionsManagerViewModelTests.swift
+++ b/VaderCleanerTests/ExtensionsManagerViewModelTests.swift
@@ -1,0 +1,162 @@
+// ExtensionsManagerViewModelTests.swift
+// Drives the ExtensionsManagerViewModel state machine — load, type grouping, removal, and failure paths — through injected fakes so no real extension state is touched.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class ExtensionsManagerViewModelTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertTrue(vm.items.isEmpty)
+        XCTAssertTrue(vm.groupedByType.isEmpty)
+    }
+
+    // MARK: - Refresh
+
+    /// `refresh()` populates `items` and lands `.ready`.
+    func test_refresh_populatesItemsAndBecomesReady() async {
+        let vm = makeViewModel(discover: {
+            [Self.item(name: "A", type: .safariExtension)]
+        })
+        await vm.refresh()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.items.map(\.name), ["A"])
+    }
+
+    /// A throwing discovery surfaces `.failed(stage: .loading, ...)`.
+    func test_refresh_failureTransitionsToFailed() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(discover: { throw Boom() })
+        await vm.refresh()
+        if case .failed(let stage, _) = vm.phase {
+            XCTAssertEqual(stage, .loading)
+        } else {
+            XCTFail("Expected .failed(.loading), got \(vm.phase)")
+        }
+        XCTAssertTrue(vm.items.isEmpty)
+    }
+
+    // MARK: - Grouping
+
+    /// `groupedByType` buckets items by `ExtensionType` and emits the
+    /// groups in `ExtensionType.allCases` declaration order, skipping
+    /// empty buckets.
+    func test_groupedByType_bucketsInAllCasesOrder() async {
+        let vm = makeViewModel(discover: {
+            [
+                Self.item(name: "Login", type: .loginItemFromApp),
+                Self.item(name: "Safari1", type: .safariExtension),
+                Self.item(name: "Mail1", type: .mailPlugin),
+                Self.item(name: "Safari2", type: .safariExtension)
+            ]
+        })
+        await vm.refresh()
+
+        let grouped = vm.groupedByType
+        XCTAssertEqual(grouped.map(\.0),
+                       [.safariExtension, .mailPlugin, .loginItemFromApp])
+        XCTAssertEqual(grouped.first?.1.map(\.name), ["Safari1", "Safari2"])
+    }
+
+    /// Empty discovery → `.ready` with no groups (drives the empty state).
+    func test_groupedByType_emptyWhenNoItems() async {
+        let vm = makeViewModel(discover: { [] })
+        await vm.refresh()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertTrue(vm.groupedByType.isEmpty)
+    }
+
+    // MARK: - Removal
+
+    /// A successful removal drops the row, re-groups, and lands `.ready`.
+    func test_remove_dropsItemAndReturnsToReady() async {
+        let target = Self.item(name: "Doomed", type: .mailPlugin)
+        let keep = Self.item(name: "Keeper", type: .safariExtension)
+        let vm = makeViewModel(
+            discover: { [target, keep] },
+            remove: { _ in }
+        )
+        await vm.refresh()
+        await vm.remove(target)
+
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.items.map(\.name), ["Keeper"])
+        XCTAssertEqual(vm.groupedByType.map(\.0), [.safariExtension])
+    }
+
+    /// The removed item is the one passed to the injected remover.
+    func test_remove_forwardsTheSelectedItemToRemover() async {
+        let target = Self.item(name: "Doomed", type: .internetPlugin)
+        var removed: ExtensionItem?
+        let vm = makeViewModel(
+            discover: { [target] },
+            remove: { removed = $0 }
+        )
+        await vm.refresh()
+        await vm.remove(target)
+        XCTAssertEqual(removed, target)
+    }
+
+    /// A throwing remover surfaces `.failed(stage: .removing, ...)` and
+    /// leaves the item list intact so the user can retry.
+    func test_remove_failureTransitionsToFailedRemoving() async {
+        struct Boom: Error {}
+        let target = Self.item(name: "Doomed", type: .mailPlugin)
+        let vm = makeViewModel(
+            discover: { [target] },
+            remove: { _ in throw Boom() }
+        )
+        await vm.refresh()
+        await vm.remove(target)
+
+        if case .failed(let stage, _) = vm.phase {
+            XCTAssertEqual(stage, .removing)
+        } else {
+            XCTFail("Expected .failed(.removing), got \(vm.phase)")
+        }
+        XCTAssertEqual(vm.items.map(\.name), ["Doomed"])
+    }
+
+    /// `dismissResult()` returns a failed VM to `.ready` so the user can
+    /// retry without re-running discovery.
+    func test_dismissResult_returnsToReady() async {
+        struct Boom: Error {}
+        let target = Self.item(name: "Doomed", type: .mailPlugin)
+        let vm = makeViewModel(
+            discover: { [target] },
+            remove: { _ in throw Boom() }
+        )
+        await vm.refresh()
+        await vm.remove(target)
+        vm.dismissResult()
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        discover: @escaping ExtensionsManagerViewModel.Discover = { [] },
+        remove: @escaping ExtensionsManagerViewModel.Remove = { _ in }
+    ) -> ExtensionsManagerViewModel {
+        ExtensionsManagerViewModel(discover: discover, remove: remove)
+    }
+
+    private static func item(
+        name: String,
+        type: ExtensionType
+    ) -> ExtensionItem {
+        ExtensionItem(
+            name: name,
+            path: URL(fileURLWithPath: "/tmp/\(name)"),
+            bundleID: nil,
+            type: type,
+            isEnabled: true,
+            size: 0
+        )
+    }
+}

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -10,6 +10,8 @@ final class HelperDeletionPolicyTests: XCTestCase {
     private var cacheRoot: URL!
     private var logsRoot: URL!
     private var varFoldersRoot: URL!
+    private var mailBundlesRoot: URL!
+    private var internetPluginsRoot: URL!
     private var applicationsRoot: URL!
     private var libraryApplicationSupportRoot: URL!
     private var frameworksRoot: URL!
@@ -25,6 +27,8 @@ final class HelperDeletionPolicyTests: XCTestCase {
         cacheRoot = tempRoot.appendingPathComponent("Library/Caches", isDirectory: true)
         logsRoot = tempRoot.appendingPathComponent("Library/Logs", isDirectory: true)
         varFoldersRoot = tempRoot.appendingPathComponent("private/var/folders", isDirectory: true)
+        mailBundlesRoot = tempRoot.appendingPathComponent("Library/Mail/Bundles", isDirectory: true)
+        internetPluginsRoot = tempRoot.appendingPathComponent("Library/Internet Plug-Ins", isDirectory: true)
         applicationsRoot = tempRoot.appendingPathComponent("Applications", isDirectory: true)
         libraryApplicationSupportRoot = tempRoot.appendingPathComponent("Library/Application Support", isDirectory: true)
         frameworksRoot = tempRoot.appendingPathComponent("Library/Frameworks", isDirectory: true)
@@ -37,6 +41,8 @@ final class HelperDeletionPolicyTests: XCTestCase {
             cacheRoot,
             logsRoot,
             varFoldersRoot,
+            mailBundlesRoot,
+            internetPluginsRoot,
             applicationsRoot,
             libraryApplicationSupportRoot,
             frameworksRoot,
@@ -53,7 +59,9 @@ final class HelperDeletionPolicyTests: XCTestCase {
             allowedDescendantRoots: [
                 cacheRoot,
                 logsRoot,
-                varFoldersRoot
+                varFoldersRoot,
+                mailBundlesRoot,
+                internetPluginsRoot
             ],
             allowedLaunchPlistRoots: [
                 launchAgentsRoot,
@@ -82,6 +90,39 @@ final class HelperDeletionPolicyTests: XCTestCase {
         let url = cacheRoot.appendingPathComponent("com.example/file.bin")
 
         XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_acceptsSystemMailBundleDescendant() throws {
+        let url = mailBundlesRoot.appendingPathComponent("GPGMail.mailbundle")
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    func test_validateDeletionPath_acceptsSystemInternetPluginDescendant() throws {
+        let url = internetPluginsRoot.appendingPathComponent("Flash Player.plugin")
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path), url.standardizedFileURL)
+    }
+
+    /// Production-policy pins for the Extensions Manager: the two system
+    /// product directories must validate. Path-prefix validation does not
+    /// stat the target, so no `XCTSkipUnless` / on-disk fixture is needed.
+    func test_productionPolicy_acceptsSystemMailBundle() throws {
+        let path = "/Library/Mail/Bundles/Foo.mailbundle"
+
+        XCTAssertEqual(
+            try HelperDeletionPolicy.production.validateDeletionPath(path).path,
+            URL(fileURLWithPath: path).standardizedFileURL.path
+        )
+    }
+
+    func test_productionPolicy_acceptsSystemInternetPlugin() throws {
+        let path = "/Library/Internet Plug-Ins/Example.plugin"
+
+        XCTAssertEqual(
+            try HelperDeletionPolicy.production.validateDeletionPath(path).path,
+            URL(fileURLWithPath: path).standardizedFileURL.path
+        )
     }
 
     func test_productionPolicy_acceptsVarFoldersAlias() throws {

--- a/todo.md
+++ b/todo.md
@@ -38,7 +38,7 @@
 - [x] **Prompt 18** — Privacy feature (browser detection + data clearing + recent files)
 - [x] **Prompt 19** — App Uninstaller (discovery + associated files + deletion)
 - [x] **Prompt 20** — App Updater (App Store + Sparkle)
-- [ ] **Prompt 21** — Extensions Manager (Safari, browser, Mail, internet plugins, login items)
+- [x] **Prompt 21** — Extensions Manager (Safari, browser, Mail, internet plugins, login items)
 
 ## Phase 4 — Optimization & Security
 


### PR DESCRIPTION
## Summary

Implements **Prompt 21** from `plan.md` — the Extensions Manager feature. Discovers Safari/browser extensions, Mail plugins, internet plug-ins, and login-item launch agents, groups them by `ExtensionType`, and removes the selected item after a destructive confirmation.

- `ExtensionItem` value type + `ExtensionType` enum (stable raw values, `displayName` for section headings).
- Five protocol-seamed discoverers (`ExtensionDiscovering`), each injectable with a temp home / system root for hermetic tests:
  - `SafariExtensionDiscovery`, `BrowserExtensionDiscovery`, `MailPluginDiscovery`, `InternetPluginDiscovery`, `LaunchAgentDiscovery`.
  - `LaunchAgentDiscovery.userAgents()` reads `~/Library/LaunchAgents`; `isEnabled` is the inverse of the plist `Disabled` key (launchd's authoritative source).
- `ExtensionsManagerViewModel` (`@MainActor` `ObservableObject`): runs the five discoverers concurrently via `async let`, groups by type in `allCases` order, `refresh()` / `remove(_:)` / `dismissResult()` state machine with a generation token.
- `ExtensionsManagerView` + `ExtensionsManagerViewSubviews` wired into `NavigationSection.extensions` (replaces the placeholder) in `ContentView` and `VaderCleanerApp`.

## Design notes / deviations from `plan.md`

- **Naming follows the test contract.** The plan's implementation bullet names the launch-agent discoverer `LoginItemAppDiscovery`, but the test bullet pins `LaunchAgentDiscovery.userAgents()` — the type is `LaunchAgentDiscovery`; `LoginItemAppDiscovery` is not created.
- **Safari is honest about modern macOS.** On macOS 14+ Safari extensions ship as `.appex` via PluginKit and `SFSafariExtensionManager` cannot enumerate third-party extensions, so `SafariExtensionDiscovery.extensions()` does a real directory scan of `~/Library/Safari/Extensions/` and returns `[]` when absent — no dead SFSafariExtensionManager-querying code.
- **Removal routing is least-privilege.** User-writable paths (including `~/Library/LaunchAgents`) are removed in-process via `FileManager`. Only `/Library` / `/System` paths (system Mail bundles, system internet plug-ins) escalate through the privileged helper — launch-agent plists via the dedicated `removeLaunchAgent(path:)`, everything else via batched `deleteFiles(_:)`. This intentionally means user-owned launch agents do **not** go through the helper.
- **Helper allowlist extended (post-review).** `HelperDeletionPolicy.production` previously rejected `/Library/Mail/Bundles` and `/Library/Internet Plug-Ins`, so system-item removal always failed validation. This PR adds exactly those two product directories to `allowedDescendantRoots` — narrow and purpose-built for this feature; the helper still refuses anything else under `/Library`. Covered by new `HelperDeletionPolicyTests` accept tests + production-policy pins.

## Test plan

- [x] 25 new unit tests: `ExtensionItemTests`, `ExtensionDiscoveryTests` (hermetic temp-dir fixtures for all five discoverers, including the `Disabled`-key flip), `ExtensionsManagerViewModelTests` (load / grouping order / remove / failure paths).
- [x] Full suite green: **482 tests, 0 failures** (25 feature tests + 4 new helper-policy tests).
- [x] `xcodebuild build` succeeds with no new warnings.
- [ ] **UI not manually exercised** — this environment denied assistive access and screen-recording permission, so the sidebar/grouped-list/confirmation flow was verified only via the SwiftUI `#Preview`, the build, and unit tests, not by clicking through the running app.
- Note: the `live()` removal path for `/Library` items uses `HelperConnectionManager.shared` and is not driven by the closure-injected tests (same untested-in-tests posture as `SystemJunkDeleter`).

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensions Manager in the sidebar: discovers Safari/Chrome/Firefox extensions, Mail & Internet plugins, login items; supports refresh, remove (with confirmation), progress, empty and error states, and groups items by type.
* **Tests**
  * Unit tests covering discovery, item modeling, view-model state transitions, UI subviews, and privileged-deletion policy.
* **Chores**
  * Expanded privileged-deletion allowlist and updated TODO/documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
