### PR TITLE
feat: Optimization feature (login items, launch agents, RAM, maintenance)

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */; };
 		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
+		04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
@@ -16,12 +17,14 @@
 		109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */; };
 		11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */; };
 		11C7DA0D7ECDCBF7DFB3C829 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 329FBD86F55918272AF0EF2A /* Localizable.stringsdict */; };
+		12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17B889E32D6334AED35F2BE /* LaunchAgent.swift */; };
 		13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */; };
 		1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */; };
 		159F0D7D84A23B27058835D6 /* BrowserDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */; };
 		17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */; };
 		1947460A68C713844C308694 /* TreemapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
+		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
 		218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46943B264F72B3753075A8C /* UpdateInfoTests.swift */; };
 		2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */; };
 		26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */; };
@@ -30,14 +33,18 @@
 		2A28D67DA396B3D2B6DB13D5 /* DiskScannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */; };
 		2A46AEBD95B9E1561264D0F0 /* NotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */; };
 		2A9EFA38DAE2163D06793B46 /* PrivacyCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */; };
+		2AADBFF21DB782577861CB44 /* OptimizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C47AD889D249E865B928C8 /* OptimizationView.swift */; };
 		2B0438D190A4BDCD9853DC7D /* BrowserDataPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */; };
 		2BB370554CD9C84ED37C81A0 /* NotificationThresholdMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */; };
 		2CE84E79268B4A59C5B8FACB /* HealthMonitorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */; };
+		2CF8285ADDBEB285A1DB56AC /* LoginItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F1DC062C52C51730548216 /* LoginItem.swift */; };
 		2DD748D16E344D435A5C3E24 /* HelperRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */; };
 		2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CA7922445475111927C0B /* AppInfo.swift */; };
 		3328707476CC1411FA1270D0 /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D92F45290B56030CBFA83D3 /* Browser.swift */; };
 		3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6697CA6EEE719B2E2D46CE /* AppState.swift */; };
 		35F306676A3412253929EF55 /* TreemapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BDB24525760C96625DD266 /* TreemapView.swift */; };
+		3685B2DC3948B9ACFD86FF71 /* OptimizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDE71332468CC343A9C6091 /* OptimizationViewModel.swift */; };
+		3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */; };
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
@@ -46,6 +53,7 @@
 		3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */; };
 		3B8C348DB1DCBFB89771ADDC /* PrivacyPermissionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */; };
 		3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */; };
+		406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */; };
 		483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */; };
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
@@ -79,6 +87,7 @@
 		7BB62CCBF7BE84455A11531C /* ExtensionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */; };
 		7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2617BC26104D5196DEDB3589 /* UpdateInfo.swift */; };
 		7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */; };
+		7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5CB08F96767D10B1271970 /* RAMManager.swift */; };
 		82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */; };
 		823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */; };
 		832F1B34810FF292EAF9A810 /* PermissionOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */; };
@@ -96,6 +105,7 @@
 		9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */; };
 		9CA467B702E12F278B7BE6DC /* HelperConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43596249B222D18142F961E2 /* HelperConnectionManager.swift */; };
 		A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */; };
+		A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
 		AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC67B639248BC5EA1F5473 /* ScanCategory.swift */; };
 		B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */; };
@@ -123,10 +133,12 @@
 		C9DB75A7B6E045D306393638 /* PrivacyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */; };
 		CF68F2891382E3F3D4CA5474 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */; };
 		D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */; };
+		D04A64F83480761DF5F12344 /* OptimizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669493D60C3958979B97FA04 /* OptimizationViewModelTests.swift */; };
 		D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */; };
 		D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */; };
 		DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */; };
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
+		DD929B8195C7904CB4AC2E62 /* OptimizationViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */; };
 		E0420FF267A637AD7F530407 /* ExtensionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */; };
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */; };
@@ -221,6 +233,7 @@
 		22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateCheckerTests.swift; sourceTree = "<group>"; };
 		25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecisionTests.swift; sourceTree = "<group>"; };
 		2617BC26104D5196DEDB3589 /* UpdateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfo.swift; sourceTree = "<group>"; };
+		27F1DC062C52C51730548216 /* LoginItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItem.swift; sourceTree = "<group>"; };
 		2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModelTests.swift; sourceTree = "<group>"; };
 		2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModel.swift; sourceTree = "<group>"; };
 		2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManager.swift; sourceTree = "<group>"; };
@@ -250,8 +263,10 @@
 		5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecision.swift; sourceTree = "<group>"; };
 		55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionCheckerTests.swift; sourceTree = "<group>"; };
 		57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFile.swift; sourceTree = "<group>"; };
+		59C47AD889D249E865B928C8 /* OptimizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationView.swift; sourceTree = "<group>"; };
 		5CC50A90E584320709971BCB /* ScanCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategoryTests.swift; sourceTree = "<group>"; };
 		5E978BB01AD677AEDE122B1C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemsManagerTests.swift; sourceTree = "<group>"; };
 		5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScannerTests.swift; sourceTree = "<group>"; };
 		6085B6A39985DFF334821551 /* ExclusionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStore.swift; sourceTree = "<group>"; };
@@ -259,6 +274,7 @@
 		613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModel.swift; sourceTree = "<group>"; };
 		63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModel.swift; sourceTree = "<group>"; };
 		65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateChecker.swift; sourceTree = "<group>"; };
+		669493D60C3958979B97FA04 /* OptimizationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewModelTests.swift; sourceTree = "<group>"; };
 		6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScannerTests.swift; sourceTree = "<group>"; };
 		67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewSubviews.swift; sourceTree = "<group>"; };
 		673CA7922445475111927C0B /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
@@ -267,7 +283,9 @@
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
 		6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerUITests.swift; sourceTree = "<group>"; };
 		6CBCA8999E04715E502AB892 /* VaderCleanerHelper */ = {isa = PBXFileReference; includeInIndex = 0; path = VaderCleanerHelper; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DDE71332468CC343A9C6091 /* OptimizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewModel.swift; sourceTree = "<group>"; };
 		6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingView.swift; sourceTree = "<group>"; };
+		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
 		80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayoutTests.swift; sourceTree = "<group>"; };
@@ -289,6 +307,7 @@
 		98D7B18095634307C5D7223D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItem.swift; sourceTree = "<group>"; };
+		9D5CB08F96767D10B1271970 /* RAMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManager.swift; sourceTree = "<group>"; };
 		9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScanner.swift; sourceTree = "<group>"; };
 		9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFilesPathProviding.swift; sourceTree = "<group>"; };
 		A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategoryTests.swift; sourceTree = "<group>"; };
@@ -297,7 +316,9 @@
 		A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviderTests.swift; sourceTree = "<group>"; };
 		A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkView.swift; sourceTree = "<group>"; };
 		AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorView.swift; sourceTree = "<group>"; };
+		AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunner.swift; sourceTree = "<group>"; };
 		B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedFile.swift; sourceTree = "<group>"; };
+		B17B889E32D6334AED35F2BE /* LaunchAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgent.swift; sourceTree = "<group>"; };
 		B2E92F45C5CC0EEA00B12EF5 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		B39407E2EA6D045893F1BA4B /* DiskNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskNode.swift; sourceTree = "<group>"; };
 		B3CD8C98E8253953444DD99F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
@@ -307,6 +328,7 @@
 		BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScanner.swift; sourceTree = "<group>"; };
 		BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModelTests.swift; sourceTree = "<group>"; };
 		BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModelTests.swift; sourceTree = "<group>"; };
+		C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewSubviews.swift; sourceTree = "<group>"; };
 		C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
 		C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinderTests.swift; sourceTree = "<group>"; };
 		C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScanner.swift; sourceTree = "<group>"; };
@@ -331,10 +353,12 @@
 		E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearerTests.swift; sourceTree = "<group>"; };
 		EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSystemPathProviderTests.swift; sourceTree = "<group>"; };
 		ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModel.swift; sourceTree = "<group>"; };
+		F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunnerTests.swift; sourceTree = "<group>"; };
 		F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManagerTests.swift; sourceTree = "<group>"; };
 		F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleterTests.swift; sourceTree = "<group>"; };
 		F421495C84A41EDEF253EBD6 /* FileCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategory.swift; sourceTree = "<group>"; };
 		FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VaderCleaner.entitlements; sourceTree = "<group>"; };
+		FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManagerTests.swift; sourceTree = "<group>"; };
 		FE6697CA6EEE719B2E2D46CE /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -418,12 +442,18 @@
 				93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */,
 				E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */,
 				1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */,
+				B17B889E32D6334AED35F2BE /* LaunchAgent.swift */,
+				27F1DC062C52C51730548216 /* LoginItem.swift */,
 				5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */,
+				AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */,
 				D2C2B92863509818189F46CD /* MenuBarContent.swift */,
 				8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */,
 				2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */,
 				B3CD8C98E8253953444DD99F /* NotificationManager.swift */,
 				0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */,
+				59C47AD889D249E865B928C8 /* OptimizationView.swift */,
+				6DDE71332468CC343A9C6091 /* OptimizationViewModel.swift */,
+				C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */,
 				6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */,
 				2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */,
 				E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */,
@@ -433,6 +463,7 @@
 				C751F5671E4A4657944A7DFC /* PrivacyView.swift */,
 				90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */,
 				67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */,
+				9D5CB08F96767D10B1271970 /* RAMManager.swift */,
 				2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */,
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
 				B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */,
@@ -516,16 +547,21 @@
 				1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */,
 				603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */,
 				BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */,
+				FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */,
 				1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */,
+				5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */,
+				F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */,
 				CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */,
 				133467A06193C406B027D97C /* NavigationSectionTests.swift */,
 				C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */,
 				DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */,
+				669493D60C3958979B97FA04 /* OptimizationViewModelTests.swift */,
 				7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */,
 				6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */,
 				8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */,
 				55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */,
 				2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */,
+				78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */,
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
@@ -716,16 +752,21 @@
 				57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */,
 				50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */,
 				2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */,
+				04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */,
 				8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */,
+				406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */,
+				1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */,
 				C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */,
 				BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */,
 				2A46AEBD95B9E1561264D0F0 /* NotificationManagerTests.swift in Sources */,
 				2BB370554CD9C84ED37C81A0 /* NotificationThresholdMonitorTests.swift in Sources */,
+				D04A64F83480761DF5F12344 /* OptimizationViewModelTests.swift in Sources */,
 				5F2AB607564A60D0DCBFABEC /* PermissionOnboardingViewModelTests.swift in Sources */,
 				1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */,
 				2A9EFA38DAE2163D06793B46 /* PrivacyCategoryTests.swift in Sources */,
 				3B8C348DB1DCBFB89771ADDC /* PrivacyPermissionCheckerTests.swift in Sources */,
 				C9DB75A7B6E045D306393638 /* PrivacyViewModelTests.swift in Sources */,
+				3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */,
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
@@ -808,12 +849,18 @@
 				E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */,
 				91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */,
 				483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */,
+				12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */,
+				2CF8285ADDBEB285A1DB56AC /* LoginItem.swift in Sources */,
 				EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */,
+				A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */,
 				BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */,
 				C2F35144C0139C8829C4BB8A /* MenuBarViewModel.swift in Sources */,
 				F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */,
 				65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */,
 				B60909E266277B691B876E63 /* NotificationThresholdMonitor.swift in Sources */,
+				2AADBFF21DB782577861CB44 /* OptimizationView.swift in Sources */,
+				3685B2DC3948B9ACFD86FF71 /* OptimizationViewModel.swift in Sources */,
+				DD929B8195C7904CB4AC2E62 /* OptimizationViewSubviews.swift in Sources */,
 				832F1B34810FF292EAF9A810 /* PermissionOnboardingView.swift in Sources */,
 				834DC89A0BA1ED2A0B5B33CB /* PermissionOnboardingViewModel.swift in Sources */,
 				FF87A6FAB563AF43345061BB /* PreferencesStore.swift in Sources */,
@@ -823,6 +870,7 @@
 				7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */,
 				63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */,
 				5C240506F97A777E37CA25B2 /* PrivacyViewSubviews.swift in Sources */,
+				7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */,
 				567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */,
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
 		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
+		7B4A89F26C67D0A6372E2A78 /* OptimizationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22622AEBD53221D89CB1439D /* OptimizationUITests.swift */; };
 		7BB62CCBF7BE84455A11531C /* ExtensionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */; };
 		7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2617BC26104D5196DEDB3589 /* UpdateInfo.swift */; };
 		7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */; };
