### PR TITLE
feat: ClamAV integration — detection, DB update, scanning, parsing

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
 		109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */; };
+		117989F5D9137A7400CE8760 /* ClamAVScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */; };
 		11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */; };
 		11C7DA0D7ECDCBF7DFB3C829 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 329FBD86F55918272AF0EF2A /* Localizable.stringsdict */; };
 		12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17B889E32D6334AED35F2BE /* LaunchAgent.swift */; };
@@ -23,10 +24,13 @@
 		159F0D7D84A23B27058835D6 /* BrowserDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */; };
 		17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */; };
 		1947460A68C713844C308694 /* TreemapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */; };
+		196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
 		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
+		20A0A0A414E0D919060C99D2 /* MalwareThreatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */; };
 		218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46943B264F72B3753075A8C /* UpdateInfoTests.swift */; };
 		2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */; };
+		25057052F5E478AD7B692B9F /* ClamAVOutputParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */; };
 		26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */; };
 		26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */; };
 		28B2F4C32E608BD283DB2DE5 /* VaderCleanerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */; };
@@ -65,6 +69,7 @@
 		55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
 		567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */; };
 		57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */; };
+		5B5767BC82C24D92B50032FE /* MalwareOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */; };
 		5C240506F97A777E37CA25B2 /* PrivacyViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */; };
 		5DF68FC234F70DA478496658 /* SystemStatsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */; };
 		5F2AB607564A60D0DCBFABEC /* PermissionOnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */; };
@@ -81,6 +86,7 @@
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
 		6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */; };
 		6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */; };
+		725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */; };
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
 		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
@@ -89,6 +95,7 @@
 		7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2617BC26104D5196DEDB3589 /* UpdateInfo.swift */; };
 		7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */; };
 		7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5CB08F96767D10B1271970 /* RAMManager.swift */; };
+		80B190269BF951513C453663 /* ClamAVDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5BB068BDD86F2C6D2FC966 /* ClamAVDetector.swift */; };
 		82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */; };
 		823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */; };
 		832F1B34810FF292EAF9A810 /* PermissionOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */; };
@@ -98,6 +105,7 @@
 		85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */; };
 		892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
+		8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
 		91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */; };
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
@@ -108,6 +116,7 @@
 		A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */; };
 		A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
+		ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */; };
 		AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC67B639248BC5EA1F5473 /* ScanCategory.swift */; };
 		B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */; };
 		B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39407E2EA6D045893F1BA4B /* DiskNode.swift */; };
@@ -118,9 +127,11 @@
 		B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */; };
 		B6B4FF9883F54E8F60010ACB /* VaderCleanerHelper in Embed Dependencies */ = {isa = PBXBuildFile; fileRef = 6CBCA8999E04715E502AB892 /* VaderCleanerHelper */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B7DADC9127C373029FC8198A /* AppUninstallerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D62624319B764770F02292 /* AppUninstallerViewModel.swift */; };
+		B9E44C0566F7DFAFAF8A6071 /* MalwareThreat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5741874005D8A34BB7D82287 /* MalwareThreat.swift */; };
 		B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */; };
 		BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2B92863509818189F46CD /* MenuBarContent.swift */; };
 		BABEDA3326E05DC3A8356E3D /* AppStoreUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */; };
+		BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */; };
 		BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133467A06193C406B027D97C /* NavigationSectionTests.swift */; };
 		BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC391B523110720320AD89 /* SystemPathProviding.swift */; };
 		BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */; };
@@ -138,12 +149,15 @@
 		D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */; };
 		D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */; };
 		DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */; };
+		DC099BEFD567C81EAA36519E /* ClamAVScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */; };
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
 		DD929B8195C7904CB4AC2E62 /* OptimizationViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */; };
 		E0420FF267A637AD7F530407 /* ExtensionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */; };
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */; };
 		E370FDA389CDFEC249437640 /* AppIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */; };
+		E39551732C1E81A0418FF7EE /* MalwareOnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */; };
+		E5548C91729D71FDA8D8ADC8 /* MalwareOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */; };
 		E5E7952A56BA88D9CA86A1B5 /* HTTPFetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */; };
 		E7B7C87B22F9328A45CC6A4B /* AppStoreUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */; };
 		EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */; };
