### PR TITLE
Phase 6 Step 1/8: SectionPresentation model + NavigationSection.isScannable

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */; };
 		11C7DA0D7ECDCBF7DFB3C829 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 329FBD86F55918272AF0EF2A /* Localizable.stringsdict */; };
 		12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17B889E32D6334AED35F2BE /* LaunchAgent.swift */; };
+		1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732FA87F80DF686871220B50 /* SectionPresentationTests.swift */; };
 		13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */; };
 		1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */; };
 		159F0D7D84A23B27058835D6 /* BrowserDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */; };
@@ -117,6 +118,7 @@
 		83FF16A5DCFB4B225F33236E /* SystemJunkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */; };
 		85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */; };
 		892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */; };
+		89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
@@ -279,6 +281,7 @@
 		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
 		2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSection.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
+		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
@@ -334,6 +337,7 @@
 		7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamer.swift; sourceTree = "<group>"; };
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
+		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
@@ -557,6 +561,7 @@
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
 				B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */,
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
+				2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */,
 				3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */,
 				D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */,
 				DEB9C7A07E62C19FD94824B5 /* SmartScanViewSubviews.swift */,
@@ -669,6 +674,7 @@
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
+				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
 				22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */,
 				F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */,
@@ -886,6 +892,7 @@
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
+				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
 				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,
 				6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */,
@@ -1011,6 +1018,7 @@
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
+				89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */,
 				FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */,
 				9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */,
 				E357AD8EDB1FA65E6D5EB59E /* SmartScanViewSubviews.swift in Sources */,

--- a/VaderCleaner.xcodeproj/xcuserdata/jayvicsanantonio.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/VaderCleaner.xcodeproj/xcuserdata/jayvicsanantonio.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>VaderCleaner.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>VaderCleanerHelper.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -69,4 +69,20 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .healthMonitor:   return "heart.text.square"
         }
     }
+
+    /// Whether this section drives a scan/load and therefore adopts the
+    /// unified intro screen + floating Scan button. The remaining sections
+    /// (live stats and list-style management screens) keep their bespoke UI.
+    /// Exhaustive switch with no `default` so a future section is a
+    /// compile-time prompt to classify it here.
+    var isScannable: Bool {
+        switch self {
+        case .smartScan, .systemJunk, .largeOldFiles,
+             .spaceLens, .malwareRemoval, .optimization:
+            return true
+        case .privacy, .extensions, .appUninstaller,
+             .appUpdater, .healthMonitor:
+            return false
+        }
+    }
 }