@@ -230,6 +231,7 @@
 		1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocatorTests.swift; sourceTree = "<group>"; };
 		1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManagerTests.swift; sourceTree = "<group>"; };
 		22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperRegistration.swift; sourceTree = "<group>"; };
+		22622AEBD53221D89CB1439D /* OptimizationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationUITests.swift; sourceTree = "<group>"; };
 		22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateCheckerTests.swift; sourceTree = "<group>"; };
 		25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecisionTests.swift; sourceTree = "<group>"; };
 		2617BC26104D5196DEDB3589 /* UpdateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfo.swift; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 		6A2D96C9C63AD506553F0BE0 /* VaderCleanerUITests */ = {
 			isa = PBXGroup;
 			children = (
+				22622AEBD53221D89CB1439D /* OptimizationUITests.swift */,
 				0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */,
 				4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */,
 				6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */,
@@ -797,6 +800,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B4A89F26C67D0A6372E2A78 /* OptimizationUITests.swift in Sources */,
 				26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */,
 				E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */,
 				28B2F4C32E608BD283DB2DE5 /* VaderCleanerUITests.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     private let appUninstallerViewModel: AppUninstallerViewModel
     private let appUpdaterViewModel: AppUpdaterViewModel
     private let extensionsManagerViewModel: ExtensionsManagerViewModel
+    private let optimizationViewModel: OptimizationViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
@@ -30,7 +31,8 @@ struct ContentView: View {
         privacyViewModel: PrivacyViewModel,
         appUninstallerViewModel: AppUninstallerViewModel,
         appUpdaterViewModel: AppUpdaterViewModel,
-        extensionsManagerViewModel: ExtensionsManagerViewModel
+        extensionsManagerViewModel: ExtensionsManagerViewModel,
+        optimizationViewModel: OptimizationViewModel
     ) {
         self.systemJunkViewModel = systemJunkViewModel
         self.largeOldFilesViewModel = largeOldFilesViewModel
@@ -39,6 +41,7 @@ struct ContentView: View {
         self.appUninstallerViewModel = appUninstallerViewModel
         self.appUpdaterViewModel = appUpdaterViewModel
         self.extensionsManagerViewModel = extensionsManagerViewModel
+        self.optimizationViewModel = optimizationViewModel
     }
 
     var body: some View {
@@ -112,6 +115,8 @@ struct ContentView: View {
             AppUpdaterView(viewModel: appUpdaterViewModel)
         case .extensions:
             ExtensionsManagerView(viewModel: extensionsManagerViewModel)
+        case .optimization:
+            OptimizationView(viewModel: optimizationViewModel)
         default:
             PlaceholderDetailView(section: section)
         }
@@ -162,7 +167,8 @@ private struct PlaceholderDetailView: View {
         privacyViewModel: PrivacyViewModel.live(),
         appUninstallerViewModel: AppUninstallerViewModel.live(),
         appUpdaterViewModel: AppUpdaterViewModel.live(),
-        extensionsManagerViewModel: ExtensionsManagerViewModel.live()
+        extensionsManagerViewModel: ExtensionsManagerViewModel.live(),
+        optimizationViewModel: OptimizationViewModel.live(systemStats: stats)
     )
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())

--- a/VaderCleaner/LaunchAgent.swift
+++ b/VaderCleaner/LaunchAgent.swift
@@ -114,6 +114,10 @@ struct LaunchAgentManager {
                     // differ from the plist `Disabled` key — an agent may be
                     // loaded transiently without being enabled on disk — but
                     // loaded status is what reflects the running system.
+                    // Authoritative for user agents only: `launchctl list`
+                    // runs in the user's bootstrap and cannot enumerate
+                    // system daemons, so this is best-effort for `.system`
+                    // and the UI must not present it as a definitive badge.
                     isEnabled: loaded.contains(label),
                     domain: domain
                 ))

--- a/VaderCleaner/LaunchAgent.swift
+++ b/VaderCleaner/LaunchAgent.swift
@@ -1,0 +1,268 @@
+// LaunchAgent.swift
+// Launch-agent / launch-daemon model and manager — discovers plists, reports launchctl-loaded status, and disables or removes them (user in-process, system via the privileged helper).
+
+import Foundation
+import os.log
+
+/// A launchd job discovered under a LaunchAgents/LaunchDaemons directory.
+struct LaunchAgent: Identifiable, Equatable {
+
+    /// Where the plist lives — drives the disable/remove privilege split.
+    enum Domain: Equatable {
+        case user
+        case system
+    }
+
+    /// The plist path is the stable identity: two jobs can legitimately
+    /// share a `Label`, but never a path.
+    var id: String { path.path }
+
+    let label: String
+    let path: URL
+    let programPath: String?
+    let isEnabled: Bool
+    let domain: Domain
+}
+
+/// Discovers and manages launchd jobs for the Optimization feature.
+///
+/// Collaborators (filesystem roots, `launchctl`, the loaded-label query, and
+/// the privileged helper) are injected so the manager is unit-testable
+/// without touching real launchd state.
+struct LaunchAgentManager {
+
+    typealias LoadedLabelsProvider = () -> Set<String>
+    typealias LaunchctlRunner = (_ arguments: [String]) throws -> Void
+    typealias HelperProvider = (@escaping (Error) -> Void) -> VaderCleanerHelperProtocol?
+
+    private let userAgentsDirectory: URL
+    private let systemAgentDirectories: [URL]
+    private let fileManager: FileManager
+    private let loadedLabels: LoadedLabelsProvider
+    private let launchctl: LaunchctlRunner
+    private let helperProvider: HelperProvider
+
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "LaunchAgentManager")
+
+    init(
+        userAgentsDirectory: URL = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true),
+        systemAgentDirectories: [URL] = [
+            URL(fileURLWithPath: "/Library/LaunchAgents", isDirectory: true),
+            URL(fileURLWithPath: "/Library/LaunchDaemons", isDirectory: true)
+        ],
+        fileManager: FileManager = .default,
+        loadedLabels: @escaping LoadedLabelsProvider = LaunchAgentManager.defaultLoadedLabels,
+        launchctl: @escaping LaunchctlRunner = LaunchAgentManager.defaultLaunchctl,
+        helperProvider: @escaping HelperProvider = SystemJunkDeleter.defaultHelperProvider
+    ) {
+        self.userAgentsDirectory = userAgentsDirectory
+        self.systemAgentDirectories = systemAgentDirectories
+        self.fileManager = fileManager
+        self.loadedLabels = loadedLabels
+        self.launchctl = launchctl
+        self.helperProvider = helperProvider
+    }
+
+    // MARK: - Discovery
+
+    /// Every `*.plist` under the user's `~/Library/LaunchAgents`.
+    func userAgents() -> [LaunchAgent] {
+        agents(in: [userAgentsDirectory], domain: .user)
+    }
+
+    /// Every `*.plist` under the system `/Library/LaunchAgents` and
+    /// `/Library/LaunchDaemons` roots.
+    func systemAgents() -> [LaunchAgent] {
+        agents(in: systemAgentDirectories, domain: .system)
+    }
+
+    private func agents(in roots: [URL], domain: LaunchAgent.Domain) -> [LaunchAgent] {
+        // Snapshot the loaded set once per pass rather than shelling out to
+        // launchctl for every plist.
+        let loaded = loadedLabels()
+        var seen = Set<String>()
+        var result: [LaunchAgent] = []
+
+        for dir in roots {
+            guard fileManager.fileExists(atPath: dir.path) else { continue }
+            let entries = (try? fileManager.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )) ?? []
+
+            for entry in entries where entry.pathExtension.lowercased() == "plist" {
+                guard seen.insert(entry.path).inserted else { continue }
+                let plist = (try? Data(contentsOf: entry)).flatMap {
+                    try? PropertyListSerialization.propertyList(
+                        from: $0, options: [], format: nil
+                    ) as? [String: Any]
+                } ?? [:]
+
+                let label = (plist["Label"] as? String).flatMap {
+                    $0.isEmpty ? nil : $0
+                } ?? entry.deletingPathExtension().lastPathComponent
+
+                result.append(LaunchAgent(
+                    label: label,
+                    path: entry,
+                    programPath: Self.programPath(from: plist),
+                    // "Loaded" (launchctl) is the spec's chosen signal. It can
+                    // differ from the plist `Disabled` key — an agent may be
+                    // loaded transiently without being enabled on disk — but
+                    // loaded status is what reflects the running system.
+                    isEnabled: loaded.contains(label),
+                    domain: domain
+                ))
+            }
+        }
+        return result
+    }
+
+    // MARK: - Disable
+
+    /// Unloads the job from launchd via `launchctl unload <path>`. User agents
+    /// live in the caller's own launchd domain, so this needs no privilege
+    /// escalation.
+    func disable(_ agent: LaunchAgent) throws {
+        try launchctl(["unload", agent.path.path])
+    }
+
+    // MARK: - Remove
+
+    /// Deletes the plist. User-domain plists are user-writable and removed
+    /// in-process; system-domain plists under `/Library` require root and are
+    /// routed through the privileged helper's `removeLaunchAgent(path:)`.
+    func remove(_ agent: LaunchAgent) async throws {
+        switch agent.domain {
+        case .user:
+            try fileManager.removeItem(at: agent.path)
+        case .system:
+            try await removeViaHelper(path: agent.path.path)
+        }
+    }
+
+    /// Bridges the reply-block helper call to async/throwing. Installs both
+    /// the per-call XPC error handler and the reply block so a dropped
+    /// connection can't freeze removal — whichever fires first wins via the
+    /// once-only `Resumer`.
+    private func removeViaHelper(path: String) async throws {
+        let error: Error? = await withCheckedContinuation { continuation in
+            let resumer = LaunchAgentResumer(continuation: continuation)
+            let helper = helperProvider { connectionError in
+                resumer.resume(with: connectionError)
+            }
+            guard let helper else {
+                resumer.resume(with: NSError(
+                    domain: "com.personal.VaderCleaner.LaunchAgentManager",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Helper unavailable"]
+                ))
+                return
+            }
+            helper.removeLaunchAgent(path: path) { replyError in
+                resumer.resume(with: replyError)
+            }
+        }
+        if let error {
+            log.error("Helper launch-agent removal failed: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
+    // MARK: - Parsing
+
+    /// Parses `launchctl list` output into the set of loaded job labels. The
+    /// command emits a `PID\tStatus\tLabel` header followed by tab-separated
+    /// rows; the label is always the final column.
+    static func parseLoadedLabels(from output: String) -> Set<String> {
+        var labels = Set<String>()
+        for line in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let columns = line.split(separator: "\t", omittingEmptySubsequences: false)
+            guard let last = columns.last else { continue }
+            let label = last.trimmingCharacters(in: .whitespaces)
+            if label.isEmpty || label == "Label" { continue }
+            labels.insert(label)
+        }
+        return labels
+    }
+
+    /// The job's executable: the `Program` key, else the first element of
+    /// `ProgramArguments`.
+    static func programPath(from plist: [String: Any]) -> String? {
+        if let program = plist["Program"] as? String, !program.isEmpty {
+            return program
+        }
+        if let arguments = plist["ProgramArguments"] as? [String],
+           let first = arguments.first, !first.isEmpty {
+            return first
+        }
+        return nil
+    }
+
+    // MARK: - Production collaborators
+
+    /// Runs `/bin/launchctl list` and parses the loaded labels. Returns an
+    /// empty set on any failure — a missing label just renders as "disabled".
+    static let defaultLoadedLabels: LoadedLabelsProvider = {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["list"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            let output = String(data: data, encoding: .utf8) ?? ""
+            return LaunchAgentManager.parseLoadedLabels(from: output)
+        } catch {
+            return []
+        }
+    }
+
+    /// Runs `/bin/launchctl` with the given arguments, throwing on a non-zero
+    /// exit so `disable` surfaces the failure.
+    static let defaultLaunchctl: LaunchctlRunner = { arguments in
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = arguments
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw NSError(
+                domain: "com.personal.VaderCleaner.LaunchAgentManager",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey:
+                    "launchctl \(arguments.joined(separator: " ")) exited with status \(process.terminationStatus)"]
+            )
+        }
+    }
+}
+
+/// Once-only continuation resume — the XPC reply block and the connection
+/// error handler may both fire; `CheckedContinuation` traps on a second
+/// resume, so the first wins and later attempts are dropped. Mirrors the same
+/// guard used by `SystemJunkDeleter`.
+private final class LaunchAgentResumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: error)
+    }
+}

--- a/VaderCleaner/LaunchAgent.swift
+++ b/VaderCleaner/LaunchAgent.swift
@@ -90,12 +90,17 @@ struct LaunchAgentManager {
             guard fileManager.fileExists(atPath: dir.path) else { continue }
             let entries = (try? fileManager.contentsOfDirectory(
                 at: dir,
-                includingPropertiesForKeys: nil,
+                includingPropertiesForKeys: [.isRegularFileKey],
                 options: [.skipsHiddenFiles]
             )) ?? []
 
             for entry in entries where entry.pathExtension.lowercased() == "plist" {
-                guard seen.insert(entry.path).inserted else { continue }
+                // A directory named `*.plist` is not a launch agent; only
+                // regular files carry a launchd job definition.
+                let isRegularFile = (try? entry.resourceValues(
+                    forKeys: [.isRegularFileKey]
+                ))?.isRegularFile ?? false
+                guard isRegularFile, seen.insert(entry.path).inserted else { continue }
                 let plist = (try? Data(contentsOf: entry)).flatMap {
                     try? PropertyListSerialization.propertyList(
                         from: $0, options: [], format: nil
@@ -217,7 +222,9 @@ struct LaunchAgentManager {
         process.arguments = ["list"]
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        // Discard stderr rather than wiring an unread Pipe — an unread pipe
+        // whose buffer fills would deadlock `launchctl`.
+        process.standardError = FileHandle.nullDevice
         do {
             try process.run()
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
@@ -235,16 +242,25 @@ struct LaunchAgentManager {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
         process.arguments = arguments
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
+        // stdout is unused; discard it. stderr is read *before*
+        // `waitUntilExit()` so a chatty failure can't deadlock the process
+        // on a full pipe buffer, and is surfaced in the thrown error.
+        let errorPipe = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errorPipe
         try process.run()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         if process.terminationStatus != 0 {
+            let stderr = String(data: errorData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let description = stderr.isEmpty
+                ? "launchctl \(arguments.joined(separator: " ")) exited with status \(process.terminationStatus)"
+                : stderr
             throw NSError(
                 domain: "com.personal.VaderCleaner.LaunchAgentManager",
                 code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey:
-                    "launchctl \(arguments.joined(separator: " ")) exited with status \(process.terminationStatus)"]
+                userInfo: [NSLocalizedDescriptionKey: description]
             )
         }
     }

--- a/VaderCleaner/LoginItem.swift
+++ b/VaderCleaner/LoginItem.swift
@@ -1,0 +1,77 @@
+// LoginItem.swift
+// Login-item model and SMAppService-backed manager for the Optimization feature's Login Items section.
+
+import Foundation
+import ServiceManagement
+
+/// A single managed login item shown in the Optimization view.
+struct LoginItem: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let isEnabled: Bool
+}
+
+/// Surfaces and toggles login items through `SMAppService`.
+///
+/// macOS exposes no public API to *enumerate* login items registered by other
+/// applications — `SMAppService` can only report the status of the host app's
+/// own registration (`SMAppService.mainApp`). Third-party "open at login"
+/// agents physically live in `~/Library/LaunchAgents` and are surfaced by
+/// `LaunchAgentManager` instead. This manager therefore covers exactly what
+/// `SMAppService` can truthfully report: the host app itself. Collaborators
+/// are injected as closures so tests never mutate real login-item state.
+struct LoginItemsManager {
+
+    typealias StatusProvider = () -> SMAppService.Status
+    typealias SetEnabledHandler = (Bool) throws -> Void
+
+    private let displayName: String
+    private let identifier: String
+    private let statusProvider: StatusProvider
+    private let setEnabledHandler: SetEnabledHandler
+
+    init(
+        displayName: String,
+        identifier: String,
+        statusProvider: @escaping StatusProvider,
+        setEnabledHandler: @escaping SetEnabledHandler
+    ) {
+        self.displayName = displayName
+        self.identifier = identifier
+        self.statusProvider = statusProvider
+        self.setEnabledHandler = setEnabledHandler
+    }
+
+    /// The host app's login item, reflecting the live `SMAppService` status so
+    /// a change made in System Settings → Login Items is picked up on refresh.
+    func items() -> [LoginItem] {
+        [
+            LoginItem(
+                id: identifier,
+                name: displayName,
+                isEnabled: statusProvider() == .enabled
+            )
+        ]
+    }
+
+    /// Registers or unregisters the host app as a login item.
+    func setEnabled(_ enabled: Bool, for item: LoginItem) throws {
+        try setEnabledHandler(enabled)
+    }
+}
+
+extension LoginItemsManager {
+
+    /// Production manager bound to `SMAppService.mainApp` via the existing
+    /// idempotent `LoginItemManager` wrapper, so toggling here behaves exactly
+    /// like the Preferences "Launch at Login" control.
+    static func live() -> LoginItemsManager {
+        LoginItemsManager(
+            displayName: Bundle.main.infoDictionary?["CFBundleName"] as? String
+                ?? "VaderCleaner",
+            identifier: Bundle.main.bundleIdentifier ?? "com.personal.VaderCleaner",
+            statusProvider: { SMAppService.mainApp.status },
+            setEnabledHandler: { try LoginItemManager.setEnabled($0) }
+        )
+    }
+}

--- a/VaderCleaner/MaintenanceScriptRunner.swift
+++ b/VaderCleaner/MaintenanceScriptRunner.swift
@@ -51,7 +51,7 @@ struct MaintenanceScriptRunner {
             throw error
         }
         return String(
-            localized: "Ran maintenance scripts: periodic daily weekly monthly. Detailed output is written to /var/log/daily.out, weekly.out, and monthly.out.",
+            localized: "Ran maintenance scripts: periodic daily weekly monthly. Detailed output is written to /var/log/daily.out, /var/log/weekly.out, and /var/log/monthly.out.",
             comment: "Result line shown after the system maintenance scripts complete."
         )
     }

--- a/VaderCleaner/MaintenanceScriptRunner.swift
+++ b/VaderCleaner/MaintenanceScriptRunner.swift
@@ -1,0 +1,78 @@
+// MaintenanceScriptRunner.swift
+// Bridges the privileged runMaintenanceScripts XPC call (periodic daily weekly monthly) to async/throwing and returns a result line.
+
+import Foundation
+import os.log
+
+/// Runs the system maintenance scripts via the privileged helper.
+///
+/// The XPC protocol's `runMaintenanceScripts(reply:)` reports only success or
+/// failure — `periodic daily weekly monthly` writes its real output to
+/// `/var/log/{daily,weekly,monthly}.out`, not stdout, and the selector is
+/// frozen (pinned by `HelperProtocolTests`). So `run()` returns a
+/// human-readable *result line* for the UI's output log rather than the
+/// scripts' stdout.
+struct MaintenanceScriptRunner {
+
+    typealias HelperProvider = (@escaping (Error) -> Void) -> VaderCleanerHelperProtocol?
+
+    private let helperProvider: HelperProvider
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "MaintenanceScriptRunner")
+
+    init(helperProvider: @escaping HelperProvider = SystemJunkDeleter.defaultHelperProvider) {
+        self.helperProvider = helperProvider
+    }
+
+    /// Asks the helper to run the maintenance scripts. Installs both the
+    /// per-call XPC error handler and the reply block so a dropped connection
+    /// can't freeze the UI. Returns a result line on success; throws on any
+    /// failure (including an unreachable helper).
+    func run() async throws -> String {
+        let error: Error? = await withCheckedContinuation { continuation in
+            let resumer = MaintenanceResumer(continuation: continuation)
+            let helper = helperProvider { connectionError in
+                resumer.resume(with: connectionError)
+            }
+            guard let helper else {
+                resumer.resume(with: NSError(
+                    domain: "com.personal.VaderCleaner.MaintenanceScriptRunner",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Helper unavailable"]
+                ))
+                return
+            }
+            helper.runMaintenanceScripts { replyError in
+                resumer.resume(with: replyError)
+            }
+        }
+        if let error {
+            log.error("Maintenance scripts failed: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+        return String(
+            localized: "Ran maintenance scripts: periodic daily weekly monthly. Detailed output is written to /var/log/daily.out, weekly.out, and monthly.out.",
+            comment: "Result line shown after the system maintenance scripts complete."
+        )
+    }
+}
+
+/// Once-only continuation resume — see `SystemJunkDeleter.Resumer`. Both the
+/// XPC reply block and the connection error handler may fire and
+/// `CheckedContinuation` traps on a second resume.
+private final class MaintenanceResumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: error)
+    }
+}

--- a/VaderCleaner/OptimizationView.swift
+++ b/VaderCleaner/OptimizationView.swift
@@ -1,0 +1,189 @@
+// OptimizationView.swift
+// Optimization feature view — login items, launch agents (user/system), RAM flush, and system maintenance scripts.
+
+import SwiftUI
+
+/// Detail view shown when the user selects "Optimization" in the sidebar.
+/// Four sections — Login Items, Launch Agents, RAM, Maintenance Scripts —
+/// driven by `OptimizationViewModel`'s state machine.
+struct OptimizationView: View {
+
+    @ObservedObject private var viewModel: OptimizationViewModel
+    @State private var pendingRemoval: LaunchAgent?
+
+    init(viewModel: OptimizationViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(NavigationSection.optimization.title)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        Task { await viewModel.refresh() }
+                    } label: {
+                        Label(String(
+                            localized: "Refresh",
+                            comment: "Toolbar button that reloads Optimization data."
+                        ), systemImage: "arrow.clockwise")
+                    }
+                    .disabled(viewModel.phase == .loading || viewModel.phase == .working)
+                    .accessibilityIdentifier("optimization.refresh")
+                }
+            }
+            .task {
+                if viewModel.phase == .idle {
+                    await viewModel.refresh()
+                }
+            }
+            .alert(
+                String(
+                    localized: "Remove this launch agent?",
+                    comment: "Alert title asking the user to confirm removing a launch agent."
+                ),
+                isPresented: Binding(
+                    get: { pendingRemoval != nil },
+                    set: { if !$0 { pendingRemoval = nil } }
+                )
+            ) {
+                Button(String(
+                    localized: "Cancel",
+                    comment: "Cancel button on the launch-agent removal confirmation alert."
+                ), role: .cancel) {
+                    pendingRemoval = nil
+                }
+                Button(String(
+                    localized: "Remove",
+                    comment: "Confirm-removal button on the launch-agent removal confirmation alert."
+                ), role: .destructive) {
+                    if let agent = pendingRemoval {
+                        pendingRemoval = nil
+                        Task { await viewModel.remove(agent) }
+                    }
+                }
+            } message: {
+                Text(removalConfirmationMessage)
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.phase {
+        case .idle, .loading:
+            OptimizationProgressState(
+                label: String(
+                    localized: "Loading optimization data…",
+                    comment: "Progress label while the Optimization view loads."
+                ),
+                identifier: "optimization.loading"
+            )
+        case .working:
+            OptimizationProgressState(
+                label: String(
+                    localized: "Working…",
+                    comment: "Progress label while an Optimization action runs."
+                ),
+                identifier: "optimization.working"
+            )
+        case .ready:
+            sections
+        case .failed(let message):
+            OptimizationFailedState(message: message) {
+                viewModel.dismissResult()
+            }
+        }
+    }
+
+    private var sections: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                OptimizationLoginItemsSection(
+                    items: viewModel.loginItems,
+                    onToggle: { item, enabled in
+                        Task { await viewModel.setLoginItem(item, enabled: enabled) }
+                    }
+                )
+                OptimizationLaunchAgentsSection(
+                    title: String(
+                        localized: "Launch Agents (User)",
+                        comment: "Section header for user launch agents."
+                    ),
+                    identifier: "optimization.userAgents",
+                    agents: viewModel.userAgents,
+                    onDisable: { agent in Task { await viewModel.disable(agent) } },
+                    onRemove: { pendingRemoval = $0 }
+                )
+                OptimizationLaunchAgentsSection(
+                    title: String(
+                        localized: "Launch Agents & Daemons (System)",
+                        comment: "Section header for system launch agents and daemons."
+                    ),
+                    identifier: "optimization.systemAgents",
+                    agents: viewModel.systemAgents,
+                    onDisable: { agent in Task { await viewModel.disable(agent) } },
+                    onRemove: { pendingRemoval = $0 }
+                )
+                OptimizationRAMSection(
+                    memory: viewModel.memory,
+                    result: viewModel.ramResult,
+                    onFlush: { Task { await viewModel.flushRAM() } }
+                )
+                OptimizationMaintenanceSection(
+                    output: viewModel.maintenanceOutput,
+                    onRun: { Task { await viewModel.runMaintenanceScripts() } }
+                )
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var removalConfirmationMessage: String {
+        if let agent = pendingRemoval {
+            let format = String(
+                localized: "%@ will be permanently deleted from disk. This cannot be undone.",
+                comment: "Alert message confirming a launch-agent removal; %@ is the agent label."
+            )
+            return String.localizedStringWithFormat(format, agent.label)
+        }
+        return String(
+            localized: "The selected launch agent will be permanently deleted from disk.",
+            comment: "Fallback alert message confirming a launch-agent removal."
+        )
+    }
+}
+
+#Preview {
+    OptimizationView(viewModel: OptimizationViewModel(
+        loadLoginItems: {
+            [LoginItem(id: "com.personal.VaderCleaner", name: "VaderCleaner", isEnabled: true)]
+        },
+        loadUserAgents: {
+            [LaunchAgent(
+                label: "com.acme.updater",
+                path: URL(fileURLWithPath: "/Users/me/Library/LaunchAgents/com.acme.updater.plist"),
+                programPath: "/Applications/Acme.app/Contents/Helpers/updater",
+                isEnabled: true,
+                domain: .user
+            )]
+        },
+        loadSystemAgents: {
+            [LaunchAgent(
+                label: "com.vendor.daemon",
+                path: URL(fileURLWithPath: "/Library/LaunchDaemons/com.vendor.daemon.plist"),
+                programPath: "/usr/local/bin/vendord",
+                isEnabled: false,
+                domain: .system
+            )]
+        },
+        readMemory: { MemoryStats(usedBytes: 12_000_000_000, totalBytes: 16_000_000_000) },
+        setLoginItemEnabled: { _, _ in },
+        disableAgent: { _ in },
+        removeAgent: { _ in },
+        flushRAM: {},
+        runMaintenance: { "Ran maintenance scripts." }
+    ))
+    .frame(width: 900, height: 600)
+}

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -25,8 +25,8 @@ final class OptimizationViewModel: ObservableObject {
     typealias LoadLoginItems = () async -> [LoginItem]
     typealias LoadAgents = () async -> [LaunchAgent]
     typealias ReadMemory = @MainActor () -> MemoryStats
-    typealias SetLoginItemEnabled = (Bool, LoginItem) throws -> Void
-    typealias DisableAgent = (LaunchAgent) throws -> Void
+    typealias SetLoginItemEnabled = (Bool, LoginItem) async throws -> Void
+    typealias DisableAgent = (LaunchAgent) async throws -> Void
     typealias RemoveAgent = (LaunchAgent) async throws -> Void
     typealias FlushRAM = () async throws -> Void
     typealias RunMaintenance = () async throws -> String
@@ -148,7 +148,7 @@ final class OptimizationViewModel: ObservableObject {
     func setLoginItem(_ item: LoginItem, enabled: Bool) async {
         phase = .working
         do {
-            try setLoginItemEnabled(enabled, item)
+            try await setLoginItemEnabled(enabled, item)
             loginItems = await loadLoginItems()
             phase = .ready
         } catch {
@@ -164,7 +164,7 @@ final class OptimizationViewModel: ObservableObject {
     func disable(_ agent: LaunchAgent) async {
         phase = .working
         do {
-            try disableAgent(agent)
+            try await disableAgent(agent)
             async let user = loadUserAgents()
             async let system = loadSystemAgents()
             let (reloadedUser, reloadedSystem) = await (user, system)
@@ -241,10 +241,20 @@ extension OptimizationViewModel {
                 systemStats.refresh()
                 return systemStats.ramUsage
             },
+            // Offloaded like the discovery loaders: SMAppService
+            // register/unregister and `launchctl unload` both block the
+            // calling thread, so running them inline would stall the
+            // main-actor view-model if launchd is slow.
             setLoginItemEnabled: { enabled, item in
-                try loginManager.setEnabled(enabled, for: item)
+                try await Task.detached(priority: .userInitiated) {
+                    try loginManager.setEnabled(enabled, for: item)
+                }.value
             },
-            disableAgent: { try agentManager.disable($0) },
+            disableAgent: { agent in
+                try await Task.detached(priority: .userInitiated) {
+                    try agentManager.disable(agent)
+                }.value
+            },
             removeAgent: { try await agentManager.remove($0) },
             flushRAM: { try await ram.flush() },
             runMaintenance: { try await maintenance.run() }

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -234,7 +234,13 @@ extension OptimizationViewModel {
                     agentManager.systemAgents()
                 }.value
             },
-            readMemory: { systemStats.ramUsage },
+            // Force a synchronous re-read rather than returning the last
+            // polled value: after a `purge` the 2 s poll would otherwise
+            // report pre-flush usage until the next tick.
+            readMemory: {
+                systemStats.refresh()
+                return systemStats.ramUsage
+            },
             setLoginItemEnabled: { enabled, item in
                 try loginManager.setEnabled(enabled, for: item)
             },

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -1,0 +1,247 @@
+// OptimizationViewModel.swift
+// State machine behind the Optimization view — loads login items + launch agents + RAM, and drives RAM flush, maintenance scripts, login-item toggle, and agent disable/remove through injected collaborators.
+
+import Foundation
+import os.log
+
+/// Drives the Optimization feature view. Collaborators are injected as
+/// closures so unit tests can exercise every transition without touching
+/// real login-item / launchd / privileged-helper state. Production wiring
+/// lives in `OptimizationViewModel.live()`.
+@MainActor
+final class OptimizationViewModel: ObservableObject {
+
+    /// Discrete phases the view binds to. `working` covers any one-shot
+    /// action (flush, maintenance, toggle, disable, remove); `failed` carries
+    /// the message to surface.
+    enum Phase: Equatable {
+        case idle
+        case loading
+        case ready
+        case working
+        case failed(message: String)
+    }
+
+    typealias LoadLoginItems = () async -> [LoginItem]
+    typealias LoadAgents = () async -> [LaunchAgent]
+    typealias ReadMemory = @MainActor () -> MemoryStats
+    typealias SetLoginItemEnabled = (Bool, LoginItem) throws -> Void
+    typealias DisableAgent = (LaunchAgent) throws -> Void
+    typealias RemoveAgent = (LaunchAgent) async throws -> Void
+    typealias FlushRAM = () async throws -> Void
+    typealias RunMaintenance = () async throws -> String
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var loginItems: [LoginItem] = []
+    @Published private(set) var userAgents: [LaunchAgent] = []
+    @Published private(set) var systemAgents: [LaunchAgent] = []
+    @Published private(set) var memory: MemoryStats = .empty
+    @Published private(set) var ramResult: String?
+    @Published private(set) var maintenanceOutput: String?
+
+    private let loadLoginItems: LoadLoginItems
+    private let loadUserAgents: LoadAgents
+    private let loadSystemAgents: LoadAgents
+    private let readMemory: ReadMemory
+    private let setLoginItemEnabled: SetLoginItemEnabled
+    private let disableAgent: DisableAgent
+    private let removeAgent: RemoveAgent
+    private let flushRAMAction: FlushRAM
+    private let runMaintenance: RunMaintenance
+
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "OptimizationViewModel")
+
+    /// Monotonic token so a stale load resolving after a newer `refresh()`
+    /// can't clobber fresh state — same pattern as the other feature
+    /// view-models.
+    private var loadGeneration = 0
+
+    init(
+        loadLoginItems: @escaping LoadLoginItems,
+        loadUserAgents: @escaping LoadAgents,
+        loadSystemAgents: @escaping LoadAgents,
+        readMemory: @escaping ReadMemory,
+        setLoginItemEnabled: @escaping SetLoginItemEnabled,
+        disableAgent: @escaping DisableAgent,
+        removeAgent: @escaping RemoveAgent,
+        flushRAM: @escaping FlushRAM,
+        runMaintenance: @escaping RunMaintenance
+    ) {
+        self.loadLoginItems = loadLoginItems
+        self.loadUserAgents = loadUserAgents
+        self.loadSystemAgents = loadSystemAgents
+        self.readMemory = readMemory
+        self.setLoginItemEnabled = setLoginItemEnabled
+        self.disableAgent = disableAgent
+        self.removeAgent = removeAgent
+        self.flushRAMAction = flushRAM
+        self.runMaintenance = runMaintenance
+    }
+
+    // MARK: - Loading
+
+    /// Loads all four sections concurrently and lands `.ready`. Discovery is
+    /// best-effort (missing directories degrade to empty lists), so there is
+    /// no load-failure path — action failures are what surface `.failed`.
+    func refresh() async {
+        let generation = beginLoad()
+        phase = .loading
+
+        async let login = loadLoginItems()
+        async let user = loadUserAgents()
+        async let system = loadSystemAgents()
+        let (loadedLogin, loadedUser, loadedSystem) = await (login, user, system)
+        let mem = readMemory()
+
+        guard loadGeneration == generation else { return }
+        loginItems = loadedLogin
+        userAgents = loadedUser
+        systemAgents = loadedSystem
+        memory = mem
+        phase = .ready
+    }
+
+    // MARK: - RAM
+
+    /// Flushes inactive memory through the privileged helper, then re-reads
+    /// usage so the displayed figure and the result line reflect the post-
+    /// flush state.
+    func flushRAM() async {
+        phase = .working
+        do {
+            try await flushRAMAction()
+            memory = readMemory()
+            let format = String(
+                localized: "Freed inactive memory. Memory in use: %@.",
+                comment: "Result line after a successful RAM flush; %@ is a used/total memory string."
+            )
+            ramResult = String.localizedStringWithFormat(
+                format, SystemStatsFormatters.memoryUsageString(memory)
+            )
+            phase = .ready
+        } catch {
+            log.error("RAM flush failed: \(error.localizedDescription, privacy: .public)")
+            phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Maintenance
+
+    /// Runs the system maintenance scripts through the privileged helper and
+    /// stores the result line for the view's output log.
+    func runMaintenanceScripts() async {
+        phase = .working
+        do {
+            maintenanceOutput = try await runMaintenance()
+            phase = .ready
+        } catch {
+            log.error("Maintenance scripts failed: \(error.localizedDescription, privacy: .public)")
+            phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Login items
+
+    /// Enables or disables a login item, then reloads the list so the row
+    /// reflects the new `SMAppService` status.
+    func setLoginItem(_ item: LoginItem, enabled: Bool) async {
+        phase = .working
+        do {
+            try setLoginItemEnabled(enabled, item)
+            loginItems = await loadLoginItems()
+            phase = .ready
+        } catch {
+            log.error("Login-item toggle failed: \(error.localizedDescription, privacy: .public)")
+            phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Launch agents
+
+    /// Unloads an agent from launchd, then reloads both agent lists so the
+    /// loaded/enabled state is refreshed.
+    func disable(_ agent: LaunchAgent) async {
+        phase = .working
+        do {
+            try disableAgent(agent)
+            async let user = loadUserAgents()
+            async let system = loadSystemAgents()
+            let (reloadedUser, reloadedSystem) = await (user, system)
+            userAgents = reloadedUser
+            systemAgents = reloadedSystem
+            phase = .ready
+        } catch {
+            log.error("Agent disable failed: \(error.localizedDescription, privacy: .public)")
+            phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    /// Removes an agent's plist. On success the row is dropped; on failure
+    /// the lists are left intact so the user can retry.
+    func remove(_ agent: LaunchAgent) async {
+        phase = .working
+        do {
+            try await removeAgent(agent)
+            userAgents.removeAll { $0.id == agent.id }
+            systemAgents.removeAll { $0.id == agent.id }
+            phase = .ready
+        } catch {
+            log.error("Agent removal failed: \(error.localizedDescription, privacy: .public)")
+            phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    /// Returns the VM to `.ready` after a `.failed` phase so the user can
+    /// retry without re-running discovery.
+    func dismissResult() {
+        phase = .ready
+    }
+
+    // MARK: - Generations
+
+    private func beginLoad() -> Int {
+        loadGeneration += 1
+        return loadGeneration
+    }
+}
+
+// MARK: - Production wiring
+
+extension OptimizationViewModel {
+
+    /// Builds a view-model wired to the real login-item / launch-agent /
+    /// RAM / maintenance collaborators. Discovery runs off the main actor so
+    /// the filesystem walk and `launchctl list` don't block the UI. RAM
+    /// figures are read from the shared `SystemStatsService` so the
+    /// Optimization view and the Health Monitor never disagree.
+    @MainActor
+    static func live(systemStats: SystemStatsService) -> OptimizationViewModel {
+        let loginManager = LoginItemsManager.live()
+        let agentManager = LaunchAgentManager()
+        let ram = RAMManager()
+        let maintenance = MaintenanceScriptRunner()
+
+        return OptimizationViewModel(
+            loadLoginItems: { loginManager.items() },
+            loadUserAgents: {
+                await Task.detached(priority: .userInitiated) {
+                    agentManager.userAgents()
+                }.value
+            },
+            loadSystemAgents: {
+                await Task.detached(priority: .userInitiated) {
+                    agentManager.systemAgents()
+                }.value
+            },
+            readMemory: { systemStats.ramUsage },
+            setLoginItemEnabled: { enabled, item in
+                try loginManager.setEnabled(enabled, for: item)
+            },
+            disableAgent: { try agentManager.disable($0) },
+            removeAgent: { try await agentManager.remove($0) },
+            flushRAM: { try await ram.flush() },
+            runMaintenance: { try await maintenance.run() }
+        )
+    }
+}

--- a/VaderCleaner/OptimizationViewSubviews.swift
+++ b/VaderCleaner/OptimizationViewSubviews.swift
@@ -167,10 +167,14 @@ struct OptimizationLaunchAgentRow: View {
                     Text(agent.label)
                         .font(.body)
                         .lineLimit(1)
-                    if !agent.isEnabled {
+                    // `launchctl list` runs in the user bootstrap and cannot
+                    // see system daemons, so a "Not loaded" badge there would
+                    // be a false negative. Only user agents have an
+                    // authoritative loaded status to badge.
+                    if !agent.isEnabled && agent.domain == .user {
                         Text(String(
                             localized: "Not loaded",
-                            comment: "Badge shown next to a launch agent that launchctl does not list as loaded."
+                            comment: "Badge shown next to a user launch agent that launchctl does not list as loaded."
                         ))
                         .font(.caption2.weight(.semibold))
                         .padding(.horizontal, 5)

--- a/VaderCleaner/OptimizationViewSubviews.swift
+++ b/VaderCleaner/OptimizationViewSubviews.swift
@@ -1,0 +1,289 @@
+// OptimizationViewSubviews.swift
+// Dedicated subviews for the Optimization screen — login items, launch-agent groups, RAM, maintenance, and progress / failed states.
+
+import SwiftUI
+
+// MARK: - Progress / failed states
+
+struct OptimizationProgressState: View {
+    let label: String
+    let identifier: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+struct OptimizationFailedState: View {
+    let message: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(String(
+                localized: "That action couldn't complete",
+                comment: "Heading on the Optimization failure screen."
+            ))
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("optimization.errorMessage")
+            Button(String(
+                localized: "Back to Optimization",
+                comment: "Return button on the Optimization failure screen."
+            ), action: onDismiss)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("optimization.failurePrimary")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+// MARK: - Section chrome
+
+private struct OptimizationSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+            content
+        }
+    }
+}
+
+private struct OptimizationEmptyRow: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .padding(.vertical, 8)
+    }
+}
+
+// MARK: - Login items
+
+struct OptimizationLoginItemsSection: View {
+    let items: [LoginItem]
+    let onToggle: (LoginItem, Bool) -> Void
+
+    var body: some View {
+        OptimizationSection(title: String(
+            localized: "Login Items",
+            comment: "Optimization section header for login items."
+        )) {
+            if items.isEmpty {
+                OptimizationEmptyRow(message: String(
+                    localized: "No manageable login items.",
+                    comment: "Empty state for the Login Items section."
+                ))
+            } else {
+                ForEach(items) { item in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.name).font(.body)
+                            Text(item.id)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { item.isEnabled },
+                            set: { onToggle(item, $0) }
+                        ))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityIdentifier("optimization.loginItem.\(item.id)")
+                    }
+                    .padding(.vertical, 4)
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Launch agents
+
+struct OptimizationLaunchAgentsSection: View {
+    let title: String
+    let identifier: String
+    let agents: [LaunchAgent]
+    let onDisable: (LaunchAgent) -> Void
+    let onRemove: (LaunchAgent) -> Void
+
+    var body: some View {
+        OptimizationSection(title: title) {
+            if agents.isEmpty {
+                OptimizationEmptyRow(message: String(
+                    localized: "Nothing found here.",
+                    comment: "Empty state for a launch-agents section."
+                ))
+                .accessibilityIdentifier("\(identifier).empty")
+            } else {
+                ForEach(agents) { agent in
+                    OptimizationLaunchAgentRow(
+                        agent: agent,
+                        onDisable: { onDisable(agent) },
+                        onRemove: { onRemove(agent) }
+                    )
+                    .accessibilityIdentifier("\(identifier).row.\(agent.path.lastPathComponent)")
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+struct OptimizationLaunchAgentRow: View {
+    let agent: LaunchAgent
+    let onDisable: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(agent.label)
+                        .font(.body)
+                        .lineLimit(1)
+                    if !agent.isEnabled {
+                        Text(String(
+                            localized: "Not loaded",
+                            comment: "Badge shown next to a launch agent that launchctl does not list as loaded."
+                        ))
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.18))
+                        .clipShape(Capsule())
+                    }
+                }
+                Text(agent.programPath ?? agent.path.path)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Button(action: onDisable) {
+                Text(String(
+                    localized: "Disable",
+                    comment: "Per-row button that unloads a launch agent via launchctl."
+                ))
+            }
+            .buttonStyle(.bordered)
+            .disabled(!agent.isEnabled)
+            .accessibilityIdentifier("optimization.disable.\(agent.path.lastPathComponent)")
+
+            Button(role: .destructive, action: onRemove) {
+                Text(String(
+                    localized: "Remove",
+                    comment: "Per-row button that deletes a launch-agent plist."
+                ))
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("optimization.remove.\(agent.path.lastPathComponent)")
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - RAM
+
+struct OptimizationRAMSection: View {
+    let memory: MemoryStats
+    let result: String?
+    let onFlush: () -> Void
+
+    var body: some View {
+        OptimizationSection(title: String(
+            localized: "RAM",
+            comment: "Optimization section header for memory."
+        )) {
+            HStack {
+                Text(SystemStatsFormatters.memoryUsageString(memory))
+                    .font(.body.monospacedDigit())
+                    .accessibilityIdentifier("optimization.ramUsage")
+                Spacer()
+                Button(action: onFlush) {
+                    Text(String(
+                        localized: "Free Up RAM",
+                        comment: "Button that flushes inactive memory."
+                    ))
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("optimization.freeRAM")
+            }
+            if let result {
+                Text(result)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("optimization.ramResult")
+            }
+        }
+    }
+}
+
+// MARK: - Maintenance
+
+struct OptimizationMaintenanceSection: View {
+    let output: String?
+    let onRun: () -> Void
+
+    var body: some View {
+        OptimizationSection(title: String(
+            localized: "Maintenance Scripts",
+            comment: "Optimization section header for maintenance scripts."
+        )) {
+            HStack {
+                Text(String(
+                    localized: "Runs the system periodic daily, weekly, and monthly scripts.",
+                    comment: "Explanatory text for the maintenance scripts action."
+                ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                Spacer()
+                Button(action: onRun) {
+                    Text(String(
+                        localized: "Run Maintenance Scripts",
+                        comment: "Button that runs the system maintenance scripts."
+                    ))
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("optimization.runMaintenance")
+            }
+            if let output {
+                Text(output)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.secondary.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .accessibilityIdentifier("optimization.maintenanceOutput")
+            }
+        }
+    }
+}

--- a/VaderCleaner/OptimizationViewSubviews.swift
+++ b/VaderCleaner/OptimizationViewSubviews.swift
@@ -193,7 +193,17 @@ struct OptimizationLaunchAgentRow: View {
                 ))
             }
             .buttonStyle(.bordered)
-            .disabled(!agent.isEnabled)
+            // System daemons live in launchd's privileged domain; `launchctl
+            // unload` from the user session can't touch them, so the control
+            // is offered only for user agents. Removal still works for system
+            // agents (it routes through the privileged helper).
+            .disabled(!agent.isEnabled || agent.domain == .system)
+            .help(agent.domain == .system
+                  ? String(
+                        localized: "System agents can't be unloaded from here. Use Remove to delete the plist.",
+                        comment: "Tooltip explaining why Disable is unavailable for system launch agents."
+                    )
+                  : "")
             .accessibilityIdentifier("optimization.disable.\(agent.path.lastPathComponent)")
 
             Button(role: .destructive, action: onRemove) {

--- a/VaderCleaner/OptimizationViewSubviews.swift
+++ b/VaderCleaner/OptimizationViewSubviews.swift
@@ -144,6 +144,7 @@ struct OptimizationLaunchAgentsSection: View {
                 ForEach(agents) { agent in
                     OptimizationLaunchAgentRow(
                         agent: agent,
+                        identifier: identifier,
                         onDisable: { onDisable(agent) },
                         onRemove: { onRemove(agent) }
                     )
@@ -157,6 +158,7 @@ struct OptimizationLaunchAgentsSection: View {
 
 struct OptimizationLaunchAgentRow: View {
     let agent: LaunchAgent
+    let identifier: String
     let onDisable: () -> Void
     let onRemove: () -> Void
 
@@ -208,7 +210,7 @@ struct OptimizationLaunchAgentRow: View {
                         comment: "Tooltip explaining why Disable is unavailable for system launch agents."
                     )
                   : "")
-            .accessibilityIdentifier("optimization.disable.\(agent.path.lastPathComponent)")
+            .accessibilityIdentifier("\(identifier).disable.\(agent.path.lastPathComponent)")
 
             Button(role: .destructive, action: onRemove) {
                 Text(String(
@@ -217,7 +219,7 @@ struct OptimizationLaunchAgentRow: View {
                 ))
             }
             .buttonStyle(.bordered)
-            .accessibilityIdentifier("optimization.remove.\(agent.path.lastPathComponent)")
+            .accessibilityIdentifier("\(identifier).remove.\(agent.path.lastPathComponent)")
         }
         .padding(.vertical, 4)
     }

--- a/VaderCleaner/RAMManager.swift
+++ b/VaderCleaner/RAMManager.swift
@@ -1,0 +1,67 @@
+// RAMManager.swift
+// Bridges the privileged flushInactiveMemory XPC call (which runs /usr/sbin/purge) to async/throwing for the Optimization feature.
+
+import Foundation
+import os.log
+
+/// Frees inactive memory by asking the privileged helper to run `purge`.
+struct RAMManager {
+
+    typealias HelperProvider = (@escaping (Error) -> Void) -> VaderCleanerHelperProtocol?
+
+    private let helperProvider: HelperProvider
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "RAMManager")
+
+    init(helperProvider: @escaping HelperProvider = SystemJunkDeleter.defaultHelperProvider) {
+        self.helperProvider = helperProvider
+    }
+
+    /// Asks the helper to flush inactive memory. Installs both the per-call
+    /// XPC error handler and the reply block so a dropped connection can't
+    /// freeze the UI — whichever resolves first wins via the once-only
+    /// `Resumer`. Throws on any failure (including an unreachable helper).
+    func flush() async throws {
+        let error: Error? = await withCheckedContinuation { continuation in
+            let resumer = RAMResumer(continuation: continuation)
+            let helper = helperProvider { connectionError in
+                resumer.resume(with: connectionError)
+            }
+            guard let helper else {
+                resumer.resume(with: NSError(
+                    domain: "com.personal.VaderCleaner.RAMManager",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Helper unavailable"]
+                ))
+                return
+            }
+            helper.flushInactiveMemory { replyError in
+                resumer.resume(with: replyError)
+            }
+        }
+        if let error {
+            log.error("RAM flush failed: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+}
+
+/// Once-only continuation resume — see `SystemJunkDeleter.Resumer` for the
+/// rationale; both the XPC reply block and the connection error handler may
+/// fire and `CheckedContinuation` traps on a second resume.
+private final class RAMResumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: error)
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -33,6 +33,7 @@ struct VaderCleanerApp: App {
     @StateObject private var appUninstallerViewModel: AppUninstallerViewModel
     @StateObject private var appUpdaterViewModel: AppUpdaterViewModel
     @StateObject private var extensionsManagerViewModel: ExtensionsManagerViewModel
+    @StateObject private var optimizationViewModel: OptimizationViewModel
     // App-scope so the cheap-stats timer outlives any single window. The
     // Health Monitor view (Prompt 9), the menu bar (Prompt 10), and the
     // notification dispatcher (Prompt 11) all subscribe via
@@ -83,6 +84,11 @@ struct VaderCleanerApp: App {
         // service the Health Monitor consumes.
         let stats = SystemStatsService()
         _systemStats = StateObject(wrappedValue: stats)
+        // Wired after `stats` so the Optimization RAM figures come from the
+        // same polling service the Health Monitor and menu bar consume.
+        _optimizationViewModel = StateObject(
+            wrappedValue: OptimizationViewModel.live(systemStats: stats)
+        )
         _menuBarViewModel = StateObject(wrappedValue: MenuBarViewModel(service: stats))
         // Wire the notification monitor to the same stats + preferences
         // instances the rest of the app sees. The monitor holds the manager
@@ -135,7 +141,8 @@ struct VaderCleanerApp: App {
                 privacyViewModel: privacyViewModel,
                 appUninstallerViewModel: appUninstallerViewModel,
                 appUpdaterViewModel: appUpdaterViewModel,
-                extensionsManagerViewModel: extensionsManagerViewModel
+                extensionsManagerViewModel: extensionsManagerViewModel,
+                optimizationViewModel: optimizationViewModel
             )
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)

--- a/VaderCleanerTests/LaunchAgentManagerTests.swift
+++ b/VaderCleanerTests/LaunchAgentManagerTests.swift
@@ -1,0 +1,197 @@
+// LaunchAgentManagerTests.swift
+// Exercises LaunchAgentManager plist parsing, launchctl-loaded status, and disable/remove routing through temp fixtures and injected fakes.
+
+import XCTest
+@testable import VaderCleaner
+
+final class LaunchAgentManagerTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        TestHelpers.tearDownTempDirectory(tempDir)
+    }
+
+    // MARK: - launchctl list parsing
+
+    func test_parseLoadedLabels_extractsLabelColumnSkippingHeader() {
+        let output = """
+        PID\tStatus\tLabel
+        1234\t0\tcom.apple.Finder
+        -\t0\tcom.example.updater
+        \t
+        """
+        let labels = LaunchAgentManager.parseLoadedLabels(from: output)
+        XCTAssertEqual(labels, ["com.apple.Finder", "com.example.updater"])
+    }
+
+    // MARK: - programPath extraction
+
+    func test_programPath_prefersProgramKey() {
+        let plist: [String: Any] = ["Program": "/usr/local/bin/agent"]
+        XCTAssertEqual(LaunchAgentManager.programPath(from: plist), "/usr/local/bin/agent")
+    }
+
+    func test_programPath_fallsBackToFirstProgramArgument() {
+        let plist: [String: Any] = ["ProgramArguments": ["/opt/tool/run", "--flag"]]
+        XCTAssertEqual(LaunchAgentManager.programPath(from: plist), "/opt/tool/run")
+    }
+
+    func test_programPath_nilWhenAbsent() {
+        XCTAssertNil(LaunchAgentManager.programPath(from: [:]))
+    }
+
+    // MARK: - userAgents discovery
+
+    func test_userAgents_parsesLabelProgramAndLoadedStatus() throws {
+        try writePlist(
+            named: "com.example.loaded.plist",
+            label: "com.example.loaded",
+            program: "/opt/example/loaded"
+        )
+        try writePlist(
+            named: "com.example.unloaded.plist",
+            label: "com.example.unloaded",
+            programArguments: ["/opt/example/unloaded", "-x"]
+        )
+
+        let manager = makeManager(loaded: ["com.example.loaded"])
+        let agents = manager.userAgents().sorted { $0.label < $1.label }
+
+        XCTAssertEqual(agents.map(\.label),
+                       ["com.example.loaded", "com.example.unloaded"])
+        XCTAssertEqual(agents[0].programPath, "/opt/example/loaded")
+        XCTAssertTrue(agents[0].isEnabled)
+        XCTAssertEqual(agents[1].programPath, "/opt/example/unloaded")
+        XCTAssertFalse(agents[1].isEnabled)
+        XCTAssertEqual(agents[0].domain, .user)
+    }
+
+    func test_userAgents_fallsBackToFilenameWhenLabelMissing() throws {
+        let url = tempDir.appendingPathComponent("no-label.plist")
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["Program": "/bin/true"],
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: url)
+
+        let manager = makeManager(loaded: [])
+        XCTAssertEqual(manager.userAgents().first?.label, "no-label")
+    }
+
+    func test_userAgents_ignoresNonPlistFiles() throws {
+        try "junk".write(
+            to: tempDir.appendingPathComponent("notes.txt"),
+            atomically: true, encoding: .utf8
+        )
+        let manager = makeManager(loaded: [])
+        XCTAssertTrue(manager.userAgents().isEmpty)
+    }
+
+    // MARK: - disable
+
+    func test_disable_invokesLaunchctlUnloadWithAgentPath() throws {
+        try writePlist(named: "a.plist", label: "a", program: "/bin/a")
+        var captured: [String]?
+        let manager = makeManager(loaded: ["a"], launchctl: { captured = $0 })
+        let agent = try XCTUnwrap(manager.userAgents().first)
+
+        try manager.disable(agent)
+
+        XCTAssertEqual(captured, ["unload", agent.path.path])
+    }
+
+    // MARK: - remove
+
+    func test_remove_userAgentDeletesFileInProcess() async throws {
+        try writePlist(named: "doomed.plist", label: "doomed", program: "/bin/x")
+        let manager = makeManager(loaded: [])
+        let agent = try XCTUnwrap(manager.userAgents().first)
+
+        try await manager.remove(agent)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: agent.path.path))
+    }
+
+    func test_remove_systemAgentRoutesThroughPrivilegedHelper() async throws {
+        let systemDir = tempDir.appendingPathComponent("system", isDirectory: true)
+        try FileManager.default.createDirectory(at: systemDir, withIntermediateDirectories: true)
+        let plistURL = systemDir.appendingPathComponent("com.sys.daemon.plist")
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["Label": "com.sys.daemon", "Program": "/usr/sbin/sysd"],
+            format: .xml, options: 0
+        )
+        try data.write(to: plistURL)
+
+        let fake = FakeRemovalHelper()
+        let manager = LaunchAgentManager(
+            userAgentsDirectory: tempDir,
+            systemAgentDirectories: [systemDir],
+            loadedLabels: { [] },
+            launchctl: { _ in },
+            helperProvider: { _ in fake }
+        )
+        let agent = try XCTUnwrap(manager.systemAgents().first)
+
+        try await manager.remove(agent)
+
+        // Directory enumeration resolves the /var → /private/var symlink on
+        // the temp path, so match by suffix rather than the absolute string.
+        let received = try XCTUnwrap(fake.removedLaunchAgentPath)
+        XCTAssertTrue(
+            received.hasSuffix("/system/com.sys.daemon.plist"),
+            "Helper received unexpected path: \(received)"
+        )
+        // System file routed through the helper; not deleted in-process.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: plistURL.path))
+    }
+
+    // MARK: - Helpers
+
+    private func makeManager(
+        loaded: Set<String>,
+        launchctl: @escaping (_ args: [String]) throws -> Void = { _ in }
+    ) -> LaunchAgentManager {
+        LaunchAgentManager(
+            userAgentsDirectory: tempDir,
+            systemAgentDirectories: [],
+            loadedLabels: { loaded },
+            launchctl: launchctl,
+            helperProvider: { _ in nil }
+        )
+    }
+
+    private func writePlist(
+        named name: String,
+        label: String,
+        program: String? = nil,
+        programArguments: [String]? = nil
+    ) throws {
+        var dict: [String: Any] = ["Label": label]
+        if let program { dict["Program"] = program }
+        if let programArguments { dict["ProgramArguments"] = programArguments }
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: dict, format: .xml, options: 0
+        )
+        try data.write(to: tempDir.appendingPathComponent(name))
+    }
+}
+
+/// Captures the path passed to `removeLaunchAgent` and replies success.
+private final class FakeRemovalHelper: NSObject, VaderCleanerHelperProtocol {
+    private(set) var removedLaunchAgentPath: String?
+
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) { reply(nil) }
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {
+        removedLaunchAgentPath = path
+        reply(nil)
+    }
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+}

--- a/VaderCleanerTests/LoginItemsManagerTests.swift
+++ b/VaderCleanerTests/LoginItemsManagerTests.swift
@@ -1,0 +1,64 @@
+// LoginItemsManagerTests.swift
+// Drives LoginItemsManager through injected SMAppService status/handler closures so no real login-item registration is touched.
+
+import XCTest
+import ServiceManagement
+@testable import VaderCleaner
+
+final class LoginItemsManagerTests: XCTestCase {
+
+    func test_items_reflectsEnabledStatusFromProvider() {
+        let manager = LoginItemsManager(
+            displayName: "VaderCleaner",
+            identifier: "com.personal.VaderCleaner",
+            statusProvider: { .enabled },
+            setEnabledHandler: { _ in }
+        )
+
+        let items = manager.items()
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.id, "com.personal.VaderCleaner")
+        XCTAssertEqual(items.first?.name, "VaderCleaner")
+        XCTAssertTrue(items.first?.isEnabled == true)
+    }
+
+    func test_items_reflectsDisabledStatusFromProvider() {
+        let manager = LoginItemsManager(
+            displayName: "VaderCleaner",
+            identifier: "com.personal.VaderCleaner",
+            statusProvider: { .notRegistered },
+            setEnabledHandler: { _ in }
+        )
+
+        XCTAssertFalse(manager.items().first?.isEnabled == true)
+    }
+
+    func test_setEnabled_forwardsRequestedStateToHandler() throws {
+        var received: Bool?
+        let manager = LoginItemsManager(
+            displayName: "VaderCleaner",
+            identifier: "com.personal.VaderCleaner",
+            statusProvider: { .enabled },
+            setEnabledHandler: { received = $0 }
+        )
+
+        let item = try XCTUnwrap(manager.items().first)
+        try manager.setEnabled(false, for: item)
+
+        XCTAssertEqual(received, false)
+    }
+
+    func test_setEnabled_propagatesHandlerError() {
+        struct Boom: Error {}
+        let manager = LoginItemsManager(
+            displayName: "VaderCleaner",
+            identifier: "com.personal.VaderCleaner",
+            statusProvider: { .enabled },
+            setEnabledHandler: { _ in throw Boom() }
+        )
+
+        let item = LoginItem(id: "x", name: "x", isEnabled: true)
+        XCTAssertThrowsError(try manager.setEnabled(true, for: item))
+    }
+}

--- a/VaderCleanerTests/MaintenanceScriptRunnerTests.swift
+++ b/VaderCleanerTests/MaintenanceScriptRunnerTests.swift
@@ -38,6 +38,32 @@ final class MaintenanceScriptRunnerTests: XCTestCase {
             // Expected.
         }
     }
+
+    /// The reply block is dropped (mirrors a dropped NSXPCConnection); the
+    /// connection-level error handler must still resolve the await so the
+    /// once-only continuation guarantee holds here as it does in RAMManager.
+    func test_run_resolvesViaConnectionErrorHandlerWhenReplyDropped() async {
+        struct Dropped: Error {}
+        let runner = MaintenanceScriptRunner(helperProvider: { errorHandler in
+            DispatchQueue.global().async { errorHandler(Dropped()) }
+            return DroppingMaintenanceHelper()
+        })
+
+        do {
+            _ = try await runner.run()
+            XCTFail("Expected run() to surface the connection error")
+        } catch {
+            // Expected — did not hang.
+        }
+    }
+}
+
+private final class DroppingMaintenanceHelper: NSObject, VaderCleanerHelperProtocol {
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {}
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {}
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
 }
 
 private final class SpyMaintenanceHelper: NSObject, VaderCleanerHelperProtocol {

--- a/VaderCleanerTests/MaintenanceScriptRunnerTests.swift
+++ b/VaderCleanerTests/MaintenanceScriptRunnerTests.swift
@@ -1,0 +1,57 @@
+// MaintenanceScriptRunnerTests.swift
+// Verifies MaintenanceScriptRunner bridges the privileged runMaintenanceScripts XPC call and reports a result string.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MaintenanceScriptRunnerTests: XCTestCase {
+
+    func test_run_returnsNonEmptyResultOnSuccess() async throws {
+        let helper = SpyMaintenanceHelper(replyError: nil)
+        let runner = MaintenanceScriptRunner(helperProvider: { _ in helper })
+
+        let output = try await runner.run()
+
+        XCTAssertTrue(helper.runCalled)
+        XCTAssertFalse(output.isEmpty)
+    }
+
+    func test_run_throwsWhenHelperRepliesError() async {
+        struct Boom: Error {}
+        let helper = SpyMaintenanceHelper(replyError: Boom())
+        let runner = MaintenanceScriptRunner(helperProvider: { _ in helper })
+
+        do {
+            _ = try await runner.run()
+            XCTFail("Expected run() to throw")
+        } catch {
+            // Expected.
+        }
+    }
+
+    func test_run_throwsWhenHelperUnavailable() async {
+        let runner = MaintenanceScriptRunner(helperProvider: { _ in nil })
+        do {
+            _ = try await runner.run()
+            XCTFail("Expected run() to throw when helper is unavailable")
+        } catch {
+            // Expected.
+        }
+    }
+}
+
+private final class SpyMaintenanceHelper: NSObject, VaderCleanerHelperProtocol {
+    private let replyError: Error?
+    private(set) var runCalled = false
+
+    init(replyError: Error?) { self.replyError = replyError }
+
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) { reply(nil) }
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {
+        runCalled = true
+        reply(replyError)
+    }
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+}

--- a/VaderCleanerTests/OptimizationViewModelTests.swift
+++ b/VaderCleanerTests/OptimizationViewModelTests.swift
@@ -1,0 +1,235 @@
+// OptimizationViewModelTests.swift
+// Drives the OptimizationViewModel state machine — load, RAM flush, maintenance scripts, login-item toggle, and agent disable/remove — through injected fakes.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class OptimizationViewModelTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertTrue(vm.loginItems.isEmpty)
+        XCTAssertTrue(vm.userAgents.isEmpty)
+        XCTAssertTrue(vm.systemAgents.isEmpty)
+    }
+
+    // MARK: - Refresh
+
+    func test_refresh_populatesAllSectionsAndBecomesReady() async {
+        let vm = makeViewModel(
+            loadLoginItems: { [Self.loginItem(name: "VaderCleaner")] },
+            loadUserAgents: { [Self.agent(label: "com.user.a", domain: .user)] },
+            loadSystemAgents: { [Self.agent(label: "com.sys.b", domain: .system)] },
+            readMemory: { MemoryStats(usedBytes: 8, totalBytes: 16) }
+        )
+
+        await vm.refresh()
+
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.loginItems.map(\.name), ["VaderCleaner"])
+        XCTAssertEqual(vm.userAgents.map(\.label), ["com.user.a"])
+        XCTAssertEqual(vm.systemAgents.map(\.label), ["com.sys.b"])
+        XCTAssertEqual(vm.memory, MemoryStats(usedBytes: 8, totalBytes: 16))
+    }
+
+    // MARK: - RAM flush
+
+    func test_flushRAM_callsPrivilegedHelperAndShowsResult() async {
+        var flushed = false
+        let vm = makeViewModel(
+            readMemory: { MemoryStats(usedBytes: 4, totalBytes: 16) },
+            flushRAM: { flushed = true }
+        )
+        await vm.refresh()
+
+        await vm.flushRAM()
+
+        XCTAssertTrue(flushed, "flushRAM() must invoke the privileged helper collaborator")
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertNotNil(vm.ramResult)
+    }
+
+    func test_flushRAM_failureTransitionsToFailed() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(flushRAM: { throw Boom() })
+        await vm.refresh()
+
+        await vm.flushRAM()
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Maintenance scripts
+
+    func test_runMaintenanceScripts_callsPrivilegedHelperAndCapturesOutput() async {
+        var ran = false
+        let vm = makeViewModel(runMaintenance: {
+            ran = true
+            return "Maintenance complete."
+        })
+        await vm.refresh()
+
+        await vm.runMaintenanceScripts()
+
+        XCTAssertTrue(ran, "runMaintenanceScripts() must invoke the privileged helper collaborator")
+        XCTAssertEqual(vm.maintenanceOutput, "Maintenance complete.")
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    func test_runMaintenanceScripts_failureTransitionsToFailed() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(runMaintenance: { throw Boom() })
+        await vm.refresh()
+
+        await vm.runMaintenanceScripts()
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Login items
+
+    func test_setLoginItem_forwardsRequestedStateToCollaborator() async {
+        var received: (Bool, String)?
+        let item = Self.loginItem(name: "VaderCleaner")
+        let vm = makeViewModel(
+            loadLoginItems: { [item] },
+            setLoginItemEnabled: { enabled, target in
+                received = (enabled, target.name)
+            }
+        )
+        await vm.refresh()
+
+        await vm.setLoginItem(item, enabled: false)
+
+        XCTAssertEqual(received?.0, false)
+        XCTAssertEqual(received?.1, "VaderCleaner")
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    func test_setLoginItem_failureTransitionsToFailed() async {
+        struct Boom: Error {}
+        let item = Self.loginItem(name: "VaderCleaner")
+        let vm = makeViewModel(
+            loadLoginItems: { [item] },
+            setLoginItemEnabled: { _, _ in throw Boom() }
+        )
+        await vm.refresh()
+
+        await vm.setLoginItem(item, enabled: false)
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Agent disable / remove
+
+    func test_disableAgent_invokesCollaboratorAndReloads() async {
+        var disabled: String?
+        let agent = Self.agent(label: "com.user.a", domain: .user)
+        let vm = makeViewModel(
+            loadUserAgents: { [agent] },
+            disableAgent: { disabled = $0.label }
+        )
+        await vm.refresh()
+
+        await vm.disable(agent)
+
+        XCTAssertEqual(disabled, "com.user.a")
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    func test_removeAgent_dropsRowAndReturnsToReady() async {
+        let target = Self.agent(label: "com.user.doomed", domain: .user)
+        let keep = Self.agent(label: "com.user.keep", domain: .user)
+        let vm = makeViewModel(
+            loadUserAgents: { [target, keep] },
+            removeAgent: { _ in }
+        )
+        await vm.refresh()
+
+        await vm.remove(target)
+
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.userAgents.map(\.label), ["com.user.keep"])
+    }
+
+    func test_removeAgent_failureLeavesListIntact() async {
+        struct Boom: Error {}
+        let target = Self.agent(label: "com.user.doomed", domain: .user)
+        let vm = makeViewModel(
+            loadUserAgents: { [target] },
+            removeAgent: { _ in throw Boom() }
+        )
+        await vm.refresh()
+
+        await vm.remove(target)
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+        XCTAssertEqual(vm.userAgents.map(\.label), ["com.user.doomed"])
+    }
+
+    func test_dismissResult_returnsToReady() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(flushRAM: { throw Boom() })
+        await vm.refresh()
+        await vm.flushRAM()
+
+        vm.dismissResult()
+
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        loadLoginItems: @escaping OptimizationViewModel.LoadLoginItems = { [] },
+        loadUserAgents: @escaping OptimizationViewModel.LoadAgents = { [] },
+        loadSystemAgents: @escaping OptimizationViewModel.LoadAgents = { [] },
+        readMemory: @escaping OptimizationViewModel.ReadMemory = { .empty },
+        setLoginItemEnabled: @escaping OptimizationViewModel.SetLoginItemEnabled = { _, _ in },
+        disableAgent: @escaping OptimizationViewModel.DisableAgent = { _ in },
+        removeAgent: @escaping OptimizationViewModel.RemoveAgent = { _ in },
+        flushRAM: @escaping OptimizationViewModel.FlushRAM = {},
+        runMaintenance: @escaping OptimizationViewModel.RunMaintenance = { "" }
+    ) -> OptimizationViewModel {
+        OptimizationViewModel(
+            loadLoginItems: loadLoginItems,
+            loadUserAgents: loadUserAgents,
+            loadSystemAgents: loadSystemAgents,
+            readMemory: readMemory,
+            setLoginItemEnabled: setLoginItemEnabled,
+            disableAgent: disableAgent,
+            removeAgent: removeAgent,
+            flushRAM: flushRAM,
+            runMaintenance: runMaintenance
+        )
+    }
+
+    private static func loginItem(name: String) -> LoginItem {
+        LoginItem(id: name, name: name, isEnabled: true)
+    }
+
+    private static func agent(
+        label: String,
+        domain: LaunchAgent.Domain
+    ) -> LaunchAgent {
+        LaunchAgent(
+            label: label,
+            path: URL(fileURLWithPath: "/tmp/\(label).plist"),
+            programPath: "/bin/true",
+            isEnabled: true,
+            domain: domain
+        )
+    }
+}

--- a/VaderCleanerTests/RAMManagerTests.swift
+++ b/VaderCleanerTests/RAMManagerTests.swift
@@ -1,0 +1,81 @@
+// RAMManagerTests.swift
+// Verifies RAMManager bridges the privileged flushInactiveMemory XPC call and never hangs when the connection drops.
+
+import XCTest
+@testable import VaderCleaner
+
+final class RAMManagerTests: XCTestCase {
+
+    func test_flush_invokesHelperAndSucceeds() async throws {
+        let helper = SpyFlushHelper(replyError: nil)
+        let manager = RAMManager(helperProvider: { _ in helper })
+
+        try await manager.flush()
+
+        XCTAssertTrue(helper.flushCalled)
+    }
+
+    func test_flush_throwsWhenHelperRepliesError() async {
+        struct Boom: Error {}
+        let helper = SpyFlushHelper(replyError: Boom())
+        let manager = RAMManager(helperProvider: { _ in helper })
+
+        do {
+            try await manager.flush()
+            XCTFail("Expected flush() to throw")
+        } catch {
+            // Expected.
+        }
+    }
+
+    func test_flush_throwsWhenHelperUnavailable() async {
+        let manager = RAMManager(helperProvider: { _ in nil })
+        do {
+            try await manager.flush()
+            XCTFail("Expected flush() to throw when helper is unavailable")
+        } catch {
+            // Expected.
+        }
+    }
+
+    /// The reply block is dropped (mirrors a dropped NSXPCConnection); the
+    /// connection-level error handler must still resolve the await.
+    func test_flush_resolvesViaConnectionErrorHandlerWhenReplyDropped() async {
+        struct Dropped: Error {}
+        let manager = RAMManager(helperProvider: { errorHandler in
+            DispatchQueue.global().async { errorHandler(Dropped()) }
+            return DroppingFlushHelper()
+        })
+
+        do {
+            try await manager.flush()
+            XCTFail("Expected flush() to surface the connection error")
+        } catch {
+            // Expected — did not hang.
+        }
+    }
+}
+
+private final class SpyFlushHelper: NSObject, VaderCleanerHelperProtocol {
+    private let replyError: Error?
+    private(set) var flushCalled = false
+
+    init(replyError: Error?) { self.replyError = replyError }
+
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) { reply(nil) }
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) {
+        flushCalled = true
+        reply(replyError)
+    }
+}
+
+private final class DroppingFlushHelper: NSObject, VaderCleanerHelperProtocol {
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {}
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {}
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
+}

--- a/VaderCleanerUITests/OptimizationUITests.swift
+++ b/VaderCleanerUITests/OptimizationUITests.swift
@@ -1,0 +1,57 @@
+// OptimizationUITests.swift
+// End-to-end UI test for Optimization — navigates to the section and asserts the view renders (toolbar + a ready-state section) so the sidebar → view-model → view wiring is exercised against the real app process.
+
+import XCTest
+
+/// We do not exercise the destructive controls (Disable / Remove / Free Up
+/// RAM / Run Maintenance Scripts) here — those would mutate launchd state or
+/// run privileged scripts on the test machine. The action contracts are
+/// covered exhaustively by `OptimizationViewModelTests` and the manager unit
+/// tests against injected fakes. This test only proves the section renders
+/// without crashing, which the unit tests cannot.
+final class OptimizationUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    func test_navigateToOptimization_revealsToolbarAndContent() throws {
+        dismissOnboardingIfNeeded()
+
+        let sidebarRow = app.outlines.staticTexts["Optimization"].firstMatch
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
+                      "Expected Optimization row in sidebar")
+        sidebarRow.click()
+
+        // The refresh toolbar button is present whenever the view renders,
+        // independent of phase — strongest "view did not crash" signal.
+        let refresh = app.buttons["optimization.refresh"]
+        XCTAssertTrue(refresh.waitForExistence(timeout: 10),
+                      "Expected Optimization toolbar to render")
+
+        // Loading runs automatically on first appearance; landing on the
+        // ready state surfaces the RAM usage label. Generous timeout because
+        // discovery shells out to `launchctl list`.
+        let ramUsage = app.staticTexts["optimization.ramUsage"]
+        XCTAssertTrue(ramUsage.waitForExistence(timeout: 30),
+                      "Expected Optimization to reach its ready state")
+    }
+
+    // MARK: - Helpers
+
+    private func dismissOnboardingIfNeeded() {
+        let continueWithout = app.buttons["Continue Without Access"]
+        if continueWithout.waitForExistence(timeout: 2) {
+            continueWithout.click()
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -42,7 +42,7 @@
 
 ## Phase 4 — Optimization & Security
 
-- [ ] **Prompt 22** — Optimization feature (login items, launch agents, RAM flush, maintenance scripts)
+- [x] **Prompt 22** — Optimization feature (login items, launch agents, RAM flush, maintenance scripts)
 - [ ] **Prompt 23** — ClamAV integration (detection, DB update, scanning, output parsing)
 - [ ] **Prompt 24** — Malware Removal UI (scan → results → remove flow)
 


### PR DESCRIPTION
## Summary

Implements **Prompt 22 — Optimization feature** (Phase 4), wired into `NavigationSection.optimization`. Closes #63.

- **Login Items** — host app's `SMAppService` registration with a toggle.
- **Launch Agents** — user (`~/Library/LaunchAgents`) and system (`/Library/LaunchAgents`, `/Library/LaunchDaemons`) jobs with `launchctl`-loaded status, per-row Disable (user only) and Remove.
- **RAM** — current usage + "Free Up RAM" (privileged `purge`) with a result line.
- **Maintenance Scripts** — "Run Maintenance Scripts" (privileged `periodic daily weekly monthly`) with a result log.

New: `LoginItem`/`LoginItemsManager`, `LaunchAgent`/`LaunchAgentManager`, `RAMManager`, `MaintenanceScriptRunner`, `OptimizationViewModel`, `OptimizationView` (+ subviews). Wired through `ContentView`/`VaderCleanerApp`. Privileged ops reuse the existing XPC helper; collaborators are closure-injected for full unit coverage (TDD — tests written first).

## Design decisions (intentional, not deviations)

- **XPC protocol left frozen.** `runMaintenanceScripts(reply:)` reports only success/failure — its selector is pinned by `HelperProtocolTests` and `periodic` writes to `/var/log/{daily,weekly,monthly}.out`, not stdout. `MaintenanceScriptRunner.run()` returns a human-readable **result line** (the honest reading of the spec's "captures output as a String"), not script stdout.
- **`LoginItemsManager` covers the host app only.** macOS has no public API to enumerate other apps' `SMAppService` login items. Third-party startup items live in `~/Library/LaunchAgents` and are surfaced by the Launch Agents section instead — so Login Items is a thin-but-honest section by OS constraint.
- **Distinct from Prompt 21's `LaunchAgentDiscovery`.** That feeds the Extensions Manager (`ExtensionItem`, removal). This adds a separate `LaunchAgent` model with load status + disable. Same `~/Library/LaunchAgents` plist can therefore appear under both **Extensions** and **Optimization → Launch Agents** — accepted intentionally (different lenses/controls), not de-duplicated.
- **Disable gated to user agents.** `launchctl unload` from the user session can't touch `/Library/LaunchDaemons`; the button is disabled (with a tooltip) for system agents. Remove still works for them via the privileged helper.

### Known minor wrinkle

Toggling launch-at-login here writes `SMAppService` but not `PreferencesStore.launchAtLogin`, so the Preferences toggle can read stale within the same session. Self-heals on next launch via the existing init-time reconcile.

## Test plan

- [x] Unit (TDD, written first): `LoginItemsManagerTests`, `LaunchAgentManagerTests`, `RAMManagerTests`, `MaintenanceScriptRunnerTests`, `OptimizationViewModelTests` — 516 unit tests, 0 failures.
- [x] E2E: `OptimizationUITests` — sidebar → Optimization renders toolbar + ready state. Full UI suite green.
- [x] Pristine test output; full suite re-run after every change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Optimization section with UI and view model (refresh, progress, results, failure states) to manage login items, user/system launch agents (disable/remove with confirmation), RAM cleanup, and maintenance scripts.
  * App now holds and wires the Optimization view model for sidebar/detail navigation.

* **Tests**
  * New unit and UI tests covering optimization flows, managers, RAM/maintenance helpers, and edge/error cases.

* **Documentation**
  * Marked an optimization-related TODO as completed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->