### PR TITLE
fix: surface network copy when App Updater check is offline

### DIFF
--- a/VaderCleaner/AppUpdaterError.swift
+++ b/VaderCleaner/AppUpdaterError.swift
@@ -26,13 +26,7 @@ enum AppUpdaterError: LocalizedError {
     /// failure means we could not reach the network", shared by the
     /// per-feed offline-detection path and `userFacingMessage`.
     static func isNetworkError(_ error: Error) -> Bool {
-        if error is URLError {
-            return true
-        }
-        if (error as NSError).domain == NSURLErrorDomain {
-            return true
-        }
-        return false
+        error is URLError || (error as NSError).domain == NSURLErrorDomain
     }
 
     /// Maps an arbitrary error raised while checking for updates to the

--- a/VaderCleaner/AppUpdaterError.swift
+++ b/VaderCleaner/AppUpdaterError.swift
@@ -20,6 +20,21 @@ enum AppUpdaterError: LocalizedError {
         }
     }
 
+    /// True when `error` is a URL-loading failure — a `URLError` or its
+    /// bridged `NSURLErrorDomain` `NSError` form (offline, DNS, host
+    /// unreachable, timeout). The single source of truth for "this
+    /// failure means we could not reach the network", shared by the
+    /// per-feed offline-detection path and `userFacingMessage`.
+    static func isNetworkError(_ error: Error) -> Bool {
+        if error is URLError {
+            return true
+        }
+        if (error as NSError).domain == NSURLErrorDomain {
+            return true
+        }
+        return false
+    }
+
     /// Maps an arbitrary error raised while checking for updates to the
     /// string the UI should display. URL-loading failures (offline, DNS,
     /// host unreachable, timeout — in both `URLError` and bridged
