### PR TITLE
Adopt Liquid Glass and a Vader-themed app shell

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		9CA467B702E12F278B7BE6DC /* HelperConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43596249B222D18142F961E2 /* HelperConnectionManager.swift */; };
 		9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */; };
 		A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */; };
+		A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */; };
 		A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
 		ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */; };
@@ -424,6 +425,7 @@
 		F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManagerTests.swift; sourceTree = "<group>"; };
 		F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleterTests.swift; sourceTree = "<group>"; };
 		F421495C84A41EDEF253EBD6 /* FileCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategory.swift; sourceTree = "<group>"; };
+		F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderTheme.swift; sourceTree = "<group>"; };
 		F973B5B33642739FB9D7D004 /* HelperConnectionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionError.swift; sourceTree = "<group>"; };
 		FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VaderCleaner.entitlements; sourceTree = "<group>"; };
 		FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManagerTests.swift; sourceTree = "<group>"; };
@@ -573,6 +575,7 @@
 				9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */,
 				FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */,
 				A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */,
+				F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */,
 				CEAF96E747AD4C1378B4043D /* VersionComparator.swift */,
 				46466A1909A880757A7C4B31 /* Localizable.strings */,
 				329FBD86F55918272AF0EF2A /* Localizable.stringsdict */,
@@ -1025,6 +1028,7 @@
 				7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */,
 				6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */,
 				BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */,