@@ -233,6 +247,7 @@
 		22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperRegistration.swift; sourceTree = "<group>"; };
 		22622AEBD53221D89CB1439D /* OptimizationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationUITests.swift; sourceTree = "<group>"; };
 		22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateCheckerTests.swift; sourceTree = "<group>"; };
+		232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdater.swift; sourceTree = "<group>"; };
 		25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecisionTests.swift; sourceTree = "<group>"; };
 		2617BC26104D5196DEDB3589 /* UpdateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfo.swift; sourceTree = "<group>"; };
 		27F1DC062C52C51730548216 /* LoginItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItem.swift; sourceTree = "<group>"; };
@@ -245,6 +260,7 @@
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
+		3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdaterTests.swift; sourceTree = "<group>"; };
 		3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerTests.swift; sourceTree = "<group>"; };
 		3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviding.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
@@ -255,8 +271,10 @@
 		4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsService.swift; sourceTree = "<group>"; };
 		49D62624319B764770F02292 /* AppUninstallerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModel.swift; sourceTree = "<group>"; };
 		4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayout.swift; sourceTree = "<group>"; };
+		4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScanner.swift; sourceTree = "<group>"; };
 		4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkUITests.swift; sourceTree = "<group>"; };
 		4D92F45290B56030CBFA83D3 /* Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
+		4F5BB068BDD86F2C6D2FC966 /* ClamAVDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVDetector.swift; sourceTree = "<group>"; };
 		4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateCheckerTests.swift; sourceTree = "<group>"; };
 		4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPFetching.swift; sourceTree = "<group>"; };
 		50BDB24525760C96625DD266 /* TreemapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapView.swift; sourceTree = "<group>"; };
@@ -264,6 +282,7 @@
 		5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManager.swift; sourceTree = "<group>"; };
 		5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecision.swift; sourceTree = "<group>"; };
 		55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionCheckerTests.swift; sourceTree = "<group>"; };
+		5741874005D8A34BB7D82287 /* MalwareThreat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreat.swift; sourceTree = "<group>"; };
 		57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFile.swift; sourceTree = "<group>"; };
 		59C47AD889D249E865B928C8 /* OptimizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationView.swift; sourceTree = "<group>"; };
 		5CC50A90E584320709971BCB /* ScanCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategoryTests.swift; sourceTree = "<group>"; };
@@ -284,15 +303,18 @@
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
 		6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerUITests.swift; sourceTree = "<group>"; };
+		6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		6CBCA8999E04715E502AB892 /* VaderCleanerHelper */ = {isa = PBXFileReference; includeInIndex = 0; path = VaderCleanerHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		6DDE71332468CC343A9C6091 /* OptimizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewModel.swift; sourceTree = "<group>"; };
 		6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingView.swift; sourceTree = "<group>"; };
+		7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamer.swift; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
 		80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayoutTests.swift; sourceTree = "<group>"; };
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
+		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
 		897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensView.swift; sourceTree = "<group>"; };
 		8A0F635D79B943130BAB15AE /* VaderCleaner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VaderCleaner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModel.swift; sourceTree = "<group>"; };
@@ -331,6 +353,7 @@
 		BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModelTests.swift; sourceTree = "<group>"; };
 		BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModelTests.swift; sourceTree = "<group>"; };
 		C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewSubviews.swift; sourceTree = "<group>"; };
+		C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScannerTests.swift; sourceTree = "<group>"; };
 		C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
 		C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinderTests.swift; sourceTree = "<group>"; };
 		C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScanner.swift; sourceTree = "<group>"; };
@@ -339,9 +362,11 @@
 		C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStoreTests.swift; sourceTree = "<group>"; };
 		C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewSubviews.swift; sourceTree = "<group>"; };
 		CAC2037BDF5D632418393BD9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVOutputParserTests.swift; sourceTree = "<group>"; };
 		CEAF96E747AD4C1378B4043D /* VersionComparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparator.swift; sourceTree = "<group>"; };
 		CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateChecker.swift; sourceTree = "<group>"; };
 		CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModelTests.swift; sourceTree = "<group>"; };
+		D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVOutputParser.swift; sourceTree = "<group>"; };
 		D1CC391B523110720320AD89 /* SystemPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPathProviding.swift; sourceTree = "<group>"; };
 		D1F6A5DF7364E1886699488B /* BrowserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTests.swift; sourceTree = "<group>"; };
 		D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetector.swift; sourceTree = "<group>"; };
@@ -350,9 +375,12 @@
 		DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItemTests.swift; sourceTree = "<group>"; };
 		DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitorTests.swift; sourceTree = "<group>"; };
 		E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStore.swift; sourceTree = "<group>"; };
+		E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModel.swift; sourceTree = "<group>"; };
 		E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModel.swift; sourceTree = "<group>"; };
+		E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVDetectorTests.swift; sourceTree = "<group>"; };
 		E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskNodeTests.swift; sourceTree = "<group>"; };
 		E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearerTests.swift; sourceTree = "<group>"; };
+		EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatTests.swift; sourceTree = "<group>"; };
 		EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSystemPathProviderTests.swift; sourceTree = "<group>"; };
 		ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModel.swift; sourceTree = "<group>"; };
 		F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunnerTests.swift; sourceTree = "<group>"; };
@@ -421,7 +449,11 @@
 				9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */,
 				3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */,
 				D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */,
+				4F5BB068BDD86F2C6D2FC966 /* ClamAVDetector.swift */,
+				D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */,
+				4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */,
 				C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */,
+				232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */,
 				B39407E2EA6D045893F1BA4B /* DiskNode.swift */,
 				C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */,
 				613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */,
@@ -449,6 +481,9 @@
 				27F1DC062C52C51730548216 /* LoginItem.swift */,
 				5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */,
 				AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */,
+				882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */,
+				E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */,
+				5741874005D8A34BB7D82287 /* MalwareThreat.swift */,
 				D2C2B92863509818189F46CD /* MenuBarContent.swift */,
 				8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */,
 				2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */,
@@ -466,6 +501,7 @@
 				C751F5671E4A4657944A7DFC /* PrivacyView.swift */,
 				90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */,
 				67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */,
+				7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */,
 				9D5CB08F96767D10B1271970 /* RAMManager.swift */,
 				2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */,
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
@@ -533,6 +569,10 @@
 				A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */,
 				42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */,
 				D1F6A5DF7364E1886699488B /* BrowserTests.swift */,
+				E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */,
+				CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */,
+				C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */,
+				3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */,
 				EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */,
 				E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */,
 				3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */,
@@ -554,6 +594,8 @@
 				1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */,
 				5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */,
 				F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */,
+				6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */,
+				EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */,
 				CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */,
 				133467A06193C406B027D97C /* NavigationSectionTests.swift */,
 				C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */,
@@ -738,6 +780,10 @@
 				B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */,
 				7E70FB1E6C2740467DE8467B /* BrowserDetectorTests.swift in Sources */,
 				4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */,
+				8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */,
+				725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */,
+				DC099BEFD567C81EAA36519E /* ClamAVScannerTests.swift in Sources */,
+				ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */,
 				DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */,
 				FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */,
 				82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */,
@@ -759,6 +805,8 @@
 				8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */,
 				406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */,
 				1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */,
+				E39551732C1E81A0418FF7EE /* MalwareOnboardingViewModelTests.swift in Sources */,
+				20A0A0A414E0D919060C99D2 /* MalwareThreatTests.swift in Sources */,
 				C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */,
 				BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */,
 				2A46AEBD95B9E1561264D0F0 /* NotificationManagerTests.swift in Sources */,
@@ -828,7 +876,11 @@
 				85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */,
 				2B0438D190A4BDCD9853DC7D /* BrowserDataPathProviding.swift in Sources */,
 				159F0D7D84A23B27058835D6 /* BrowserDetector.swift in Sources */,
+				80B190269BF951513C453663 /* ClamAVDetector.swift in Sources */,
+				25057052F5E478AD7B692B9F /* ClamAVOutputParser.swift in Sources */,
+				117989F5D9137A7400CE8760 /* ClamAVScanner.swift in Sources */,
 				3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */,
+				BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */,
 				B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */,
 				D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */,
 				F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */,
@@ -857,6 +909,9 @@
 				2CF8285ADDBEB285A1DB56AC /* LoginItem.swift in Sources */,
 				EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */,
 				A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */,
+				E5548C91729D71FDA8D8ADC8 /* MalwareOnboardingView.swift in Sources */,
+				5B5767BC82C24D92B50032FE /* MalwareOnboardingViewModel.swift in Sources */,
+				B9E44C0566F7DFAFAF8A6071 /* MalwareThreat.swift in Sources */,
 				BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */,
 				C2F35144C0139C8829C4BB8A /* MenuBarViewModel.swift in Sources */,
 				F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */,
@@ -874,6 +929,7 @@
 				7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */,
 				63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */,
 				5C240506F97A777E37CA25B2 /* PrivacyViewSubviews.swift in Sources */,
+				196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */,
 				7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */,
 				567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */,
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */; };
 		26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */; };
 		28B2F4C32E608BD283DB2DE5 /* VaderCleanerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */; };
+		290DC2499AC322736E1FC7E6 /* ProcessLineStreamerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */; };
 		2A28D67DA396B3D2B6DB13D5 /* DiskScannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */; };
 		2A46AEBD95B9E1561264D0F0 /* NotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */; };
 		2A9EFA38DAE2163D06793B46 /* PrivacyCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */; };
@@ -308,6 +309,7 @@
 		6DDE71332468CC343A9C6091 /* OptimizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewModel.swift; sourceTree = "<group>"; };
 		6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingView.swift; sourceTree = "<group>"; };
 		7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamer.swift; sourceTree = "<group>"; };
+		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
@@ -606,6 +608,7 @@
 				8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */,
 				55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */,
 				2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */,
+				7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */,
 				78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */,
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
@@ -817,6 +820,7 @@
 				2A9EFA38DAE2163D06793B46 /* PrivacyCategoryTests.swift in Sources */,
 				3B8C348DB1DCBFB89771ADDC /* PrivacyPermissionCheckerTests.swift in Sources */,
 				C9DB75A7B6E045D306393638 /* PrivacyViewModelTests.swift in Sources */,
+				290DC2499AC322736E1FC7E6 /* ProcessLineStreamerTests.swift in Sources */,
 				3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */,
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,

--- a/VaderCleaner/ClamAVDetector.swift
+++ b/VaderCleaner/ClamAVDetector.swift
@@ -1,0 +1,79 @@
+// ClamAVDetector.swift
+// Locates a Homebrew-installed clamscan binary across the known prefixes and reports its version.
+
+import Foundation
+
+/// Discovers whether ClamAV's `clamscan` is installed and, if so, where.
+///
+/// VaderCleaner does not bundle ClamAV; it relies on a Homebrew install
+/// living at one of the standard prefixes (`/opt/homebrew` on Apple
+/// silicon, `/usr/local` on Intel). The candidate paths, the
+/// executable-file check, and the `--version` runner are all injected so
+/// detection is unit-testable without a real install.
+struct ClamAVDetector {
+
+    typealias ExecutableCheck = (String) -> Bool
+    typealias VersionRunner = (URL) async -> String?
+
+    private let candidatePaths: [URL]
+    private let isExecutable: ExecutableCheck
+    private let versionRunner: VersionRunner
+
+    init(
+        candidatePaths: [URL] = [
+            URL(fileURLWithPath: "/opt/homebrew/bin/clamscan"),
+            URL(fileURLWithPath: "/usr/local/bin/clamscan")
+        ],
+        isExecutable: @escaping ExecutableCheck = { FileManager.default.isExecutableFile(atPath: $0) },
+        versionRunner: @escaping VersionRunner = ClamAVDetector.defaultVersionRunner
+    ) {
+        self.candidatePaths = candidatePaths
+        self.isExecutable = isExecutable
+        self.versionRunner = versionRunner
+    }
+
+    /// The first candidate that is an executable file, or `nil` when none
+    /// resolve — i.e. ClamAV is not installed.
+    func path() -> URL? {
+        candidatePaths.first { isExecutable($0.path) }
+    }
+
+    func isInstalled() -> Bool {
+        path() != nil
+    }
+
+    /// Runs `clamscan --version` and returns its trimmed banner
+    /// ("ClamAV 1.4.1/27000/..."), or `nil` when ClamAV is absent or the
+    /// binary produced no output.
+    func version() async -> String? {
+        guard let binary = path() else { return nil }
+        guard let raw = await versionRunner(binary) else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    // MARK: - Production collaborator
+
+    /// Runs `clamscan --version` off the calling thread. stdout is read
+    /// before `waitUntilExit()` and stderr is discarded so a chatty binary
+    /// can't deadlock on a full pipe buffer — the same discipline used by
+    /// `LaunchAgentManager.defaultLoadedLabels`.
+    static let defaultVersionRunner: VersionRunner = { binary in
+        await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = binary
+            process.arguments = ["--version"]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            do {
+                try process.run()
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                return String(data: data, encoding: .utf8)
+            } catch {
+                return nil
+            }
+        }.value
+    }
+}