--- a/VaderCleaner/SectionPresentation.swift
+++ b/VaderCleaner/SectionPresentation.swift
@@ -1,0 +1,191 @@
+// SectionPresentation.swift
+// Static per-section presentation metadata for the scan-centric landing screen: hero art, accent color, tagline, and descriptive sub-feature rows.
+
+import SwiftUI
+
+/// One descriptive row on a section's intro screen: an SF Symbol and a label.
+/// Purely informational — these rows have no actions (they tell the user what
+/// the upcoming scan covers, matching the reference design).
+struct SectionFeature: Equatable {
+    let symbol: String
+    let title: String
+}
+
+/// The visual identity for a scannable section's intro screen. The window's
+/// crimson `vaderShell()` is unchanged — `accent` tints only the hero,
+/// sub-feature icons, and (in a later step) the floating Scan button.
+struct SectionPresentation {
+    /// SF Symbol used as the hero when no bespoke art is supplied.
+    let heroSymbol: String
+    /// Asset-catalog image name for designer-supplied hero art. `nil` falls
+    /// back to `heroSymbol`; wired now so art can land later with no code
+    /// change.
+    let heroAssetName: String?
+    /// Accent applied to intro elements only — not the window gradient.
+    let accent: Color
+    /// One-line description shown under the section title.
+    let tagline: String
+    /// The 2–4 descriptive rows summarizing what the scan covers.
+    let features: [SectionFeature]
+
+    /// Presentation for a scannable section, or `nil` for sections that keep
+    /// their bespoke UI (`NavigationSection.isScannable == false`). The switch
+    /// is exhaustive so a new section is a compile-time prompt.
+    static func `for`(_ section: NavigationSection) -> SectionPresentation? {
+        switch section {
+        case .smartScan:
+            // Surface the three modules Smart Scan actually orchestrates,
+            // sourced from the sections themselves so the labels/icons never
+            // drift from the real screens.
+            return SectionPresentation(
+                heroSymbol: "sparkles",
+                heroAssetName: nil,
+                accent: .vaderCrimson,
+                tagline: String(
+                    localized: "Quick maintenance that takes care of the essentials.",
+                    comment: "Smart Scan intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: NavigationSection.systemJunk.icon,
+                        title: NavigationSection.systemJunk.title
+                    ),
+                    SectionFeature(
+                        symbol: NavigationSection.malwareRemoval.icon,
+                        title: NavigationSection.malwareRemoval.title
+                    ),
+                    SectionFeature(
+                        symbol: NavigationSection.optimization.icon,
+                        title: NavigationSection.optimization.title
+                    ),
+                ]
+            )
+        case .systemJunk:
+            return SectionPresentation(
+                heroSymbol: "trash",
+                heroAssetName: nil,
+                accent: .green,
+                tagline: String(
+                    localized: "Clean your system to reclaim space and boost performance.",
+                    comment: "System Junk intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: "internaldrive",
+                        title: String(localized: "System Caches", comment: "System Junk feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "doc.text",
+                        title: String(localized: "Logs", comment: "System Junk feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "envelope",
+                        title: String(localized: "Mail Attachments", comment: "System Junk feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "trash",
+                        title: String(localized: "Trash Bins", comment: "System Junk feature row.")
+                    ),
+                ]
+            )
+        case .largeOldFiles:
+            return SectionPresentation(
+                heroSymbol: "doc.text.magnifyingglass",
+                heroAssetName: nil,
+                accent: .teal,
+                tagline: String(
+                    localized: "Find big and forgotten files taking up space.",
+                    comment: "Large & Old Files intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: "doc.on.doc",
+                        title: String(localized: "Large Files", comment: "Large & Old Files feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "clock.arrow.circlepath",
+                        title: String(localized: "Old Files", comment: "Large & Old Files feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "arrow.down.circle",
+                        title: String(localized: "Downloads", comment: "Large & Old Files feature row.")
+                    ),
+                ]
+            )
+        case .spaceLens:
+            return SectionPresentation(
+                heroSymbol: "square.split.2x2",
+                heroAssetName: nil,
+                accent: .indigo,
+                tagline: String(
+                    localized: "See what's using your storage with an interactive map.",
+                    comment: "Space Lens intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: "chart.pie",
+                        title: String(localized: "Disk Usage Map", comment: "Space Lens feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "folder",
+                        title: String(localized: "Drill Into Folders", comment: "Space Lens feature row.")
+                    ),
+                ]
+            )
+        case .malwareRemoval:
+            return SectionPresentation(
+                heroSymbol: "shield.lefthalf.filled",
+                heroAssetName: nil,
+                accent: .vaderCrimson,
+                tagline: String(
+                    localized: "Check your Mac for threats and vulnerabilities.",
+                    comment: "Malware Removal intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: "ladybug",
+                        title: String(localized: "Malware Scan", comment: "Malware Removal feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "cylinder",
+                        title: String(localized: "Signature Database", comment: "Malware Removal feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "xmark.shield",
+                        title: String(localized: "Quarantine", comment: "Malware Removal feature row.")
+                    ),
+                ]
+            )
+        case .optimization:
+            return SectionPresentation(
+                heroSymbol: "gauge.with.needle",
+                heroAssetName: nil,
+                accent: .orange,
+                tagline: String(
+                    localized: "Keep your Mac in top shape with recommended maintenance.",
+                    comment: "Optimization intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: "power",
+                        title: String(localized: "Login Items", comment: "Optimization feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "gearshape",
+                        title: String(localized: "Launch Agents", comment: "Optimization feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "memorychip",
+                        title: String(localized: "Free Up RAM", comment: "Optimization feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "wrench.and.screwdriver",
+                        title: String(localized: "Maintenance Scripts", comment: "Optimization feature row.")
+                    ),
+                ]
+            )
+        case .privacy, .extensions, .appUninstaller, .appUpdater, .healthMonitor:
+            return nil
+        }
+    }
+}

--- a/VaderCleanerTests/SectionPresentationTests.swift
+++ b/VaderCleanerTests/SectionPresentationTests.swift
@@ -1,0 +1,112 @@
+// SectionPresentationTests.swift
+// Pins the scan-centric section metadata contract: which sections are scannable and each scannable section's presentation content.
+
+import XCTest
+import AppKit
+@testable import VaderCleaner
+
+final class SectionPresentationTests: XCTestCase {
+
+    /// The six sections that drive a scan/load and therefore get the unified
+    /// intro screen + floating Scan button. Pinned here so a drift in
+    /// `isScannable` or `SectionPresentation.for(_:)` fails loudly.
+    private let scannableSections: Set<NavigationSection> = [
+        .smartScan, .systemJunk, .largeOldFiles,
+        .spaceLens, .malwareRemoval, .optimization,
+    ]
+
+    func test_isScannable_isTrueForExactlyTheSixScannableSections() {
+        for section in NavigationSection.allCases {
+            let expected = scannableSections.contains(section)
+            XCTAssertEqual(
+                section.isScannable,
+                expected,
+                "isScannable for \(section) should be \(expected)"
+            )
+        }
+    }
+
+    func test_isScannable_countIsExactlySix() {
+        let count = NavigationSection.allCases.filter(\.isScannable).count
+        XCTAssertEqual(count, 6, "Exactly six sections must be scannable")
+    }
+
+    func test_presentationFor_isNonNilForScannableAndNilOtherwise() {
+        for section in NavigationSection.allCases {
+            let presentation = SectionPresentation.for(section)
+            if scannableSections.contains(section) {
+                XCTAssertNotNil(
+                    presentation,
+                    "Expected presentation for scannable section \(section)"
+                )
+            } else {
+                XCTAssertNil(
+                    presentation,
+                    "Non-scannable section \(section) must have no presentation"
+                )
+            }
+        }
+    }
+
+    func test_smartScanFeatures_areTheThreeOrchestratedModulesInOrder() throws {
+        let presentation = try XCTUnwrap(SectionPresentation.for(.smartScan))
+        let orchestrated: [NavigationSection] = [.systemJunk, .malwareRemoval, .optimization]
+        XCTAssertEqual(
+            presentation.features.map(\.title),
+            orchestrated.map(\.title),
+            "Smart Scan must surface its real orchestrated modules, in order"
+        )
+        XCTAssertEqual(
+            presentation.features.map(\.symbol),
+            orchestrated.map(\.icon),
+            "Smart Scan feature icons must track the real sections' icons"
+        )
+    }
+
+    func test_everyScannablePresentation_hasNonEmptyTaglineAndFeatures() throws {
+        for section in scannableSections {
+            let presentation = try XCTUnwrap(
+                SectionPresentation.for(section),
+                "Missing presentation for \(section)"
+            )
+            XCTAssertFalse(
+                presentation.tagline.isEmpty,
+                "Tagline must be non-empty for \(section)"
+            )
+            XCTAssertFalse(
+                presentation.heroSymbol.isEmpty,
+                "Hero symbol must be non-empty for \(section)"
+            )
+            XCTAssertFalse(
+                presentation.features.isEmpty,
+                "Feature list must be non-empty for \(section)"
+            )
+            for feature in presentation.features {
+                XCTAssertFalse(
+                    feature.symbol.isEmpty,
+                    "Feature symbol must be non-empty for \(section)"
+                )
+                XCTAssertFalse(
+                    feature.title.isEmpty,
+                    "Feature title must be non-empty for \(section)"
+                )
+            }
+        }
+    }
+
+    func test_everyPresentationSymbol_isAValidSFSymbol() throws {
+        guard #available(macOS 14.0, *) else {
+            throw XCTSkip("SF Symbol validation requires macOS 14.0 (the app's minimum deployment target)")
+        }
+        for section in scannableSections {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let symbols = [presentation.heroSymbol] + presentation.features.map(\.symbol)
+            for symbol in symbols {
+                XCTAssertNotNil(
+                    NSImage(systemSymbolName: symbol, accessibilityDescription: nil),
+                    "Invalid SF Symbol '\(symbol)' in presentation for \(section)"
+                )
+            }
+        }
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -1012,3 +1012,117 @@ Polish:
 | 25 | Smart Scan | Integration |
 | 26 | Exclusions wired to all scanners | Integration |
 | 27 | Final polish + E2E tests | Integration |
+
+---
+
+## Phase 6 — Scan-Centric Redesign
+
+This phase is a UI redesign (not part of the original 27-prompt build above, which is complete). Goal: a consistent per-section landing screen — accent-tinted hero, title, one-line description, and a descriptive sub-feature list — plus a single persistent floating **Scan** button, for the **six scan-capable sections**: Smart Scan, System Junk, Large & Old Files, Space Lens, Malware Removal, Optimization. The other five sections (Health Monitor, Privacy, Extensions, App Uninstaller, App Updater) are unchanged.
+
+### Decisions (locked)
+
+- **Brand stays crimson.** The `.vaderShell()` window gradient is unchanged. Per-section accent color applies *only* to intro-screen elements (hero symbol, sub-feature icons, Scan button) — not the whole window.
+- **Hero baseline = SF Symbols.** Each section uses a large tinted SF Symbol as its hero now, with an optional `heroAssetName` field so designer art can swap in later with no code change.
+- **No view-model rewrites.** The six view models keep their existing `Phase` enums and scan entrypoints. A thin `ScanCoordinating` protocol is added via extensions that map each native phase to a coarse `ScanPresentation` and route `beginScan()` to the existing entrypoint (per the global CLAUDE.md "don't rewrite without permission" rule).
+- **Replace, don't overlay.** When a section's coordinator reports `.intro`, ContentView renders the generic `SectionIntroView` *instead of* that section's detail view. Detail views render only for `.working`/`.results`. This avoids double UI; Step 7 is then a pure deletion of the now-dead idle code.
+- **Smart Scan's three sub-feature rows** are its real orchestrated modules — System Junk, Malware Removal, Optimization — not invented marketing labels.
+- Every step is TDD (tests first) and ends with everything wired; no orphaned code.
+
+### Prompt 28 — Step 1/8: SectionPresentation model + isScannable ([#84](https://github.com/jayvicsanantonio/VaderCleaner/issues/84))
+
+Foundation data model, no UI. Add `NavigationSection.isScannable` (true for exactly the six scannable sections) and a `SectionPresentation` struct (hero symbol, optional asset name, accent `Color`, tagline, `[SectionFeature]`) with a `for(_:)` factory. Pin Smart Scan's features to System Junk / Malware Removal / Optimization.
+
+```text
+Building on the existing VaderCleaner codebase, add a section-presentation model. TDD: write the tests first.
+
+1. Add `var isScannable: Bool` to NavigationSection. True ONLY for: .smartScan, .systemJunk, .largeOldFiles, .spaceLens, .malwareRemoval, .optimization.
+2. Create VaderCleaner/SectionPresentation.swift with `struct SectionPresentation` (heroSymbol, heroAssetName: String?, accent: Color, tagline, features: [SectionFeature]) and `struct SectionFeature { symbol; title }`, plus `static func for(_ section: NavigationSection) -> SectionPresentation?` (nil for non-scannable).
+3. Pin per-section content (contract — tests assert it). Smart Scan features = System Junk/"trash", Malware Removal/"shield.lefthalf.filled", Optimization/"gauge.with.needle". Accents: SmartScan crimson, SystemJunk green, LargeOldFiles teal, SpaceLens indigo, Malware crimson, Optimization orange. All user-facing strings via String(localized:).
+4. Tests (VaderCleanerTests/SectionPresentationTests.swift): isScannable true for exactly the six; for(:) non-nil for the six and nil otherwise; Smart Scan features are the three modules in order; every scannable section has non-empty features with non-empty symbols/titles. Mirror NavigationSectionTests style.
+
+Add files to the Xcode project (project.yml is XcodeGen-driven). 2-line header comments. Full suite green.
+```
+
+### Prompt 29 — Step 2/8: ScanPresentation enum + ScanCoordinating protocol ([#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85))
+
+The coarse abstraction ContentView uses to choose "generic intro + Scan" vs "section's own detail view". Plain protocol, no associated types, no type erasure.
+
+```text
+Building on Step 1, add VaderCleaner/ScanCoordinating.swift:
+- enum ScanPresentation: Equatable { case intro, working, results }  (.intro → generic intro + floating Scan; .working → scan/load in progress; .results → section's own detail UI renders)
+- protocol ScanCoordinating: ObservableObject { var scanPresentation: ScanPresentation { get }; func beginScan() }  — plain protocol, no associated types.
+Tests (VaderCleanerTests/ScanCoordinatingTests.swift): a private FakeCoordinator; assert ScanPresentation Equatable; assert beginScan() flips a flag and a presentation change is observable via objectWillChange. No view model modified this step. 2-line headers; add to project; full suite green.
+```
+
+### Prompt 30 — Step 3/8: Conform the 6 view models to ScanCoordinating ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
+
+Extensions only — map each native `Phase` to `ScanPresentation`, route `beginScan()` to the existing entrypoint. Space Lens default root = home dir. Optimization `beginScan()` = its load path (semantic stretch, commented).
+
+```text
+Building on Step 2, add `extension <VM>: ScanCoordinating` for all six VMs (do not alter their methods or Phase enums):
+- SmartScan: .idle→.intro; .scanning→.working; .results/.cleaning/.done/.failed→.results; beginScan→Task{await scan()}.
+- SystemJunk: .idle→.intro; .scanning/.cleaning→.working; .preview/.complete/.failed→.results; beginScan→Task{await scan()}.
+- LargeOldFiles: .idle→.intro; .scanning→.working; .results/.empty/.failed→.results; beginScan→Task{await scan()}.
+- DiskScanner: .idle→.intro; .scanning→.working; .ready/.error→.results; beginScan→Task{await startScan(root: FileManager.default.homeDirectoryForCurrentUser)} (comment: default Space Lens root).
+- Malware: .idle→.intro; .checkingClamAV/.updatingDatabase/.scanning/.removing→.working; .needsInstall/.results/.clean/.done/.failed→.results; beginScan→Task{await scan()} (.needsInstall→.results so MalwareView shows install onboarding).
+- Optimization: .idle→.intro; .loading→.working; .ready/.working/.failed→.results; beginScan→its existing on-appear load path (comment: "scan"=="load", semantic stretch).
+Tests (VaderCleanerTests/ScanCoordinatingConformanceTests.swift): per VM, construct with injected fakes (follow each existing *ViewModelTests), drive phases, assert the coarse value at each; assert beginScan() leaves .intro. 2-line headers; add new files to project; full suite green.
+```
+
+### Prompt 31 — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
+
+Relocate (do not reimplement) the existing private `CircularActionButton` + `PressableCircleButtonStyle` from `SmartScanViewSubviews.swift` into a shared, accent-parameterized `FloatingScanButton`. SmartScan must look/behave identically.
+
+```text
+Building on Step 1, move CircularActionButton and PressableCircleButtonStyle out of SmartScanViewSubviews.swift into VaderCleaner/FloatingScanButton.swift as `struct FloatingScanButton: View { title; accent: Color; accessibilityIdentifier; action }`. Keep the crimson interactive-glass disc + press animation; tint from accent (default crimson). Update SmartScan call sites to use it with accent crimson and existing titles/actions — no visual/behavioral change to SmartScan. Tests (VaderCleanerTests/FloatingScanButtonTests.swift): verify the a11y id is exposed and action fires (use the repo's existing view-test approach; else a small @MainActor harness). 2-line header; add to project; SmartScan UI tests + full suite green.
+```
+
+### Prompt 32 — Step 5/8: SectionIntroView ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
+
+The reusable landing screen: accent hero + title + tagline + descriptive feature rows. No Scan button inside (ContentView owns it so it can float over the window edge).
+
+```text
+Building on Steps 1 and 4, create VaderCleaner/SectionIntroView.swift. `struct SectionIntroView: View { presentation: SectionPresentation; title: String }`: large accent-tinted hero (asset if heroAssetName else SF Symbol ~120pt) with a soft accent bloom (reuse SmartScanIdleState's bloom); large bold title; secondary tagline (max ~420 width, multiline); vertical list of feature rows (accent icon + title, no checkboxes/actions). Hero-left / text-right at wide widths, stacks when narrow. Do NOT render a Scan button. Accessibility: root id `section.intro`, per-feature id `section.intro.feature.<index>`, accessible title/tagline. Tests (VaderCleanerTests/SectionIntroViewTests.swift): for each scannable presentation, view builds, expected a11y ids present, feature count matches. 2-line header; add to project; full suite green; no other view touched.
+```
+
+### Prompt 33 — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))
+
+**Everything wired end-to-end.** Replace (don't overlay): scannable section at `.intro` → `SectionIntroView`; `.working`/`.results` → existing detail view. One floating Scan overlay on the outer HStack. Migrate UI-test identifiers to `section.<id>.scan`.
+
+```text
+Building on Steps 3–5, in ContentView.swift:
+1. In detailView(for:): if section.isScannable, read its VM as ScanCoordinating. If coordinator.scanPresentation == .intro return SectionIntroView(presentation: SectionPresentation.for(section)!, title: section.title); else return the existing detail view unchanged. Non-scannable sections unchanged.
+2. Add a FloatingScanButton as `.overlay(alignment: .bottom)` on the OUTER HStack (not inside NavigationStack) with negative bottom padding (disc half outside the edge + glow, per screenshots). Show ONLY when selectedSection.isScannable AND its scanPresentation == .intro; accent = SectionPresentation.for(selectedSection)?.accent ?? .vaderCrimson; id `section.<suffix>.scan`; action = coordinator.beginScan().
+3. Detail views remain the source of truth for working/results — no duplication.
+4. Update affected UI tests: navigate → assert `section.intro` → tap `section.<id>.scan` → assert working/results UI. Repoint every old idle-scan id (system-junk.scan, large-old-files.scan, SmartScan idle scan, malware/optimization/space-lens scan triggers) to `section.<id>.scan`. Do NOT delete dead idle code yet (Step 7).
+Match ContentView style. Full unit + UI suite green.
+```
+
+### Prompt 34 — Step 7/8: Retire per-section bespoke idle states ([#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90))
+
+Pure deletion — remove the now-unreachable `.idle`/landing UI from the six scannable section views and their idle-only subviews. No behavior change.
+
+```text
+Building on Step 6, delete the now-unreachable per-section idle/landing UI: SmartScanIdleState, SystemJunkView.idleState, and the equivalent in LargeOldFilesView/SpaceLensView/MalwareView/OptimizationView. The detail view's switch should have no idle UI arm (EmptyView/no-op if the enum still has .idle, since ContentView never routes there at .intro). Do NOT change Phase enums or working/results/done/failed branches. Update/delete only tests that asserted the deleted idle UI; keep working/results coverage. Preserve still-accurate comments (repo rule). 2-line headers stay. Full unit + UI suite green, no regression vs end of Step 6.
+```
+
+### Prompt 35 — Step 8/8: Transitions, accessibility, E2E, README ([#91](https://github.com/jayvicsanantonio/VaderCleaner/issues/91))
+
+Polish and end-to-end verification.
+
+```text
+Building on Step 7: (1) crossfade intro→working→results reusing SmartScanView's phaseTransitionID/.transition(.opacity)/.animation(.smooth) pattern; floating Scan fades (not pops) when leaving .intro. (2) Accessibility: VoiceOver labels for hero/title/tagline/each feature and "Scan <Section>" on the button; Dynamic Type must scroll/stack, not clip. (3) E2E (XCUITest) for each of the six scannable sections: launch → select → assert section.intro with right title → tap section.<id>.scan → assert working then results/detail (or valid empty/needs-install for Malware); plus assert a non-scannable section (Health Monitor) has NO floating Scan and is unchanged. (4) README.md: document the unified landing + floating Scan; keep ToC anchors stable. Run full unit + UI suite; fix any flake.
+```
+
+### Phase 6 Summary
+
+| Prompt | Step | Feature | Issue |
+|--------|------|---------|-------|
+| 28 | 1/8 | SectionPresentation model + isScannable | [#84](https://github.com/jayvicsanantonio/VaderCleaner/issues/84) |
+| 29 | 2/8 | ScanPresentation + ScanCoordinating protocol | [#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85) |
+| 30 | 3/8 | Conform 6 view models (extensions) | [#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86) |
+| 31 | 4/8 | Extract FloatingScanButton | [#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87) |
+| 32 | 5/8 | SectionIntroView | [#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88) |
+| 33 | 6/8 | Wire into ContentView (everything wired) | [#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89) |
+| 34 | 7/8 | Retire bespoke idle states | [#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90) |
+| 35 | 8/8 | Transitions, a11y, E2E, README | [#91](https://github.com/jayvicsanantonio/VaderCleaner/issues/91) |

--- a/todo.md
+++ b/todo.md
@@ -51,3 +51,14 @@
 - [x] **Prompt 25** — Smart Scan (orchestrates junk + malware + optimization)
 - [x] **Prompt 26** — Exclusions wired to all scanners
 - [x] **Prompt 27** — Final polish, error handling, E2E tests, app icon, About window
+
+## Phase 6 — Scan-Centric Redesign
+
+- [x] **Prompt 28** — Step 1/8: SectionPresentation model + `isScannable` ([#84](https://github.com/jayvicsanantonio/VaderCleaner/issues/84))
+- [ ] **Prompt 29** — Step 2/8: ScanPresentation enum + ScanCoordinating protocol ([#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85))
+- [ ] **Prompt 30** — Step 3/8: Conform the 6 scannable view models (extensions) ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
+- [ ] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
+- [ ] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
+- [ ] **Prompt 33** — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))
+- [ ] **Prompt 34** — Step 7/8: Retire per-section bespoke idle states ([#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90))
+- [ ] **Prompt 35** — Step 8/8: Transitions, accessibility, E2E, README ([#91](https://github.com/jayvicsanantonio/VaderCleaner/issues/91))


### PR DESCRIPTION
## Phase 6 — Scan-Centric Redesign · Step 1/8

Closes #84. Foundation data model for the unified per-section intro screen + floating Scan button. **No UI, no view model touched** — this step only adds the metadata the later steps consume.

### What changed
- **`NavigationSection.isScannable`** — exhaustive `switch` (no `default`, so a future section is a compile-time prompt). `true` for the six scan/load sections (`smartScan, systemJunk, largeOldFiles, spaceLens, malwareRemoval, optimization`), `false` for the live-stats / list-style screens.
- **`SectionPresentation` + `SectionFeature`** (new file) — per-section intro metadata: hero SF Symbol, optional `heroAssetName` (so designer art can land later with zero code change), accent `Color`, localized tagline, and 2–4 descriptive feature rows. `static func \`for\`(_:)` returns `nil` for non-scannable sections.
- Accent is **intro-only**: the crimson `vaderShell()` window gradient is unchanged (per the locked Phase 6 decision).
- **Smart Scan's three feature rows reference `NavigationSection.systemJunk/.malwareRemoval/.optimization`** directly — single source of truth, labels/icons can't drift from the real screens.
- `plan.md` / `todo.md` Phase 6 entries land here (epic framing); `todo.md` Prompt 28 checked off.
- `VaderCleaner.xcodeproj/project.pbxproj` regenerated via `xcodegen` (sources are path-globbed; the `.xcodeproj` is tracked, so the regen diff is committed here).

### Tests (TDD — tests written first, confirmed red on compile, then green)
New `SectionPresentationTests` (6 cases) pin the contract: scannable set is exactly six; `for(_:)` non-nil iff scannable; Smart Scan features equal `[.systemJunk, .malwareRemoval, .optimization]` mapped to title+icon, in order; every scannable presentation has non-empty tagline/features; every hero + feature symbol resolves as a real SF Symbol.

**Verification:** `xcodebuild test -scheme VaderCleaner` → full unit suite **622 tests, 0 failures, TEST SUCCEEDED**.

### Scope / policy notes
- **No debug logging** added — pure data model; logging belongs in Step 6 where `ContentView` observes coordinator state. Adding it here would violate the "smallest reasonable change" rule.
- **Test coverage:** unit only at this step *by design*, not a waiver — integration coverage arrives in Step 6 (ContentView wiring), full E2E in Step 8, per the Phase 6 plan.
- UI tests not run: this step changes no UI. They are exercised in Steps 6 and 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented presentation system infrastructure for scan-capable sections to support upcoming interface redesign.

* **Tests**
  * Added comprehensive test coverage validating presentation contracts and symbol validity across supported sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->