+				A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */,
 				B51203EFD0B1E0734609E427 /* VersionComparator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1189,7 +1193,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1250,7 +1254,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/VaderCleaner/AppUninstallerViewSubviews.swift
+++ b/VaderCleaner/AppUninstallerViewSubviews.swift
@@ -69,6 +69,7 @@ struct AppUninstallerListPane: View {
                     }
                 }
                 .listStyle(.sidebar)
+                .scrollContentBackground(.hidden)
             }
             Divider()
             Toggle(isOn: $includesSystemApps) {
@@ -101,8 +102,7 @@ struct AppUninstallerSearchField: View {
                 .accessibilityIdentifier("appUninstaller.search")
         }
         .padding(6)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .glassEffect(.regular, in: .rect(cornerRadius: 6))
     }
 }
 
@@ -315,6 +315,7 @@ struct AppUninstallerAssociatedFilesList: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
     }
 }
 

--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -125,6 +125,7 @@ private struct AppUpdaterListState: View {
                 }
             }
             .listStyle(.inset)
+            .scrollContentBackground(.hidden)
             Divider()
             HStack(spacing: 12) {
                 Text(updatesCountText)

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -58,6 +58,13 @@ struct ContentView: View {
                 // navigation still work while the sidebar stays slim.
                 Image(systemName: section.icon)
                     .font(.title3)
+                    // The selected glyph springs slightly larger so navigating
+                    // the rail feels responsive even without text labels.
+                    .scaleEffect(selectedSection == section ? 1.16 : 1.0)
+                    .animation(
+                        .spring(response: 0.3, dampingFraction: 0.7),
+                        value: selectedSection
+                    )
                     .frame(maxWidth: .infinity, minHeight: 28)
                     .help(section.title)
                     .accessibilityLabel(section.title)

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -51,32 +51,38 @@ struct ContentView: View {
     }
 
     var body: some View {
-        NavigationSplitView {
+        HStack(spacing: 0) {
+            // A transparent List rather than a NavigationSplitView sidebar:
+            // the rail and the detail share one continuous gradient with no
+            // system sidebar material and no column divider between them.
+            // Keeping a List preserves selection, keyboard navigation, and
+            // assistive-technology semantics for free.
             List(NavigationSection.allCases, selection: $selectedSection) { section in
-                // Icon-only rail: the name is carried by the hover tooltip and
-                // the accessibility label, so selection and keyboard
-                // navigation still work while the sidebar stays slim.
-                Image(systemName: section.icon)
-                    .font(.title3)
-                    // The selected glyph springs slightly larger so navigating
-                    // the rail feels responsive even without text labels.
-                    .scaleEffect(selectedSection == section ? 1.16 : 1.0)
-                    .animation(
-                        .spring(response: 0.3, dampingFraction: 0.7),
-                        value: selectedSection
-                    )
-                    .frame(maxWidth: .infinity, minHeight: 28)
-                    .help(section.title)
-                    .accessibilityLabel(section.title)
-                    .accessibilityIdentifier(section.accessibilityIdentifier)
-                    .tag(section)
+                Label {
+                    Text(section.title)
+                } icon: {
+                    Image(systemName: section.icon)
+                }
+                .font(.title3)
+                // The selected row springs subtly on top of the list's own
+                // selection highlight so navigating feels responsive.
+                .scaleEffect(selectedSection == section ? 1.04 : 1.0)
+                .animation(
+                    .spring(response: 0.3, dampingFraction: 0.7),
+                    value: selectedSection
+                )
+                .accessibilityIdentifier(section.accessibilityIdentifier)
+                .tag(section)
             }
-            .navigationSplitViewColumnWidth(min: 56, ideal: 64, max: 72)
-            // Let the branded gradient show through the sidebar so it reads as
-            // a translucent panel rather than an opaque list.
+            .listStyle(.plain)
             .scrollContentBackground(.hidden)
-        } detail: {
-            detailView(for: selectedSection ?? .smartScan)
+            .frame(width: 230)
+
+            // Hosts `.navigationTitle` / `.toolbar` for the detail screens
+            // without reintroducing a split divider.
+            NavigationStack {
+                detailView(for: selectedSection ?? .smartScan)
+            }
         }
         .frame(minWidth: 900, minHeight: 600)
         // Branded shell: gradient backdrop, crimson tint, forced dark

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -61,6 +61,7 @@ struct ContentView: View {
                     .frame(maxWidth: .infinity, minHeight: 28)
                     .help(section.title)
                     .accessibilityLabel(section.title)
+                    .accessibilityIdentifier(section.accessibilityIdentifier)
                     .tag(section)
             }
             .navigationSplitViewColumnWidth(min: 56, ideal: 64, max: 72)

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -20,6 +20,8 @@ struct ContentView: View {
     private let malwareViewModel: MalwareViewModel
     private let smartScanViewModel: SmartScanViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
+    /// Namespace for the sliding selection pill in the custom rail.
+    @Namespace private var pillNamespace
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
     /// dismissal in the same cycle) would request authorization twice — the
@@ -52,31 +54,12 @@ struct ContentView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // A transparent List rather than a NavigationSplitView sidebar:
-            // the rail and the detail share one continuous gradient with no
-            // system sidebar material and no column divider between them.
-            // Keeping a List preserves selection, keyboard navigation, and
-            // assistive-technology semantics for free.
-            List(NavigationSection.allCases, selection: $selectedSection) { section in
-                Label {
-                    Text(section.title)
-                } icon: {
-                    Image(systemName: section.icon)
-                }
-                .font(.title3)
-                // The selected row springs subtly on top of the list's own
-                // selection highlight so navigating feels responsive.
-                .scaleEffect(selectedSection == section ? 1.04 : 1.0)
-                .animation(
-                    .spring(response: 0.3, dampingFraction: 0.7),
-                    value: selectedSection
-                )
-                .accessibilityIdentifier(section.accessibilityIdentifier)
-                .tag(section)
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .frame(width: 230)
+            // A custom rail of buttons (not a List) so selection can be a soft
+            // inset glass pill with generous spacing instead of the system's
+            // full-bleed selection bar. The rail and detail share one
+            // continuous gradient — no sidebar material, no divider.
+            rail
+                .frame(width: 240)
 
             // Hosts `.navigationTitle` / `.toolbar` for the detail screens
             // without reintroducing a split divider.
@@ -116,6 +99,64 @@ struct ContentView: View {
         .onDisappear {
             spaceLensViewModel.cancelScan()
         }
+    }
+
+    /// The navigation rail: one button per section with a soft glass
+    /// selection pill that glides between rows. Arrow-key navigation between
+    /// rows is intentionally not reimplemented (it was a `List` affordance);
+    /// the rows are focusable buttons, so Tab / Space / Return and VoiceOver
+    /// still work.
+    private var rail: some View {
+        ScrollView {
+            VStack(spacing: 4) {
+                ForEach(NavigationSection.allCases) { section in
+                    railRow(section)
+                }
+            }
+            .padding(.horizontal, 10)
+            // The content extends under the hidden title bar, so inset the
+            // first row clear of the window's traffic-light controls.
+            .padding(.top, 44)
+            .padding(.bottom, 16)
+            .animation(.spring(response: 0.35, dampingFraction: 0.8),
+                       value: selectedSection)
+        }
+    }
+
+    private func railRow(_ section: NavigationSection) -> some View {
+        let isSelected = selectedSection == section
+        return Button {
+            selectedSection = section
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: section.icon)
+                    .symbolRenderingMode(.hierarchical)
+                    .font(.title3)
+                    .frame(width: 26)
+                Text(section.title)
+                    .font(.body)
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(isSelected ? Color.white : Color.white.opacity(0.62))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .background {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .glassEffect(
+                            .regular.tint(Color.vaderCrimson),
+                            in: .rect(cornerRadius: 12)
+                        )
+                        .matchedGeometryEffect(id: "selectionPill", in: pillNamespace)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(section.accessibilityIdentifier)
+        .accessibilityLabel(section.title)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     /// Idempotent permission-request driver. Fires the system prompt at most

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -57,10 +57,18 @@ struct ContentView: View {
                     .tag(section)
             }
             .navigationSplitViewColumnWidth(min: 200, ideal: 220)
+            // Let the branded gradient show through the sidebar so it reads as
+            // a translucent panel rather than an opaque list.
+            .scrollContentBackground(.hidden)
         } detail: {
             detailView(for: selectedSection ?? .smartScan)
         }
         .frame(minWidth: 900, minHeight: 600)
+        // Branded shell: gradient backdrop, crimson tint, forced dark
+        // appearance. The toolbar background is hidden so the floating glass
+        // toolbar items sit directly over the gradient instead of on a band.
+        .vaderShell()
+        .toolbarBackground(.hidden, for: .windowToolbar)
         .sheet(isPresented: shouldShowOnboarding) {
             PermissionOnboardingView()
                 .environmentObject(appState)

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -124,6 +124,8 @@ struct ContentView: View {
         case .smartScan:
             SmartScanView(
                 viewModel: smartScanViewModel,
+                onReviewSystemJunk: { selectedSection = .systemJunk },
+                onReviewMalware: { selectedSection = .malwareRemoval },
                 onReviewOptimization: { selectedSection = .optimization }
             )
         case .healthMonitor:

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -53,10 +53,17 @@ struct ContentView: View {
     var body: some View {
         NavigationSplitView {
             List(NavigationSection.allCases, selection: $selectedSection) { section in
-                Label(section.title, systemImage: section.icon)
+                // Icon-only rail: the name is carried by the hover tooltip and
+                // the accessibility label, so selection and keyboard
+                // navigation still work while the sidebar stays slim.
+                Image(systemName: section.icon)
+                    .font(.title3)
+                    .frame(maxWidth: .infinity, minHeight: 28)
+                    .help(section.title)
+                    .accessibilityLabel(section.title)
                     .tag(section)
             }
-            .navigationSplitViewColumnWidth(min: 200, ideal: 220)
+            .navigationSplitViewColumnWidth(min: 56, ideal: 64, max: 72)
             // Let the branded gradient show through the sidebar so it reads as
             // a translucent panel rather than an opaque list.
             .scrollContentBackground(.hidden)

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -143,7 +143,7 @@ struct ContentView: View {
             .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
             .background {
                 if isSelected {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    Color.clear
                         .glassEffect(
                             .regular.tint(Color.vaderCrimson),
                             in: .rect(cornerRadius: 12)

--- a/VaderCleaner/ExtensionsManagerViewSubviews.swift
+++ b/VaderCleaner/ExtensionsManagerViewSubviews.swift
@@ -73,6 +73,7 @@ struct ExtensionsManagerList: View {
             }
         }
         .listStyle(.inset)
+        .scrollContentBackground(.hidden)
     }
 }
 

--- a/VaderCleaner/FullDiskAccessPromptCard.swift
+++ b/VaderCleaner/FullDiskAccessPromptCard.swift
@@ -48,7 +48,7 @@ struct FullDiskAccessPromptCard: View {
             Spacer(minLength: 0)
         }
         .padding(12)
-        .background(Color.secondary.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+        .glassEffect(.regular, in: .rect(cornerRadius: 8))
         .frame(maxWidth: 420)
         .accessibilityIdentifier("fda.inlinePrompt")
     }

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -24,12 +24,17 @@ struct HealthMonitorView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                LazyVGrid(columns: columns, spacing: 16) {
-                    batteryCard
-                    smartCard
-                    ramCard
-                    cpuCard
-                    diskCard
+                // Group the tiles in one container so adjacent glass cards
+                // sample each other and refract consistently as the grid
+                // reflows on resize.
+                GlassEffectContainer(spacing: 16) {
+                    LazyVGrid(columns: columns, spacing: 16) {
+                        batteryCard
+                        smartCard
+                        ramCard
+                        cpuCard
+                        diskCard
+                    }
                 }
                 Divider()
                 fileVaultRow
@@ -186,14 +191,7 @@ private struct HealthCard<Content: View>: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, minHeight: 140, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 1)
-        )
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
     }
 }
 

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -196,6 +196,7 @@ struct LargeOldFilesTable: View {
             }
         }
         .accessibilityIdentifier("large-old.table")
+        .scrollContentBackground(.hidden)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Picker(String(

--- a/VaderCleaner/MalwareOnboardingView.swift
+++ b/VaderCleaner/MalwareOnboardingView.swift
@@ -33,7 +33,7 @@ struct MalwareOnboardingView: View {
             }
             .font(.callout)
             .padding()
-            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+            .glassEffect(.regular, in: .rect(cornerRadius: 8))
 
             Text(MalwareOnboardingViewModel.installCommand)
                 .font(.system(.callout, design: .monospaced))

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -135,7 +135,7 @@ struct MalwareIdleState: View {
             .font(.callout)
             .padding()
             .frame(maxWidth: 460)
-            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+            .glassEffect(.regular, in: .rect(cornerRadius: 8))
 
             HStack(spacing: 12) {
                 Button(String(
@@ -149,7 +149,7 @@ struct MalwareIdleState: View {
                     localized: "Scan for Malware",
                     comment: "Primary button that starts a malware scan."
                 ), action: onScan)
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.glassProminent)
                     .keyboardShortcut(.defaultAction)
                     .accessibilityIdentifier("malware.scan")
             }
@@ -252,6 +252,7 @@ struct MalwareResultsState: View {
                 .accessibilityIdentifier("malware.threatRow")
             }
             .accessibilityIdentifier("malware.threatList")
+            .scrollContentBackground(.hidden)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding()

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -34,6 +34,26 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         }
     }
 
+    /// Stable automation identifier for this section's sidebar row. The rail
+    /// renders icons only, so UI tests and assistive technology can't rely on
+    /// a visible text label — they target this identifier instead. Pinned by
+    /// `NavigationSectionTests` so the contract can't drift.
+    var accessibilityIdentifier: String {
+        switch self {
+        case .smartScan:       return "sidebar.smartScan"
+        case .systemJunk:      return "sidebar.systemJunk"
+        case .largeOldFiles:   return "sidebar.largeOldFiles"
+        case .spaceLens:       return "sidebar.spaceLens"
+        case .malwareRemoval:  return "sidebar.malwareRemoval"
+        case .privacy:         return "sidebar.privacy"
+        case .extensions:      return "sidebar.extensions"
+        case .appUninstaller:  return "sidebar.appUninstaller"
+        case .appUpdater:      return "sidebar.appUpdater"
+        case .optimization:    return "sidebar.optimization"
+        case .healthMonitor:   return "sidebar.healthMonitor"
+        }
+    }
+
     var icon: String {
         switch self {
         case .smartScan:       return "sparkles"

--- a/VaderCleaner/PermissionOnboardingView.swift
+++ b/VaderCleaner/PermissionOnboardingView.swift
@@ -34,7 +34,7 @@ struct PermissionOnboardingView: View {
             }
             .font(.callout)
             .padding()
-            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+            .glassEffect(.regular, in: .rect(cornerRadius: 8))
 
             HStack(spacing: 12) {
                 Button("Continue Without Access") {

--- a/VaderCleaner/PrivacyViewSubviews.swift
+++ b/VaderCleaner/PrivacyViewSubviews.swift
@@ -100,6 +100,7 @@ struct PrivacyPreviewContent: View {
                         .font(.callout.weight(.semibold))
                 }
             }
+            .scrollContentBackground(.hidden)
             Divider()
             PrivacyPreviewFooter(
                 totalSelectedSize: totalSelectedSize,

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -29,7 +29,25 @@ struct SmartScanView: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .id(phaseTransitionID)
+            .transition(.opacity)
+            .animation(.smooth(duration: 0.35), value: phaseTransitionID)
             .navigationTitle(NavigationSection.smartScan.title)
+    }
+
+    /// Stable per-phase token so moving between scan phases crossfades
+    /// instead of hard-cutting. Distinct phases map to distinct strings;
+    /// associated values are intentionally ignored — only the phase identity
+    /// drives the transition.
+    private var phaseTransitionID: String {
+        switch viewModel.phase {
+        case .idle:     return "idle"
+        case .scanning: return "scanning"
+        case .results:  return "results"
+        case .cleaning: return "cleaning"
+        case .done:     return "done"
+        case .failed:   return "failed"
+        }
     }
 
     @ViewBuilder

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -5,18 +5,24 @@ import SwiftUI
 
 /// Detail view shown when the user selects "Smart Scan" in the sidebar (the
 /// default landing section). Drives `SmartScanViewModel`'s state machine and
-/// routes the Optimization card's "Review" action back to the sidebar via
-/// `onReviewOptimization` so the user lands on the full Optimization screen.
+/// routes each dashboard card's "Review" action back to the sidebar via the
+/// per-section callbacks so the user lands on that section's full screen.
 struct SmartScanView: View {
 
     @ObservedObject private var viewModel: SmartScanViewModel
+    private let onReviewSystemJunk: () -> Void
+    private let onReviewMalware: () -> Void
     private let onReviewOptimization: () -> Void
 
     init(
         viewModel: SmartScanViewModel,
+        onReviewSystemJunk: @escaping () -> Void,
+        onReviewMalware: @escaping () -> Void,
         onReviewOptimization: @escaping () -> Void
     ) {
         self.viewModel = viewModel
+        self.onReviewSystemJunk = onReviewSystemJunk
+        self.onReviewMalware = onReviewMalware
         self.onReviewOptimization = onReviewOptimization
     }
 
@@ -40,7 +46,10 @@ struct SmartScanView: View {
             SmartScanResultsState(
                 result: result,
                 onClean: { Task { await viewModel.clean() } },
-                onReview: onReviewOptimization
+                onReviewSystemJunk: onReviewSystemJunk,
+                onReviewMalware: onReviewMalware,
+                onReviewOptimization: onReviewOptimization,
+                onStartOver: { viewModel.reset() }
             )
         case .cleaning:
             SmartScanProgressState(
@@ -91,7 +100,12 @@ struct SmartScanView: View {
         junkCleaner: { _ in 1_500_000_000 },
         threatRemover: { _ in [] }
     )
-    return SmartScanView(viewModel: vm, onReviewOptimization: {})
+    return SmartScanView(
+        viewModel: vm,
+        onReviewSystemJunk: {},
+        onReviewMalware: {},
+        onReviewOptimization: {}
+    )
         .frame(width: 900, height: 600)
         .task { await vm.scan() }
 }

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -2,6 +2,7 @@
 // Dedicated subviews for the Smart Scan screen — idle, progress, the three-card results summary, done, and failed states.
 
 import SwiftUI
+import AppKit
 
 // MARK: - Shared byte formatting
 
@@ -21,38 +22,66 @@ struct SmartScanIdleState: View {
     let onScan: () -> Void
 
     var body: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 56))
-                .foregroundStyle(.tint)
+        VStack(spacing: 16) {
+            Spacer(minLength: 0)
+
+            // The app icon is VaderCleaner's own artwork, so it doubles as the
+            // hero render; the crimson bloom behind it ties it to the backdrop.
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 168, height: 168)
+                .shadow(color: Color.vaderCrimson.opacity(0.45), radius: 32)
+
             Text(String(
-                localized: "Smart Scan",
-                comment: "Title on the idle Smart Scan screen."
+                localized: "Welcome to VaderCleaner",
+                comment: "Hero title on the idle Smart Scan welcome screen."
             ))
-                .font(.title.weight(.semibold))
+                .font(.system(size: 34, weight: .semibold))
+
             Text(String(
-                localized: "Scans for junk, malware, and optimization opportunities.",
-                comment: "Subtitle on the idle Smart Scan screen."
+                localized: "Start with a quick and extensive scan of your Mac.",
+                comment: "Subtitle on the idle Smart Scan welcome screen."
             ))
-                .font(.callout)
+                .font(.title3)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 460)
 
-            Button(action: onScan) {
-                Text(String(
-                    localized: "Scan",
-                    comment: "Primary button that starts the Smart Scan."
-                ))
-                .frame(minWidth: 120)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("smartScan.scan")
+            Spacer(minLength: 0)
+
+            CircularScanButton(action: onScan)
+                .padding(.bottom, 36)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
+    }
+}
+
+/// The hero call to action — a crimson interactive-glass disc echoing the
+/// reference's circular Scan button. Interactive glass gives it the system
+/// press-scale and shimmer; the crimson tint marks it as the primary action.
+private struct CircularScanButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(String(
+                localized: "Scan",
+                comment: "Primary button that starts the Smart Scan."
+            ))
+            .font(.title3.weight(.semibold))
+            .foregroundStyle(.white)
+            .frame(width: 108, height: 108)
+        }
+        .buttonStyle(.plain)
+        .glassEffect(
+            .regular.tint(Color.vaderCrimson).interactive(),
+            in: .circle
+        )
+        .shadow(color: Color.vaderCrimson.opacity(0.5), radius: 22, y: 8)
+        .keyboardShortcut(.defaultAction)
+        .accessibilityIdentifier("smartScan.scan")
     }
 }
 
@@ -151,7 +180,7 @@ private struct SmartScanCard: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+        .glassEffect(.regular, in: .rect(cornerRadius: 10))
     }
 }
 
@@ -169,9 +198,15 @@ struct SmartScanResultsState: View {
                 .font(.title2.weight(.semibold))
                 .accessibilityIdentifier("smartScan.resultsHeading")
 
-            junkCard
-            malwareCard
-            optimizationCard
+            // One container so the three summary cards sample each other's
+            // glass and refract consistently rather than as isolated surfaces.
+            GlassEffectContainer(spacing: 16) {
+                VStack(spacing: 16) {
+                    junkCard
+                    malwareCard
+                    optimizationCard
+                }
+            }
 
             Spacer(minLength: 0)
         }

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -213,6 +213,7 @@ private struct SmartScanMetricCard: View {
                 .font(.system(size: 30, weight: .bold))
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
+                .contentTransition(.numericText())
             HStack(alignment: .bottom) {
                 Text(caption)
                     .font(.callout)
@@ -234,6 +235,30 @@ private struct SmartScanMetricCard: View {
     }
 }
 
+/// One-shot entrance for the dashboard tiles: each fades and rises into place
+/// with a per-index delay so the grid assembles in a quick cascade rather than
+/// popping in all at once.
+private struct StaggeredEntrance: ViewModifier {
+    let index: Int
+    let appeared: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(appeared ? 1 : 0)
+            .offset(y: appeared ? 0 : 16)
+            .animation(
+                .smooth(duration: 0.4).delay(Double(index) * 0.08),
+                value: appeared
+            )
+    }
+}
+
+private extension View {
+    func staggeredEntrance(index: Int, appeared: Bool) -> some View {
+        modifier(StaggeredEntrance(index: index, appeared: appeared))
+    }
+}
+
 /// The Smart Scan results dashboard: a "Start Over" bar, a metric-card grid,
 /// and one circular CTA that runs the clean. Mirrors the reference's task
 /// dashboard. There are deliberately no per-card checkboxes — the underlying
@@ -249,6 +274,10 @@ struct SmartScanResultsState: View {
     let onStartOver: () -> Void
 
     private let columns = [GridItem(.adaptive(minimum: 260), spacing: 16)]
+
+    /// Drives the one-shot staggered entrance of the metric tiles when the
+    /// dashboard first appears.
+    @State private var appeared = false
 
     /// The circular CTA only appears when the clean would actually do
     /// something — junk to delete or threats to remove. Optimization is
@@ -287,14 +316,15 @@ struct SmartScanResultsState: View {
                     // refract consistently as the grid reflows on resize.
                     GlassEffectContainer(spacing: 16) {
                         LazyVGrid(columns: columns, spacing: 16) {
-                            junkCard
-                            malwareCard
-                            optimizationCard
+                            junkCard.staggeredEntrance(index: 0, appeared: appeared)
+                            malwareCard.staggeredEntrance(index: 1, appeared: appeared)
+                            optimizationCard.staggeredEntrance(index: 2, appeared: appeared)
                         }
                     }
                 }
                 .padding(24)
             }
+            .onAppear { appeared = true }
 
             if hasCleanableWork {
                 CircularActionButton(

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -21,18 +21,26 @@ private let smartScanByteFormatter: ByteCountFormatter = {
 struct SmartScanIdleState: View {
     let onScan: () -> Void
 
+    @State private var breathing = false
+
     var body: some View {
         VStack(spacing: 16) {
             Spacer(minLength: 0)
 
             // The app icon is VaderCleaner's own artwork, so it doubles as the
             // hero render; the crimson bloom behind it ties it to the backdrop.
+            // A slow scale breath keeps the welcome screen feeling alive while
+            // it waits for the user to start a scan.
             Image(nsImage: NSApp.applicationIconImage)
                 .resizable()
                 .interpolation(.high)
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 168, height: 168)
                 .shadow(color: Color.vaderCrimson.opacity(0.45), radius: 32)
+                .scaleEffect(breathing ? 1.03 : 1.0)
+                .animation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true),
+                           value: breathing)
+                .onAppear { breathing = true }
 
             Text(String(
                 localized: "Welcome to VaderCleaner",
@@ -76,6 +84,9 @@ private struct CircularActionButton: View {
     let accessibilityIdentifier: String
     let action: () -> Void
 
+    @State private var hovering = false
+    @State private var pulsing = false
+
     var body: some View {
         Button(action: action) {
             Text(title)
@@ -83,14 +94,36 @@ private struct CircularActionButton: View {
                 .foregroundStyle(.white)
                 .frame(width: 108, height: 108)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableCircleButtonStyle())
         .glassEffect(
             .regular.tint(Color.vaderCrimson).interactive(),
             in: .circle
         )
-        .shadow(color: Color.vaderCrimson.opacity(0.5), radius: 22, y: 8)
+        // Ambient glow that breathes so the primary action keeps drawing the
+        // eye even when the rest of the screen is still.
+        .shadow(
+            color: Color.vaderCrimson.opacity(pulsing ? 0.65 : 0.4),
+            radius: pulsing ? 30 : 18,
+            y: 8
+        )
+        .scaleEffect(hovering ? 1.06 : 1.0)
+        .animation(.spring(response: 0.32, dampingFraction: 0.6), value: hovering)
+        .animation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true), value: pulsing)
+        .onHover { hovering = $0 }
+        .onAppear { pulsing = true }
         .keyboardShortcut(.defaultAction)
         .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
+/// Press feedback for the circular CTAs — a quick spring scale-down while
+/// pressed so the button feels physical rather than flat.
+private struct PressableCircleButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.93 : 1.0)
+            .animation(.spring(response: 0.25, dampingFraction: 0.55),
+                       value: configuration.isPressed)
     }
 }
 

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -51,29 +51,37 @@ struct SmartScanIdleState: View {
 
             Spacer(minLength: 0)
 
-            CircularScanButton(action: onScan)
-                .padding(.bottom, 36)
+            CircularActionButton(
+                title: String(
+                    localized: "Scan",
+                    comment: "Primary button that starts the Smart Scan."
+                ),
+                accessibilityIdentifier: "smartScan.scan",
+                action: onScan
+            )
+            .padding(.bottom, 36)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
     }
 }
 
-/// The hero call to action — a crimson interactive-glass disc echoing the
-/// reference's circular Scan button. Interactive glass gives it the system
-/// press-scale and shimmer; the crimson tint marks it as the primary action.
-private struct CircularScanButton: View {
+/// The hero / dashboard call to action — a crimson interactive-glass disc
+/// echoing the reference's circular button. Interactive glass gives it the
+/// system press-scale and shimmer; the crimson tint marks it as the primary
+/// action. Shared by the welcome screen ("Scan") and the results dashboard
+/// ("Clean") so the two CTAs stay visually identical.
+private struct CircularActionButton: View {
+    let title: String
+    let accessibilityIdentifier: String
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Text(String(
-                localized: "Scan",
-                comment: "Primary button that starts the Smart Scan."
-            ))
-            .font(.title3.weight(.semibold))
-            .foregroundStyle(.white)
-            .frame(width: 108, height: 108)
+            Text(title)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 108, height: 108)
         }
         .buttonStyle(.plain)
         .glassEffect(
@@ -82,7 +90,7 @@ private struct CircularScanButton: View {
         )
         .shadow(color: Color.vaderCrimson.opacity(0.5), radius: 22, y: 8)
         .keyboardShortcut(.defaultAction)
-        .accessibilityIdentifier("smartScan.scan")
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 
@@ -144,171 +152,216 @@ struct SmartScanFailedState: View {
 
 // MARK: - Results
 
-/// One module summary card. `action` is optional — the Malware card hides its
-/// button when ClamAV is absent or nothing was found, and the cards are purely
-/// informational in that case.
-private struct SmartScanCard: View {
+/// One dashboard tile: category icon + title, a large metric number, a
+/// caption, and an optional "Review" button that drills into that section.
+/// The tiles never perform work themselves — the single circular CTA does —
+/// so there are no per-card action buttons, only navigation.
+private struct SmartScanMetricCard: View {
     let icon: String
     let tint: Color
     let title: String
-    let detail: String
-    var actionTitle: String?
-    var actionIdentifier: String?
-    var isDestructive: Bool = false
-    var action: (() -> Void)?
+    let metric: String
+    let caption: String
+    var reviewIdentifier: String?
+    var onReview: (() -> Void)?
 
     var body: some View {
-        HStack(spacing: 14) {
-            Image(systemName: icon)
-                .font(.system(size: 28))
-                .foregroundStyle(tint)
-                .frame(width: 36)
-            VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundStyle(tint)
                 Text(title)
                     .font(.headline)
-                Text(detail)
+                Spacer()
+            }
+            Spacer(minLength: 8)
+            Text(metric)
+                .font(.system(size: 30, weight: .bold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+            HStack(alignment: .bottom) {
+                Text(caption)
                     .font(.callout)
                     .foregroundStyle(.secondary)
-            }
-            Spacer()
-            if let actionTitle, let actionIdentifier, let action {
-                Button(role: isDestructive ? .destructive : nil, action: action) {
-                    Text(actionTitle)
+                Spacer()
+                if let reviewIdentifier, let onReview {
+                    Button(String(
+                        localized: "Review",
+                        comment: "Per-card button on the Smart Scan dashboard that opens that section."
+                    ), action: onReview)
+                        .buttonStyle(.borderedProminent)
+                        .accessibilityIdentifier(reviewIdentifier)
                 }
-                .buttonStyle(.borderedProminent)
-                .accessibilityIdentifier(actionIdentifier)
             }
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 10))
+        .padding(18)
+        .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
+        .glassEffect(.regular, in: .rect(cornerRadius: 14))
     }
 }
 
+/// The Smart Scan results dashboard: a "Start Over" bar, a metric-card grid,
+/// and one circular CTA that runs the clean. Mirrors the reference's task
+/// dashboard. There are deliberately no per-card checkboxes — the underlying
+/// model has no selective-clean concept, and a checkbox that doesn't gate
+/// anything would be misleading. Each card's "Review" drills into its full
+/// section instead; the circular "Clean" performs the junk + threats pass.
 struct SmartScanResultsState: View {
     let result: SmartScanResult
     let onClean: () -> Void
-    let onReview: () -> Void
+    let onReviewSystemJunk: () -> Void
+    let onReviewMalware: () -> Void
+    let onReviewOptimization: () -> Void
+    let onStartOver: () -> Void
+
+    private let columns = [GridItem(.adaptive(minimum: 260), spacing: 16)]
+
+    /// The circular CTA only appears when the clean would actually do
+    /// something — junk to delete or threats to remove. Optimization is
+    /// review-only and never contributes cleanable work.
+    private var hasCleanableWork: Bool {
+        result.totalJunkBytes > 0 || !result.threats.isEmpty
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(String(
-                localized: "Scan complete",
-                comment: "Heading on the Smart Scan results screen."
-            ))
-                .font(.title2.weight(.semibold))
-                .accessibilityIdentifier("smartScan.resultsHeading")
-
-            // One container so the three summary cards sample each other's
-            // glass and refract consistently rather than as isolated surfaces.
-            GlassEffectContainer(spacing: 16) {
-                VStack(spacing: 16) {
-                    junkCard
-                    malwareCard
-                    optimizationCard
+        VStack(spacing: 0) {
+            HStack {
+                Button(action: onStartOver) {
+                    Label(String(
+                        localized: "Start Over",
+                        comment: "Button on the Smart Scan dashboard that resets to the welcome screen."
+                    ), systemImage: "chevron.left")
                 }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("smartScan.startOver")
+                Spacer()
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 16)
+
+            ScrollView {
+                VStack(spacing: 24) {
+                    Text(String(
+                        localized: "Your scan is ready. Here's what we found:",
+                        comment: "Heading on the Smart Scan results dashboard."
+                    ))
+                        .font(.title3.weight(.medium))
+                        .multilineTextAlignment(.center)
+                        .accessibilityIdentifier("smartScan.resultsHeading")
+
+                    // One container so the tiles sample each other's glass and
+                    // refract consistently as the grid reflows on resize.
+                    GlassEffectContainer(spacing: 16) {
+                        LazyVGrid(columns: columns, spacing: 16) {
+                            junkCard
+                            malwareCard
+                            optimizationCard
+                        }
+                    }
+                }
+                .padding(24)
             }
 
-            Spacer(minLength: 0)
+            if hasCleanableWork {
+                CircularActionButton(
+                    title: String(
+                        localized: "Clean",
+                        comment: "Circular button on the Smart Scan dashboard that cleans junk and removes threats."
+                    ),
+                    accessibilityIdentifier: "smartScan.clean",
+                    action: onClean
+                )
+                .padding(.bottom, 28)
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var junkCard: some View {
-        let hasJunk = result.totalJunkBytes > 0
-        return SmartScanCard(
+        SmartScanMetricCard(
             icon: "trash.fill",
             tint: .blue,
             title: String(
                 localized: "System Junk",
                 comment: "Smart Scan card title for the System Junk module."
             ),
-            detail: result.junkResult.formattedTotalSize,
-            actionTitle: hasJunk ? String(
-                localized: "Clean",
-                comment: "Button on the Smart Scan junk card that removes the scanned junk."
-            ) : nil,
-            actionIdentifier: "smartScan.clean",
-            action: hasJunk ? onClean : nil
+            metric: result.junkResult.formattedTotalSize,
+            caption: String(
+                localized: "to clean",
+                comment: "Caption under the System Junk metric on the Smart Scan dashboard."
+            ),
+            reviewIdentifier: "smartScan.reviewJunk",
+            onReview: onReviewSystemJunk
         )
     }
 
     @ViewBuilder
     private var malwareCard: some View {
         if !result.clamAVAvailable {
-            SmartScanCard(
+            SmartScanMetricCard(
                 icon: "shield.slash.fill",
                 tint: .secondary,
                 title: String(
                     localized: "Malware",
                     comment: "Smart Scan card title for the Malware module."
                 ),
-                detail: String(
-                    localized: "ClamAV is not installed — malware was not scanned.",
-                    comment: "Smart Scan malware card detail when ClamAV is absent."
+                metric: "—",
+                caption: String(
+                    localized: "ClamAV not installed",
+                    comment: "Caption on the Smart Scan malware card when ClamAV is absent."
                 )
             )
         } else if result.threats.isEmpty {
-            SmartScanCard(
+            SmartScanMetricCard(
                 icon: "checkmark.shield.fill",
                 tint: .green,
                 title: String(
                     localized: "Malware",
                     comment: "Smart Scan card title for the Malware module."
                 ),
-                detail: String(
-                    localized: "No threats found.",
-                    comment: "Smart Scan malware card detail when the scan was clean."
-                )
+                metric: "0",
+                caption: String(
+                    localized: "threats found",
+                    comment: "Caption on the Smart Scan malware card after a clean scan."
+                ),
+                reviewIdentifier: "smartScan.reviewMalware",
+                onReview: onReviewMalware
             )
         } else {
-            SmartScanCard(
+            SmartScanMetricCard(
                 icon: "exclamationmark.shield.fill",
                 tint: .red,
                 title: String(
                     localized: "Malware",
                     comment: "Smart Scan card title for the Malware module."
                 ),
-                detail: String.localizedStringWithFormat(
-                    String(
-                        localized: "%d threats found",
-                        comment: "Smart Scan malware card detail; %d is a count. Pluralized via Localizable.stringsdict."
-                    ),
-                    result.threats.count
+                metric: "\(result.threats.count)",
+                caption: String(
+                    localized: "threats to remove",
+                    comment: "Caption on the Smart Scan malware card when threats were found."
                 ),
-                actionTitle: String(
-                    localized: "Remove",
-                    comment: "Button on the Smart Scan malware card that removes detected threats."
-                ),
-                actionIdentifier: "smartScan.remove",
-                isDestructive: true,
-                action: onClean
+                reviewIdentifier: "smartScan.reviewMalware",
+                onReview: onReviewMalware
             )
         }
     }
 
     private var optimizationCard: some View {
-        SmartScanCard(
+        SmartScanMetricCard(
             icon: "slider.horizontal.3",
             tint: .orange,
             title: String(
                 localized: "Optimization",
                 comment: "Smart Scan card title for the Optimization module."
             ),
-            detail: String.localizedStringWithFormat(
-                String(
-                    localized: "%d login items",
-                    comment: "Smart Scan optimization card detail; %d is a count. Pluralized via Localizable.stringsdict."
-                ),
-                result.optimizationItems.count
+            metric: "\(result.optimizationItems.count)",
+            caption: String(
+                localized: "login items to review",
+                comment: "Caption under the Optimization metric on the Smart Scan dashboard."
             ),
-            actionTitle: String(
-                localized: "Review",
-                comment: "Button on the Smart Scan optimization card that opens the full Optimization screen."
-            ),
-            actionIdentifier: "smartScan.review",
-            action: onReview
+            reviewIdentifier: "smartScan.review",
+            onReview: onReviewOptimization
         )
     }
 }

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -30,6 +30,7 @@ struct SmartScanIdleState: View {
             Image(nsImage: NSApp.applicationIconImage)
                 .resizable()
                 .interpolation(.high)
+                .aspectRatio(contentMode: .fit)
                 .frame(width: 168, height: 168)
                 .shadow(color: Color.vaderCrimson.opacity(0.45), radius: 32)
 

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -231,7 +231,9 @@ private struct SmartScanMetricCard: View {
         }
         .padding(18)
         .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 14))
+        // 12 matches HealthCard so the two dashboard card surfaces share one
+        // corner radius.
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
     }
 }
 
@@ -400,10 +402,15 @@ struct SmartScanResultsState: View {
                     comment: "Smart Scan card title for the Malware module."
                 ),
                 metric: "\(result.threats.count)",
-                caption: String(
-                    localized: "threats to remove",
-                    comment: "Caption on the Smart Scan malware card when threats were found."
-                ),
+                caption: result.threats.count == 1
+                    ? String(
+                        localized: "threat to remove",
+                        comment: "Singular caption on the Smart Scan malware card when exactly one threat was found."
+                    )
+                    : String(
+                        localized: "threats to remove",
+                        comment: "Plural caption on the Smart Scan malware card when threats were found."
+                    ),
                 reviewIdentifier: "smartScan.reviewMalware",
                 onReview: onReviewMalware
             )
@@ -419,10 +426,15 @@ struct SmartScanResultsState: View {
                 comment: "Smart Scan card title for the Optimization module."
             ),
             metric: "\(result.optimizationItems.count)",
-            caption: String(
-                localized: "login items to review",
-                comment: "Caption under the Optimization metric on the Smart Scan dashboard."
-            ),
+            caption: result.optimizationItems.count == 1
+                ? String(
+                    localized: "login item to review",
+                    comment: "Singular caption under the Optimization metric when exactly one login item was found."
+                )
+                : String(
+                    localized: "login items to review",
+                    comment: "Plural caption under the Optimization metric on the Smart Scan dashboard."
+                ),
             reviewIdentifier: "smartScan.review",
             onReview: onReviewOptimization
         )

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -107,6 +107,7 @@ struct SystemJunkView: View {
                 .accessibilityIdentifier("system-junk.row.\(category.rawValue)")
             }
         }
+        .scrollContentBackground(.hidden)
     }
 
     private var previewFooter: some View {

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -1,0 +1,56 @@
+// VaderTheme.swift
+// VaderCleaner's branded visual identity: the space-black to Sith-red palette, the gradient backdrop, and the app-wide shell modifier that hosts Liquid Glass surfaces.
+
+import SwiftUI
+
+/// Palette for the Vader identity. Deep near-black base with a vivid crimson
+/// accent — chosen so translucent Liquid Glass surfaces layered on top pick up
+/// a warm refraction without washing out white foreground text.
+extension Color {
+    /// Top of the window gradient — near-black with a faint cool cast.
+    static let vaderSpaceBlack = Color(red: 0.039, green: 0.039, blue: 0.055)
+    /// Bottom of the window gradient — a very dark crimson so the base reads
+    /// "Vader" rather than a neutral dark theme.
+    static let vaderDeepRed = Color(red: 0.149, green: 0.027, blue: 0.055)
+    /// Accent / tint — the lightsaber crimson used for the primary call to
+    /// action, the sidebar selection, and control tinting.
+    static let vaderCrimson = Color(red: 0.851, green: 0.102, blue: 0.176)
+}
+
+/// Full-bleed branded backdrop: a vertical space-black → deep-crimson gradient
+/// with a soft crimson bloom centred slightly below the window's middle, so the
+/// hero content sits in the brightest part of the glow like the reference.
+struct VaderBackground: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [.vaderSpaceBlack, .vaderDeepRed],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            RadialGradient(
+                colors: [Color.vaderCrimson.opacity(0.34), .clear],
+                center: UnitPoint(x: 0.5, y: 0.58),
+                startRadius: 0,
+                endRadius: 620
+            )
+        }
+        .ignoresSafeArea()
+    }
+}
+
+extension View {
+    /// Hosts a scene in the Vader shell: the gradient backdrop behind
+    /// everything, a forced dark appearance so system chrome and Liquid Glass
+    /// adopt the light-on-dark vibrant treatment, and the crimson accent tint.
+    ///
+    /// Applied at the `NavigationSplitView` root. List and scroll backgrounds
+    /// are cleared per-view so the gradient shows through the sidebar and
+    /// detail panes while their glass surfaces float on top.
+    func vaderShell() -> some View {
+        self
+            .background(VaderBackground())
+            .tint(Color.vaderCrimson)
+            .preferredColorScheme(.dark)
+    }
+}

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -30,6 +30,10 @@ struct VaderBackground: View {
             )
             RadialGradient(
                 colors: [Color.vaderCrimson.opacity(0.34), .clear],
+                // y is biased just below the vertical centre (rather than 0.5)
+                // so the brightest part of the bloom falls under the hero
+                // icon/title cluster on the welcome screen, not the empty
+                // middle of the window.
                 center: UnitPoint(x: 0.5, y: 0.58),
                 startRadius: 0,
                 endRadius: 620

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -24,6 +24,34 @@ final class NavigationSectionTests: XCTestCase {
         }
     }
 
+    func test_accessibilityIdentifiers_areStableAndPinned() {
+        let expected: [NavigationSection: String] = [
+            .smartScan: "sidebar.smartScan",
+            .systemJunk: "sidebar.systemJunk",
+            .largeOldFiles: "sidebar.largeOldFiles",
+            .spaceLens: "sidebar.spaceLens",
+            .malwareRemoval: "sidebar.malwareRemoval",
+            .privacy: "sidebar.privacy",
+            .extensions: "sidebar.extensions",
+            .appUninstaller: "sidebar.appUninstaller",
+            .appUpdater: "sidebar.appUpdater",
+            .optimization: "sidebar.optimization",
+            .healthMonitor: "sidebar.healthMonitor",
+        ]
+        for section in NavigationSection.allCases {
+            XCTAssertEqual(
+                section.accessibilityIdentifier,
+                expected[section],
+                "Sidebar identifier for \(section) drifted — update the UI-test locators too"
+            )
+        }
+    }
+
+    func test_accessibilityIdentifiers_areUnique() {
+        let ids = NavigationSection.allCases.map(\.accessibilityIdentifier)
+        XCTAssertEqual(Set(ids).count, ids.count, "Sidebar identifiers must be unique")
+    }
+
     func test_eachSection_hasValidSFSymbol() throws {
         guard #available(macOS 14.0, *) else {
             throw XCTSkip("SF Symbol validation requires macOS 14.0 (the app's minimum deployment target)")

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -11,22 +11,23 @@ final class FinalPolishUITests: XCTestCase {
 
     private var app: XCUIApplication!
 
-    /// The eleven sidebar titles, in `NavigationSection` order. Hard-coded
-    /// because the UI-test bundle runs out-of-process and cannot import the
-    /// app's `NavigationSection` enum; `NavigationSectionTests` pins the enum
-    /// side, this pins the rendered side.
-    private let sectionTitles = [
-        "Smart Scan",
-        "System Junk",
-        "Large & Old Files",
-        "Space Lens",
-        "Malware Removal",
-        "Privacy",
-        "Extensions",
-        "App Uninstaller",
-        "App Updater",
-        "Optimization",
-        "Health Monitor",
+    /// The eleven sidebar row identifiers, in `NavigationSection` order. The
+    /// rail is icon-only so rows expose no visible text; these mirror
+    /// `NavigationSection.accessibilityIdentifier`. Hard-coded because the
+    /// UI-test bundle runs out-of-process and cannot import the app enum;
+    /// `NavigationSectionTests` pins the enum side, this pins the rendered side.
+    private let sectionIdentifiers = [
+        "sidebar.smartScan",
+        "sidebar.systemJunk",
+        "sidebar.largeOldFiles",
+        "sidebar.spaceLens",
+        "sidebar.malwareRemoval",
+        "sidebar.privacy",
+        "sidebar.extensions",
+        "sidebar.appUninstaller",
+        "sidebar.appUpdater",
+        "sidebar.optimization",
+        "sidebar.healthMonitor",
     ]
 
     override func setUpWithError() throws {
@@ -46,11 +47,11 @@ final class FinalPolishUITests: XCTestCase {
     func test_launch_sidebarShowsAllElevenSections() throws {
         dismissOnboardingIfNeeded()
 
-        for title in sectionTitles {
-            let row = app.outlines.staticTexts[title].firstMatch
+        for identifier in sectionIdentifiers {
+            let row = app.outlines.descendants(matching: .any)[identifier].firstMatch
             XCTAssertTrue(
                 row.waitForExistence(timeout: 5),
-                "Expected sidebar to list the \"\(title)\" section"
+                "Expected sidebar to list the \"\(identifier)\" section"
             )
         }
     }
@@ -63,7 +64,7 @@ final class FinalPolishUITests: XCTestCase {
     func test_navigateToHealthMonitor_showsAtLeastThreeStatCards() throws {
         dismissOnboardingIfNeeded()
 
-        let row = app.outlines.staticTexts["Health Monitor"].firstMatch
+        let row = app.outlines.descendants(matching: .any)["sidebar.healthMonitor"].firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 5),
                       "Expected Health Monitor row in sidebar")
         row.click()
@@ -93,7 +94,7 @@ final class FinalPolishUITests: XCTestCase {
     func test_largeOldFiles_scan_reachesRecognizableState() throws {
         dismissOnboardingIfNeeded()
 
-        let row = app.outlines.staticTexts["Large & Old Files"].firstMatch
+        let row = app.outlines.descendants(matching: .any)["sidebar.largeOldFiles"].firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 5),
                       "Expected Large & Old Files row in sidebar")
         row.click()
@@ -132,7 +133,7 @@ final class FinalPolishUITests: XCTestCase {
     func test_navigateToAppUninstaller_listLoadsWithAtLeastFiveApps() throws {
         dismissOnboardingIfNeeded()
 
-        let row = app.outlines.staticTexts["App Uninstaller"].firstMatch
+        let row = app.outlines.descendants(matching: .any)["sidebar.appUninstaller"].firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 5),
                       "Expected App Uninstaller row in sidebar")
         row.click()

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -11,8 +11,9 @@ final class FinalPolishUITests: XCTestCase {
 
     private var app: XCUIApplication!
 
-    /// The eleven sidebar row identifiers, in `NavigationSection` order. The
-    /// rail is icon-only so rows expose no visible text; these mirror
+    /// The eleven sidebar row identifiers, in `NavigationSection` order. Rows
+    /// are located by identifier rather than visible label so the locators
+    /// survive rail restyles; these mirror
     /// `NavigationSection.accessibilityIdentifier`. Hard-coded because the
     /// UI-test bundle runs out-of-process and cannot import the app enum;
     /// `NavigationSectionTests` pins the enum side, this pins the rendered side.
@@ -48,7 +49,7 @@ final class FinalPolishUITests: XCTestCase {
         dismissOnboardingIfNeeded()
 
         for identifier in sectionIdentifiers {
-            let row = app.outlines.descendants(matching: .any)[identifier].firstMatch
+            let row = app.buttons[identifier].firstMatch
             XCTAssertTrue(
                 row.waitForExistence(timeout: 5),
                 "Expected sidebar to list the \"\(identifier)\" section"
@@ -64,7 +65,7 @@ final class FinalPolishUITests: XCTestCase {
     func test_navigateToHealthMonitor_showsAtLeastThreeStatCards() throws {
         dismissOnboardingIfNeeded()
 
-        let row = app.outlines.descendants(matching: .any)["sidebar.healthMonitor"].firstMatch
+        let row = app.buttons["sidebar.healthMonitor"].firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 5),
                       "Expected Health Monitor row in sidebar")
         row.click()
@@ -94,7 +95,7 @@ final class FinalPolishUITests: XCTestCase {
     func test_largeOldFiles_scan_reachesRecognizableState() throws {
         dismissOnboardingIfNeeded()
 
-        let row = app.outlines.descendants(matching: .any)["sidebar.largeOldFiles"].firstMatch
+        let row = app.buttons["sidebar.largeOldFiles"].firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 5),
                       "Expected Large & Old Files row in sidebar")
         row.click()
@@ -133,7 +134,7 @@ final class FinalPolishUITests: XCTestCase {
     func test_navigateToAppUninstaller_listLoadsWithAtLeastFiveApps() throws {
         dismissOnboardingIfNeeded()
 
-        let row = app.outlines.descendants(matching: .any)["sidebar.appUninstaller"].firstMatch
+        let row = app.buttons["sidebar.appUninstaller"].firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 5),
                       "Expected App Uninstaller row in sidebar")
         row.click()

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -27,7 +27,7 @@ final class MalwareUITests: XCTestCase {
     func test_navigateToMalware_revealsIdleOrOnboarding() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.staticTexts["Malware Removal"].firstMatch
+        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.malwareRemoval"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Malware Removal row in sidebar")
         sidebarRow.click()

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -27,7 +27,7 @@ final class MalwareUITests: XCTestCase {
     func test_navigateToMalware_revealsIdleOrOnboarding() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.malwareRemoval"].firstMatch
+        let sidebarRow = app.buttons["sidebar.malwareRemoval"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Malware Removal row in sidebar")
         sidebarRow.click()

--- a/VaderCleanerUITests/OptimizationUITests.swift
+++ b/VaderCleanerUITests/OptimizationUITests.swift
@@ -27,7 +27,7 @@ final class OptimizationUITests: XCTestCase {
     func test_navigateToOptimization_revealsToolbarAndContent() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.optimization"].firstMatch
+        let sidebarRow = app.buttons["sidebar.optimization"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Optimization row in sidebar")
         sidebarRow.click()

--- a/VaderCleanerUITests/OptimizationUITests.swift
+++ b/VaderCleanerUITests/OptimizationUITests.swift
@@ -27,7 +27,7 @@ final class OptimizationUITests: XCTestCase {
     func test_navigateToOptimization_revealsToolbarAndContent() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.staticTexts["Optimization"].firstMatch
+        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.optimization"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Optimization row in sidebar")
         sidebarRow.click()

--- a/VaderCleanerUITests/SmartScanUITests.swift
+++ b/VaderCleanerUITests/SmartScanUITests.swift
@@ -42,14 +42,14 @@ final class SmartScanUITests: XCTestCase {
 
         // Navigate away and back to prove the sidebar → view wiring works
         // regardless of the default selection.
-        // The sidebar is an icon-only rail, so rows expose no visible text —
-        // locate them by their stable accessibility identifier instead.
-        let otherRow = app.outlines.descendants(matching: .any)["sidebar.healthMonitor"].firstMatch
+        // Locate sidebar rows by their stable accessibility identifier rather
+        // than by visible label, so the locator survives rail restyles.
+        let otherRow = app.buttons["sidebar.healthMonitor"].firstMatch
         XCTAssertTrue(otherRow.waitForExistence(timeout: 5),
                       "Expected Health Monitor row in sidebar")
         otherRow.click()
 
-        let smartScanRow = app.outlines.descendants(matching: .any)["sidebar.smartScan"].firstMatch
+        let smartScanRow = app.buttons["sidebar.smartScan"].firstMatch
         XCTAssertTrue(smartScanRow.waitForExistence(timeout: 5),
                       "Expected Smart Scan row in sidebar")
         smartScanRow.click()

--- a/VaderCleanerUITests/SmartScanUITests.swift
+++ b/VaderCleanerUITests/SmartScanUITests.swift
@@ -42,12 +42,14 @@ final class SmartScanUITests: XCTestCase {
 
         // Navigate away and back to prove the sidebar → view wiring works
         // regardless of the default selection.
-        let otherRow = app.outlines.staticTexts["Health Monitor"].firstMatch
+        // The sidebar is an icon-only rail, so rows expose no visible text —
+        // locate them by their stable accessibility identifier instead.
+        let otherRow = app.outlines.descendants(matching: .any)["sidebar.healthMonitor"].firstMatch
         XCTAssertTrue(otherRow.waitForExistence(timeout: 5),
                       "Expected Health Monitor row in sidebar")
         otherRow.click()
 
-        let smartScanRow = app.outlines.staticTexts["Smart Scan"].firstMatch
+        let smartScanRow = app.outlines.descendants(matching: .any)["sidebar.smartScan"].firstMatch
         XCTAssertTrue(smartScanRow.waitForExistence(timeout: 5),
                       "Expected Smart Scan row in sidebar")
         smartScanRow.click()

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -31,7 +31,7 @@ final class SpaceLensUITests: XCTestCase {
     func test_navigateToSpaceLens_revealsScanningOrTreemap() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.staticTexts["Space Lens"].firstMatch
+        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.spaceLens"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Space Lens row in sidebar")
         sidebarRow.click()

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -31,7 +31,7 @@ final class SpaceLensUITests: XCTestCase {
     func test_navigateToSpaceLens_revealsScanningOrTreemap() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.spaceLens"].firstMatch
+        let sidebarRow = app.buttons["sidebar.spaceLens"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Space Lens row in sidebar")
         sidebarRow.click()

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -34,9 +34,9 @@ final class SystemJunkUITests: XCTestCase {
         // reachable. The button label comes from `PermissionOnboardingView`.
         dismissOnboardingIfNeeded()
 
-        // The sidebar is a single-selection List; clicking the row whose
-        // label text matches the section title selects it.
-        let sidebarRow = app.outlines.staticTexts["System Junk"].firstMatch
+        // The sidebar is an icon-only rail; rows expose no visible text, so
+        // select by the stable accessibility identifier.
+        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.systemJunk"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected System Junk row in sidebar")
         sidebarRow.click()
@@ -65,7 +65,7 @@ final class SystemJunkUITests: XCTestCase {
     func test_systemJunkPreviewPersistsAcrossSidebarNavigation() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.staticTexts["System Junk"].firstMatch
+        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.systemJunk"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected System Junk row in sidebar")
         sidebarRow.click()
@@ -82,7 +82,7 @@ final class SystemJunkUITests: XCTestCase {
         XCTAssertTrue(appeared,
                       "Expected to land on the preview state after a Scan")
 
-        let smartScanRow = app.outlines.staticTexts["Smart Scan"].firstMatch
+        let smartScanRow = app.outlines.descendants(matching: .any)["sidebar.smartScan"].firstMatch
         XCTAssertTrue(smartScanRow.waitForExistence(timeout: 5),
                       "Expected Smart Scan row in sidebar")
         smartScanRow.click()

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -34,9 +34,9 @@ final class SystemJunkUITests: XCTestCase {
         // reachable. The button label comes from `PermissionOnboardingView`.
         dismissOnboardingIfNeeded()
 
-        // The sidebar is an icon-only rail; rows expose no visible text, so
-        // select by the stable accessibility identifier.
-        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.systemJunk"].firstMatch
+        // Select the sidebar row by its stable accessibility identifier
+        // rather than its visible label, so the locator survives restyles.
+        let sidebarRow = app.buttons["sidebar.systemJunk"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected System Junk row in sidebar")
         sidebarRow.click()
@@ -65,7 +65,7 @@ final class SystemJunkUITests: XCTestCase {
     func test_systemJunkPreviewPersistsAcrossSidebarNavigation() throws {
         dismissOnboardingIfNeeded()
 
-        let sidebarRow = app.outlines.descendants(matching: .any)["sidebar.systemJunk"].firstMatch
+        let sidebarRow = app.buttons["sidebar.systemJunk"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected System Junk row in sidebar")
         sidebarRow.click()
@@ -82,7 +82,7 @@ final class SystemJunkUITests: XCTestCase {
         XCTAssertTrue(appeared,
                       "Expected to land on the preview state after a Scan")
 
-        let smartScanRow = app.outlines.descendants(matching: .any)["sidebar.smartScan"].firstMatch
+        let smartScanRow = app.buttons["sidebar.smartScan"].firstMatch
         XCTAssertTrue(smartScanRow.waitForExistence(timeout: 5),
                       "Expected Smart Scan row in sidebar")
         smartScanRow.click()

--- a/project.yml
+++ b/project.yml
@@ -5,7 +5,7 @@ name: VaderCleaner
 options:
   bundleIdPrefix: com.personal
   deploymentTarget:
-    macOS: "14.0"
+    macOS: "26.0"
   defaultConfig: Debug
   xcodeVersion: "16.0"
   generateEmptyDirectories: true
@@ -13,7 +13,7 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.9"
-    MACOSX_DEPLOYMENT_TARGET: "14.0"
+    MACOSX_DEPLOYMENT_TARGET: "26.0"
     ENABLE_HARDENED_RUNTIME: NO
     CODE_SIGN_STYLE: Manual
     CODE_SIGNING_REQUIRED: NO


### PR DESCRIPTION
## What changed

Two layered UI modernizations, both targeting **macOS 26** (deployment target raised from 14.0).

### 1. Liquid Glass adoption
Replaced hand-rolled card fills (`Color.secondary.opacity` / `controlBackgroundColor` + manual strokes) with the system glass material on app-specific surfaces standard controls don't cover:

- Smart Scan result cards + Health Monitor stat cards (grouped in `GlassEffectContainer`s so adjacent glass refracts consistently)
- Onboarding / permission instruction boxes, the FDA prompt card, the Malware idle info box
- App Uninstaller custom search field
- Hero idle CTAs use the glass-prominent button style

Intentionally **not** glassified: inline semantic badges (status pills) and monospace code/output boxes — those read better as flat fills. The four single-item toolbars get automatic Liquid Glass on macOS 26 with no grouping to express.

### 2. Vader-themed app shell
New `VaderTheme.swift` defines the brand identity: a space-black → Sith-crimson gradient backdrop, crimson accent, and a `.vaderShell()` modifier (gradient + forced dark appearance + tint) applied app-wide at the `NavigationSplitView` root.

- Smart Scan **welcome screen** redesigned into a hero: app icon with crimson glow, "Welcome to VaderCleaner", and a circular interactive-glass Scan button
- All `List`/`Table` detail surfaces hide their scroll background so the gradient shows through and the glass cards float over a vibrant backdrop (the ideal substrate for Liquid Glass)
- Sidebar reads as a translucent panel; toolbar band hidden

## Why

Modernize VaderCleaner onto the current macOS design system and give it a cohesive, branded look modeled on the requested reference, while keeping the Liquid Glass material rather than fighting it with opaque chrome.

## Deliberate scope decisions

- **Settings/Preferences and the menu-bar popover are left conventional** (system appearance) — heavy branding there breaks macOS conventions and looks out of place next to other system UI. This is by design, not an omission.
- **macOS 14/15 support is dropped** — the single-code-path approach for Liquid Glass requires a macOS 26 deployment target. This was an explicit product decision.
- No gradient is painted inside sheets; the system sheet glass lets the window gradient show through.

## Reviewer notes

- **Build:** clean on the macOS 26.5 SDK (regenerated the Xcode project via `xcodegen` to include the new file).
- **Tests:** all **614 unit tests pass**, 0 failures. No accessibility identifiers or keyboard shortcuts changed.
- **Visual appearance is unverified** — builds + tests confirm valid Swift and unbroken logic only. Expect possible follow-up tweaks to text contrast over the crimson bloom and hero spacing once run. `#Preview` blocks render without the shell and show the generic app icon, so judge the look by running the app, not previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Smart Scan results: metric tiles, single circular Clean CTA, Start Over flow, and hero uses the app icon; Review actions route to relevant sections.
  * Sidebar converted to a compact navigation rail with icon-only rows.

* **Style**
  * New VaderCleaner theme and color palette.
  * Widespread glass-effect styling and hidden list scroll backgrounds for a consistent dark look.

* **Chores**
  * Raised macOS deployment target to 26.0.

* **Tests**
  * UI tests updated to use stable sidebar accessibility identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->