--- a/VaderCleaner/ClamAVOutputParser.swift
+++ b/VaderCleaner/ClamAVOutputParser.swift
@@ -22,26 +22,32 @@ enum ClamAVOutputParser {
     private static let separator = ": "
 
     static func parse(_ output: String) -> [MalwareThreat] {
-        var threats: [MalwareThreat] = []
-        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard line.hasSuffix(foundSuffix) else { continue }
+        output
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { parseLine(String($0)) }
+    }
 
-            let body = String(line.dropLast(foundSuffix.count))
-            guard let separatorRange = body.range(of: separator, options: .backwards) else {
-                continue
-            }
+    /// Parses a single `clamscan` line, returning a threat only for an
+    /// infected (`… FOUND`) verdict. `OK`, `ERROR`, summary, and progress
+    /// lines yield `nil`. Used by the scanner to parse output as it streams
+    /// rather than buffering the whole run.
+    static func parseLine(_ rawLine: String) -> MalwareThreat? {
+        let line = rawLine.trimmingCharacters(in: .whitespaces)
+        guard line.hasSuffix(foundSuffix) else { return nil }
 
-            let path = String(body[..<separatorRange.lowerBound])
-            let threatName = String(body[separatorRange.upperBound...])
-                .trimmingCharacters(in: .whitespaces)
-            guard !path.isEmpty, !threatName.isEmpty else { continue }
-
-            threats.append(MalwareThreat(
-                filePath: URL(fileURLWithPath: path),
-                threatName: threatName
-            ))
+        let body = String(line.dropLast(foundSuffix.count))
+        guard let separatorRange = body.range(of: separator, options: .backwards) else {
+            return nil
         }
-        return threats
+
+        let path = String(body[..<separatorRange.lowerBound])
+        let threatName = String(body[separatorRange.upperBound...])
+            .trimmingCharacters(in: .whitespaces)
+        guard !path.isEmpty, !threatName.isEmpty else { return nil }
+
+        return MalwareThreat(
+            filePath: URL(fileURLWithPath: path),
+            threatName: threatName
+        )
     }
 }

--- a/VaderCleaner/ClamAVOutputParser.swift
+++ b/VaderCleaner/ClamAVOutputParser.swift
@@ -1,0 +1,47 @@
+// ClamAVOutputParser.swift
+// Parses clamscan stdout into typed MalwareThreat values, isolating the infected lines from OK/ERROR/summary noise.
+
+import Foundation
+
+/// Turns raw `clamscan` output into `MalwareThreat` values.
+///
+/// `clamscan` prints one line per scanned file using the format
+/// `"<path>: <signature> FOUND"` for hits, `"<path>: OK"` for clean files,
+/// and `"<path>: <reason> ERROR"` for files it couldn't read. Only the
+/// `FOUND` lines are threats; everything else (including the
+/// `----- SCAN SUMMARY -----` block) is ignored.
+enum ClamAVOutputParser {
+
+    /// Suffix every infected line ends with. clamscan signature names never
+    /// contain spaces, so this token unambiguously marks a hit.
+    private static let foundSuffix = " FOUND"
+
+    /// Separator clamscan writes between the file path and the signature
+    /// name. A path may legitimately contain `": "`, so the split is taken
+    /// at the *last* occurrence — the threat name is always the final field.
+    private static let separator = ": "
+
+    static func parse(_ output: String) -> [MalwareThreat] {
+        var threats: [MalwareThreat] = []
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard line.hasSuffix(foundSuffix) else { continue }
+
+            let body = String(line.dropLast(foundSuffix.count))
+            guard let separatorRange = body.range(of: separator, options: .backwards) else {
+                continue
+            }
+
+            let path = String(body[..<separatorRange.lowerBound])
+            let threatName = String(body[separatorRange.upperBound...])
+                .trimmingCharacters(in: .whitespaces)
+            guard !path.isEmpty, !threatName.isEmpty else { continue }
+
+            threats.append(MalwareThreat(
+                filePath: URL(fileURLWithPath: path),
+                threatName: threatName
+            ))
+        }
+        return threats
+    }
+}

--- a/VaderCleaner/ClamAVScanner.swift
+++ b/VaderCleaner/ClamAVScanner.swift
@@ -55,9 +55,11 @@ struct ClamAVScanner {
         let arguments = ["--recursive", "--infected", "--no-summary"]
             + paths.map(\.path)
 
-        let collector = LineCollector()
+        let collector = ThreatCollector()
         let status = try await runner(binary, arguments) { line in
-            collector.append(line)
+            if let threat = ClamAVOutputParser.parseLine(line) {
+                collector.append(threat)
+            }
             progress(line)
         }
 
@@ -74,7 +76,7 @@ struct ClamAVScanner {
             )
         }
 
-        return ClamAVOutputParser.parse(collector.joined())
+        return collector.snapshot()
     }
 
     // MARK: - Production collaborator
@@ -88,23 +90,23 @@ struct ClamAVScanner {
     }
 }
 
-/// Thread-safe accumulator for the scan's stdout lines. `ProcessLineStreamer`
-/// invokes the line callback from its background read loop, so the buffer is
-/// guarded the same way as `SystemJunkDeleter`'s once-only resumer.
-private final class LineCollector: @unchecked Sendable {
+/// Thread-safe accumulator for threats parsed as the scan streams.
+/// `ProcessLineStreamer` invokes the line callback from its background read
+/// loop, so the buffer is guarded the same way as `SystemJunkDeleter`'s
+/// once-only resumer.
+private final class ThreatCollector: @unchecked Sendable {
     private let lock = NSLock()
-    private var lines: [String] = []
+    private var threats: [MalwareThreat] = []
 
-    func append(_ line: String) {
+    func append(_ threat: MalwareThreat) {
         lock.lock()
-        lines.append(line)
+        threats.append(threat)
         lock.unlock()
     }
 
-    func joined() -> String {
+    func snapshot() -> [MalwareThreat] {
         lock.lock()
-        let snapshot = lines
-        lock.unlock()
-        return snapshot.joined(separator: "\n")
+        defer { lock.unlock() }
+        return threats
     }
 }

--- a/VaderCleaner/ClamAVScanner.swift
+++ b/VaderCleaner/ClamAVScanner.swift
@@ -1,0 +1,110 @@
+// ClamAVScanner.swift
+// Runs clamscan over the requested paths, streams progress line by line, and returns the parsed list of detected threats.
+
+import Foundation
+import os.log
+
+/// Scans paths for malware with `clamscan` and returns the matches.
+///
+/// The binary location comes from a `ClamAVDetector`; the actual process
+/// run is delegated to an injected `ScanRunner` so argument construction
+/// and exit-code handling are unit-testable without a real ClamAV. Output
+/// is both forwarded to the caller's `progress` closure (for a live log)
+/// and accumulated for parsing once the scan completes.
+struct ClamAVScanner {
+
+    /// Runs `executable arguments`, invoking `onLine` per stdout line, and
+    /// returns the process exit code.
+    typealias ScanRunner = (
+        _ executable: URL,
+        _ arguments: [String],
+        _ onLine: @escaping (String) -> Void
+    ) async throws -> Int32
+
+    private let detector: ClamAVDetector
+    private let runner: ScanRunner
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "ClamAVScanner")
+
+    init(
+        detector: ClamAVDetector = ClamAVDetector(),
+        runner: @escaping ScanRunner = ClamAVScanner.defaultRunner
+    ) {
+        self.detector = detector
+        self.runner = runner
+    }
+
+    /// Scans `paths` recursively, reporting infected files only. `progress`
+    /// receives each `clamscan` output line as it streams.
+    ///
+    /// `clamscan` exits 0 when nothing is found and 1 when at least one
+    /// infection is found — both are *successful* scans. Only exit code 2
+    /// (a hard error) or an unreachable binary throws.
+    func scan(
+        paths: [URL],
+        progress: @escaping (String) -> Void
+    ) async throws -> [MalwareThreat] {
+        guard let binary = detector.path() else {
+            throw NSError(
+                domain: "com.personal.VaderCleaner.ClamAVScanner",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "ClamAV is not installed"]
+            )
+        }
+
+        let arguments = ["--recursive", "--infected", "--no-summary"]
+            + paths.map(\.path)
+
+        let collector = LineCollector()
+        let status = try await runner(binary, arguments) { line in
+            collector.append(line)
+            progress(line)
+        }
+
+        // 0 = clean, 1 = virus(es) found, 2 = error. Anything else (or a
+        // negative signal status) is a failure we surface rather than
+        // silently report "no threats".
+        guard status == 0 || status == 1 else {
+            log.error("clamscan exited with status \(status, privacy: .public)")
+            throw NSError(
+                domain: "com.personal.VaderCleaner.ClamAVScanner",
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey:
+                    "clamscan exited with status \(status)"]
+            )
+        }
+
+        return ClamAVOutputParser.parse(collector.joined())
+    }
+
+    // MARK: - Production collaborator
+
+    static let defaultRunner: ScanRunner = { executable, arguments, onLine in
+        try await ProcessLineStreamer.run(
+            executable: executable,
+            arguments: arguments,
+            onLine: onLine
+        )
+    }
+}
+
+/// Thread-safe accumulator for the scan's stdout lines. `ProcessLineStreamer`
+/// invokes the line callback from its background read loop, so the buffer is
+/// guarded the same way as `SystemJunkDeleter`'s once-only resumer.
+private final class LineCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [String] = []
+
+    func append(_ line: String) {
+        lock.lock()
+        lines.append(line)
+        lock.unlock()
+    }
+
+    func joined() -> String {
+        lock.lock()
+        let snapshot = lines
+        lock.unlock()
+        return snapshot.joined(separator: "\n")
+    }
+}

