### PR TITLE
feat: Malware Removal UI — scan, results, remove flow

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
 		04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
+		09756E0B2E09D8BF521C1141 /* MalwareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7315AD5A081B0855C316F00F /* MalwareView.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
@@ -52,6 +53,7 @@
 		3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */; };
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
+		390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
 		3A0AAEEE22026F9D96D875B2 /* PrivacyCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */; };
 		3A3C0E7B444AE96C4C2D1C8F /* HealthMonitorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */; };
@@ -59,6 +61,7 @@
 		3B8C348DB1DCBFB89771ADDC /* PrivacyPermissionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */; };
 		3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */; };
 		406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */; };
+		4156DAE09EB7579F22FA6959 /* MalwareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */; };
 		483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */; };
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
@@ -87,6 +90,8 @@
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
 		6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */; };
 		6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */; };
+		70D8E3251176A02F51CB78FD /* MalwareThreatRemoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */; };
+		710F2D2D1D68AEDE1A9462CD /* MalwareViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A9C2E47C91B66B79030BE7 /* MalwareViewModelTests.swift */; };
 		725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */; };
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
@@ -99,6 +104,7 @@
 		80B190269BF951513C453663 /* ClamAVDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5BB068BDD86F2C6D2FC966 /* ClamAVDetector.swift */; };
 		82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */; };
 		823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */; };
+		82DB89EC1E0EAFD90FB6018D /* MalwareUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */; };
 		832F1B34810FF292EAF9A810 /* PermissionOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */; };
 		8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */; };
 		834DC89A0BA1ED2A0B5B33CB /* PermissionOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */; };
@@ -122,6 +128,7 @@
 		B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */; };
 		B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39407E2EA6D045893F1BA4B /* DiskNode.swift */; };
 		B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */; };
+		B21023E22AFF4D8C13F3EDA3 /* MalwareThreatRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF767348D39506E36221A89D /* MalwareThreatRemover.swift */; };
 		B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */; };
 		B51203EFD0B1E0734609E427 /* VersionComparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAF96E747AD4C1378B4043D /* VersionComparator.swift */; };
 		B60909E266277B691B876E63 /* NotificationThresholdMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */; };
