### PR TITLE
Phase 6 Step 2/8: ScanPresentation enum + ScanCoordinating protocol

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
 		09756E0B2E09D8BF521C1141 /* MalwareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7315AD5A081B0855C316F00F /* MalwareView.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
+		102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
 		109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */; };
@@ -124,6 +125,7 @@
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
 		91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */; };
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
+		9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */; };
 		99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC50A90E584320709971BCB /* ScanCategoryTests.swift */; };
 		9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */; };
 		9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */; };
@@ -280,6 +282,7 @@
 		2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanViewModelTests.swift; sourceTree = "<group>"; };
 		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
 		2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSection.swift; sourceTree = "<group>"; };
+		2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingTests.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
@@ -374,6 +377,7 @@
 		A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemoverTests.swift; sourceTree = "<group>"; };
 		A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviderTests.swift; sourceTree = "<group>"; };
 		A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkView.swift; sourceTree = "<group>"; };
+		AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinating.swift; sourceTree = "<group>"; };
 		AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorView.swift; sourceTree = "<group>"; };
 		AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunner.swift; sourceTree = "<group>"; };
 		B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedFile.swift; sourceTree = "<group>"; };
@@ -559,6 +563,7 @@
 				9D5CB08F96767D10B1271970 /* RAMManager.swift */,
 				2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */,
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
+				AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */,
 				B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */,
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
 				2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */,
@@ -673,6 +678,7 @@
 				78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */,
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
+				2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
@@ -891,6 +897,7 @@
 				3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */,
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
+				102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
@@ -1016,6 +1023,7 @@
 				7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */,
 				567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */,
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,
+				9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */,
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */,

--- a/VaderCleaner.xcodeproj/xcuserdata/jayvicsanantonio.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/VaderCleaner.xcodeproj/xcuserdata/jayvicsanantonio.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>VaderCleaner.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>VaderCleanerHelper.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/VaderCleaner/ScanCoordinating.swift
+++ b/VaderCleaner/ScanCoordinating.swift
@@ -1,0 +1,33 @@
+// ScanCoordinating.swift
+// Coarse scan-state abstraction letting ContentView pick the generic intro + floating Scan button vs. a scannable section's own detail UI.
+
+import Combine
+
+/// The three coarse phases ContentView distinguishes for a scannable section.
+/// Each scannable view model keeps its own richer phase enum and maps it onto
+/// one of these (the mapping lands in a later step, via extensions).
+enum ScanPresentation: Equatable {
+    /// Show the generic SectionIntroView + floating Scan button.
+    case intro
+    /// The section's scan or load is in progress.
+    case working
+    /// Render the section's own detail UI. Results, preview, done, failed, and
+    /// needs-install all collapse here — the detail view's internal switch
+    /// handles the specifics.
+    case results
+}
+
+/// Adopted (in a later step) by the six scannable view models so ContentView
+/// can drive the unified intro → scan → detail flow without knowing each
+/// model's bespoke phase enum or scan entrypoint.
+///
+/// Deliberately a plain `ObservableObject` protocol: no associated types and
+/// no type erasure. ContentView already holds every view model as its
+/// concrete type, so it reads `scanPresentation` and calls `beginScan()`
+/// directly.
+protocol ScanCoordinating: ObservableObject {
+    /// The coarse phase ContentView switches on.
+    var scanPresentation: ScanPresentation { get }
+    /// Start the section's scan or load.
+    func beginScan()
+}