@@ -30,10 +45,7 @@ enum AppUpdaterError: LocalizedError {
         if error is AppUpdaterError {
             return networkMessage
         }
-        if error is URLError {
-            return networkMessage
-        }
-        if (error as NSError).domain == NSURLErrorDomain {
+        if isNetworkError(error) {
             return networkMessage
         }
         return error.localizedDescription

--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -299,8 +299,8 @@ private struct AppUpdaterFailedState: View {
 #Preview {
     AppUpdaterView(viewModel: AppUpdaterViewModel(
         discover: { _ in [] },
-        checkAppStore: { _ in nil },
-        checkSparkle: { _ in nil },
+        checkAppStore: { _ in .noResult },
+        checkSparkle: { _ in .noResult },
         opener: { _ in }
     ))
     .frame(width: 900, height: 600)

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -229,56 +229,52 @@ final class AppUpdaterViewModel: ObservableObject {
         app: AppInfo,
         check: CheckAppStore
     ) async -> AppCheckOutcome {
-        let lookup: AppStoreLookup
         switch await check(app.bundleID) {
         case .unreachable:
             return .unreachable
         case .noResult:
             return .noUpdate
-        case .found(let value):
-            lookup = value
+        case .found(let lookup):
+            let installed = app.version ?? "0"
+            guard VersionComparator.isNewer(version: lookup.version, than: installed) else {
+                return .noUpdate
+            }
+            return .update(UpdateInfo(
+                appName: app.name,
+                bundleID: app.bundleID,
+                bundleURL: app.bundleURL,
+                installedVersion: installed,
+                latestVersion: lookup.version,
+                source: .appStore,
+                updateURL: lookup.appStoreURL
+            ))
         }
-        let installed = app.version ?? "0"
-        guard VersionComparator.isNewer(version: lookup.version, than: installed) else {
-            return .noUpdate
-        }
-        return .update(UpdateInfo(
-            appName: app.name,
-            bundleID: app.bundleID,
-            bundleURL: app.bundleURL,
-            installedVersion: installed,
-            latestVersion: lookup.version,
-            source: .appStore,
-            updateURL: lookup.appStoreURL
-        ))
     }
 
     private static func checkSparkleUpdate(
         app: AppInfo,
         check: CheckSparkle
     ) async -> AppCheckOutcome {
-        let item: SparkleAppcastItem
         switch await check(app) {
         case .unreachable:
             return .unreachable
         case .noResult:
             return .noUpdate
-        case .found(let value):
-            item = value
+        case .found(let item):
+            let installed = app.version ?? "0"
+            guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else {
+                return .noUpdate
+            }
+            return .update(UpdateInfo(
+                appName: app.name,
+                bundleID: app.bundleID,
+                bundleURL: app.bundleURL,
+                installedVersion: installed,
+                latestVersion: item.shortVersion,
+                source: .sparkle,
+                updateURL: item.downloadURL
+            ))
         }
-        let installed = app.version ?? "0"
-        guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else {
-            return .noUpdate
-        }
-        return .update(UpdateInfo(
-            appName: app.name,
-            bundleID: app.bundleID,
-            bundleURL: app.bundleURL,
-            installedVersion: installed,
-            latestVersion: item.shortVersion,
-            source: .sparkle,
-            updateURL: item.downloadURL
-        ))
     }
 }
 

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -11,12 +11,20 @@ import os.log
 /// update", so a genuinely offline check can surface the network copy
 /// while a single dead feed still never blanks the whole list. Generic
 /// over the payload so the App Store and Sparkle channels share one
-/// three-way shape (a result, a reached feed with nothing to offer, or
-/// an unreachable feed) instead of two near-identical enums.
+/// shape instead of near-identical enums.
+///
+/// `.noResult` means a network round-trip completed but carried nothing
+/// actionable (no MAS entry, nothing newer, or a swallowed non-network
+/// failure) — proof the network is up. `.skipped` means no request was
+/// ever made (e.g. the app carries no `SUFeedURL`), so it must stay
+/// neutral in the offline decision: counting a skipped app as "reached"
+/// would mask a genuinely offline machine the moment one non-updatable
+/// app is installed — which is essentially always.
 enum CheckResult<Payload: Sendable>: Sendable {
     case found(Payload)
     case noResult
     case unreachable
+    case skipped
 }
 
 /// Drives the App Updater feature view (check → ready → update).
@@ -133,6 +141,10 @@ final class AppUpdaterViewModel: ObservableObject {
                     anyReachable = true
                 case .unreachable:
                     anyUnreachable = true
+                case .skipped:
+                    // No request was made — neither evidence the
+                    // network is up nor that it is down.
+                    break
                 }
             }
 
@@ -197,12 +209,15 @@ final class AppUpdaterViewModel: ObservableObject {
     /// feed was reached but there is nothing newer to offer (including a
     /// swallowed non-network failure — the server answered, so the
     /// network is fine). `.unreachable` means the feed could not be
-    /// reached at all. The aggregator in `checkForUpdates()` uses the
-    /// reachable/unreachable split to tell "up to date" from "offline".
+    /// reached at all. `.skipped` means no request was attempted (no
+    /// feed configured). The aggregator in `checkForUpdates()` uses the
+    /// reachable/unreachable split to tell "up to date" from "offline",
+    /// and keeps `.skipped` out of that split entirely.
     private enum AppCheckOutcome {
         case update(UpdateInfo)
         case noUpdate
         case unreachable
+        case skipped
     }
 
     /// Dispatches a single app to the correct update channel. Factored
@@ -234,6 +249,8 @@ final class AppUpdaterViewModel: ObservableObject {
             return .unreachable
         case .noResult:
             return .noUpdate
+        case .skipped:
+            return .skipped
         case .found(let lookup):
             let installed = app.version ?? "0"
             guard VersionComparator.isNewer(version: lookup.version, than: installed) else {
@@ -260,6 +277,8 @@ final class AppUpdaterViewModel: ObservableObject {
             return .unreachable
         case .noResult:
             return .noUpdate
+        case .skipped:
+            return .skipped
         case .found(let item):
             let installed = app.version ?? "0"
             guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else {
@@ -310,7 +329,7 @@ extension AppUpdaterViewModel {
                 }
             },
             checkSparkle: { app in
-                guard let feedURL = sparkle.feedURL(for: app) else { return .noResult }
+                guard let feedURL = sparkle.feedURL(for: app) else { return .skipped }
                 do {
                     if let item = try await sparkle.fetchAppcast(feedURL: feedURL) {
                         return .found(item)

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -5,22 +5,16 @@ import AppKit
 import Foundation
 import os.log
 
-/// Outcome of a single App Store update lookup. `.unreachable` is the
+/// Outcome of a single update-feed lookup. `.unreachable` is the
 /// signal Prompt 20's swallow contract was missing: it lets the
 /// view-model tell "this feed was down" apart from "this app has no
 /// update", so a genuinely offline check can surface the network copy
-/// while a single dead feed still never blanks the whole list.
-enum AppStoreCheckResult: Sendable {
-    case lookup(AppStoreLookup)
-    case noResult
-    case unreachable
-}
-
-/// Sparkle counterpart of `AppStoreCheckResult`. Same three-way split:
-/// an appcast item, a reached feed with nothing to offer, or a feed we
-/// could not reach because the network was down.
-enum SparkleCheckResult: Sendable {
-    case item(SparkleAppcastItem)
+/// while a single dead feed still never blanks the whole list. Generic
+/// over the payload so the App Store and Sparkle channels share one
+/// three-way shape (a result, a reached feed with nothing to offer, or
+/// an unreachable feed) instead of two near-identical enums.
+enum CheckResult<Payload: Sendable>: Sendable {
+    case found(Payload)
     case noResult
     case unreachable
 }
@@ -42,8 +36,8 @@ final class AppUpdaterViewModel: ObservableObject {
     }
 
     typealias Discover       = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
-    typealias CheckAppStore  = @Sendable (_ bundleID: String) async -> AppStoreCheckResult
-    typealias CheckSparkle   = @Sendable (_ app: AppInfo) async -> SparkleCheckResult
+    typealias CheckAppStore  = @Sendable (_ bundleID: String) async -> CheckResult<AppStoreLookup>
+    typealias CheckSparkle   = @Sendable (_ app: AppInfo) async -> CheckResult<SparkleAppcastItem>
     typealias Opener         = @Sendable (_ url: URL) async -> Void
 
     @Published private(set) var phase: Phase = .idle
@@ -241,7 +235,7 @@ final class AppUpdaterViewModel: ObservableObject {
             return .unreachable
         case .noResult:
             return .noUpdate
-        case .lookup(let value):
+        case .found(let value):
             lookup = value
         }
         let installed = app.version ?? "0"
@@ -269,7 +263,7 @@ final class AppUpdaterViewModel: ObservableObject {
             return .unreachable
         case .noResult:
             return .noUpdate
-        case .item(let value):
+        case .found(let value):
             item = value
         }
         let installed = app.version ?? "0"
@@ -307,7 +301,7 @@ extension AppUpdaterViewModel {
             checkAppStore: { bundleID in
                 do {
                     if let lookup = try await appStore.latestVersion(forBundleID: bundleID) {
-                        return .lookup(lookup)
+                        return .found(lookup)
                     }
                     return .noResult
                 } catch {
@@ -323,7 +317,7 @@ extension AppUpdaterViewModel {
                 guard let feedURL = sparkle.feedURL(for: app) else { return .noResult }
                 do {
                     if let item = try await sparkle.fetchAppcast(feedURL: feedURL) {
-                        return .item(item)
+                        return .found(item)
                     }
                     return .noResult
                 } catch {

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -5,6 +5,26 @@ import AppKit
 import Foundation
 import os.log
 
+/// Outcome of a single App Store update lookup. `.unreachable` is the
+/// signal Prompt 20's swallow contract was missing: it lets the
+/// view-model tell "this feed was down" apart from "this app has no
+/// update", so a genuinely offline check can surface the network copy
+/// while a single dead feed still never blanks the whole list.
+enum AppStoreCheckResult: Sendable {
+    case lookup(AppStoreLookup)
+    case noResult
+    case unreachable
+}
+
+/// Sparkle counterpart of `AppStoreCheckResult`. Same three-way split:
+/// an appcast item, a reached feed with nothing to offer, or a feed we
+/// could not reach because the network was down.
+enum SparkleCheckResult: Sendable {
+    case item(SparkleAppcastItem)
+    case noResult
+    case unreachable
+}
+
 /// Drives the App Updater feature view (check → ready → update).
 ///
 /// All collaborators are injected as closures so unit tests can drive
@@ -22,8 +42,8 @@ final class AppUpdaterViewModel: ObservableObject {
     }
 
     typealias Discover       = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
-    typealias CheckAppStore  = @Sendable (_ bundleID: String) async -> AppStoreLookup?
-    typealias CheckSparkle   = @Sendable (_ app: AppInfo) async -> SparkleAppcastItem?
+    typealias CheckAppStore  = @Sendable (_ bundleID: String) async -> AppStoreCheckResult
+    typealias CheckSparkle   = @Sendable (_ app: AppInfo) async -> SparkleCheckResult
     typealias Opener         = @Sendable (_ url: URL) async -> Void
 
     @Published private(set) var phase: Phase = .idle
@@ -70,7 +90,7 @@ final class AppUpdaterViewModel: ObservableObject {
             // makes the data flow obvious.
             let appStoreCheck = self.checkAppStore
             let sparkleCheck = self.checkSparkle
-            let updates = await withTaskGroup(of: UpdateInfo?.self) { group -> [UpdateInfo] in
+            let outcomes = await withTaskGroup(of: AppCheckOutcome.self) { group -> [AppCheckOutcome] in
                 // Bounded concurrency: a machine with hundreds of installed
                 // apps would otherwise fire hundreds of simultaneous HTTPS
                 // requests at the iTunes Search API and assorted Sparkle
@@ -88,9 +108,9 @@ final class AppUpdaterViewModel: ObservableObject {
                     }
                     nextIndex += 1
                 }
-                var results: [UpdateInfo] = []
-                while let item = await group.next() {
-                    if let item { results.append(item) }
+                var results: [AppCheckOutcome] = []
+                while let outcome = await group.next() {
+                    results.append(outcome)
                     if nextIndex < apps.count {
                         let app = apps[nextIndex]
                         group.addTask {
@@ -106,12 +126,42 @@ final class AppUpdaterViewModel: ObservableObject {
                 return results
             }
             guard self.checkGeneration == generation else { return }
+
+            var updates: [UpdateInfo] = []
+            var anyReachable = false
+            var anyUnreachable = false
+            for outcome in outcomes {
+                switch outcome {
+                case .update(let info):
+                    updates.append(info)
+                    anyReachable = true
+                case .noUpdate:
+                    anyReachable = true
+                case .unreachable:
+                    anyUnreachable = true
+                }
+            }
+
             // Sort case-insensitively by app name so the list order is
             // deterministic between successive checks.
             self.availableUpdates = updates.sorted {
                 $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
             }
-            self.phase = .ready
+
+            // Offline only when *every* feed we contacted was
+            // unreachable and not one came back with an answer. If even
+            // one feed responded — or we found updates — the network is
+            // up and Prompt 20's partial degradation stands: show what
+            // we have rather than a network error.
+            if updates.isEmpty, !anyReachable, anyUnreachable {
+                self.phase = .failed(
+                    message: AppUpdaterError.userFacingMessage(
+                        for: AppUpdaterError.networkUnavailable
+                    )
+                )
+            } else {
+                self.phase = .ready
+            }
         } catch {
             // Privacy: errors may include user-specific paths.
             log.error("App Updater discovery failed: \(String(describing: error), privacy: .private)")
@@ -149,6 +199,18 @@ final class AppUpdaterViewModel: ObservableObject {
         return checkGeneration
     }
 
+    /// Per-app result after version comparison. `.noUpdate` means the
+    /// feed was reached but there is nothing newer to offer (including a
+    /// swallowed non-network failure — the server answered, so the
+    /// network is fine). `.unreachable` means the feed could not be
+    /// reached at all. The aggregator in `checkForUpdates()` uses the
+    /// reachable/unreachable split to tell "up to date" from "offline".
+    private enum AppCheckOutcome {
+        case update(UpdateInfo)
+        case noUpdate
+        case unreachable
+    }
+
     /// Dispatches a single app to the correct update channel. Factored
     /// out of `checkForUpdates()` so the bounded-concurrency window can
     /// schedule the same task body in two places without duplication.
@@ -156,7 +218,7 @@ final class AppUpdaterViewModel: ObservableObject {
         app: AppInfo,
         appStoreCheck: CheckAppStore,
         sparkleCheck: CheckSparkle
-    ) async -> UpdateInfo? {
+    ) async -> AppCheckOutcome {
         if app.isAppStore {
             return await checkAppStoreUpdate(app: app, check: appStoreCheck)
         } else {
@@ -166,18 +228,27 @@ final class AppUpdaterViewModel: ObservableObject {
 
     /// Runs the App Store lookup and folds the result into an
     /// `UpdateInfo` if (and only if) the remote version is newer than
-    /// the installed one. A network failure inside the lookup returns
-    /// `nil` — one slow checker must not blank the whole update list.
+    /// the installed one. An unreachable feed reports `.unreachable` so
+    /// the aggregator can distinguish offline from up-to-date; one slow
+    /// checker still must not blank the whole update list.
     private static func checkAppStoreUpdate(
         app: AppInfo,
         check: CheckAppStore
-    ) async -> UpdateInfo? {
-        guard let lookup = await check(app.bundleID) else { return nil }
+    ) async -> AppCheckOutcome {
+        let lookup: AppStoreLookup
+        switch await check(app.bundleID) {
+        case .unreachable:
+            return .unreachable
+        case .noResult:
+            return .noUpdate
+        case .lookup(let value):
+            lookup = value
+        }
         let installed = app.version ?? "0"
         guard VersionComparator.isNewer(version: lookup.version, than: installed) else {
-            return nil
+            return .noUpdate
         }
-        return UpdateInfo(
+        return .update(UpdateInfo(
             appName: app.name,
             bundleID: app.bundleID,
             bundleURL: app.bundleURL,
@@ -185,19 +256,27 @@ final class AppUpdaterViewModel: ObservableObject {
             latestVersion: lookup.version,
             source: .appStore,
             updateURL: lookup.appStoreURL
-        )
+        ))
     }
 
     private static func checkSparkleUpdate(
         app: AppInfo,
         check: CheckSparkle
-    ) async -> UpdateInfo? {
-        guard let item = await check(app) else { return nil }
+    ) async -> AppCheckOutcome {
+        let item: SparkleAppcastItem
+        switch await check(app) {
+        case .unreachable:
+            return .unreachable
+        case .noResult:
+            return .noUpdate
+        case .item(let value):
+            item = value
+        }
         let installed = app.version ?? "0"
         guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else {
-            return nil
+            return .noUpdate
         }
-        return UpdateInfo(
+        return .update(UpdateInfo(
             appName: app.name,
             bundleID: app.bundleID,
             bundleURL: app.bundleURL,
@@ -205,7 +284,7 @@ final class AppUpdaterViewModel: ObservableObject {
             latestVersion: item.shortVersion,
             source: .sparkle,
             updateURL: item.downloadURL
-        )
+        ))
     }
 }
 
@@ -227,17 +306,28 @@ extension AppUpdaterViewModel {
             },
             checkAppStore: { bundleID in
                 do {
-                    return try await appStore.latestVersion(forBundleID: bundleID)
+                    if let lookup = try await appStore.latestVersion(forBundleID: bundleID) {
+                        return .lookup(lookup)
+                    }
+                    return .noResult
                 } catch {
-                    return nil
+                    // Re-surface only loss of connectivity. Every other
+                    // failure (a decode error, a malformed response)
+                    // stays swallowed as `.noResult` so one bad app can
+                    // never blank the list — Prompt 20's partial-
+                    // degradation contract is preserved, not reversed.
+                    return AppUpdaterError.isNetworkError(error) ? .unreachable : .noResult
                 }
             },
             checkSparkle: { app in
-                guard let feedURL = sparkle.feedURL(for: app) else { return nil }
+                guard let feedURL = sparkle.feedURL(for: app) else { return .noResult }
                 do {
-                    return try await sparkle.fetchAppcast(feedURL: feedURL)
+                    if let item = try await sparkle.fetchAppcast(feedURL: feedURL) {
+                        return .item(item)
+                    }
+                    return .noResult
                 } catch {
-                    return nil
+                    return AppUpdaterError.isNetworkError(error) ? .unreachable : .noResult
                 }
             },
             opener: { url in

--- a/VaderCleanerTests/AppUpdaterViewModelTests.swift
+++ b/VaderCleanerTests/AppUpdaterViewModelTests.swift
@@ -266,6 +266,58 @@ final class AppUpdaterViewModelTests: XCTestCase {
         XCTAssertTrue(vm.availableUpdates.isEmpty)
     }
 
+    /// The regression that motivated the `.skipped` case: a real Mac
+    /// always has non-updatable apps (no `SUFeedURL`). Offline, the
+    /// App Store feed is `.unreachable` and the non-Sparkle app is
+    /// `.skipped`. A skipped check made no network request, so it must
+    /// NOT count as "reachable" — otherwise it masks the offline state
+    /// and the user sees "all up to date" while disconnected.
+    func test_checkForUpdates_skippedAppsDoNotMaskOffline_failsWithNetworkCopy() async {
+        let masApp = makeApp(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let nonSparkleApp = makeApp(
+            name: "Plain",
+            bundleID: "com.acme.plain",
+            version: "1.0.0",
+            isAppStore: false
+        )
+        let vm = makeViewModel(
+            discover: { _ in [masApp, nonSparkleApp] },
+            checkAppStore: { _ in .unreachable },
+            checkSparkle: { _ in .skipped }
+        )
+        await vm.checkForUpdates()
+        XCTAssertEqual(
+            vm.phase,
+            .failed(message: "Could not check for updates. Check your internet connection.")
+        )
+        XCTAssertTrue(vm.availableUpdates.isEmpty)
+    }
+
+    /// No app on the machine supports update checks (every check is
+    /// `.skipped`) — no network request was ever made, so this is not
+    /// an offline state. It stays `.ready` with an empty list rather
+    /// than falsely claiming the network is down.
+    func test_checkForUpdates_allSkipped_staysReady() async {
+        let nonSparkleApp = makeApp(
+            name: "Plain",
+            bundleID: "com.acme.plain",
+            version: "1.0.0",
+            isAppStore: false
+        )
+        let vm = makeViewModel(
+            discover: { _ in [nonSparkleApp] },
+            checkSparkle: { _ in .skipped }
+        )
+        await vm.checkForUpdates()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertTrue(vm.availableUpdates.isEmpty)
+    }
+
     // MARK: - Update routing
 
     /// `update(_:)` opens the update URL via the injected opener. The

--- a/VaderCleanerTests/AppUpdaterViewModelTests.swift
+++ b/VaderCleanerTests/AppUpdaterViewModelTests.swift
@@ -45,12 +45,12 @@ final class AppUpdaterViewModelTests: XCTestCase {
             checkAppStore: { bundleID in
                 switch bundleID {
                 case "com.acme.helio":
-                    return .lookup(AppStoreLookup(
+                    return .found(AppStoreLookup(
                         version: "5.4.1",
                         appStoreURL: URL(string: "https://apps.apple.com/app/id123")!
                     ))
                 case "com.unrelated.solar":
-                    return .lookup(AppStoreLookup(
+                    return .found(AppStoreLookup(
                         version: "2.0.0",
                         appStoreURL: URL(string: "https://apps.apple.com/app/id999")!
                     ))
@@ -60,7 +60,7 @@ final class AppUpdaterViewModelTests: XCTestCase {
             },
             checkSparkle: { app in
                 guard app.bundleID == "com.acme.mango" else { return .noResult }
-                return .item(SparkleAppcastItem(
+                return .found(SparkleAppcastItem(
                     shortVersion: "2.0.0",
                     version: "2000",
                     downloadURL: URL(string: "https://example.com/mango-2.dmg")!
@@ -96,7 +96,7 @@ final class AppUpdaterViewModelTests: XCTestCase {
         let vm = makeViewModel(
             discover: { _ in [app] },
             checkAppStore: { _ in
-                .lookup(AppStoreLookup(
+                .found(AppStoreLookup(
                     version: "1.0.0",
                     appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
                 ))
@@ -204,7 +204,7 @@ final class AppUpdaterViewModelTests: XCTestCase {
             discover: { _ in [downApp, liveApp] },
             checkAppStore: { bundleID in
                 guard bundleID == "com.acme.bolt" else { return .unreachable }
-                return .lookup(AppStoreLookup(
+                return .found(AppStoreLookup(
                     version: "2.0.0",
                     appStoreURL: URL(string: "https://apps.apple.com/app/id2")!
                 ))
@@ -301,7 +301,7 @@ final class AppUpdaterViewModelTests: XCTestCase {
         let vm = makeViewModel(
             discover: { _ in [app] },
             checkAppStore: { _ in
-                .lookup(AppStoreLookup(
+                .found(AppStoreLookup(
                     version: "2.0.0",
                     appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
                 ))

--- a/VaderCleanerTests/AppUpdaterViewModelTests.swift
+++ b/VaderCleanerTests/AppUpdaterViewModelTests.swift
@@ -45,26 +45,26 @@ final class AppUpdaterViewModelTests: XCTestCase {
             checkAppStore: { bundleID in
                 switch bundleID {
                 case "com.acme.helio":
-                    return AppStoreLookup(
+                    return .lookup(AppStoreLookup(
                         version: "5.4.1",
                         appStoreURL: URL(string: "https://apps.apple.com/app/id123")!
-                    )
+                    ))
                 case "com.unrelated.solar":
-                    return AppStoreLookup(
+                    return .lookup(AppStoreLookup(
                         version: "2.0.0",
                         appStoreURL: URL(string: "https://apps.apple.com/app/id999")!
-                    )
+                    ))
                 default:
-                    return nil
+                    return .noResult
                 }
             },
             checkSparkle: { app in
-                guard app.bundleID == "com.acme.mango" else { return nil }
-                return SparkleAppcastItem(
+                guard app.bundleID == "com.acme.mango" else { return .noResult }
+                return .item(SparkleAppcastItem(
                     shortVersion: "2.0.0",
                     version: "2000",
                     downloadURL: URL(string: "https://example.com/mango-2.dmg")!
-                )
+                ))
             }
         )
 
@@ -96,10 +96,10 @@ final class AppUpdaterViewModelTests: XCTestCase {
         let vm = makeViewModel(
             discover: { _ in [app] },
             checkAppStore: { _ in
-                AppStoreLookup(
+                .lookup(AppStoreLookup(
                     version: "1.0.0",
                     appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
-                )
+                ))
             }
         )
         await vm.checkForUpdates()
@@ -114,8 +114,8 @@ final class AppUpdaterViewModelTests: XCTestCase {
         let sparkleCalls = ActorBox(0)
         let vm = makeViewModel(
             discover: { _ in [] },
-            checkAppStore: { _ in await appStoreCalls.increment(); return nil },
-            checkSparkle: { _ in await sparkleCalls.increment(); return nil }
+            checkAppStore: { _ in await appStoreCalls.increment(); return .noResult },
+            checkSparkle: { _ in await sparkleCalls.increment(); return .noResult }
         )
         await vm.checkForUpdates()
         XCTAssertEqual(vm.phase, .ready)
@@ -153,6 +153,119 @@ final class AppUpdaterViewModelTests: XCTestCase {
         )
     }
 
+    /// Genuine offline: every feed we contacted was unreachable and not
+    /// one came back with an answer. The whole check must surface the
+    /// actionable network copy instead of the misleading "all apps are
+    /// up to date" empty-but-`.ready` state.
+    func test_checkForUpdates_allFeedsUnreachable_failsWithNetworkCopy() async {
+        let masApp = makeApp(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let sparkleApp = makeApp(
+            name: "Mango",
+            bundleID: "com.acme.mango",
+            version: "1.0.0",
+            isAppStore: false
+        )
+        let vm = makeViewModel(
+            discover: { _ in [masApp, sparkleApp] },
+            checkAppStore: { _ in .unreachable },
+            checkSparkle: { _ in .unreachable }
+        )
+        await vm.checkForUpdates()
+        XCTAssertEqual(
+            vm.phase,
+            .failed(message: "Could not check for updates. Check your internet connection.")
+        )
+        XCTAssertTrue(vm.availableUpdates.isEmpty)
+    }
+
+    /// Partial degradation (Prompt 20) must survive: one unreachable
+    /// feed alongside reachable ones still lands `.ready` showing the
+    /// updates we could find — the dead feed is silently dropped, never
+    /// promoted to a whole-check network error.
+    func test_checkForUpdates_oneFeedUnreachableOthersReachable_staysReadyWithReachableUpdate() async {
+        let downApp = makeApp(
+            name: "Aria",
+            bundleID: "com.acme.aria",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let liveApp = makeApp(
+            name: "Bolt",
+            bundleID: "com.acme.bolt",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let vm = makeViewModel(
+            discover: { _ in [downApp, liveApp] },
+            checkAppStore: { bundleID in
+                guard bundleID == "com.acme.bolt" else { return .unreachable }
+                return .lookup(AppStoreLookup(
+                    version: "2.0.0",
+                    appStoreURL: URL(string: "https://apps.apple.com/app/id2")!
+                ))
+            }
+        )
+        await vm.checkForUpdates()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.availableUpdates.map(\.bundleID), ["com.acme.bolt"])
+        XCTAssertEqual(vm.availableUpdates.first?.latestVersion, "2.0.0")
+    }
+
+    /// A non-network per-app failure (e.g. a decode error the live
+    /// closure swallows as `.noResult`) is a *reached* feed — the server
+    /// answered — so an all-`.noResult` pass with no updates stays
+    /// `.ready`, not the offline copy. Guards the network detection
+    /// against over-triggering.
+    func test_checkForUpdates_nonNetworkFailuresStayReady() async {
+        let app = makeApp(
+            name: "Helio",
+            bundleID: "com.acme.helio",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            checkAppStore: { _ in .noResult }
+        )
+        await vm.checkForUpdates()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertTrue(vm.availableUpdates.isEmpty)
+    }
+
+    /// Online but unremarkable: one feed responded with "nothing newer"
+    /// while another happened to be unreachable, and there are no
+    /// updates to show. Because at least one feed answered, this is the
+    /// genuine "all apps are up to date" state, not offline — the lone
+    /// flaky feed must not flip the whole check to the network error.
+    func test_checkForUpdates_someReachableNoUpdatesWithFlakyFeed_staysReady() async {
+        let reachedApp = makeApp(
+            name: "Aria",
+            bundleID: "com.acme.aria",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let flakyApp = makeApp(
+            name: "Bolt",
+            bundleID: "com.acme.bolt",
+            version: "1.0.0",
+            isAppStore: true
+        )
+        let vm = makeViewModel(
+            discover: { _ in [reachedApp, flakyApp] },
+            checkAppStore: { bundleID in
+                bundleID == "com.acme.aria" ? .noResult : .unreachable
+            }
+        )
+        await vm.checkForUpdates()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertTrue(vm.availableUpdates.isEmpty)
+    }
+
     // MARK: - Update routing
 
     /// `update(_:)` opens the update URL via the injected opener. The
@@ -188,10 +301,10 @@ final class AppUpdaterViewModelTests: XCTestCase {
         let vm = makeViewModel(
             discover: { _ in [app] },
             checkAppStore: { _ in
-                AppStoreLookup(
+                .lookup(AppStoreLookup(
                     version: "2.0.0",
                     appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
-                )
+                ))
             },
             opener: { url in await opened.set(opened.value + [url]) }
         )
@@ -205,8 +318,8 @@ final class AppUpdaterViewModelTests: XCTestCase {
 
     private func makeViewModel(
         discover: @escaping AppUpdaterViewModel.Discover = { _ in [] },
-        checkAppStore: @escaping AppUpdaterViewModel.CheckAppStore = { _ in nil },
-        checkSparkle: @escaping AppUpdaterViewModel.CheckSparkle = { _ in nil },
+        checkAppStore: @escaping AppUpdaterViewModel.CheckAppStore = { _ in .noResult },
+        checkSparkle: @escaping AppUpdaterViewModel.CheckSparkle = { _ in .noResult },
         opener: @escaping AppUpdaterViewModel.Opener = { _ in }
     ) -> AppUpdaterViewModel {
         AppUpdaterViewModel(


### PR DESCRIPTION
## Summary

The App Updater showed **"All apps are up to date"** when the machine was offline — a false positive — instead of the actionable network copy ("Could not check for updates. Check your internet connection.").

Root cause: in `AppUpdaterViewModel.live()` the App Store and Sparkle checker closures wrapped network calls in `do { ... } catch { return nil }`, deliberately swallowing *all* errors (including `URLError`) so one unreachable feed couldn't blank the whole list (Prompt 20's intentional partial-degradation design). A genuinely offline check therefore looked identical to "nothing to update."

## What changed

- **`AppUpdaterError.swift`** — added `isNetworkError(_:)` as the single source of truth for "this is a URL-loading failure" (`URLError` / bridged `NSURLErrorDomain`). `userFacingMessage(for:)` now delegates to it; behavior unchanged (existing `AppUpdaterErrorTests` stay green).
- **`AppUpdaterViewModel.swift`** — `CheckAppStore`/`CheckSparkle` seams now return `AppStoreCheckResult`/`SparkleCheckResult` with a third outcome: `.lookup`/`.item`, `.noResult`, `.unreachable`. `live()` re-surfaces **only** network errors as `.unreachable` and still swallows non-network per-app failures as `.noResult`. `checkForUpdates()` aggregates reachability and routes to `.failed` with the network copy **only** when `updates.isEmpty && !anyReachable && anyUnreachable`.
- **`AppUpdaterView.swift`** — preview closures updated to the new return type.
- **`AppUpdaterViewModelTests.swift`** — migrated existing closures; added coverage for: all feeds offline → `.failed` + network copy; one feed offline + others fine → `.ready` with reachable updates; all-`.noResult` → `.ready`; mixed unreachable + reached-no-update → `.ready`.

## Why this design

The richer return enum (vs. making the closures `async throws`) keeps Prompt 20's partial-degradation contract **preserved, not reversed**: non-network and "no result" still yield no update and never blank the list; the offline copy only appears when *every* contacted feed was unreachable and none responded. A `throws` approach would have forced re-catching per-app throws inside the TaskGroup and re-aggregating into a sentinel anyway — i.e. reinventing the enum, less cleanly.

## Reviewer notes

- This branch was fast-forwarded to `main` first to pick up the Prompt 27 baseline (`AppUpdaterError.swift` + the `userFacingMessage` catch-path wiring), which the task's stated prerequisites depend on.
- Verification is at the `vm.phase` seam that `AppUpdaterView` consumes; the app was **not** manually launched with networking disabled to confirm the rendered banner end-to-end.

## Test plan

- [x] `xcodegen generate && xcodebuild -scheme VaderCleaner -configuration Debug -destination 'platform=macOS' test -only-testing:VaderCleanerTests` — 608 tests, 0 failures
- [x] `AppUpdaterViewModelTests` — 12 tests, 0 failures (incl. 4 new offline / partial-degradation cases)
- [ ] Manual: launch app with networking off, confirm the network copy renders instead of "All apps are up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized update-check result handling so different update sources report unified outcomes (including skipped, unreachable, no-result).
  * Preview now shows the “no results” scenario for update checks.

* **Bug Fixes**
  * Improved network/offline detection to show the offline message only when feeds are truly unreachable.
  * When some feeds are flaky, updates from reachable sources are still displayed.

* **Tests**
  * Added tests covering offline/degradation and skipped-feed behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->