--- a/VaderCleaner/DatabaseUpdater.swift
+++ b/VaderCleaner/DatabaseUpdater.swift
@@ -20,14 +20,12 @@ struct DatabaseUpdater {
         _ onLine: @escaping (String) -> Void
     ) async throws -> Int32
 
-    /// The signature files freshclam maintains. `.cvd` and `.cld` are the
-    /// two on-disk forms of each database; only one of the pair exists at
-    /// a time, so all candidates are probed.
-    private static let signatureFileNames = [
-        "main.cvd", "main.cld",
-        "daily.cvd", "daily.cld",
-        "bytecode.cvd", "bytecode.cld"
-    ]
+    /// The two on-disk forms of a ClamAV signature database. `freshclam`
+    /// keeps `main`, `daily`, and `bytecode` plus optional extras
+    /// (`safebrowsing`, third-party feeds), so the directory is scanned by
+    /// extension rather than against a fixed filename list — a hardcoded
+    /// list would miss extra databases and report a stale last-update time.
+    private static let signatureExtensions: Set<String> = ["cvd", "cld"]
 
     private let databaseDirectories: [URL]
     private let freshclamPaths: [URL]
@@ -61,10 +59,15 @@ struct DatabaseUpdater {
     func lastUpdateDate() -> Date? {
         var newest: Date?
         for directory in databaseDirectories {
-            for name in Self.signatureFileNames {
-                let path = directory.appendingPathComponent(name).path
+            let entries = (try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            for entry in entries
+            where Self.signatureExtensions.contains(entry.pathExtension.lowercased()) {
                 guard
-                    let attributes = try? fileManager.attributesOfItem(atPath: path),
+                    let attributes = try? fileManager.attributesOfItem(atPath: entry.path),
                     let modified = attributes[.modificationDate] as? Date
                 else { continue }
                 if newest == nil || modified > newest! {

--- a/VaderCleaner/DatabaseUpdater.swift
+++ b/VaderCleaner/DatabaseUpdater.swift
@@ -1,0 +1,115 @@
+// DatabaseUpdater.swift
+// Reports the ClamAV signature database's last-update time and refreshes it by running freshclam.
+
+import Foundation
+
+/// Tracks and refreshes the ClamAV signature database.
+///
+/// Homebrew keeps signatures under `<prefix>/var/lib/clamav` as `.cvd`
+/// (compressed, full) or `.cld` (incremental) files; their modification
+/// time is the most reliable "last updated" signal without parsing
+/// `freshclam.log`. Refreshing runs the `freshclam` tool. Database
+/// directories, the `freshclam` location, the executable check, and the
+/// runner are injected so both queries and updates are unit-testable
+/// without a real ClamAV install.
+struct DatabaseUpdater {
+
+    typealias ExecutableCheck = (String) -> Bool
+    typealias FreshclamRunner = (
+        _ executable: URL,
+        _ onLine: @escaping (String) -> Void
+    ) async throws -> Int32
+
+    /// The signature files freshclam maintains. `.cvd` and `.cld` are the
+    /// two on-disk forms of each database; only one of the pair exists at
+    /// a time, so all candidates are probed.
+    private static let signatureFileNames = [
+        "main.cvd", "main.cld",
+        "daily.cvd", "daily.cld",
+        "bytecode.cvd", "bytecode.cld"
+    ]
+
+    private let databaseDirectories: [URL]
+    private let freshclamPaths: [URL]
+    private let fileManager: FileManager
+    private let isExecutable: ExecutableCheck
+    private let runner: FreshclamRunner
+
+    init(
+        databaseDirectories: [URL] = [
+            URL(fileURLWithPath: "/opt/homebrew/var/lib/clamav", isDirectory: true),
+            URL(fileURLWithPath: "/usr/local/var/lib/clamav", isDirectory: true)
+        ],
+        freshclamPaths: [URL] = [
+            URL(fileURLWithPath: "/opt/homebrew/bin/freshclam"),
+            URL(fileURLWithPath: "/usr/local/bin/freshclam")
+        ],
+        fileManager: FileManager = .default,
+        isExecutable: @escaping ExecutableCheck = { FileManager.default.isExecutableFile(atPath: $0) },
+        runner: @escaping FreshclamRunner = DatabaseUpdater.defaultRunner
+    ) {
+        self.databaseDirectories = databaseDirectories
+        self.freshclamPaths = freshclamPaths
+        self.fileManager = fileManager
+        self.isExecutable = isExecutable
+        self.runner = runner
+    }
+
+    /// The newest modification date across every signature file in every
+    /// configured database directory, or `nil` when none are present
+    /// (ClamAV not installed, or `freshclam` never run).
+    func lastUpdateDate() -> Date? {
+        var newest: Date?
+        for directory in databaseDirectories {
+            for name in Self.signatureFileNames {
+                let path = directory.appendingPathComponent(name).path
+                guard
+                    let attributes = try? fileManager.attributesOfItem(atPath: path),
+                    let modified = attributes[.modificationDate] as? Date
+                else { continue }
+                if newest == nil || modified > newest! {
+                    newest = modified
+                }
+            }
+        }
+        return newest
+    }
+
+    /// First `freshclam` candidate that is executable, or `nil` when the
+    /// updater is not installed.
+    func freshclamPath() -> URL? {
+        freshclamPaths.first { isExecutable($0.path) }
+    }
+
+    /// Runs `freshclam`, forwarding each output line to `progress`. Throws
+    /// when `freshclam` is absent or exits non-zero (it returns 0 on both a
+    /// successful update and an already-current database).
+    func update(progress: @escaping (String) -> Void = { _ in }) async throws {
+        guard let executable = freshclamPath() else {
+            throw NSError(
+                domain: "com.personal.VaderCleaner.DatabaseUpdater",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "freshclam is not installed"]
+            )
+        }
+        let status = try await runner(executable, progress)
+        guard status == 0 else {
+            throw NSError(
+                domain: "com.personal.VaderCleaner.DatabaseUpdater",
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey:
+                    "freshclam exited with status \(status)"]
+            )
+        }
+    }
+
+    // MARK: - Production collaborator
+
+    static let defaultRunner: FreshclamRunner = { executable, onLine in
+        try await ProcessLineStreamer.run(
+            executable: executable,
+            arguments: [],
+            onLine: onLine
+        )
+    }
+}

--- a/VaderCleaner/MalwareOnboardingView.swift
+++ b/VaderCleaner/MalwareOnboardingView.swift
@@ -1,0 +1,77 @@
+// MalwareOnboardingView.swift
+// Shown when ClamAV is missing — explains the Homebrew requirement and offers install / re-check actions.
+
+import SwiftUI
+
+struct MalwareOnboardingView: View {
+    @ObservedObject var viewModel: MalwareOnboardingViewModel
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "shield.lefthalf.filled")
+                .font(.system(size: 56))
+                .foregroundStyle(.tint)
+
+            Text("ClamAV Required")
+                .font(.title)
+                .fontWeight(.semibold)
+
+            Text(
+                "VaderCleaner uses ClamAV, a free open-source antivirus engine, " +
+                "to scan for malware, adware, and ransomware. Install it with " +
+                "Homebrew to enable malware scanning."
+            )
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Click Install via Homebrew below", systemImage: "1.circle.fill")
+                Label("Paste the copied command into Terminal and run it", systemImage: "2.circle.fill")
+                Label("Wait for the install to finish", systemImage: "3.circle.fill")
+                Label("Click Check Again to continue", systemImage: "4.circle.fill")
+            }
+            .font(.callout)
+            .padding()
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+
+            Text(MalwareOnboardingViewModel.installCommand)
+                .font(.system(.callout, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
+
+            HStack(spacing: 12) {
+                Button("Check Again") {
+                    viewModel.checkAgain()
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button("Install via Homebrew") {
+                    viewModel.installViaHomebrew()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(28)
+        .frame(width: 520)
+    }
+}
+
+#Preview {
+    MalwareOnboardingView(
+        viewModel: MalwareOnboardingViewModel(
+            detector: ClamAVDetector(
+                candidatePaths: [],
+                isExecutable: { _ in false },
+                versionRunner: { _ in nil }
+            ),
+            copyToPasteboard: { _ in },
+            openTerminal: {}
+        )
+    )
+}

--- a/VaderCleaner/MalwareOnboardingViewModel.swift
+++ b/VaderCleaner/MalwareOnboardingViewModel.swift
@@ -1,0 +1,66 @@
+// MalwareOnboardingViewModel.swift
+// Backs the ClamAV-missing onboarding sheet — tracks install state and drives the Homebrew-install / re-check actions.
+
+import Foundation
+import AppKit
+import Combine
+
+/// Drives `MalwareOnboardingView`, shown when ClamAV is not installed.
+///
+/// "Install via Homebrew" copies the install command to the pasteboard and
+/// opens Terminal — deliberately *not* `osascript`, which would trigger an
+/// Automation-permission prompt mid-onboarding. The pasteboard write and
+/// Terminal launch are injected so the view-model is testable without side
+/// effects.
+@MainActor
+final class MalwareOnboardingViewModel: ObservableObject {
+
+    /// The Homebrew command the user runs to install ClamAV.
+    static let installCommand = "brew install clamav"
+
+    /// Whether ClamAV is currently detected. Published so the view dismisses
+    /// the onboarding once "Check Again" finds an install.
+    @Published private(set) var isInstalled: Bool
+
+    private let detector: ClamAVDetector
+    private let copyToPasteboard: (String) -> Void
+    private let openTerminal: () -> Void
+
+    init(
+        detector: ClamAVDetector = ClamAVDetector(),
+        copyToPasteboard: @escaping (String) -> Void = MalwareOnboardingViewModel.defaultCopyToPasteboard,
+        openTerminal: @escaping () -> Void = MalwareOnboardingViewModel.defaultOpenTerminal
+    ) {
+        self.detector = detector
+        self.copyToPasteboard = copyToPasteboard
+        self.openTerminal = openTerminal
+        self.isInstalled = detector.isInstalled()
+    }
+
+    /// Re-runs detection after the user installs ClamAV out-of-band.
+    func checkAgain() {
+        isInstalled = detector.isInstalled()
+    }
+
+    /// Stages the install command on the clipboard and brings Terminal
+    /// forward so the user can paste-and-run it.
+    func installViaHomebrew() {
+        copyToPasteboard(Self.installCommand)
+        openTerminal()
+    }
+
+    // MARK: - Production collaborators
+
+    static let defaultCopyToPasteboard: (String) -> Void = { command in
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(command, forType: .string)
+    }
+
+    static let defaultOpenTerminal: () -> Void = {
+        guard let terminal = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.Terminal"
+        ) else { return }
+        NSWorkspace.shared.open(terminal)
+    }
+}

--- a/VaderCleaner/MalwareThreat.swift
+++ b/VaderCleaner/MalwareThreat.swift
@@ -1,0 +1,15 @@
+// MalwareThreat.swift
+// A single infected file reported by a ClamAV scan: its location and the matched signature name.
+
+import Foundation
+
+/// One infected file found by `clamscan`. Identity is the file path — a scan
+/// reports at most one verdict per file, and the path is what the removal
+/// flow (Prompt 24) acts on.
+struct MalwareThreat: Identifiable, Equatable, Sendable {
+
+    var id: String { filePath.path }
+
+    let filePath: URL
+    let threatName: String
+}

--- a/VaderCleaner/ProcessLineStreamer.swift
+++ b/VaderCleaner/ProcessLineStreamer.swift
@@ -1,0 +1,63 @@
+// ProcessLineStreamer.swift
+// Runs a child process and delivers its stdout one complete line at a time, used by the ClamAV scan and database-update flows.
+
+import Foundation
+
+/// Runs an external command and streams its stdout line by line.
+///
+/// `freshclam` and `clamscan` emit progress continuously over a long run, so
+/// the UI wants each line as it arrives rather than one blob at the end.
+/// `availableData` hands back arbitrary byte chunks — a single read can split
+/// a line or carry several — so output is buffered and only emitted on a
+/// newline boundary, with the trailing partial line flushed at EOF so a final
+/// `FOUND` verdict is never lost.
+enum ProcessLineStreamer {
+
+    private static let newline: UInt8 = 0x0A
+
+    /// Launches `executable arguments`, invoking `onLine` for every complete
+    /// stdout line (and the final unterminated one), and returns the process
+    /// termination status. The blocking read loop runs off the caller's
+    /// thread. stderr is routed to `/dev/null` so a chatty command can't
+    /// deadlock on an unread pipe buffer.
+    static func run(
+        executable: URL,
+        arguments: [String],
+        onLine: @escaping (String) -> Void
+    ) async throws -> Int32 {
+        try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = executable
+            process.arguments = arguments
+            let outputPipe = Pipe()
+            process.standardOutput = outputPipe
+            process.standardError = FileHandle.nullDevice
+
+            try process.run()
+
+            let handle = outputPipe.fileHandleForReading
+            var buffer = Data()
+            while case let chunk = handle.availableData, !chunk.isEmpty {
+                buffer.append(chunk)
+                while let newlineIndex = buffer.firstIndex(of: newline) {
+                    let lineData = buffer.subdata(in: buffer.startIndex..<newlineIndex)
+                    buffer.removeSubrange(buffer.startIndex...newlineIndex)
+                    emit(lineData, to: onLine)
+                }
+            }
+            // EOF — the process closed stdout without a final newline.
+            emit(buffer, to: onLine)
+
+            process.waitUntilExit()
+            return process.terminationStatus
+        }.value
+    }
+
+    private static func emit(_ data: Data, to onLine: (String) -> Void) {
+        guard !data.isEmpty,
+              let raw = String(data: data, encoding: .utf8) else { return }
+        let line = raw.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+        guard !line.isEmpty else { return }
+        onLine(line)
+    }
+}

--- a/VaderCleanerTests/ClamAVDetectorTests.swift
+++ b/VaderCleanerTests/ClamAVDetectorTests.swift
@@ -1,0 +1,68 @@
+// ClamAVDetectorTests.swift
+// Verifies ClamAVDetector locates the clamscan binary across injected candidate paths and reports version via an injected runner.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ClamAVDetectorTests: XCTestCase {
+
+    private let homebrew = URL(fileURLWithPath: "/opt/homebrew/bin/clamscan")
+    private let local = URL(fileURLWithPath: "/usr/local/bin/clamscan")
+
+    func test_isInstalled_returnsBool_falseWhenNoCandidateIsExecutable() {
+        let detector = ClamAVDetector(
+            candidatePaths: [homebrew, local],
+            isExecutable: { _ in false },
+            versionRunner: { _ in nil }
+        )
+        XCTAssertFalse(detector.isInstalled())
+    }
+
+    func test_path_returnsFirstExecutableCandidate() {
+        let detector = ClamAVDetector(
+            candidatePaths: [homebrew, local],
+            isExecutable: { $0 == self.local.path },
+            versionRunner: { _ in nil }
+        )
+        XCTAssertEqual(detector.path(), local)
+        XCTAssertTrue(detector.isInstalled())
+    }
+
+    func test_path_prefersEarlierCandidateWhenMultipleExecutable() {
+        let detector = ClamAVDetector(
+            candidatePaths: [homebrew, local],
+            isExecutable: { _ in true },
+            versionRunner: { _ in nil }
+        )
+        XCTAssertEqual(detector.path(), homebrew)
+    }
+
+    func test_path_isNilWhenNothingExecutable() {
+        let detector = ClamAVDetector(
+            candidatePaths: [homebrew, local],
+            isExecutable: { _ in false },
+            versionRunner: { _ in nil }
+        )
+        XCTAssertNil(detector.path())
+    }
+
+    func test_version_returnsTrimmedRunnerOutputWhenInstalled() async {
+        let detector = ClamAVDetector(
+            candidatePaths: [homebrew],
+            isExecutable: { _ in true },
+            versionRunner: { _ in "ClamAV 1.4.1/27000/Mon\n" }
+        )
+        let version = await detector.version()
+        XCTAssertEqual(version, "ClamAV 1.4.1/27000/Mon")
+    }
+
+    func test_version_isNilWhenNotInstalled() async {
+        let detector = ClamAVDetector(
+            candidatePaths: [homebrew],
+            isExecutable: { _ in false },
+            versionRunner: { _ in "should not be called" }
+        )
+        let version = await detector.version()
+        XCTAssertNil(version)
+    }
+}

--- a/VaderCleanerTests/ClamAVOutputParserTests.swift
+++ b/VaderCleanerTests/ClamAVOutputParserTests.swift
@@ -47,6 +47,19 @@ final class ClamAVOutputParserTests: XCTestCase {
         XCTAssertEqual(threats[0].threatName, "Eicar-Test-Signature")
     }
 
+    func test_parseLine_returnsThreatForFoundLineAndNilOtherwise() {
+        let threat = ClamAVOutputParser.parseLine(
+            "/Users/x/evil.bin: Eicar-Test-Signature FOUND"
+        )
+        XCTAssertEqual(threat?.filePath, URL(fileURLWithPath: "/Users/x/evil.bin"))
+        XCTAssertEqual(threat?.threatName, "Eicar-Test-Signature")
+
+        XCTAssertNil(ClamAVOutputParser.parseLine("/Users/x/a.txt: OK"))
+        XCTAssertNil(ClamAVOutputParser.parseLine("/var/db/x: Access denied ERROR"))
+        XCTAssertNil(ClamAVOutputParser.parseLine("Scanning /Users/x"))
+        XCTAssertNil(ClamAVOutputParser.parseLine(""))
+    }
+
     func test_parse_ignoresErrorAndSummaryLines() {
         let output = """
         /private/var/db/locked.db: Access denied ERROR

--- a/VaderCleanerTests/ClamAVOutputParserTests.swift
+++ b/VaderCleanerTests/ClamAVOutputParserTests.swift
@@ -1,0 +1,62 @@
+// ClamAVOutputParserTests.swift
+// Exercises ClamAVOutputParser against representative clamscan output: infected lines, clean scans, colon-bearing paths, and non-threat noise.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ClamAVOutputParserTests: XCTestCase {
+
+    func test_parse_extractsPathAndThreatNameFromInfectedLines() {
+        let output = """
+        /Users/x/Downloads/evil.bin: Eicar-Test-Signature FOUND
+        /Users/x/Library/Caches/bad.dmg: Osx.Trojan.Generic-1 FOUND
+        """
+        let threats = ClamAVOutputParser.parse(output)
+
+        XCTAssertEqual(threats.count, 2)
+        XCTAssertEqual(threats[0].filePath, URL(fileURLWithPath: "/Users/x/Downloads/evil.bin"))
+        XCTAssertEqual(threats[0].threatName, "Eicar-Test-Signature")
+        XCTAssertEqual(threats[1].filePath, URL(fileURLWithPath: "/Users/x/Library/Caches/bad.dmg"))
+        XCTAssertEqual(threats[1].threatName, "Osx.Trojan.Generic-1")
+    }
+
+    func test_parse_returnsEmptyForCleanScanOutput() {
+        let output = """
+        /Users/x/Documents/report.pdf: OK
+        /Users/x/Documents/photo.jpg: OK
+        """
+        XCTAssertTrue(ClamAVOutputParser.parse(output).isEmpty)
+    }
+
+    func test_parse_returnsEmptyForEmptyOutput() {
+        XCTAssertTrue(ClamAVOutputParser.parse("").isEmpty)
+        XCTAssertTrue(ClamAVOutputParser.parse("   \n  \n").isEmpty)
+    }
+
+    func test_parse_handlesPathsContainingColons() {
+        // The separator before the threat name is the LAST ": "; a colon in
+        // the path itself must not split the file off prematurely.
+        let output = "/Users/x/notes: meeting 3:30.txt: Eicar-Test-Signature FOUND"
+        let threats = ClamAVOutputParser.parse(output)
+
+        XCTAssertEqual(threats.count, 1)
+        XCTAssertEqual(
+            threats[0].filePath,
+            URL(fileURLWithPath: "/Users/x/notes: meeting 3:30.txt")
+        )
+        XCTAssertEqual(threats[0].threatName, "Eicar-Test-Signature")
+    }
+
+    func test_parse_ignoresErrorAndSummaryLines() {
+        let output = """
+        /private/var/db/locked.db: Access denied ERROR
+        /Users/x/Downloads/evil.bin: Eicar-Test-Signature FOUND
+        ----------- SCAN SUMMARY -----------
+        Infected files: 1
+        """
+        let threats = ClamAVOutputParser.parse(output)
+
+        XCTAssertEqual(threats.count, 1)
+        XCTAssertEqual(threats[0].threatName, "Eicar-Test-Signature")
+    }
+}

--- a/VaderCleanerTests/ClamAVScannerTests.swift
+++ b/VaderCleanerTests/ClamAVScannerTests.swift
@@ -1,0 +1,106 @@
+// ClamAVScannerTests.swift
+// Verifies ClamAVScanner builds correct clamscan arguments, streams progress, treats exit 0/1 as success, and throws on hard errors or a missing binary.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ClamAVScannerTests: XCTestCase {
+
+    private let binary = URL(fileURLWithPath: "/opt/homebrew/bin/clamscan")
+
+    func test_scan_buildsRecursiveInfectedNoSummaryArgumentsWithPaths() async throws {
+        var capturedExecutable: URL?
+        var capturedArguments: [String]?
+        let scanner = makeScanner(installed: true) { executable, arguments, _ in
+            capturedExecutable = executable
+            capturedArguments = arguments
+            return 0
+        }
+
+        _ = try await scanner.scan(
+            paths: [URL(fileURLWithPath: "/Users/x"), URL(fileURLWithPath: "/tmp/y")],
+            progress: { _ in }
+        )
+
+        XCTAssertEqual(capturedExecutable, binary)
+        XCTAssertEqual(
+            capturedArguments,
+            ["--recursive", "--infected", "--no-summary", "/Users/x", "/tmp/y"]
+        )
+    }
+
+    func test_scan_returnsEmptyAndForwardsProgressOnCleanExitZero() async throws {
+        var progressLines: [String] = []
+        let scanner = makeScanner(installed: true) { _, _, onLine in
+            onLine("Scanning /Users/x/a.txt")
+            onLine("/Users/x/a.txt: OK")
+            return 0
+        }
+
+        let threats = try await scanner.scan(
+            paths: [URL(fileURLWithPath: "/Users/x")],
+            progress: { progressLines.append($0) }
+        )
+
+        XCTAssertTrue(threats.isEmpty)
+        XCTAssertEqual(progressLines, ["Scanning /Users/x/a.txt", "/Users/x/a.txt: OK"])
+    }
+
+    func test_scan_parsesThreatsOnExitOne() async throws {
+        // clamscan exits 1 when at least one infected file is found — this is
+        // a successful scan with results, NOT a failure.
+        let scanner = makeScanner(installed: true) { _, _, onLine in
+            onLine("/Users/x/evil.bin: Eicar-Test-Signature FOUND")
+            return 1
+        }
+
+        let threats = try await scanner.scan(
+            paths: [URL(fileURLWithPath: "/Users/x")],
+            progress: { _ in }
+        )
+
+        XCTAssertEqual(threats.count, 1)
+        XCTAssertEqual(threats[0].threatName, "Eicar-Test-Signature")
+        XCTAssertEqual(threats[0].filePath, URL(fileURLWithPath: "/Users/x/evil.bin"))
+    }
+
+    func test_scan_throwsOnHardErrorExitTwo() async {
+        let scanner = makeScanner(installed: true) { _, _, _ in 2 }
+        do {
+            _ = try await scanner.scan(
+                paths: [URL(fileURLWithPath: "/Users/x")],
+                progress: { _ in }
+            )
+            XCTFail("Expected scan() to throw on clamscan exit code 2")
+        } catch {
+            // Expected.
+        }
+    }
+
+    func test_scan_throwsWhenClamAVNotInstalled() async {
+        let scanner = makeScanner(installed: false) { _, _, _ in 0 }
+        do {
+            _ = try await scanner.scan(
+                paths: [URL(fileURLWithPath: "/Users/x")],
+                progress: { _ in }
+            )
+            XCTFail("Expected scan() to throw when clamscan is absent")
+        } catch {
+            // Expected.
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeScanner(
+        installed: Bool,
+        runner: @escaping ClamAVScanner.ScanRunner
+    ) -> ClamAVScanner {
+        let detector = ClamAVDetector(
+            candidatePaths: [binary],
+            isExecutable: { _ in installed },
+            versionRunner: { _ in nil }
+        )
+        return ClamAVScanner(detector: detector, runner: runner)
+    }
+}

--- a/VaderCleanerTests/DatabaseUpdaterTests.swift
+++ b/VaderCleanerTests/DatabaseUpdaterTests.swift
@@ -1,0 +1,117 @@
+// DatabaseUpdaterTests.swift
+// Verifies DatabaseUpdater reports the newest signature-file mtime and routes update() through an injected freshclam runner.
+
+import XCTest
+@testable import VaderCleaner
+
+final class DatabaseUpdaterTests: XCTestCase {
+
+    private var dbDir: URL!
+
+    override func setUpWithError() throws {
+        dbDir = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        TestHelpers.tearDownTempDirectory(dbDir)
+    }
+
+    // MARK: - lastUpdateDate
+
+    func test_lastUpdateDate_isNilWhenNoSignatureFilesPresent() {
+        let updater = makeUpdater()
+        XCTAssertNil(updater.lastUpdateDate())
+    }
+
+    func test_lastUpdateDate_returnsNewestSignatureFileModificationDate() throws {
+        let old = Date(timeIntervalSince1970: 1_600_000_000)
+        let recent = Date(timeIntervalSince1970: 1_700_000_000)
+
+        try writeSignatureFile(named: "main.cvd", modified: old)
+        try writeSignatureFile(named: "daily.cld", modified: recent)
+        try writeSignatureFile(named: "bytecode.cvd", modified: old)
+
+        let updater = makeUpdater()
+        let date = try XCTUnwrap(updater.lastUpdateDate())
+        XCTAssertEqual(date.timeIntervalSince1970, recent.timeIntervalSince1970, accuracy: 1.0)
+    }
+
+    func test_lastUpdateDate_ignoresUnrelatedFiles() throws {
+        try writeSignatureFile(named: "freshclam.log", modified: Date())
+        let updater = makeUpdater()
+        XCTAssertNil(updater.lastUpdateDate())
+    }
+
+    // MARK: - update
+
+    func test_update_invokesFreshclamRunnerAndForwardsProgress() async throws {
+        var capturedExecutable: URL?
+        var lines: [String] = []
+        let updater = DatabaseUpdater(
+            databaseDirectories: [dbDir],
+            freshclamPaths: [URL(fileURLWithPath: "/opt/homebrew/bin/freshclam")],
+            isExecutable: { _ in true },
+            runner: { executable, onLine in
+                capturedExecutable = executable
+                onLine("Downloading daily.cvd")
+                onLine("daily.cvd updated")
+                return 0
+            }
+        )
+
+        try await updater.update { lines.append($0) }
+
+        XCTAssertEqual(capturedExecutable?.path, "/opt/homebrew/bin/freshclam")
+        XCTAssertEqual(lines, ["Downloading daily.cvd", "daily.cvd updated"])
+    }
+
+    func test_update_throwsOnNonZeroExit() async {
+        let updater = DatabaseUpdater(
+            databaseDirectories: [dbDir],
+            freshclamPaths: [URL(fileURLWithPath: "/opt/homebrew/bin/freshclam")],
+            isExecutable: { _ in true },
+            runner: { _, _ in 1 }
+        )
+        do {
+            try await updater.update()
+            XCTFail("Expected update() to throw on non-zero freshclam exit")
+        } catch {
+            // Expected.
+        }
+    }
+
+    func test_update_throwsWhenFreshclamNotInstalled() async {
+        let updater = DatabaseUpdater(
+            databaseDirectories: [dbDir],
+            freshclamPaths: [URL(fileURLWithPath: "/opt/homebrew/bin/freshclam")],
+            isExecutable: { _ in false },
+            runner: { _, _ in 0 }
+        )
+        do {
+            try await updater.update()
+            XCTFail("Expected update() to throw when freshclam is absent")
+        } catch {
+            // Expected.
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeUpdater() -> DatabaseUpdater {
+        DatabaseUpdater(
+            databaseDirectories: [dbDir],
+            freshclamPaths: [URL(fileURLWithPath: "/opt/homebrew/bin/freshclam")],
+            isExecutable: { _ in true },
+            runner: { _, _ in 0 }
+        )
+    }
+
+    private func writeSignatureFile(named name: String, modified: Date) throws {
+        let url = dbDir.appendingPathComponent(name)
+        try Data([0x00]).write(to: url)
+        try FileManager.default.setAttributes(
+            [.modificationDate: modified],
+            ofItemAtPath: url.path
+        )
+    }
+}

--- a/VaderCleanerTests/DatabaseUpdaterTests.swift
+++ b/VaderCleanerTests/DatabaseUpdaterTests.swift
@@ -42,6 +42,18 @@ final class DatabaseUpdaterTests: XCTestCase {
         XCTAssertNil(updater.lastUpdateDate())
     }
 
+    func test_lastUpdateDate_considersNonStandardSignatureDatabases() throws {
+        // freshclam also maintains optional databases (e.g. safebrowsing,
+        // third-party feeds) — a fixed filename list would miss these and
+        // report a stale timestamp.
+        let recent = Date(timeIntervalSince1970: 1_700_000_000)
+        try writeSignatureFile(named: "main.cvd", modified: Date(timeIntervalSince1970: 1_600_000_000))
+        try writeSignatureFile(named: "safebrowsing.cld", modified: recent)
+
+        let date = try XCTUnwrap(makeUpdater().lastUpdateDate())
+        XCTAssertEqual(date.timeIntervalSince1970, recent.timeIntervalSince1970, accuracy: 1.0)
+    }
+
     // MARK: - update
 
     func test_update_invokesFreshclamRunnerAndForwardsProgress() async throws {

--- a/VaderCleanerTests/MalwareOnboardingViewModelTests.swift
+++ b/VaderCleanerTests/MalwareOnboardingViewModelTests.swift
@@ -1,0 +1,55 @@
+// MalwareOnboardingViewModelTests.swift
+// Tests that MalwareOnboardingViewModel reflects ClamAV detection state and wires the Homebrew-install action.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class MalwareOnboardingViewModelTests: XCTestCase {
+
+    private func detector(installed: Bool) -> ClamAVDetector {
+        ClamAVDetector(
+            candidatePaths: [URL(fileURLWithPath: "/opt/homebrew/bin/clamscan")],
+            isExecutable: { _ in installed },
+            versionRunner: { _ in nil }
+        )
+    }
+
+    func test_isInstalled_reflectsDetectorAtInit() {
+        XCTAssertFalse(MalwareOnboardingViewModel(detector: detector(installed: false)).isInstalled)
+        XCTAssertTrue(MalwareOnboardingViewModel(detector: detector(installed: true)).isInstalled)
+    }
+
+    func test_checkAgain_reReadsDetectionState() {
+        var installed = false
+        let sut = MalwareOnboardingViewModel(
+            detector: ClamAVDetector(
+                candidatePaths: [URL(fileURLWithPath: "/opt/homebrew/bin/clamscan")],
+                isExecutable: { _ in installed },
+                versionRunner: { _ in nil }
+            )
+        )
+        XCTAssertFalse(sut.isInstalled)
+
+        installed = true
+        sut.checkAgain()
+
+        XCTAssertTrue(sut.isInstalled)
+    }
+
+    func test_installViaHomebrew_copiesCommandAndOpensTerminal() {
+        var copied: String?
+        var openedTerminal = false
+        let sut = MalwareOnboardingViewModel(
+            detector: detector(installed: false),
+            copyToPasteboard: { copied = $0 },
+            openTerminal: { openedTerminal = true }
+        )
+
+        sut.installViaHomebrew()
+
+        XCTAssertEqual(copied, "brew install clamav")
+        XCTAssertEqual(MalwareOnboardingViewModel.installCommand, "brew install clamav")
+        XCTAssertTrue(openedTerminal)
+    }
+}

--- a/VaderCleanerTests/MalwareThreatTests.swift
+++ b/VaderCleanerTests/MalwareThreatTests.swift
@@ -1,0 +1,33 @@
+// MalwareThreatTests.swift
+// Verifies MalwareThreat derives its identity from the file path and compares by value.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MalwareThreatTests: XCTestCase {
+
+    func test_id_isThePathOfTheInfectedFile() {
+        let threat = MalwareThreat(
+            filePath: URL(fileURLWithPath: "/Users/x/Downloads/evil.bin"),
+            threatName: "Eicar-Test-Signature"
+        )
+        XCTAssertEqual(threat.id, "/Users/x/Downloads/evil.bin")
+    }
+
+    func test_equality_isByValue() {
+        let a = MalwareThreat(
+            filePath: URL(fileURLWithPath: "/tmp/a"),
+            threatName: "Win.Test.EICAR_HDB-1"
+        )
+        let b = MalwareThreat(
+            filePath: URL(fileURLWithPath: "/tmp/a"),
+            threatName: "Win.Test.EICAR_HDB-1"
+        )
+        let c = MalwareThreat(
+            filePath: URL(fileURLWithPath: "/tmp/a"),
+            threatName: "Other.Threat"
+        )
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+}

--- a/VaderCleanerTests/ProcessLineStreamerTests.swift
+++ b/VaderCleanerTests/ProcessLineStreamerTests.swift
@@ -1,0 +1,76 @@
+// ProcessLineStreamerTests.swift
+// Exercises ProcessLineStreamer end-to-end via /bin/sh: newline splitting, trailing-partial flush at EOF, exit-code propagation, and empty output.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ProcessLineStreamerTests: XCTestCase {
+
+    private let sh = URL(fileURLWithPath: "/bin/sh")
+
+    func test_run_splitsNewlineTerminatedOutputIntoLines() async throws {
+        let collector = Collector()
+        let status = try await ProcessLineStreamer.run(
+            executable: sh,
+            arguments: ["-c", "printf 'a\\nb\\nc\\n'"],
+            onLine: collector.append
+        )
+        XCTAssertEqual(status, 0)
+        XCTAssertEqual(collector.snapshot(), ["a", "b", "c"])
+    }
+
+    func test_run_flushesTrailingPartialLineWithoutFinalNewline() async throws {
+        // The final "y" has no terminating newline — it must still be
+        // delivered (a final "… FOUND" verdict can land here).
+        let collector = Collector()
+        let status = try await ProcessLineStreamer.run(
+            executable: sh,
+            arguments: ["-c", "printf 'x\\ny'"],
+            onLine: collector.append
+        )
+        XCTAssertEqual(status, 0)
+        XCTAssertEqual(collector.snapshot(), ["x", "y"])
+    }
+
+    func test_run_propagatesNonZeroExitStatus() async throws {
+        let collector = Collector()
+        let status = try await ProcessLineStreamer.run(
+            executable: sh,
+            arguments: ["-c", "exit 2"],
+            onLine: collector.append
+        )
+        XCTAssertEqual(status, 2)
+        XCTAssertTrue(collector.snapshot().isEmpty)
+    }
+
+    func test_run_handlesEmptyOutput() async throws {
+        let collector = Collector()
+        let status = try await ProcessLineStreamer.run(
+            executable: sh,
+            arguments: ["-c", "true"],
+            onLine: collector.append
+        )
+        XCTAssertEqual(status, 0)
+        XCTAssertTrue(collector.snapshot().isEmpty)
+    }
+
+    /// `onLine` is invoked from the streamer's background read loop, so the
+    /// collected lines are guarded the same way production callers guard
+    /// their accumulators.
+    private final class Collector: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lines: [String] = []
+
+        func append(_ line: String) {
+            lock.lock()
+            lines.append(line)
+            lock.unlock()
+        }
+
+        func snapshot() -> [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return lines
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -43,7 +43,7 @@
 ## Phase 4 — Optimization & Security
 
 - [x] **Prompt 22** — Optimization feature (login items, launch agents, RAM flush, maintenance scripts)
-- [ ] **Prompt 23** — ClamAV integration (detection, DB update, scanning, output parsing)
+- [x] **Prompt 23** — ClamAV integration (detection, DB update, scanning, output parsing)
 - [ ] **Prompt 24** — Malware Removal UI (scan → results → remove flow)
 
 ## Phase 5 — Integration & Polish


### PR DESCRIPTION
## Summary

Implements the ClamAV malware-scanning **engine layer** for the Malware Removal feature (Phase 4, Prompt 23). UI wiring (MalwareView/MalwareViewModel, ContentView routing) is intentionally deferred to Prompt 24.

- **ClamAVDetector** — locates the Homebrew `clamscan` binary across `/opt/homebrew` and `/usr/local`; `isInstalled()`, `path()`, async `version()`.
- **ClamAVOutputParser + MalwareThreat** — parses `"<path>: <signature> FOUND"` lines, splitting on the **last** `": "` so colon-bearing paths survive; ignores `OK`/`ERROR`/summary noise.
- **DatabaseUpdater** — newest signature-file (`*.cvd`/`*.cld`) mtime as the last-update date; `update()` runs `freshclam` with streamed progress.
- **ClamAVScanner** — runs `clamscan --recursive --infected --no-summary`; exit **0 and 1 are success** (1 = infections found), only exit 2 / signal throws.
- **ProcessLineStreamer** — shared newline-buffered stdout streamer; flushes the trailing partial line at EOF so a final `FOUND` verdict is never lost.
- **MalwareOnboardingView / ViewModel** — shown when ClamAV is absent; copies `brew install clamav` to the pasteboard and opens Terminal (avoids the `osascript` Automation-permission prompt).

All collaborators (paths, executable check, process runner) are injected — the suite is fully green **without a real ClamAV install**, per the no-mock / real-data rule.

Closes #67

## Test plan

- [x] TDD: failing tests written first, then implementation.
- [x] **Unit suite deterministically green: 548/548** across two full runs (`VaderCleanerTests`).
- [x] New coverage: `ClamAVDetectorTests`, `ClamAVOutputParserTests` (incl. colon-in-path), `DatabaseUpdaterTests`, `ClamAVScannerTests` (arg construction + exit 0/1/2), `MalwareThreatTests`, `MalwareOnboardingViewModelTests`, `ProcessLineStreamerTests` (real `/bin/sh`: split, EOF-partial flush, exit code, empty).
- [x] No `ContentView`/Optimization changes (deferred / out of scope).
- [ ] ⚠️ Pre-existing **full-suite XCUITest flakiness** (unrelated to this change): different `VaderCleanerUITests` fail per run (Optimization in run 1, SystemJunk in run 2), all pass in isolation, unit suite always green. Tracked in #68 (relates to #66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated ClamAV-based malware detection and scanning capabilities
  * Automated signature database updates for current threat definitions
  * Onboarding guidance with step-by-step ClamAV installation instructions via Homebrew
  * Real-time progress feedback during scanning and database update operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->