### PR TITLE
Exclusions wired to all scanners

### DIFF
--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -11,6 +11,7 @@ struct AppUninstallerView: View {
 
     @ObservedObject private var viewModel: AppUninstallerViewModel
     @StateObject private var iconCache: AppIconCache
+    @EnvironmentObject private var exclusions: ExclusionsStore
     @State private var showUninstallConfirmation = false
 
     init(viewModel: AppUninstallerViewModel, iconCache: AppIconCache = AppIconCache()) {
@@ -90,6 +91,7 @@ struct AppUninstallerView: View {
                     }
                 ),
                 onSelect: viewModel.select,
+                onAddToExclusions: { exclusions.add(path: $0.bundleURL.path) },
                 iconCache: iconCache
             )
             .frame(minWidth: 260, idealWidth: 300, maxWidth: 360)

--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -144,4 +144,5 @@ struct AppUninstallerView: View {
         recycle: { _, _ in 0 }
     ))
     .frame(width: 900, height: 600)
+    .environmentObject(ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!))
 }

--- a/VaderCleaner/AppUninstallerViewModel.swift
+++ b/VaderCleaner/AppUninstallerViewModel.swift
@@ -307,16 +307,23 @@ extension AppUninstallerViewModel {
 
     /// Build a view-model wired to the real `DefaultAppDiscovery`,
     /// `DefaultAssociatedFileFinder`, and `NSWorkspace.recycle(...)`.
+    /// The exclusions snapshot is captured per lookup (a fresh
+    /// `DefaultAssociatedFileFinder` is cheap — it only stores config)
+    /// so a freshly-added Preferences exclusion takes effect on the next
+    /// app selection.
     @MainActor
-    static func live() -> AppUninstallerViewModel {
+    static func live(exclusions: ExclusionsStore) -> AppUninstallerViewModel {
         let discovery = DefaultAppDiscovery()
-        let finder = DefaultAssociatedFileFinder()
         return AppUninstallerViewModel(
             discover: { includingSystemApps in
                 try await discovery.installedApps(includingSystemApps: includingSystemApps)
             },
-            findFiles: { bundleID in
-                await finder.find(forBundleID: bundleID)
+            findFiles: { [weak exclusions] bundleID in
+                let excluded = await MainActor.run {
+                    (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
+                }
+                let finder = DefaultAssociatedFileFinder(excluding: excluded)
+                return await finder.find(forBundleID: bundleID)
             },
             measureSize: { url in
                 await discovery.bundleSize(at: url)

--- a/VaderCleaner/AppUninstallerViewSubviews.swift
+++ b/VaderCleaner/AppUninstallerViewSubviews.swift
@@ -59,7 +59,10 @@ struct AppUninstallerListPane: View {
                             .tag(Optional(app.id))
                             .accessibilityIdentifier("appUninstaller.row.\(app.bundleID)")
                             .contextMenu {
-                                Button("Add to Exclusions") {
+                                Button(String(
+                                    localized: "Add to Exclusions",
+                                    comment: "Context menu item that adds the selected app to the scan-exclusions list."
+                                )) {
                                     onAddToExclusions(app)
                                 }
                             }

--- a/VaderCleaner/AppUninstallerViewSubviews.swift
+++ b/VaderCleaner/AppUninstallerViewSubviews.swift
@@ -37,6 +37,7 @@ struct AppUninstallerListPane: View {
     @Binding var searchQuery: String
     @Binding var includesSystemApps: Bool
     let onSelect: (AppInfo.ID?) -> Void
+    let onAddToExclusions: (AppInfo) -> Void
     @ObservedObject var iconCache: AppIconCache
 
     var body: some View {
@@ -57,6 +58,11 @@ struct AppUninstallerListPane: View {
                                               iconCache: iconCache)
                             .tag(Optional(app.id))
                             .accessibilityIdentifier("appUninstaller.row.\(app.bundleID)")
+                            .contextMenu {
+                                Button("Add to Exclusions") {
+                                    onAddToExclusions(app)
+                                }
+                            }
                     }
                 }
                 .listStyle(.sidebar)

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -26,23 +26,32 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
     private let fileManager: FileManager
     private let homeDirectory: URL
     private let systemLibraryDirectory: URL
+    /// Canonicalised user exclusions. Any candidate whose canonical path
+    /// equals or sits beneath one of these is dropped from the result so
+    /// the uninstaller never Trashes a path the user told the app to
+    /// leave alone. Injected (like `homeDirectory`) so the production
+    /// wiring can snapshot the live `ExclusionsStore` per uninstall.
+    private let canonicalExclusions: [String]
     private let log = Logger(subsystem: "com.personal.VaderCleaner",
                              category: "AssociatedFileFinder")
 
     init(
         fileManager: FileManager = .default,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        systemLibraryDirectory: URL = URL(fileURLWithPath: "/Library", isDirectory: true)
+        systemLibraryDirectory: URL = URL(fileURLWithPath: "/Library", isDirectory: true),
+        excluding: [URL] = []
     ) {
         self.fileManager = fileManager
         self.homeDirectory = homeDirectory
         self.systemLibraryDirectory = systemLibraryDirectory
+        self.canonicalExclusions = excluding.map(PathExclusionMatcher.canonicalize)
     }
 
     func find(forBundleID bundleID: String) async -> [AssociatedFile] {
         let fileManager = fileManager
         let userLibrary = homeDirectory.appendingPathComponent("Library", isDirectory: true)
         let systemLibrary = systemLibraryDirectory
+        let canonicalExclusions = canonicalExclusions
 
         return await Task.detached(priority: .userInitiated) {
             var results: [AssociatedFile] = []
@@ -176,6 +185,20 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
                 category: .launchDaemons,
                 fileManager: fileManager
             ))
+
+            // Drop anything the user excluded. The candidate count here is
+            // small (a handful of fixed locations per bundle ID), so the
+            // per-path symlink resolution `canonicalize` does is cheap —
+            // unlike the bulk scanners, which project through a root mapper
+            // to avoid a syscall per enumerated file.
+            if !canonicalExclusions.isEmpty {
+                results.removeAll { file in
+                    PathExclusionMatcher.isExcluded(
+                        path: PathExclusionMatcher.canonicalize(file.url),
+                        by: canonicalExclusions
+                    )
+                }
+            }
 
             // Stable order: category (in declaration order), then URL path —
             // makes the rendered list deterministic across runs and makes

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -191,11 +191,23 @@ struct DefaultAssociatedFileFinder: AssociatedFileFinding, Sendable {
             // per-path symlink resolution `canonicalize` does is cheap —
             // unlike the bulk scanners, which project through a root mapper
             // to avoid a syscall per enumerated file.
+            //
+            // A candidate is dropped when it is itself excluded *or* when
+            // an excluded path lives inside it. The uninstaller recycles
+            // each candidate as one unit, so emitting a parent directory
+            // that contains an excluded descendant would Trash the
+            // excluded subtree along with it. Erring toward "leave the
+            // parent alone" is the safe choice — it never deletes data
+            // the user told us to keep.
             if !canonicalExclusions.isEmpty {
                 results.removeAll { file in
-                    PathExclusionMatcher.isExcluded(
-                        path: PathExclusionMatcher.canonicalize(file.url),
+                    let canonicalPath = PathExclusionMatcher.canonicalize(file.url)
+                    return PathExclusionMatcher.isExcluded(
+                        path: canonicalPath,
                         by: canonicalExclusions
+                    ) || PathExclusionMatcher.containsExcludedDescendant(
+                        of: canonicalPath,
+                        in: canonicalExclusions
                     )
                 }
             }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -155,9 +155,9 @@ struct ContentView: View {
     return ContentView(
         systemJunkViewModel: SystemJunkViewModel.live(exclusions: exclusions),
         largeOldFilesViewModel: LargeOldFilesViewModel.live(exclusions: exclusions),
-        spaceLensViewModel: DiskScannerViewModel.live(),
+        spaceLensViewModel: DiskScannerViewModel.live(exclusions: exclusions),
         privacyViewModel: PrivacyViewModel.live(),
-        appUninstallerViewModel: AppUninstallerViewModel.live(),
+        appUninstallerViewModel: AppUninstallerViewModel.live(exclusions: exclusions),
         appUpdaterViewModel: AppUpdaterViewModel.live(),
         extensionsManagerViewModel: ExtensionsManagerViewModel.live(),
         optimizationViewModel: OptimizationViewModel.live(systemStats: stats),

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -117,6 +117,28 @@ struct DiskScanner: DiskScanning {
             ? nil
             : PathExclusionMatcher.makeCanonicalPathMapper(for: resolvedRoot)
 
+        // The scan root itself can be on the exclusions list (e.g. the
+        // user excluded their home folder and Space Lens defaults to it).
+        // The child-loop filter only sees descendants, so without this
+        // check the whole excluded root would still be walked and
+        // reported. Mirrors `FileScanner`'s root-level skip; here we hand
+        // back an empty tree (rather than emit nothing) because the VM
+        // needs a `DiskNode` to land in `.ready`.
+        if let pathMapper,
+           PathExclusionMatcher.isExcluded(
+            path: pathMapper.canonicalRootPath,
+            by: canonicalExclusions
+           ) {
+            return DiskNode(
+                url: root,
+                name: root.lastPathComponent,
+                size: 0,
+                isDirectory: true,
+                children: [],
+                isAccessible: true
+            )
+        }
+
         // Validate the root up front. Inside `buildNode` we `try?`
         // metadata reads so a single broken descendant doesn't abort
         // the walk — but at the root, the same forgiveness silently
@@ -209,7 +231,15 @@ struct DiskScanner: DiskScanning {
         }
 
         if resourceValues?.isPackage == true {
-            let result = try await PackageDirectorySizer.recursiveSizeResult(of: url) {
+            // Thread exclusions into the package rollup so an excluded
+            // path *inside* a `.app`/other bundle doesn't get counted
+            // toward the package's (and every ancestor's) reported size.
+            // `PackageDirectorySizer` builds its own root-relative mapper
+            // from `url`, so the canonical exclusions match there too.
+            let result = try await PackageDirectorySizer.recursiveSizeResult(
+                of: url,
+                excluding: canonicalExclusions
+            ) {
                 counter.value += 1
                 progress(counter.value)
             }

--- a/VaderCleaner/DiskScanner.swift
+++ b/VaderCleaner/DiskScanner.swift
@@ -9,7 +9,7 @@ import os.log
 /// than through a fake. Listed so future features (Smart Scan, etc.) can
 /// substitute their own walker if needed.
 protocol DiskScanning {
-    func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode
+    func scan(root: URL, excluding: [URL], progress: @escaping (Int) -> Void) async throws -> DiskNode
 }
 
 /// Conditions under which a scan can't run at all, as distinct from a
@@ -89,7 +89,11 @@ struct DiskScanner: DiskScanning {
         var value: Int = 0
     }
 
-    func scan(root: URL, progress: @escaping (Int) -> Void) async throws -> DiskNode {
+    func scan(
+        root: URL,
+        excluding: [URL] = [],
+        progress: @escaping (Int) -> Void
+    ) async throws -> DiskNode {
         // Resolve symlinks at the root only. macOS exposes `/tmp`,
         // `/var`, and `/etc` as symlinks to `/private/...`; if the user
         // picks one as a Space Lens root, the symlink-skip branch
@@ -101,6 +105,17 @@ struct DiskScanner: DiskScanning {
         // *original* URL so the user sees the path they actually
         // selected.
         let resolvedRoot = root.resolvingSymlinksInPath()
+
+        // Exclusions are matched on canonical paths. The mapper projects
+        // each enumerated URL onto the same canonical form the user's
+        // stored exclusions use (see `FileScanner` for the shared
+        // semantics) without a per-entry symlink-resolution syscall.
+        // `nil` when there are no exclusions so the common case pays
+        // nothing.
+        let canonicalExclusions = excluding.map(PathExclusionMatcher.canonicalize)
+        let pathMapper = canonicalExclusions.isEmpty
+            ? nil
+            : PathExclusionMatcher.makeCanonicalPathMapper(for: resolvedRoot)
 
         // Validate the root up front. Inside `buildNode` we `try?`
         // metadata reads so a single broken descendant doesn't abort
@@ -119,6 +134,8 @@ struct DiskScanner: DiskScanning {
             at: resolvedRoot,
             counter: counter,
             progress: progress,
+            canonicalExclusions: canonicalExclusions,
+            pathMapper: pathMapper,
             isRoot: true
         )
     }
@@ -148,6 +165,8 @@ struct DiskScanner: DiskScanning {
         at url: URL,
         counter: FileCounter,
         progress: @escaping (Int) -> Void,
+        canonicalExclusions: [String],
+        pathMapper: PathExclusionMatcher.CanonicalPathMapper?,
         isRoot: Bool = false
     ) async throws -> DiskNode {
         try Task.checkCancellation()
@@ -252,7 +271,24 @@ struct DiskScanner: DiskScanning {
                 // policy note.
                 continue
             }
-            let child = try await buildNode(at: entry, counter: counter, progress: progress)
+            // A path the user excluded is dropped from the tree entirely:
+            // not added as a child and not rolled into this directory's
+            // size. Space Lens answers "where are my bytes" — an excluded
+            // subtree the user asked us to ignore must not skew its
+            // ancestors' reported totals.
+            if let pathMapper {
+                let canonicalPath = pathMapper.canonicalPath(for: entry)
+                if PathExclusionMatcher.isExcluded(path: canonicalPath, by: canonicalExclusions) {
+                    continue
+                }
+            }
+            let child = try await buildNode(
+                at: entry,
+                counter: counter,
+                progress: progress,
+                canonicalExclusions: canonicalExclusions,
+                pathMapper: pathMapper
+            )
             rolledUpSize += child.size
             children.append(child)
         }

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -350,11 +350,18 @@ extension DiskScannerViewModel.Phase: Equatable {
 extension DiskScannerViewModel {
 
     /// Build a view-model wired to the real `DiskScanner`. Mirrors the
-    /// `LargeOldFilesViewModel.live(...)` pattern.
+    /// `LargeOldFilesViewModel.live(...)` pattern — the exclusions snapshot
+    /// is captured per scan so a freshly-added Preferences exclusion takes
+    /// effect on the very next scan.
     @MainActor
-    static func live() -> DiskScannerViewModel {
-        DiskScannerViewModel(scanner: { url, progress in
-            try await DiskScanner().scan(root: url, progress: progress)
+    static func live(exclusions: ExclusionsStore) -> DiskScannerViewModel {
+        DiskScannerViewModel(scanner: { [weak exclusions] url, progress in
+            let excluded = (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
+            return try await DiskScanner().scan(
+                root: url,
+                excluding: excluded,
+                progress: progress
+            )
         })
     }
 }

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -11,6 +11,7 @@ struct LargeOldFilesView: View {
     @ObservedObject private var viewModel: LargeOldFilesViewModel
     @StateObject private var fileIconCache = FileIconCache()
     @EnvironmentObject private var notificationMonitor: NotificationThresholdMonitor
+    @EnvironmentObject private var exclusions: ExclusionsStore
 
     /// Drives the "Are you sure?" alert before destructive actions. Held on
     /// the view rather than the VM so the confirmation copy can reference
@@ -70,7 +71,8 @@ struct LargeOldFilesView: View {
                 onRescan: startScan,
                 onDeleteSelected: requestDeletionForSelection,
                 onShowInFinder: LargeOldFilesActions.showInFinder,
-                onDeleteFile: requestDeletionForSingle
+                onDeleteFile: requestDeletionForSingle,
+                onAddToExclusions: { exclusions.add(path: $0.url.path) }
             )
         case .empty:
             LargeOldFilesEmptyState(onScanAgain: viewModel.scanAgain)

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -152,4 +152,5 @@ private struct PendingDeletion: Identifiable {
         deleter: { _ in [] }
     ))
     .frame(width: 800, height: 520)
+    .environmentObject(ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!))
 }

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -98,6 +98,7 @@ struct LargeOldFilesResultsContent: View {
     let onDeleteSelected: () -> Void
     let onShowInFinder: (ScannedFile) -> Void
     let onDeleteFile: (ScannedFile) -> Void
+    let onAddToExclusions: (ScannedFile) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -108,7 +109,8 @@ struct LargeOldFilesResultsContent: View {
                 isSelected: isSelected,
                 onToggleSelection: onToggleSelection,
                 onShowInFinder: onShowInFinder,
-                onDeleteFile: onDeleteFile
+                onDeleteFile: onDeleteFile,
+                onAddToExclusions: onAddToExclusions
             )
             Divider()
             LargeOldFilesFooter(
@@ -132,6 +134,7 @@ struct LargeOldFilesTable: View {
     let onToggleSelection: (ScannedFile) -> Void
     let onShowInFinder: (ScannedFile) -> Void
     let onDeleteFile: (ScannedFile) -> Void
+    let onAddToExclusions: (ScannedFile) -> Void
 
     var body: some View {
         Table(files) {
@@ -155,7 +158,8 @@ struct LargeOldFilesTable: View {
                     file: file,
                     fileIconCache: fileIconCache,
                     onShowInFinder: onShowInFinder,
-                    onDelete: onDeleteFile
+                    onDelete: onDeleteFile,
+                    onAddToExclusions: onAddToExclusions
                 )
             }
 
@@ -231,6 +235,7 @@ struct LargeOldFilesRowNameCell: View {
     @ObservedObject var fileIconCache: FileIconCache
     let onShowInFinder: (ScannedFile) -> Void
     let onDelete: (ScannedFile) -> Void
+    let onAddToExclusions: (ScannedFile) -> Void
 
     var body: some View {
         HStack(spacing: 6) {
@@ -244,6 +249,9 @@ struct LargeOldFilesRowNameCell: View {
         .contextMenu {
             Button("Show in Finder") {
                 onShowInFinder(file)
+            }
+            Button("Add to Exclusions") {
+                onAddToExclusions(file)
             }
             Divider()
             Button("Delete", role: .destructive) {

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -250,7 +250,10 @@ struct LargeOldFilesRowNameCell: View {
             Button("Show in Finder") {
                 onShowInFinder(file)
             }
-            Button("Add to Exclusions") {
+            Button(String(
+                localized: "Add to Exclusions",
+                comment: "Context menu item that adds the selected file to the scan-exclusions list."
+            )) {
                 onAddToExclusions(file)
             }
             Divider()

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -73,9 +73,13 @@ struct VaderCleanerApp: App {
         _largeOldFilesViewModel = StateObject(
             wrappedValue: LargeOldFilesViewModel.live(exclusions: exclusions)
         )
-        _spaceLensViewModel = StateObject(wrappedValue: DiskScannerViewModel.live())
+        _spaceLensViewModel = StateObject(
+            wrappedValue: DiskScannerViewModel.live(exclusions: exclusions)
+        )
         _privacyViewModel = StateObject(wrappedValue: PrivacyViewModel.live())
-        _appUninstallerViewModel = StateObject(wrappedValue: AppUninstallerViewModel.live())
+        _appUninstallerViewModel = StateObject(
+            wrappedValue: AppUninstallerViewModel.live(exclusions: exclusions)
+        )
         _appUpdaterViewModel = StateObject(wrappedValue: AppUpdaterViewModel.live())
         _extensionsManagerViewModel = StateObject(wrappedValue: ExtensionsManagerViewModel.live())
         // Construct the polling service and the menu bar view-model in the

--- a/VaderCleanerTests/AssociatedFileFinderTests.swift
+++ b/VaderCleanerTests/AssociatedFileFinderTests.swift
@@ -342,6 +342,40 @@ final class AssociatedFileFinderTests: XCTestCase {
         }
     }
 
+    /// The uninstaller recycles each associated path as one unit. If the
+    /// user excluded something *inside* a candidate directory, emitting
+    /// the parent would Trash the excluded subtree along with it — so the
+    /// parent candidate must be suppressed entirely (the safe choice:
+    /// never delete data the user told us to keep).
+    func test_find_suppressesParentContainingExcludedDescendant() async throws {
+        try makeFile(
+            under: "Library/Application Support/com.acme.helio/keep-me/important.bin",
+            size: 64
+        )
+        try makeFile(under: "Library/Logs/com.acme.helio/app.log", size: 32)
+        let excludedDescendant = home.appendingPathComponent(
+            "Library/Application Support/com.acme.helio/keep-me",
+            isDirectory: true
+        )
+
+        let finder = DefaultAssociatedFileFinder(
+            fileManager: .default,
+            homeDirectory: home,
+            systemLibraryDirectory: systemLibrary,
+            excluding: [excludedDescendant]
+        )
+        let result = await finder.find(forBundleID: "com.acme.helio")
+
+        XCTAssertFalse(
+            result.contains { $0.category == .applicationSupport },
+            "Parent Application Support dir must be suppressed — it contains an excluded path"
+        )
+        XCTAssertTrue(
+            result.contains { $0.category == .logs },
+            "Unrelated logs must still be found"
+        )
+    }
+
     // MARK: - Ordering
 
     /// Results are stably ordered by category in declaration order, then

--- a/VaderCleanerTests/AssociatedFileFinderTests.swift
+++ b/VaderCleanerTests/AssociatedFileFinderTests.swift
@@ -305,6 +305,43 @@ final class AssociatedFileFinderTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    // MARK: - Exclusions
+
+    /// A path on the user's exclusions list must never enter the
+    /// uninstall plan. Without this the uninstaller could Trash a
+    /// cache/support directory the user explicitly told the app to
+    /// leave alone (e.g. a shared model directory under
+    /// `~/Library/Application Support`).
+    func test_find_skipsExcludedPaths() async throws {
+        try makeFile(under: "Library/Caches/com.acme.helio/blob.bin", size: 64)
+        try makeFile(under: "Library/Logs/com.acme.helio/app.log", size: 32)
+        let excludedCaches = home
+            .appendingPathComponent("Library/Caches/com.acme.helio", isDirectory: true)
+
+        let finder = DefaultAssociatedFileFinder(
+            fileManager: .default,
+            homeDirectory: home,
+            systemLibraryDirectory: systemLibrary,
+            excluding: [excludedCaches]
+        )
+        let result = await finder.find(forBundleID: "com.acme.helio")
+
+        XCTAssertFalse(
+            result.contains { $0.category == .cache },
+            "Excluded cache directory must not appear in the uninstall plan"
+        )
+        XCTAssertTrue(
+            result.contains { $0.category == .logs },
+            "Non-excluded logs must still be found"
+        )
+        for file in result {
+            XCTAssertFalse(
+                file.url.path.hasPrefix(excludedCaches.path),
+                "Excluded path leaked: \(file.url.path)"
+            )
+        }
+    }
+
     // MARK: - Ordering
 
     /// Results are stably ordered by category in declaration order, then

--- a/VaderCleanerTests/BrowserDataClearerTests.swift
+++ b/VaderCleanerTests/BrowserDataClearerTests.swift
@@ -106,6 +106,48 @@ final class BrowserDataClearerTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: cacheDir.path))
     }
 
+    /// **Deliberate inversion of plan.md Prompt 26 — see issue #38 / #75.**
+    ///
+    /// Privacy is a targeted "clear my browser data" action, not a broad
+    /// safe-defaults sweep. Applying the user's general exclusions list
+    /// here would silently leave behind data the user explicitly asked to
+    /// clear. So `BrowserDataClearer` intentionally does **not** consult
+    /// `ExclusionsStore`: a path being on the exclusions list must not stop
+    /// it from being cleared. This test locks that contract in so a future
+    /// change can't re-wire exclusions into Privacy without consciously
+    /// deleting this assertion.
+    @MainActor
+    func test_clear_ignoresExclusionsByDesign() async throws {
+        let history = try TestHelpers.createDummyFile(
+            named: "History.db",
+            size: 100,
+            in: tempRoot
+        )
+
+        // Put the very path we're about to clear on the exclusions list.
+        // Isolated suite so the test never touches the user's real
+        // UserDefaults.
+        let suiteName = "BrowserDataClearerTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let exclusions = ExclusionsStore(defaults: defaults)
+        exclusions.add(path: history.path)
+        XCTAssertTrue(
+            exclusions.exclusions.contains { history.path.hasPrefix($0) },
+            "Precondition: the path must actually be on the exclusions list"
+        )
+
+        let provider = StubProvider(paths: [.history: [history]])
+        let clearer = BrowserDataClearer(pathProvider: provider)
+
+        try await clearer.clear(category: .history, browser: .chrome)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: history.path),
+            "Privacy must clear data even when its path is excluded — exclusions are intentionally not consulted here (issue #38)"
+        )
+    }
+
     /// `clear` must tolerate missing paths so a partially-populated browser
     /// (e.g. cookies file exists but cache dir doesn't) doesn't raise an
     /// error mid-clear and leave the user staring at a misleading "couldn't

--- a/VaderCleanerTests/BrowserDataClearerTests.swift
+++ b/VaderCleanerTests/BrowserDataClearerTests.swift
@@ -132,10 +132,6 @@ final class BrowserDataClearerTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let exclusions = ExclusionsStore(defaults: defaults)
         exclusions.add(path: history.path)
-        XCTAssertTrue(
-            exclusions.exclusions.contains { history.path.hasPrefix($0) },
-            "Precondition: the path must actually be on the exclusions list"
-        )
 
         let provider = StubProvider(paths: [.history: [history]])
         let clearer = BrowserDataClearer(pathProvider: provider)

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -306,4 +306,41 @@ final class DiskScannerTests: XCTestCase {
             XCTAssertLessThanOrEqual(lhs, rhs, "Progress counts must never decrease")
         }
     }
+
+    // MARK: - Exclusions
+
+    /// A path the user excluded must not appear anywhere in the tree, and
+    /// its bytes must not be rolled into the parent's size. Space Lens is a
+    /// "where are my bytes" view — an excluded directory the user asked us
+    /// to ignore would otherwise still dominate the treemap and skew every
+    /// ancestor's reported size.
+    func test_scan_skipsExcludedPathsInTree() async throws {
+        let kept = tempRoot.appendingPathComponent("kept", isDirectory: true)
+        let excluded = tempRoot.appendingPathComponent("excluded", isDirectory: true)
+        let excludedSub = excluded.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: kept, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: excludedSub, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "keep.bin", size: 32, in: kept)
+        try TestHelpers.createDummyFile(named: "secret.bin", size: 64, in: excluded)
+        try TestHelpers.createDummyFile(named: "deep.bin", size: 128, in: excludedSub)
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(
+            root: tempRoot,
+            excluding: [excluded],
+            progress: { _ in }
+        )
+
+        XCTAssertNil(
+            root.children.first { $0.name == "excluded" },
+            "Excluded directory must not appear in the tree"
+        )
+        let keptNode = try XCTUnwrap(root.children.first { $0.name == "kept" })
+        XCTAssertEqual(keptNode.size, 32)
+        XCTAssertEqual(
+            root.size,
+            32,
+            "Excluded bytes (64 + 128) must not roll into the parent total"
+        )
+    }
 }

--- a/VaderCleanerTests/DiskScannerTests.swift
+++ b/VaderCleanerTests/DiskScannerTests.swift
@@ -343,4 +343,51 @@ final class DiskScannerTests: XCTestCase {
             "Excluded bytes (64 + 128) must not roll into the parent total"
         )
     }
+
+    /// When the scan root *itself* is on the exclusions list (e.g. the
+    /// user excluded their home folder and Space Lens defaults to it),
+    /// the whole tree must be empty rather than walked. The child-loop
+    /// filter only sees descendants, so this is exercised by the
+    /// dedicated root-level check.
+    func test_scan_returnsEmptyTreeWhenRootItselfExcluded() async throws {
+        try TestHelpers.createDummyFile(named: "a.bin", size: 100, in: tempRoot)
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(
+            root: tempRoot,
+            excluding: [tempRoot],
+            progress: { _ in }
+        )
+
+        XCTAssertEqual(root.size, 0, "An excluded root must report zero bytes")
+        XCTAssertTrue(root.children.isEmpty, "An excluded root must have no children")
+    }
+
+    /// A package is rolled up as a single leaf; an excluded path *inside*
+    /// the package must still be subtracted from that rollup, otherwise
+    /// the excluded bytes silently re-enter via the package total and
+    /// every ancestor's size.
+    func test_scan_excludesPathsInsidePackageFromRollup() async throws {
+        let package = tempRoot.appendingPathComponent("Photos.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        let excludedInside = contents.appendingPathComponent("excluded", isDirectory: true)
+        try FileManager.default.createDirectory(at: excludedInside, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "keep.bin", size: 32, in: contents)
+        try TestHelpers.createDummyFile(named: "secret.bin", size: 64, in: excludedInside)
+
+        let scanner = DiskScanner()
+        let root = try await scanner.scan(
+            root: tempRoot,
+            excluding: [excludedInside],
+            progress: { _ in }
+        )
+
+        let packageNode = try XCTUnwrap(root.children.first { $0.name == "Photos.app" })
+        XCTAssertEqual(
+            packageNode.size,
+            32,
+            "Excluded 64 bytes inside the package must not count toward its rollup"
+        )
+        XCTAssertEqual(root.size, 32)
+    }
 }

--- a/todo.md
+++ b/todo.md
@@ -49,5 +49,5 @@
 ## Phase 5 — Integration & Polish
 
 - [x] **Prompt 25** — Smart Scan (orchestrates junk + malware + optimization)
-- [ ] **Prompt 26** — Exclusions wired to all scanners
+- [x] **Prompt 26** — Exclusions wired to all scanners
 - [ ] **Prompt 27** — Final polish, error handling, E2E tests, app icon, About window


### PR DESCRIPTION
## Summary

Completes **Prompt 26** (first unchecked item in `todo.md`). `SystemJunkScanner` / `LargeOldFilesScanner` / `FileScanner` already honored exclusions; this wires the remaining scanners and surfaces "Add to Exclusions" in the UI.

- **DiskScanner**: skips excluded subtrees in its own recursive walker (it does not use `FileScanner`), so excluded bytes don't roll into ancestor sizes in the Space Lens treemap. `DiskScannerViewModel.live(exclusions:)` snapshots the list per scan.
- **AssociatedFileFinder**: filters the App Uninstaller plan through the user's exclusions (config-injected, mirrors `homeDirectory`). `AppUninstallerViewModel.live(exclusions:)` snapshots per lookup.
- **"Add to Exclusions" context menu** in Large & Old Files rows and App Uninstaller rows, backed by the app-wide `ExclusionsStore` environment object.
- Threaded `exclusions` through `VaderCleanerApp` + `ContentView` preview wiring.

### Deliberate deviation from plan.md (flagged)

plan.md says to wire `BrowserDataClearer`. **Issue #38 deliberately overrode this**: Privacy is a targeted "clear my browser data" action — applying the general exclusions list would silently leave behind data the user explicitly asked to clear. Confirmed with maintainer. Instead of a silent skip, `BrowserDataClearerTests.test_clear_ignoresExclusionsByDesign` asserts `clear()` still removes an excluded path, locking the inversion in so it can't be re-wired by accident.

## Test plan

- [x] `DiskScannerTests.test_scan_skipsExcludedPathsInTree` (TDD)
- [x] `AssociatedFileFinderTests.test_find_skipsExcludedPaths` (TDD)
- [x] `BrowserDataClearerTests.test_clear_ignoresExclusionsByDesign` (#38 lock-in)
- [x] Pre-existing `SystemJunkScannerTests` / `LargeOldFilesScannerTests` exclusion coverage verified unchanged
- [x] Full unit suite green: **593 tests, 0 failures**
- [x] App + all test targets (incl. UITests) build clean
- [ ] Manual: right-click "Add to Exclusions" in Large & Old Files and App Uninstaller, confirm Preferences → Exclusions reflects it

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now exclude specific apps from the uninstaller and files from scan results
  * Added "Add to Exclusions" context menu options for quick exclusion management
  * All scanning operations now respect user-defined exclusions

* **Tests**
  * Expanded test coverage for exclusion handling across all scanner implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->