--- a/VaderCleanerTests/ScanCoordinatingTests.swift
+++ b/VaderCleanerTests/ScanCoordinatingTests.swift
@@ -1,0 +1,57 @@
+// ScanCoordinatingTests.swift
+// Pins the coarse scan-state contract: ScanPresentation Equatable behavior and the ScanCoordinating protocol's beginScan() + observability surface.
+
+import XCTest
+import Combine
+@testable import VaderCleaner
+
+final class ScanCoordinatingTests: XCTestCase {
+
+    /// Minimal stand-in for the real scannable view models (which conform in a
+    /// later step). `@Published` satisfies the protocol's get-only
+    /// `scanPresentation` requirement and gives `objectWillChange` for free;
+    /// `beginScanCalled` records that the coordinator's entrypoint ran.
+    private final class FakeCoordinator: ScanCoordinating {
+        @Published var scanPresentation: ScanPresentation = .intro
+        private(set) var beginScanCalled = false
+
+        func beginScan() {
+            beginScanCalled = true
+        }
+    }
+
+    func test_scanPresentation_equatableDistinguishesAllCases() {
+        XCTAssertEqual(ScanPresentation.intro, .intro)
+        XCTAssertEqual(ScanPresentation.working, .working)
+        XCTAssertEqual(ScanPresentation.results, .results)
+
+        XCTAssertNotEqual(ScanPresentation.intro, .working)
+        XCTAssertNotEqual(ScanPresentation.working, .results)
+        XCTAssertNotEqual(ScanPresentation.intro, .results)
+    }
+
+    func test_beginScan_flipsTheFakesFlag() {
+        let fake = FakeCoordinator()
+        XCTAssertFalse(fake.beginScanCalled, "Flag must start false")
+
+        fake.beginScan()
+
+        XCTAssertTrue(fake.beginScanCalled, "beginScan() must record that it ran")
+    }
+
+    func test_presentationChange_isObservableViaObjectWillChange() {
+        let fake = FakeCoordinator()
+        var fired = false
+        let cancellable = fake.objectWillChange.sink { _ in fired = true }
+
+        fake.scanPresentation = .working
+
+        withExtendedLifetime(cancellable) {
+            XCTAssertTrue(
+                fired,
+                "Mutating scanPresentation must publish through objectWillChange"
+            )
+        }
+        XCTAssertEqual(fake.scanPresentation, .working)
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -55,7 +55,7 @@
 ## Phase 6 — Scan-Centric Redesign
 
 - [x] **Prompt 28** — Step 1/8: SectionPresentation model + `isScannable` ([#84](https://github.com/jayvicsanantonio/VaderCleaner/issues/84))
-- [ ] **Prompt 29** — Step 2/8: ScanPresentation enum + ScanCoordinating protocol ([#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85))
+- [x] **Prompt 29** — Step 2/8: ScanPresentation enum + ScanCoordinating protocol ([#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85))
 - [ ] **Prompt 30** — Step 3/8: Conform the 6 scannable view models (extensions) ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
 - [ ] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
 - [ ] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))


### PR DESCRIPTION
## Phase 6 — Scan-Centric Redesign · Step 2/8

Closes #85. Coarse scan-state abstraction that lets `ContentView` decide **"generic intro + floating Scan"** vs. **"section's own detail UI"** without knowing each view model's bespoke `Phase` enum. **No UI, no view model touched, no conformances** — those land in Step 3 (per the global `CLAUDE.md` no-rewrite rule, view models will satisfy this via extensions later).

### What changed
- **`ScanPresentation`** (new file `VaderCleaner/ScanCoordinating.swift`) — `Equatable` enum, `.intro / .working / .results`:
  - `.intro` → generic `SectionIntroView` + floating Scan button
  - `.working` → the section's scan/load is in progress
  - `.results` → the section's own detail UI renders; results / preview / done / failed / needs-install **all collapse onto this one case** (the detail view's internal switch handles the specifics)
- **`ScanCoordinating`** — a **plain** `ObservableObject` protocol: `var scanPresentation: ScanPresentation { get }` + `func beginScan()`. **No associated types, no type erasure** — `ContentView` already holds each VM as its concrete type and calls these directly.
- `project.pbxproj` regenerated via `xcodegen` (sources are path-globbed; the `.xcodeproj` is tracked, so the **+8-line** regen diff is committed here, mirroring the Step 1 PR). `xcschememanagement.plist` orderHint churn is the same xcodegen artifact Step 1 carried.
- `todo.md` Prompt 29 checked off (same PR, matching Step 1's convention).

### Tests (TDD — written first, confirmed red on the missing symbols)
New `VaderCleanerTests/ScanCoordinatingTests.swift` (3 tests) with a private `FakeCoordinator` (`@Published var scanPresentation` + `beginScanCalled` flag):
- `test_scanPresentation_equatableDistinguishesAllCases` — each case equals itself; `.intro/.working/.results` mutually distinct.
- `test_beginScan_flipsTheFakesFlag` — `beginScan()` records that it ran.
- `test_presentationChange_isObservableViaObjectWillChange` — mutating `scanPresentation` publishes through `objectWillChange` (cancellable kept alive with `withExtendedLifetime`).

**Full unit suite green: 625 tests, 0 failures** (622 → 625, no regressions).

### Acceptance criteria
- [x] `ScanPresentation` enum with `.intro/.working/.results`, Equatable
- [x] `ScanCoordinating` is a plain `ObservableObject` protocol (no associated types)
- [x] No existing view model modified in this step
- [x] `ScanCoordinatingTests` pass; full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