@@ -235,6 +242,7 @@
 		0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitor.swift; sourceTree = "<group>"; };
 		0D4E92A146A223EA836C156D /* ScanResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResultTests.swift; sourceTree = "<group>"; };
 		0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensUITests.swift; sourceTree = "<group>"; };
+		0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModel.swift; sourceTree = "<group>"; };
 		1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewSubviews.swift; sourceTree = "<group>"; };
 		133467A06193C406B027D97C /* NavigationSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSectionTests.swift; sourceTree = "<group>"; };
 		13A5713F5928025F9FE34A43 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -310,6 +318,7 @@
 		6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingView.swift; sourceTree = "<group>"; };
 		7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamer.swift; sourceTree = "<group>"; };
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
+		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
@@ -336,9 +345,11 @@
 		9D5CB08F96767D10B1271970 /* RAMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManager.swift; sourceTree = "<group>"; };
 		9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScanner.swift; sourceTree = "<group>"; };
 		9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFilesPathProviding.swift; sourceTree = "<group>"; };
+		A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareUITests.swift; sourceTree = "<group>"; };
 		A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategoryTests.swift; sourceTree = "<group>"; };
 		A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerApp.swift; sourceTree = "<group>"; };
 		A3852658DC221FB8B03631D1 /* HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocol.swift; sourceTree = "<group>"; };
+		A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemoverTests.swift; sourceTree = "<group>"; };
 		A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviderTests.swift; sourceTree = "<group>"; };
 		A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkView.swift; sourceTree = "<group>"; };
 		AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorView.swift; sourceTree = "<group>"; };
@@ -353,6 +364,7 @@
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
 		BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScanner.swift; sourceTree = "<group>"; };
 		BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModelTests.swift; sourceTree = "<group>"; };
+		BF767348D39506E36221A89D /* MalwareThreatRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemover.swift; sourceTree = "<group>"; };
 		BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModelTests.swift; sourceTree = "<group>"; };
 		C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewSubviews.swift; sourceTree = "<group>"; };
 		C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScannerTests.swift; sourceTree = "<group>"; };
@@ -372,8 +384,10 @@
 		D1CC391B523110720320AD89 /* SystemPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPathProviding.swift; sourceTree = "<group>"; };
 		D1F6A5DF7364E1886699488B /* BrowserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTests.swift; sourceTree = "<group>"; };
 		D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetector.swift; sourceTree = "<group>"; };
+		D2A9C2E47C91B66B79030BE7 /* MalwareViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModelTests.swift; sourceTree = "<group>"; };
 		D2C2B92863509818189F46CD /* MenuBarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContent.swift; sourceTree = "<group>"; };
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
+		DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewSubviews.swift; sourceTree = "<group>"; };
 		DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItemTests.swift; sourceTree = "<group>"; };
 		DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitorTests.swift; sourceTree = "<group>"; };
 		E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStore.swift; sourceTree = "<group>"; };
@@ -422,6 +436,7 @@
 		6A2D96C9C63AD506553F0BE0 /* VaderCleanerUITests */ = {
 			isa = PBXGroup;
 			children = (
+				A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */,
 				22622AEBD53221D89CB1439D /* OptimizationUITests.swift */,
 				0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */,
 				4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */,
@@ -486,6 +501,10 @@
 				882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */,
 				E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */,
 				5741874005D8A34BB7D82287 /* MalwareThreat.swift */,
+				BF767348D39506E36221A89D /* MalwareThreatRemover.swift */,
+				7315AD5A081B0855C316F00F /* MalwareView.swift */,
+				0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */,
+				DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */,
 				D2C2B92863509818189F46CD /* MenuBarContent.swift */,
 				8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */,
 				2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */,
@@ -597,7 +616,9 @@
 				5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */,
 				F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */,
 				6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */,
+				A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */,
 				EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */,
+				D2A9C2E47C91B66B79030BE7 /* MalwareViewModelTests.swift */,
 				CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */,
 				133467A06193C406B027D97C /* NavigationSectionTests.swift */,
 				C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */,
@@ -809,7 +830,9 @@
 				406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */,
 				1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */,
 				E39551732C1E81A0418FF7EE /* MalwareOnboardingViewModelTests.swift in Sources */,
+				70D8E3251176A02F51CB78FD /* MalwareThreatRemoverTests.swift in Sources */,
 				20A0A0A414E0D919060C99D2 /* MalwareThreatTests.swift in Sources */,
+				710F2D2D1D68AEDE1A9462CD /* MalwareViewModelTests.swift in Sources */,
 				C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */,
 				BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */,
 				2A46AEBD95B9E1561264D0F0 /* NotificationManagerTests.swift in Sources */,
@@ -852,6 +875,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82DB89EC1E0EAFD90FB6018D /* MalwareUITests.swift in Sources */,
 				7B4A89F26C67D0A6372E2A78 /* OptimizationUITests.swift in Sources */,
 				26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */,
 				E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */,
@@ -916,6 +940,10 @@
 				E5548C91729D71FDA8D8ADC8 /* MalwareOnboardingView.swift in Sources */,
 				5B5767BC82C24D92B50032FE /* MalwareOnboardingViewModel.swift in Sources */,
 				B9E44C0566F7DFAFAF8A6071 /* MalwareThreat.swift in Sources */,
+				B21023E22AFF4D8C13F3EDA3 /* MalwareThreatRemover.swift in Sources */,
+				09756E0B2E09D8BF521C1141 /* MalwareView.swift in Sources */,
+				4156DAE09EB7579F22FA6959 /* MalwareViewModel.swift in Sources */,
+				390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */,
 				BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */,
 				C2F35144C0139C8829C4BB8A /* MenuBarViewModel.swift in Sources */,
 				F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
     private let appUpdaterViewModel: AppUpdaterViewModel
     private let extensionsManagerViewModel: ExtensionsManagerViewModel
     private let optimizationViewModel: OptimizationViewModel
+    private let malwareViewModel: MalwareViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
@@ -32,7 +33,8 @@ struct ContentView: View {
         appUninstallerViewModel: AppUninstallerViewModel,
         appUpdaterViewModel: AppUpdaterViewModel,
         extensionsManagerViewModel: ExtensionsManagerViewModel,
-        optimizationViewModel: OptimizationViewModel
+        optimizationViewModel: OptimizationViewModel,
+        malwareViewModel: MalwareViewModel
     ) {
         self.systemJunkViewModel = systemJunkViewModel
         self.largeOldFilesViewModel = largeOldFilesViewModel
@@ -42,6 +44,7 @@ struct ContentView: View {
         self.appUpdaterViewModel = appUpdaterViewModel
         self.extensionsManagerViewModel = extensionsManagerViewModel
         self.optimizationViewModel = optimizationViewModel
+        self.malwareViewModel = malwareViewModel
     }
 
     var body: some View {
@@ -117,6 +120,8 @@ struct ContentView: View {
             ExtensionsManagerView(viewModel: extensionsManagerViewModel)
         case .optimization:
             OptimizationView(viewModel: optimizationViewModel)
+        case .malwareRemoval:
+            MalwareView(viewModel: malwareViewModel)
         default:
             PlaceholderDetailView(section: section)
         }
@@ -160,6 +165,7 @@ private struct PlaceholderDetailView: View {
     let stats = SystemStatsService(autostart: false)
     let prefs = PreferencesStore(defaults: UserDefaults(suiteName: "preview")!)
     let exclusions = ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!)
+    let notificationManager = NotificationManager()
     return ContentView(
         systemJunkViewModel: SystemJunkViewModel.live(exclusions: exclusions),
         largeOldFilesViewModel: LargeOldFilesViewModel.live(exclusions: exclusions),
@@ -168,7 +174,11 @@ private struct PlaceholderDetailView: View {
         appUninstallerViewModel: AppUninstallerViewModel.live(),
         appUpdaterViewModel: AppUpdaterViewModel.live(),
         extensionsManagerViewModel: ExtensionsManagerViewModel.live(),
-        optimizationViewModel: OptimizationViewModel.live(systemStats: stats)
+        optimizationViewModel: OptimizationViewModel.live(systemStats: stats),
+        malwareViewModel: MalwareViewModel.live(
+            dispatcher: notificationManager,
+            preferences: prefs
+        )
     )
         .environmentObject(AppState(checker: { true }))
         .environmentObject(PermissionOnboardingViewModel())
@@ -176,6 +186,6 @@ private struct PlaceholderDetailView: View {
         .environmentObject(NotificationThresholdMonitor(
             stats: stats,
             preferences: prefs,
-            dispatcher: NotificationManager()
+            dispatcher: notificationManager
         ))
 }

--- a/VaderCleaner/MalwareThreatRemover.swift
+++ b/VaderCleaner/MalwareThreatRemover.swift
@@ -1,0 +1,164 @@
+// MalwareThreatRemover.swift
+// Deletes the infected files reported by a ClamAV scan, routing user-domain paths through FileManager and protected paths through the privileged XPC helper, and returns the threats that could not be removed.
+
+import Foundation
+import os.log
+
+/// Quarantines (deletes) the files behind a list of `MalwareThreat`s.
+///
+/// Routing reuses `SystemJunkDeleter.requiresHelper(path:)` — the same policy
+/// that decides which System Junk paths need privilege escalation — so the
+/// two features can never disagree about what `/Library`, `/private/var`,
+/// `/System`, `/Applications`, or per-volume `.Trashes/...` mean. User-domain
+/// files are removed in-process; protected files are batched to the helper.
+///
+/// `remove(_:)` returns the threats it could **not** delete so the view-model
+/// can keep them on screen for a retry rather than silently dropping them.
+/// A user-domain file that is already gone counts as removed: a re-run after
+/// the user manually trashed the file should report success, not an error.
+struct MalwareThreatRemover {
+
+    /// Closure that yields a fresh helper proxy bound to the supplied per-call
+    /// XPC error handler, or `nil` when the helper is unreachable. Accepting
+    /// the error handler at provider time lets each helper call be resumed by
+    /// whichever of the reply block or the connection-level error handler
+    /// fires first — the same seam `SystemJunkDeleter` uses.
+    typealias HelperProvider = (@escaping (Error) -> Void) -> VaderCleanerHelperProtocol?
+
+    private let fileManager: FileManager
+    private let helperProvider: HelperProvider
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "MalwareThreatRemover")
+
+    init(
+        fileManager: FileManager = .default,
+        helperProvider: @escaping HelperProvider = MalwareThreatRemover.defaultHelperProvider
+    ) {
+        self.fileManager = fileManager
+        self.helperProvider = helperProvider
+    }
+
+    /// Deletes every threat's file and returns the threats that survived.
+    /// User-domain files are removed individually so one undeletable file
+    /// doesn't block the rest; protected files are sent to the helper in a
+    /// single batch.
+    func remove(_ threats: [MalwareThreat]) async -> [MalwareThreat] {
+        let (helperThreats, userThreats) = partition(threats)
+
+        var failures: [MalwareThreat] = []
+
+        for threat in userThreats {
+            do {
+                try fileManager.removeItem(at: threat.filePath)
+            } catch {
+                // A file that no longer exists is, for our purposes, removed.
+                // Anything still on disk after a throw is a genuine failure
+                // (locked, permission denied) the user must see.
+                if fileManager.fileExists(atPath: threat.filePath.path) {
+                    log.error("In-process removal failed for \(threat.filePath.path, privacy: .private(mask: .hash)): \(error.localizedDescription, privacy: .public)")
+                    failures.append(threat)
+                }
+            }
+        }
+
+        if !helperThreats.isEmpty {
+            let helperSucceeded = await deleteViaHelper(helperThreats)
+            if !helperSucceeded {
+                failures.append(contentsOf: helperThreats)
+            }
+        }
+
+        return failures
+    }
+
+    /// Splits `threats` into `(needsHelper, userDomain)` using the shared
+    /// System Junk routing rule.
+    private func partition(
+        _ threats: [MalwareThreat]
+    ) -> ([MalwareThreat], [MalwareThreat]) {
+        threats.reduce(into: ([MalwareThreat](), [MalwareThreat]())) { acc, threat in
+            if SystemJunkDeleter.requiresHelper(path: threat.filePath.path) {
+                acc.0.append(threat)
+            } else {
+                acc.1.append(threat)
+            }
+        }
+    }
+
+    /// Sends the protected paths to the privileged helper as one batch.
+    /// Returns `true` only on a clean reply. The XPC interface reports a
+    /// single error for the whole batch and cannot say which paths
+    /// individually succeeded, so on any error (or an unreachable helper) we
+    /// treat the entire batch as failed rather than over-claim progress —
+    /// the same honesty contract as `SystemJunkDeleter`.
+    ///
+    /// `NSXPCConnection` may fire the connection-level error handler instead
+    /// of the per-call reply block; installing both with a once-only resumer
+    /// guarantees the await always resolves and never freezes the removal UI.
+    private func deleteViaHelper(_ threats: [MalwareThreat]) async -> Bool {
+        let paths = threats.map(\.filePath.path)
+
+        let error: Error? = await withCheckedContinuation { continuation in
+            let resumer = HelperCallResumer(continuation: continuation)
+            let helper = helperProvider { connectionError in
+                resumer.resume(with: connectionError)
+            }
+            guard let helper else {
+                resumer.resume(with: NSError(
+                    domain: "com.personal.VaderCleaner.MalwareThreatRemover",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Helper unavailable"]
+                ))
+                return
+            }
+            helper.deleteFiles(paths) { replyError in
+                resumer.resume(with: replyError)
+            }
+        }
+
+        if let error {
+            log.error("Helper removal failed for \(paths.count, privacy: .public) paths: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Production collaborator
+
+    /// Default helper provider — returns the proxy from
+    /// `HelperConnectionManager.shared` bound to the per-call error handler,
+    /// logging the connection error in addition to forwarding it.
+    static let defaultHelperProvider: HelperProvider = { errorHandler in
+        let log = Logger(subsystem: "com.personal.VaderCleaner",
+                         category: "MalwareThreatRemover.HelperProvider")
+        return HelperConnectionManager.shared.helper { error in
+            log.error("Helper connection error: \(error.localizedDescription, privacy: .public)")
+            errorHandler(error)
+        }
+    }
+}
+
+// MARK: - Once-only continuation resume
+
+/// Wraps a `CheckedContinuation` so exactly one of the paths that may
+/// complete it (XPC reply block, connection-level error handler, or the
+/// "helper unavailable" early return) actually resumes — `CheckedContinuation`
+/// traps on a second resume. Kept file-private; `SystemJunkDeleter` has an
+/// equivalent private type and refactoring it to share would touch tested
+/// unrelated code.
+private final class HelperCallResumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: error)
+    }
+}

--- a/VaderCleaner/MalwareView.swift
+++ b/VaderCleaner/MalwareView.swift
@@ -1,0 +1,153 @@
+// MalwareView.swift
+// Malware Removal feature view — ClamAV onboarding when absent, otherwise the scan → results → remove flow driven by MalwareViewModel's state machine.
+
+import SwiftUI
+
+/// Detail view shown when the user selects "Malware Removal" in the sidebar.
+/// When ClamAV is missing it shows the install onboarding; otherwise it walks
+/// the scan / results / removal state machine of `MalwareViewModel`.
+struct MalwareView: View {
+
+    @ObservedObject private var viewModel: MalwareViewModel
+    @StateObject private var onboardingViewModel = MalwareOnboardingViewModel()
+    @State private var confirmingRemoval = false
+
+    init(viewModel: MalwareViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(NavigationSection.malwareRemoval.title)
+            .task {
+                if viewModel.phase == .idle {
+                    await viewModel.prepare()
+                }
+            }
+            // The onboarding view-model re-checks installation on "Check
+            // Again"; once ClamAV appears, pull the malware flow out of the
+            // needsInstall state without making the user navigate away.
+            .onChange(of: onboardingViewModel.isInstalled) { _, installed in
+                if installed {
+                    Task { await viewModel.prepare() }
+                }
+            }
+            .alert(
+                String(
+                    localized: "Remove all detected threats?",
+                    comment: "Alert title confirming malware removal."
+                ),
+                isPresented: $confirmingRemoval
+            ) {
+                Button(String(
+                    localized: "Cancel",
+                    comment: "Cancel button on the malware removal confirmation alert."
+                ), role: .cancel) {}
+                Button(String(
+                    localized: "Remove",
+                    comment: "Confirm button on the malware removal confirmation alert."
+                ), role: .destructive) {
+                    Task { await viewModel.removeThreats() }
+                }
+            } message: {
+                Text(String(
+                    localized: "The infected files will be permanently deleted. This cannot be undone.",
+                    comment: "Body of the malware removal confirmation alert."
+                ))
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.phase {
+        case .needsInstall:
+            MalwareOnboardingView(viewModel: onboardingViewModel)
+        case .idle:
+            MalwareIdleState(
+                lastScanDate: viewModel.lastScanDate,
+                databaseUpdatedDate: viewModel.databaseUpdatedDate,
+                onScan: { viewModel.startScan() },
+                onUpdateDatabase: { Task { await viewModel.updateDatabaseManually() } }
+            )
+        case .checkingClamAV:
+            MalwareProgressState(
+                label: String(
+                    localized: "Checking ClamAV…",
+                    comment: "Progress label while verifying the ClamAV install."
+                ),
+                detail: nil,
+                identifier: "malware.checking"
+            )
+        case .updatingDatabase(let progress):
+            MalwareProgressState(
+                label: String(
+                    localized: "Updating signature database…",
+                    comment: "Progress label while freshclam refreshes signatures."
+                ),
+                detail: progress,
+                identifier: "malware.updatingDatabase"
+            )
+        case .scanning(let progress):
+            MalwareProgressState(
+                label: String(
+                    localized: "Scanning for malware…",
+                    comment: "Progress label while clamscan runs."
+                ),
+                detail: progress,
+                identifier: "malware.scanning",
+                onCancel: { viewModel.cancel() }
+            )
+        case .clean:
+            MalwareCleanState(
+                lastScanDate: viewModel.lastScanDate,
+                onScanAgain: { viewModel.startScan() }
+            )
+        case .results(let threats):
+            MalwareResultsState(
+                threats: threats,
+                onRemoveAll: { confirmingRemoval = true }
+            )
+        case .removing:
+            MalwareProgressState(
+                label: String(
+                    localized: "Removing threats…",
+                    comment: "Progress label while infected files are deleted."
+                ),
+                detail: nil,
+                identifier: "malware.removing"
+            )
+        case .done(let removedCount):
+            MalwareDoneState(
+                removedCount: removedCount,
+                onDone: { viewModel.dismissResult() }
+            )
+        case .failed(let message):
+            MalwareFailedState(message: message) {
+                viewModel.dismissResult()
+            }
+        }
+    }
+}
+
+#Preview("Results") {
+    let vm = MalwareViewModel(
+        checkInstalled: { true },
+        databaseLastUpdated: { Date() },
+        updateDatabase: { _ in },
+        scan: { _ in
+            [
+                MalwareThreat(
+                    filePath: URL(fileURLWithPath: "/Users/me/Downloads/evil.bin"),
+                    threatName: "Eicar-Test-Signature"
+                )
+            ]
+        },
+        removeThreats: { _ in [] },
+        notify: { _ in },
+        shouldNotify: { true }
+    )
+    return MalwareView(viewModel: vm)
+        .frame(width: 900, height: 600)
+        .task { await vm.scan() }
+}

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -88,9 +88,12 @@ final class MalwareViewModel: ObservableObject {
 
     // MARK: - Scan
 
-    /// Launches a scan in a retained task so `cancel()` can stop it.
+    /// Launches a scan in a retained task so `cancel()` can stop it. Any
+    /// in-flight scan is cancelled first so a double-tap can't leave two
+    /// scans racing `phase` updates.
     func startScan() {
-        scanTask = Task { await scan() }
+        scanTask?.cancel()
+        scanTask = Task { [weak self] in await self?.scan() }
     }
 
     /// Cancels an in-flight scan and returns to idle. The underlying
@@ -106,6 +109,9 @@ final class MalwareViewModel: ObservableObject {
     /// On threats found, dispatches the detection notification (gated by the
     /// user's preference) and lands `.results`; otherwise `.clean`.
     func scan() async {
+        // Clear task ownership on every exit so `scanTask` is non-nil only
+        // while a scan is genuinely in flight.
+        defer { scanTask = nil }
         phase = .checkingClamAV
         guard checkInstalled() else {
             phase = .needsInstall
@@ -118,7 +124,12 @@ final class MalwareViewModel: ObservableObject {
             phase = .updatingDatabase(progress: "")
             do {
                 try await updateDatabase { [weak self] line in
-                    self?.phase = .updatingDatabase(progress: line)
+                    // ProcessLineStreamer invokes this from a detached
+                    // background task; hop to the main actor before touching
+                    // the @Published phase.
+                    Task { @MainActor in
+                        self?.phase = .updatingDatabase(progress: line)
+                    }
                 }
             } catch {
                 log.error("Database update failed: \(error.localizedDescription, privacy: .public)")
@@ -133,7 +144,11 @@ final class MalwareViewModel: ObservableObject {
         let found: [MalwareThreat]
         do {
             found = try await scanAction { [weak self] line in
-                self?.phase = .scanning(progress: line)
+                // Streamed from ProcessLineStreamer's detached task; hop to
+                // the main actor before mutating the @Published phase.
+                Task { @MainActor in
+                    self?.phase = .scanning(progress: line)
+                }
             }
         } catch {
             log.error("Scan failed: \(error.localizedDescription, privacy: .public)")
@@ -177,7 +192,11 @@ final class MalwareViewModel: ObservableObject {
         phase = .updatingDatabase(progress: "")
         do {
             try await updateDatabase { [weak self] line in
-                self?.phase = .updatingDatabase(progress: line)
+                // Streamed from ProcessLineStreamer's detached task; hop to
+                // the main actor before mutating the @Published phase.
+                Task { @MainActor in
+                    self?.phase = .updatingDatabase(progress: line)
+                }
             }
         } catch {
             log.error("Manual database update failed: \(error.localizedDescription, privacy: .public)")

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -59,6 +59,11 @@ final class MalwareViewModel: ObservableObject {
     /// The in-flight scan, retained so the view's Cancel button can drop it.
     private var scanTask: Task<Void, Never>?
 
+    /// Monotonic token so a cancelled older scan's cleanup can't clear the
+    /// `scanTask` handle owned by a newer one — the same generation guard the
+    /// other feature view-models use against stale async completions.
+    private var scanGeneration = 0
+
     init(
         checkInstalled: @escaping CheckInstalled,
         databaseLastUpdated: @escaping DatabaseLastUpdated,
@@ -93,7 +98,9 @@ final class MalwareViewModel: ObservableObject {
     /// scans racing `phase` updates.
     func startScan() {
         scanTask?.cancel()
-        scanTask = Task { [weak self] in await self?.scan() }
+        scanGeneration += 1
+        let generation = scanGeneration
+        scanTask = Task { [weak self] in await self?.scan(generation: generation) }
     }
 
     /// Cancels an in-flight scan and returns to idle. The underlying
@@ -109,9 +116,17 @@ final class MalwareViewModel: ObservableObject {
     /// On threats found, dispatches the detection notification (gated by the
     /// user's preference) and lands `.results`; otherwise `.clean`.
     func scan() async {
-        // Clear task ownership on every exit so `scanTask` is non-nil only
-        // while a scan is genuinely in flight.
-        defer { scanTask = nil }
+        scanGeneration += 1
+        await scan(generation: scanGeneration)
+    }
+
+    /// Generation-guarded scan body. Only the newest scan clears `scanTask`
+    /// on exit, so a cancelled older scan resolving late can't strip the
+    /// handle (and `cancel()` protection) from a newer in-flight scan.
+    private func scan(generation: Int) async {
+        defer {
+            if scanGeneration == generation { scanTask = nil }
+        }
         phase = .checkingClamAV
         guard checkInstalled() else {
             phase = .needsInstall

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -1,0 +1,242 @@
+// MalwareViewModel.swift
+// State machine behind the Malware Removal view — checks ClamAV, refreshes a stale signature database, scans the home directory, dispatches a detection notification, and removes threats via FileManager + the privileged helper.
+
+import Foundation
+import os.log
+
+/// Drives the Malware Removal feature view. Collaborators are injected as
+/// closures so unit tests can exercise every transition without a real
+/// ClamAV install, freshclam run, or privileged-helper connection.
+/// Production wiring lives in `MalwareViewModel.live()`.
+@MainActor
+final class MalwareViewModel: ObservableObject {
+
+    /// Discrete phases the view binds to. The happy path is
+    /// `idle → checkingClamAV → (updatingDatabase) → scanning →
+    /// (results | clean) → removing → done`; `needsInstall` routes to the
+    /// ClamAV onboarding and `failed` carries a message to surface.
+    enum Phase: Equatable {
+        case idle
+        case needsInstall
+        case checkingClamAV
+        case updatingDatabase(progress: String)
+        case scanning(progress: String)
+        case results([MalwareThreat])
+        case clean
+        case removing
+        case done(removedCount: Int)
+        case failed(message: String)
+    }
+
+    typealias CheckInstalled = () -> Bool
+    typealias DatabaseLastUpdated = () -> Date?
+    typealias UpdateDatabase = (@escaping (String) -> Void) async throws -> Void
+    typealias Scan = (@escaping (String) -> Void) async throws -> [MalwareThreat]
+    /// Returns the threats it could **not** remove (empty == full success).
+    typealias RemoveThreats = ([MalwareThreat]) async -> [MalwareThreat]
+    typealias Notify = (String) -> Void
+    typealias ShouldNotify = () -> Bool
+
+    /// A signature database older than this is refreshed before a scan so a
+    /// stale install doesn't miss recent threats.
+    private static let databaseMaxAge: TimeInterval = 24 * 60 * 60
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var lastScanDate: Date?
+    @Published private(set) var databaseUpdatedDate: Date?
+
+    private let checkInstalled: CheckInstalled
+    private let databaseLastUpdated: DatabaseLastUpdated
+    private let updateDatabase: UpdateDatabase
+    private let scanAction: Scan
+    private let removeThreatsAction: RemoveThreats
+    private let notify: Notify
+    private let shouldNotify: ShouldNotify
+
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "MalwareViewModel")
+
+    /// The in-flight scan, retained so the view's Cancel button can drop it.
+    private var scanTask: Task<Void, Never>?
+
+    init(
+        checkInstalled: @escaping CheckInstalled,
+        databaseLastUpdated: @escaping DatabaseLastUpdated,
+        updateDatabase: @escaping UpdateDatabase,
+        scan: @escaping Scan,
+        removeThreats: @escaping RemoveThreats,
+        notify: @escaping Notify,
+        shouldNotify: @escaping ShouldNotify
+    ) {
+        self.checkInstalled = checkInstalled
+        self.databaseLastUpdated = databaseLastUpdated
+        self.updateDatabase = updateDatabase
+        self.scanAction = scan
+        self.removeThreatsAction = removeThreats
+        self.notify = notify
+        self.shouldNotify = shouldNotify
+    }
+
+    // MARK: - Lifecycle
+
+    /// Called when the view appears. Surfaces the onboarding when ClamAV is
+    /// absent and publishes the database date for the idle screen.
+    func prepare() async {
+        databaseUpdatedDate = databaseLastUpdated()
+        phase = checkInstalled() ? .idle : .needsInstall
+    }
+
+    // MARK: - Scan
+
+    /// Launches a scan in a retained task so `cancel()` can stop it.
+    func startScan() {
+        scanTask = Task { await scan() }
+    }
+
+    /// Cancels an in-flight scan and returns to idle. The underlying
+    /// `clamscan` process is not force-terminated here — the cancel keeps the
+    /// UI responsive; full process teardown is deferred to later polish.
+    func cancel() {
+        scanTask?.cancel()
+        scanTask = nil
+        phase = .idle
+    }
+
+    /// Checks ClamAV → refreshes a stale database → scans the home directory.
+    /// On threats found, dispatches the detection notification (gated by the
+    /// user's preference) and lands `.results`; otherwise `.clean`.
+    func scan() async {
+        phase = .checkingClamAV
+        guard checkInstalled() else {
+            phase = .needsInstall
+            return
+        }
+
+        let lastUpdate = databaseLastUpdated()
+        databaseUpdatedDate = lastUpdate
+        if isDatabaseStale(lastUpdate) {
+            phase = .updatingDatabase(progress: "")
+            do {
+                try await updateDatabase { [weak self] line in
+                    self?.phase = .updatingDatabase(progress: line)
+                }
+            } catch {
+                log.error("Database update failed: \(error.localizedDescription, privacy: .public)")
+                phase = .failed(message: error.localizedDescription)
+                return
+            }
+            databaseUpdatedDate = databaseLastUpdated()
+        }
+        if Task.isCancelled { return }
+
+        phase = .scanning(progress: "")
+        let found: [MalwareThreat]
+        do {
+            found = try await scanAction { [weak self] line in
+                self?.phase = .scanning(progress: line)
+            }
+        } catch {
+            log.error("Scan failed: \(error.localizedDescription, privacy: .public)")
+            phase = .failed(message: error.localizedDescription)
+            return
+        }
+        if Task.isCancelled { return }
+
+        lastScanDate = Date()
+        if found.isEmpty {
+            phase = .clean
+        } else {
+            if shouldNotify(), let first = found.first {
+                notify(first.threatName)
+            }
+            phase = .results(found)
+        }
+    }
+
+    // MARK: - Removal
+
+    /// Removes every threat currently shown. Fully removed → `.done`; any
+    /// survivors are kept in `.results` so the user can retry per row.
+    func removeThreats() async {
+        guard case .results(let threats) = phase, !threats.isEmpty else { return }
+        phase = .removing
+
+        let failures = await removeThreatsAction(threats)
+        if failures.isEmpty {
+            phase = .done(removedCount: threats.count)
+        } else {
+            log.error("\(failures.count, privacy: .public) of \(threats.count, privacy: .public) threats could not be removed")
+            phase = .results(failures)
+        }
+    }
+
+    // MARK: - Database
+
+    /// Refreshes the signature database on demand from the idle screen.
+    func updateDatabaseManually() async {
+        phase = .updatingDatabase(progress: "")
+        do {
+            try await updateDatabase { [weak self] line in
+                self?.phase = .updatingDatabase(progress: line)
+            }
+        } catch {
+            log.error("Manual database update failed: \(error.localizedDescription, privacy: .public)")
+            phase = .failed(message: error.localizedDescription)
+            return
+        }
+        databaseUpdatedDate = databaseLastUpdated()
+        phase = .idle
+    }
+
+    // MARK: - Recovery
+
+    /// Returns to idle from `.failed`, `.clean`, or `.done` so the user can
+    /// start a fresh scan.
+    func dismissResult() {
+        phase = .idle
+    }
+
+    // MARK: - Helpers
+
+    private func isDatabaseStale(_ lastUpdate: Date?) -> Bool {
+        guard let lastUpdate else { return true }
+        return Date().timeIntervalSince(lastUpdate) > Self.databaseMaxAge
+    }
+}
+
+// MARK: - Production wiring
+
+extension MalwareViewModel {
+
+    /// Builds a view-model wired to the real ClamAV detector, database
+    /// updater, scanner (over the user's home directory), threat remover, and
+    /// notification dispatcher. The dispatcher is passed in rather than
+    /// constructed here so the whole app shares one `NotificationManager`
+    /// instance — a second one would silently steal the
+    /// `UNUserNotificationCenter` delegate from the threshold monitor.
+    @MainActor
+    static func live(
+        dispatcher: NotificationDispatching,
+        preferences: PreferencesStore
+    ) -> MalwareViewModel {
+        let detector = ClamAVDetector()
+        let databaseUpdater = DatabaseUpdater()
+        let scanner = ClamAVScanner(detector: detector)
+        let remover = MalwareThreatRemover()
+        let home = FileManager.default.homeDirectoryForCurrentUser
+
+        return MalwareViewModel(
+            checkInstalled: { detector.isInstalled() },
+            databaseLastUpdated: { databaseUpdater.lastUpdateDate() },
+            updateDatabase: { progress in
+                try await databaseUpdater.update(progress: progress)
+            },
+            scan: { progress in
+                try await scanner.scan(paths: [home], progress: progress)
+            },
+            removeThreats: { await remover.remove($0) },
+            notify: { dispatcher.sendMalwareDetectedNotification(threatName: $0) },
+            shouldNotify: { preferences.notifyMalwareFound }
+        )
+    }
+}

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -115,9 +115,12 @@ final class MalwareViewModel: ObservableObject {
     /// Checks ClamAV → refreshes a stale database → scans the home directory.
     /// On threats found, dispatches the detection notification (gated by the
     /// user's preference) and lands `.results`; otherwise `.clean`.
+    /// Awaitable entry point used by tests and previews. Routes through
+    /// `startScan()` so the scan is owned by `scanTask` and remains
+    /// cancellable, then awaits its completion.
     func scan() async {
-        scanGeneration += 1
-        await scan(generation: scanGeneration)
+        startScan()
+        await scanTask?.value
     }
 
     /// Generation-guarded scan body. Only the newest scan clears `scanTask`
@@ -140,10 +143,11 @@ final class MalwareViewModel: ObservableObject {
             do {
                 try await updateDatabase { [weak self] line in
                     // ProcessLineStreamer invokes this from a detached
-                    // background task; hop to the main actor before touching
-                    // the @Published phase.
+                    // background task; hop to the main actor and drop the
+                    // line if a newer scan has since superseded this one.
                     Task { @MainActor in
-                        self?.phase = .updatingDatabase(progress: line)
+                        guard let self, self.scanGeneration == generation else { return }
+                        self.phase = .updatingDatabase(progress: line)
                     }
                 }
             } catch {
@@ -160,9 +164,11 @@ final class MalwareViewModel: ObservableObject {
         do {
             found = try await scanAction { [weak self] line in
                 // Streamed from ProcessLineStreamer's detached task; hop to
-                // the main actor before mutating the @Published phase.
+                // the main actor and drop the line if a newer scan has since
+                // superseded this one.
                 Task { @MainActor in
-                    self?.phase = .scanning(progress: line)
+                    guard let self, self.scanGeneration == generation else { return }
+                    self.phase = .scanning(progress: line)
                 }
             }
         } catch {

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -14,10 +14,7 @@ private func relativeOrNever(_ date: Date?) -> String {
             comment: "Shown when no scan has run or the signature database has never been updated."
         )
     }
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    formatter.timeStyle = .short
-    return formatter.string(from: date)
+    return date.formatted(date: .abbreviated, time: .shortened)
 }
 
 // MARK: - Progress / failed states
@@ -215,8 +212,8 @@ struct MalwareResultsState: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(String.localizedStringWithFormat(
                         String(
-                            localized: "%lld threat(s) found",
-                            comment: "Heading on the malware results screen; %lld is a count."
+                            localized: "%d threats found",
+                            comment: "Heading on the malware results screen; %d is a count. Pluralized via Localizable.stringsdict."
                         ),
                         threats.count
                     ))
@@ -274,8 +271,8 @@ struct MalwareDoneState: View {
                 .foregroundStyle(.green)
             Text(String.localizedStringWithFormat(
                 String(
-                    localized: "Removed %lld threat(s)",
-                    comment: "Heading after malware removal completes; %lld is a count."
+                    localized: "Removed %d threats",
+                    comment: "Heading after malware removal completes; %d is a count. Pluralized via Localizable.stringsdict."
                 ),
                 removedCount
             ))

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -1,0 +1,295 @@
+// MalwareViewSubviews.swift
+// Dedicated subviews for the Malware Removal screen — idle, progress, clean, results list, done, and failed states.
+
+import SwiftUI
+
+// MARK: - Shared date formatting
+
+/// Renders a "last scan" / "database updated" timestamp, or "Never" when the
+/// app has no record yet.
+private func relativeOrNever(_ date: Date?) -> String {
+    guard let date else {
+        return String(
+            localized: "Never",
+            comment: "Shown when no scan has run or the signature database has never been updated."
+        )
+    }
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .short
+    return formatter.string(from: date)
+}
+
+// MARK: - Progress / failed states
+
+struct MalwareProgressState: View {
+    let label: String
+    let detail: String?
+    let identifier: String
+    var onCancel: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            if let detail, !detail.isEmpty {
+                Text(detail)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: 460)
+                    .accessibilityIdentifier("\(identifier).detail")
+            }
+            if let onCancel {
+                Button(String(
+                    localized: "Cancel",
+                    comment: "Button that stops an in-progress malware scan."
+                ), action: onCancel)
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("malware.cancel")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+struct MalwareFailedState: View {
+    let message: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(String(
+                localized: "That scan couldn't complete",
+                comment: "Heading on the Malware Removal failure screen."
+            ))
+                .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("malware.errorMessage")
+            Button(String(
+                localized: "Back to Malware Removal",
+                comment: "Return button on the Malware Removal failure screen."
+            ), action: onDismiss)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("malware.failurePrimary")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+// MARK: - Idle
+
+struct MalwareIdleState: View {
+    let lastScanDate: Date?
+    let databaseUpdatedDate: Date?
+    let onScan: () -> Void
+    let onUpdateDatabase: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "shield.lefthalf.filled")
+                .font(.system(size: 56))
+                .foregroundStyle(.tint)
+            Text(String(
+                localized: "Scan for Malware",
+                comment: "Title on the idle Malware Removal screen."
+            ))
+                .font(.title.weight(.semibold))
+            Text(String(
+                localized: "VaderCleaner uses ClamAV to scan your home folder for malware, adware, and ransomware.",
+                comment: "Explanatory subtitle on the idle Malware Removal screen."
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+
+            VStack(alignment: .leading, spacing: 8) {
+                LabeledContent(String(
+                    localized: "Last scan",
+                    comment: "Row label for the most recent malware scan time."
+                )) {
+                    Text(relativeOrNever(lastScanDate))
+                        .accessibilityIdentifier("malware.lastScanDate")
+                }
+                Divider()
+                LabeledContent(String(
+                    localized: "Signature database updated",
+                    comment: "Row label for the ClamAV signature database's last update time."
+                )) {
+                    Text(relativeOrNever(databaseUpdatedDate))
+                        .accessibilityIdentifier("malware.databaseUpdatedDate")
+                }
+            }
+            .font(.callout)
+            .padding()
+            .frame(maxWidth: 460)
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+
+            HStack(spacing: 12) {
+                Button(String(
+                    localized: "Update Database",
+                    comment: "Button that refreshes the ClamAV signature database via freshclam."
+                ), action: onUpdateDatabase)
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("malware.updateDatabase")
+
+                Button(String(
+                    localized: "Scan for Malware",
+                    comment: "Primary button that starts a malware scan."
+                ), action: onScan)
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("malware.scan")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+// MARK: - Clean
+
+struct MalwareCleanState: View {
+    let lastScanDate: Date?
+    let onScanAgain: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.shield.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text(String(
+                localized: "No threats found",
+                comment: "Heading shown after a clean malware scan."
+            ))
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("malware.cleanHeading")
+            Text(String.localizedStringWithFormat(
+                String(
+                    localized: "Last scanned %@.",
+                    comment: "Subtitle on the clean malware result; %@ is a date."
+                ),
+                relativeOrNever(lastScanDate)
+            ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Button(String(
+                localized: "Scan Again",
+                comment: "Button that starts another malware scan after a clean result."
+            ), action: onScanAgain)
+                .controlSize(.large)
+                .accessibilityIdentifier("malware.scanAgain")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+// MARK: - Results
+
+struct MalwareResultsState: View {
+    let threats: [MalwareThreat]
+    let onRemoveAll: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.shield.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(.red)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String.localizedStringWithFormat(
+                        String(
+                            localized: "%lld threat(s) found",
+                            comment: "Heading on the malware results screen; %lld is a count."
+                        ),
+                        threats.count
+                    ))
+                        .font(.title2.weight(.semibold))
+                        .accessibilityIdentifier("malware.threatCount")
+                    Text(String(
+                        localized: "Review the infected files below, then remove them.",
+                        comment: "Subtitle on the malware results screen."
+                    ))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button(role: .destructive, action: onRemoveAll) {
+                    Text(String(
+                        localized: "Remove All Threats",
+                        comment: "Button that deletes every detected malware file."
+                    ))
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("malware.removeAll")
+            }
+
+            List(threats) { threat in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(threat.threatName)
+                        .font(.body.weight(.medium))
+                    Text(threat.filePath.path)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                }
+                .padding(.vertical, 2)
+                .accessibilityIdentifier("malware.threatRow")
+            }
+            .accessibilityIdentifier("malware.threatList")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding()
+    }
+}
+
+// MARK: - Done
+
+struct MalwareDoneState: View {
+    let removedCount: Int
+    let onDone: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.shield.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text(String.localizedStringWithFormat(
+                String(
+                    localized: "Removed %lld threat(s)",
+                    comment: "Heading after malware removal completes; %lld is a count."
+                ),
+                removedCount
+            ))
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("malware.doneHeading")
+            Button(String(
+                localized: "Done",
+                comment: "Button that returns to the idle Malware Removal screen after removal."
+            ), action: onDone)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("malware.doneButton")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -34,6 +34,7 @@ struct VaderCleanerApp: App {
     @StateObject private var appUpdaterViewModel: AppUpdaterViewModel
     @StateObject private var extensionsManagerViewModel: ExtensionsManagerViewModel
     @StateObject private var optimizationViewModel: OptimizationViewModel
+    @StateObject private var malwareViewModel: MalwareViewModel
     // App-scope so the cheap-stats timer outlives any single window. The
     // Health Monitor view (Prompt 9), the menu bar (Prompt 10), and the
     // notification dispatcher (Prompt 11) all subscribe via
@@ -90,6 +91,20 @@ struct VaderCleanerApp: App {
             wrappedValue: OptimizationViewModel.live(systemStats: stats)
         )
         _menuBarViewModel = StateObject(wrappedValue: MenuBarViewModel(service: stats))
+        // One NotificationManager for the whole app. Its init registers
+        // itself as the `UNUserNotificationCenter` delegate (a weak property);
+        // a second instance would silently steal that registration, so the
+        // threshold monitor and the Malware feature share this one.
+        let notificationManager = NotificationManager()
+        // Wired after `stats` so manual malware scans surface a detection
+        // banner through the same dispatcher the threshold monitor uses, and
+        // honour the same `notifyMalwareFound` preference.
+        _malwareViewModel = StateObject(
+            wrappedValue: MalwareViewModel.live(
+                dispatcher: notificationManager,
+                preferences: prefs
+            )
+        )
         // Wire the notification monitor to the same stats + preferences
         // instances the rest of the app sees. The monitor holds the manager
         // strongly via `dispatcher`, and ContentView drives the permission
@@ -100,7 +115,7 @@ struct VaderCleanerApp: App {
             wrappedValue: NotificationThresholdMonitor(
                 stats: stats,
                 preferences: prefs,
-                dispatcher: NotificationManager()
+                dispatcher: notificationManager
             )
         )
     }
@@ -142,7 +157,8 @@ struct VaderCleanerApp: App {
                 appUninstallerViewModel: appUninstallerViewModel,
                 appUpdaterViewModel: appUpdaterViewModel,
                 extensionsManagerViewModel: extensionsManagerViewModel,
-                optimizationViewModel: optimizationViewModel
+                optimizationViewModel: optimizationViewModel,
+                malwareViewModel: malwareViewModel
             )
                 .environmentObject(appState)
                 .environmentObject(onboardingViewModel)

--- a/VaderCleaner/en.lproj/Localizable.stringsdict
+++ b/VaderCleaner/en.lproj/Localizable.stringsdict
@@ -18,5 +18,37 @@
             <string>%d items</string>
         </dict>
     </dict>
+    <key>%d threats found</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@threats@ found</string>
+        <key>threats</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>one</key>
+            <string>%d threat</string>
+            <key>other</key>
+            <string>%d threats</string>
+        </dict>
+    </dict>
+    <key>Removed %d threats</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>Removed %#@threats@</string>
+        <key>threats</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>one</key>
+            <string>%d threat</string>
+            <key>other</key>
+            <string>%d threats</string>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/VaderCleanerTests/MalwareThreatRemoverTests.swift
+++ b/VaderCleanerTests/MalwareThreatRemoverTests.swift
@@ -1,0 +1,167 @@
+// MalwareThreatRemoverTests.swift
+// Pins MalwareThreatRemover's user/system path routing, exercises in-process deletion against a temp directory, and routes protected paths through an injected fake helper so no privileged XPC connection is required.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class MalwareThreatRemoverTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    // MARK: - User-domain removal
+
+    /// An infected file in a user-writable location is removed in-process and
+    /// is not reported as a failure.
+    func test_remove_userDomainFile_deletesAndReportsNoFailures() async throws {
+        let url = try TestHelpers.createDummyFile(named: "evil.bin", size: 64, in: tempRoot)
+        let threat = MalwareThreat(filePath: url, threatName: "Eicar-Test-Signature")
+
+        let remover = MalwareThreatRemover(helperProvider: { _ in nil })
+        let failures = await remover.remove([threat])
+
+        XCTAssertTrue(failures.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    /// A threat whose file is already gone is effectively removed — it must
+    /// NOT be reported as a failure (a quarantine tool re-running on a file
+    /// the user already trashed should report success, not error).
+    func test_remove_alreadyAbsentUserFile_isNotAFailure() async {
+        let absent = tempRoot.appendingPathComponent("missing.bin")
+        let threat = MalwareThreat(filePath: absent, threatName: "X")
+
+        let remover = MalwareThreatRemover(helperProvider: { _ in nil })
+        let failures = await remover.remove([threat])
+
+        XCTAssertTrue(failures.isEmpty)
+    }
+
+    // MARK: - Helper-domain routing
+
+    /// A threat under a protected prefix must be handed to the privileged
+    /// helper, not deleted in-process. On a successful helper reply it is not
+    /// a failure.
+    func test_remove_protectedPath_routesThroughHelperAndSucceeds() async {
+        let systemURL = URL(fileURLWithPath: "/Library/Application Support/com.bogus/evil.dylib")
+        let threat = MalwareThreat(filePath: systemURL, threatName: "OSX.Bad")
+
+        let fakeHelper = FakeHelper(replyError: nil)
+        let remover = MalwareThreatRemover(helperProvider: { _ in fakeHelper })
+        let failures = await remover.remove([threat])
+
+        XCTAssertTrue(failures.isEmpty)
+        XCTAssertEqual(fakeHelper.receivedPaths, [systemURL.path])
+    }
+
+    /// If the helper reports an error, every protected-path threat in the
+    /// batch is a failure — the XPC protocol cannot tell us which paths
+    /// individually succeeded, so we do not claim partial success.
+    func test_remove_protectedPath_helperErrorReportsFailure() async {
+        let systemURL = URL(fileURLWithPath: "/Library/LaunchDaemons/com.bogus.plist")
+        let threat = MalwareThreat(filePath: systemURL, threatName: "OSX.Bad")
+
+        let fakeHelper = FakeHelper(replyError: NSError(domain: "test", code: 1))
+        let remover = MalwareThreatRemover(helperProvider: { _ in fakeHelper })
+        let failures = await remover.remove([threat])
+
+        XCTAssertEqual(failures, [threat])
+    }
+
+    /// When the helper is unavailable (typical dev environment), protected
+    /// threats are reported as failures rather than silently dropped.
+    func test_remove_protectedPath_unavailableHelperReportsFailure() async {
+        let systemURL = URL(fileURLWithPath: "/System/Library/Foo/evil")
+        let threat = MalwareThreat(filePath: systemURL, threatName: "OSX.Bad")
+
+        let remover = MalwareThreatRemover(helperProvider: { _ in nil })
+        let failures = await remover.remove([threat])
+
+        XCTAssertEqual(failures, [threat])
+    }
+
+    /// Mixed batch: the user-domain file is deleted in-process while the
+    /// protected file is routed to the helper. Only the genuinely failing
+    /// path is returned.
+    func test_remove_mixedBatch_splitsBetweenFileManagerAndHelper() async throws {
+        let userURL = try TestHelpers.createDummyFile(named: "u.bin", size: 32, in: tempRoot)
+        let userThreat = MalwareThreat(filePath: userURL, threatName: "Adware")
+        let systemURL = URL(fileURLWithPath: "/Library/Caches/com.bogus/evil")
+        let systemThreat = MalwareThreat(filePath: systemURL, threatName: "OSX.Bad")
+
+        let fakeHelper = FakeHelper(replyError: nil)
+        let remover = MalwareThreatRemover(helperProvider: { _ in fakeHelper })
+        let failures = await remover.remove([userThreat, systemThreat])
+
+        XCTAssertTrue(failures.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: userURL.path))
+        XCTAssertEqual(fakeHelper.receivedPaths, [systemURL.path])
+    }
+
+    /// Regression for the XPC continuation hang: when the connection-level
+    /// error handler fires instead of the per-call reply block, `remove()`
+    /// must still resolve (reporting the protected threats as failures)
+    /// rather than hang forever.
+    func test_remove_resumesWhenHelperConnectionErrorFiresInsteadOfReply() async {
+        let systemURL = URL(fileURLWithPath: "/Library/Caches/com.bogus/evil")
+        let threat = MalwareThreat(filePath: systemURL, threatName: "OSX.Bad")
+
+        let droppingHelper = DroppingReplyHelper()
+        let remover = MalwareThreatRemover(helperProvider: { errorHandler in
+            errorHandler(NSError(domain: "test.xpc", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Connection invalidated"
+            ]))
+            return droppingHelper
+        })
+
+        let failures = await remover.remove([threat])
+
+        XCTAssertEqual(failures, [threat])
+    }
+}
+
+// MARK: - Test doubles
+
+/// Minimal `VaderCleanerHelperProtocol` stand-in — captures the paths it was
+/// asked to delete and replies with the supplied error (or nil for success).
+private final class FakeHelper: NSObject, VaderCleanerHelperProtocol {
+    private let replyError: Error?
+    private(set) var receivedPaths: [String] = []
+
+    init(replyError: Error?) {
+        self.replyError = replyError
+    }
+
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {
+        receivedPaths = paths
+        reply(replyError)
+    }
+
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+}
+
+/// Helper stand-in that drops the reply block — models the `NSXPCConnection`
+/// failure mode where the connection-level error handler fires instead.
+private final class DroppingReplyHelper: NSObject, VaderCleanerHelperProtocol {
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {}
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {}
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
+}

--- a/VaderCleanerTests/MalwareViewModelTests.swift
+++ b/VaderCleanerTests/MalwareViewModelTests.swift
@@ -1,0 +1,316 @@
+// MalwareViewModelTests.swift
+// Drives the MalwareViewModel state machine — install check, conditional database update, scan, results/clean, notification dispatch, and threat removal — through injected fakes.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class MalwareViewModelTests: XCTestCase {
+
+    private let threat = MalwareThreat(
+        filePath: URL(fileURLWithPath: "/Users/me/Downloads/evil.bin"),
+        threatName: "Eicar-Test-Signature"
+    )
+
+    // MARK: - Initial state
+
+    func test_init_phaseIsIdle() {
+        let vm = makeViewModel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertNil(vm.lastScanDate)
+    }
+
+    func test_prepare_whenClamAVMissing_movesToNeedsInstall() async {
+        let vm = makeViewModel(checkInstalled: { false })
+        await vm.prepare()
+        XCTAssertEqual(vm.phase, .needsInstall)
+    }
+
+    func test_prepare_whenClamAVPresent_staysIdleAndPublishesDatabaseDate() async {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { date }
+        )
+        await vm.prepare()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.databaseUpdatedDate, date)
+    }
+
+    // MARK: - Scan: install gating
+
+    func test_scan_whenClamAVMissing_movesToNeedsInstall() async {
+        let vm = makeViewModel(checkInstalled: { false })
+        await vm.scan()
+        XCTAssertEqual(vm.phase, .needsInstall)
+    }
+
+    // MARK: - Scan: database freshness
+
+    func test_scan_whenDatabaseStale_updatesBeforeScanning() async {
+        var updated = false
+        let stale = Date().addingTimeInterval(-48 * 3600)
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { stale },
+            updateDatabase: { _ in updated = true },
+            scan: { _ in [] }
+        )
+
+        await vm.scan()
+
+        XCTAssertTrue(updated, "A >24h-old signature database must be refreshed before scanning")
+        XCTAssertEqual(vm.phase, .clean)
+    }
+
+    func test_scan_whenDatabaseMissing_updatesBeforeScanning() async {
+        var updated = false
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { nil },
+            updateDatabase: { _ in updated = true },
+            scan: { _ in [] }
+        )
+
+        await vm.scan()
+
+        XCTAssertTrue(updated, "A never-updated database must be refreshed before scanning")
+    }
+
+    func test_scan_whenDatabaseFresh_skipsUpdate() async {
+        var updated = false
+        let fresh = Date().addingTimeInterval(-3600)
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { fresh },
+            updateDatabase: { _ in updated = true },
+            scan: { _ in [] }
+        )
+
+        await vm.scan()
+
+        XCTAssertFalse(updated, "A database updated within 24h must not be refreshed again")
+        XCTAssertEqual(vm.phase, .clean)
+    }
+
+    // MARK: - Scan: results
+
+    func test_scan_clean_movesToCleanAndSetsLastScanDate() async {
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in [] }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(vm.phase, .clean)
+        XCTAssertNotNil(vm.lastScanDate)
+    }
+
+    func test_scan_withThreats_movesToResults() async {
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in [self.threat] }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(vm.phase, .results([threat]))
+        XCTAssertNotNil(vm.lastScanDate)
+    }
+
+    func test_scan_failure_movesToFailed() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in throw Boom() }
+        )
+
+        await vm.scan()
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    func test_scan_databaseUpdateFailure_movesToFailed() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { nil },
+            updateDatabase: { _ in throw Boom() },
+            scan: { _ in [] }
+        )
+
+        await vm.scan()
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Notification dispatch
+
+    func test_scan_withThreats_dispatchesNotificationWhenPreferenceEnabled() async {
+        var notified: String?
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in [self.threat] },
+            notify: { notified = $0 },
+            shouldNotify: { true }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(notified, threat.threatName)
+    }
+
+    func test_scan_withThreats_suppressesNotificationWhenPreferenceDisabled() async {
+        var notified: String?
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in [self.threat] },
+            notify: { notified = $0 },
+            shouldNotify: { false }
+        )
+
+        await vm.scan()
+
+        XCTAssertNil(notified, "No malware notification when notifyMalwareFound is off")
+    }
+
+    func test_scan_clean_doesNotDispatchNotification() async {
+        var notified: String?
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in [] },
+            notify: { notified = $0 },
+            shouldNotify: { true }
+        )
+
+        await vm.scan()
+
+        XCTAssertNil(notified)
+    }
+
+    // MARK: - Threat removal
+
+    func test_removeThreats_invokesRemoverForEveryThreatAndCompletes() async {
+        let second = MalwareThreat(
+            filePath: URL(fileURLWithPath: "/Users/me/Library/Caches/x"),
+            threatName: "Adware"
+        )
+        var received: [MalwareThreat] = []
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in [self.threat, second] },
+            removeThreats: { threats in
+                received = threats
+                return []
+            }
+        )
+        await vm.scan()
+
+        await vm.removeThreats()
+
+        XCTAssertEqual(received, [threat, second])
+        XCTAssertEqual(vm.phase, .done(removedCount: 2))
+    }
+
+    func test_removeThreats_partialFailure_returnsToResultsWithRemaining() async {
+        let second = MalwareThreat(
+            filePath: URL(fileURLWithPath: "/Library/Caches/x"),
+            threatName: "OSX.Bad"
+        )
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in [self.threat, second] },
+            removeThreats: { _ in [second] }
+        )
+        await vm.scan()
+
+        await vm.removeThreats()
+
+        XCTAssertEqual(vm.phase, .results([second]),
+                       "Unremoved threats should remain so the user can retry")
+    }
+
+    // MARK: - Manual database update
+
+    func test_updateDatabaseManually_refreshesAndReturnsToIdle() async {
+        var updated = false
+        let newDate = Date()
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { newDate },
+            updateDatabase: { _ in updated = true }
+        )
+
+        await vm.updateDatabaseManually()
+
+        XCTAssertTrue(updated)
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.databaseUpdatedDate, newDate)
+    }
+
+    func test_updateDatabaseManually_failureMovesToFailed() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { nil },
+            updateDatabase: { _ in throw Boom() }
+        )
+
+        await vm.updateDatabaseManually()
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    // MARK: - Recovery
+
+    func test_dismissResult_returnsToIdle() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in throw Boom() }
+        )
+        await vm.scan()
+
+        vm.dismissResult()
+
+        XCTAssertEqual(vm.phase, .idle)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        checkInstalled: @escaping MalwareViewModel.CheckInstalled = { true },
+        databaseLastUpdated: @escaping MalwareViewModel.DatabaseLastUpdated = { Date() },
+        updateDatabase: @escaping MalwareViewModel.UpdateDatabase = { _ in },
+        scan: @escaping MalwareViewModel.Scan = { _ in [] },
+        removeThreats: @escaping MalwareViewModel.RemoveThreats = { _ in [] },
+        notify: @escaping MalwareViewModel.Notify = { _ in },
+        shouldNotify: @escaping MalwareViewModel.ShouldNotify = { true }
+    ) -> MalwareViewModel {
+        MalwareViewModel(
+            checkInstalled: checkInstalled,
+            databaseLastUpdated: databaseLastUpdated,
+            updateDatabase: updateDatabase,
+            scan: scan,
+            removeThreats: removeThreats,
+            notify: notify,
+            shouldNotify: shouldNotify
+        )
+    }
+}

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -1,0 +1,61 @@
+// MalwareUITests.swift
+// End-to-end UI test for Malware Removal — navigates to the section and asserts it renders either the idle scan screen or the ClamAV onboarding (depending on whether ClamAV is installed on the test host), exercising the sidebar → view-model → view wiring against the real app process.
+
+import XCTest
+
+/// We never trigger an actual scan here — `clamscan` would walk the entire
+/// home directory for tens of seconds and make the test flaky and slow. The
+/// scan / removal contracts are covered exhaustively by
+/// `MalwareViewModelTests` and `MalwareThreatRemoverTests` against injected
+/// fakes. This test only proves the section renders without crashing, which
+/// the unit tests cannot.
+final class MalwareUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    func test_navigateToMalware_revealsIdleOrOnboarding() throws {
+        dismissOnboardingIfNeeded()
+
+        let sidebarRow = app.outlines.staticTexts["Malware Removal"].firstMatch
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
+                      "Expected Malware Removal row in sidebar")
+        sidebarRow.click()
+
+        // Either ClamAV is installed (idle "Scan for Malware" button) or it is
+        // not (the onboarding's "Check Again" button). Whichever the host
+        // produces, one of the two must appear — proving the view rendered.
+        let scanButton = app.buttons["malware.scan"]
+        let onboardingRecheck = app.buttons["Check Again"]
+
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if scanButton.exists || onboardingRecheck.exists { break }
+            usleep(200_000)
+        }
+
+        XCTAssertTrue(
+            scanButton.exists || onboardingRecheck.exists,
+            "Expected Malware Removal to render either the scan screen or the ClamAV onboarding"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func dismissOnboardingIfNeeded() {
+        let continueWithout = app.buttons["Continue Without Access"]
+        if continueWithout.waitForExistence(timeout: 2) {
+            continueWithout.click()
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -44,7 +44,7 @@
 
 - [x] **Prompt 22** — Optimization feature (login items, launch agents, RAM flush, maintenance scripts)
 - [x] **Prompt 23** — ClamAV integration (detection, DB update, scanning, output parsing)
-- [ ] **Prompt 24** — Malware Removal UI (scan → results → remove flow)
+- [x] **Prompt 24** — Malware Removal UI (scan → results → remove flow)
 
 ## Phase 5 — Integration & Polish
 


### PR DESCRIPTION
## Summary

Implements the **Malware Removal feature UI** (Phase 4, Prompt 24), building on the Prompt 23 ClamAV engine layer. Wires `NavigationSection.malwareRemoval` from placeholder to the full scan → results → remove flow.

- **MalwareViewModel** — `@MainActor` state machine: `.idle → .checkingClamAV → .updatingDatabase → .scanning → (.results | .clean) → .removing → .done`, plus `.needsInstall` (routes to the existing ClamAV onboarding) and `.failed`. Refreshes a `>24h`-old signature database before scanning; dispatches `sendMalwareDetectedNotification`, gated by the existing `PreferencesStore.notifyMalwareFound` toggle (consistent with `NotificationThresholdMonitor`); partial-removal survivors stay in `.results` for retry.
- **MalwareThreatRemover** — deletes infected files, **reusing `SystemJunkDeleter.requiresHelper` routing** (user-domain via `FileManager`, protected paths via the privileged XPC helper). An already-absent user file counts as removed. Once-only XPC continuation guard kept file-private (the `SystemJunkDeleter` equivalent is `private`; sharing it would touch tested unrelated code).
- **MalwareView / MalwareViewSubviews** — ClamAV onboarding when absent; otherwise idle (scan + last-scan / DB-updated dates + Update Database), scanning (live progress + Cancel), clean, results (threat list + Remove All, confirmation alert), removing, done, failed. Decomposed per the `OptimizationView` convention with accessibility identifiers.
- **Wiring** — `ContentView` route + `#Preview`; one shared `NotificationManager` hoisted to App scope so a second `UNUserNotificationCenter` delegate can't silently steal the threshold monitor's registration.

All collaborators injected — the suite is green **without a real ClamAV install**, per the no-mock / real-data rule.

Closes #70

## Test plan

- [x] TDD: failing `MalwareViewModelTests` / `MalwareThreatRemoverTests` written first, then implementation.
- [x] **Unit suite deterministically green: 576/576** across two full runs (`VaderCleanerTests`).
- [x] New coverage: `MalwareViewModelTests` (idle init, install gating → `.needsInstall`, stale/missing/fresh DB handling, clean/results/failed transitions, notification dispatch + preference suppression, removal full/partial, manual DB update, recovery); `MalwareThreatRemoverTests` (user vs helper routing, already-absent file, helper error / unavailable / connection-error-instead-of-reply, mixed batch).
- [x] `MalwareUITests` — navigates to the section against the real app and asserts it renders idle-or-onboarding (non-destructive: never triggers a real home-directory scan), matching the `OptimizationUITests` pattern.
- [x] App target builds (`xcodebuild build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Malware Removal workflow: onboarding when scanner missing, database updates, scanning with progress, results view, and removal flow driven by app-scoped state; notifications respect user preferences.
* **Localization**
  * Added pluralized strings for threat counts and removal summaries.
* **Tests**
  * New unit and UI tests covering scanning, removal, helper handling, and UI navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->