### PR TITLE
feat: conform 6 scannable view models to ScanCoordinating (#86)

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		09756E0B2E09D8BF521C1141 /* MalwareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7315AD5A081B0855C316F00F /* MalwareView.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B4A3928170F6E5D4C3B2A1 /* ScanCoordinatingConformanceTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
 		109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */; };
@@ -283,6 +284,7 @@
 		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
 		2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSection.swift; sourceTree = "<group>"; };
 		2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingTests.swift; sourceTree = "<group>"; };
+		C5B4A3928170F6E5D4C3B2A1 /* ScanCoordinatingConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingConformanceTests.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
@@ -679,6 +681,7 @@
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
 				2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */,
+				C5B4A3928170F6E5D4C3B2A1 /* ScanCoordinatingConformanceTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
@@ -898,6 +901,7 @@
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
 				102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* ScanCoordinatingConformanceTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -365,3 +365,28 @@ extension DiskScannerViewModel {
         })
     }
 }
+
+// MARK: - ScanCoordinating
+
+extension DiskScannerViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. `.ready`/`.error` both want the section's own detail UI
+    /// (the treemap or the error state), whose internal switch handles each.
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .scanning:
+            return .working
+        case .ready, .error:
+            return .results
+        }
+    }
+
+    func beginScan() {
+        // Space Lens needs a root URL its peers don't; the user's home
+        // directory is the default Space Lens root for the unified flow.
+        Task { await startScan(root: FileManager.default.homeDirectoryForCurrentUser) }
+    }
+}

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -315,6 +315,11 @@ extension LargeOldFilesViewModel: ScanCoordinating {
     }
 
     func beginScan() {
+        // `scan()` has no internal re-entrancy guard, so a double-tapped
+        // unified Scan button could race two concurrent disk walks whose
+        // `displayedFiles` writes interleave. Gate on the in-flight phase,
+        // mirroring `SmartScanViewModel.scan()`.
+        guard phase != .scanning else { return }
         Task { await scan() }
     }
 }

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -295,3 +295,26 @@ extension LargeOldFilesViewModel {
         return deleted
     }
 }
+
+// MARK: - ScanCoordinating
+
+extension LargeOldFilesViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. `.results`/`.empty`/`.failed` all want the section's own
+    /// detail UI, whose internal switch renders the specifics.
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .scanning:
+            return .working
+        case .results, .empty, .failed:
+            return .results
+        }
+    }
+
+    func beginScan() {
+        Task { await scan() }
+    }
+}

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -280,3 +280,27 @@ extension MalwareViewModel {
         )
     }
 }
+
+// MARK: - ScanCoordinating
+
+extension MalwareViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. `.needsInstall` maps to `.results` (not `.intro`) on
+    /// purpose: MalwareView renders its own ClamAV install onboarding for
+    /// that state rather than the generic SectionIntroView.
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .checkingClamAV, .updatingDatabase, .scanning, .removing:
+            return .working
+        case .needsInstall, .results, .clean, .done, .failed:
+            return .results
+        }
+    }
+
+    func beginScan() {
+        Task { await scan() }
+    }
+}

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -310,3 +310,31 @@ extension OptimizationViewModel {
         )
     }
 }
+
+// MARK: - ScanCoordinating
+
+extension OptimizationViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. Optimization has no idle-triggered scan — `.ready` is the
+    /// loaded review surface and `.working`/`.failed` are action outcomes —
+    /// so all three collapse to `.results`, the section's own detail UI.
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .loading:
+            return .working
+        case .ready, .working, .failed:
+            return .results
+        }
+    }
+
+    func beginScan() {
+        // Semantic stretch: Optimization has no scan. "Scan" here means
+        // "load" — the same `refresh()` the view runs on appear, which
+        // populates login items / agents / memory and drives
+        // `.idle → .loading → .ready`.
+        Task { await refresh() }
+    }
+}

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -335,6 +335,11 @@ extension OptimizationViewModel: ScanCoordinating {
         // "load" — the same `refresh()` the view runs on appear, which
         // populates login items / agents / memory and drives
         // `.idle → .loading → .ready`.
+        //
+        // `refresh()`'s generation token prevents stale writes but not
+        // redundant work, so skip kicking off another load while one (or
+        // an action in `.working`) is already in flight.
+        guard phase != .loading, phase != .working else { return }
         Task { await refresh() }
     }
 }

--- a/VaderCleaner/ScanCoordinating.swift
+++ b/VaderCleaner/ScanCoordinating.swift
@@ -25,6 +25,12 @@ enum ScanPresentation: Equatable {
 /// no type erasure. ContentView already holds every view model as its
 /// concrete type, so it reads `scanPresentation` and calls `beginScan()`
 /// directly.
+///
+/// `@MainActor`-isolated because every conformer is a `@MainActor` view model
+/// and the only consumer is SwiftUI (also main-actor). Without this the
+/// main-actor witnesses can't satisfy a nonisolated requirement, which the
+/// compiler flags as a potential data race.
+@MainActor
 protocol ScanCoordinating: ObservableObject {
     /// The coarse phase ContentView switches on.
     var scanPresentation: ScanPresentation { get }

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -232,3 +232,26 @@ extension SmartScanViewModel {
         )
     }
 }
+
+// MARK: - ScanCoordinating
+
+extension SmartScanViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. `.results`/`.cleaning`/`.done`/`.failed` all want the
+    /// section's own detail UI, whose internal switch renders the specifics.
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .scanning:
+            return .working
+        case .results, .cleaning, .done, .failed:
+            return .results
+        }
+    }
+
+    func beginScan() {
+        Task { await scan() }
+    }
+}

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -217,6 +217,11 @@ extension SystemJunkViewModel: ScanCoordinating {
     }
 
     func beginScan() {
+        // `scan()` has no internal re-entrancy guard, so a double-tapped
+        // unified Scan button could race two concurrent disk walks whose
+        // `latestResult` / `checkedCategories` writes interleave. Gate on
+        // the in-flight phases, mirroring `SmartScanViewModel.scan()`.
+        guard phase != .scanning, phase != .cleaning else { return }
         Task { await scan() }
     }
 }

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -196,3 +196,27 @@ extension SystemJunkViewModel {
         )
     }
 }
+
+// MARK: - ScanCoordinating
+
+extension SystemJunkViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. `.scanning`/`.cleaning` are both "work in flight";
+    /// `.preview`/`.complete`/`.failed` all want the section's own detail UI,
+    /// whose internal switch renders the specifics.
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .scanning, .cleaning:
+            return .working
+        case .preview, .complete, .failed:
+            return .results
+        }
+    }
+
+    func beginScan() {
+        Task { await scan() }
+    }
+}

--- a/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
+++ b/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
@@ -71,6 +71,15 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
 
     private struct Boom: Error {}
 
+    /// Counts how many times an injected entrypoint closure ran. A
+    /// `@MainActor` reference type (not a captured `var`) so the increment
+    /// stays warning-free under the VMs' main-actor isolation.
+    @MainActor
+    private final class CallCounter {
+        private(set) var count = 0
+        func bump() { count += 1 }
+    }
+
     // MARK: - SmartScanViewModel
     // Mapping: .idle→.intro; .scanning→.working; .results/.cleaning/.done/.failed→.results.
 
@@ -211,6 +220,26 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
         XCTAssertNotEqual(vm.scanPresentation, .intro)
     }
 
+    func test_systemJunk_beginScanIgnoresReentrantCallWhileScanning() async {
+        let gate = ScanGate()
+        let counter = CallCounter()
+        let vm = makeSystemJunk(scanner: {
+            counter.bump()
+            await gate.wait()
+            return ScanResult(items: [])
+        })
+
+        vm.beginScan()
+        await yieldUntil({ vm.phase == .scanning }, ".scanning")
+        vm.beginScan() // re-entrant while scanning: must be a no-op
+        await yieldUntil({ counter.count >= 1 }, "scanner invoked")
+        XCTAssertEqual(counter.count, 1)
+
+        gate.open()
+        await yieldUntil({ vm.phase != .scanning }, "scan settles")
+        XCTAssertEqual(counter.count, 1, "re-entrant beginScan must not start a second scan")
+    }
+
     // MARK: - LargeOldFilesViewModel
     // Mapping: .idle→.intro; .scanning→.working; .results/.empty/.failed→.results.
 
@@ -259,6 +288,26 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
         vm.beginScan()
         await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
         XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    func test_largeOldFiles_beginScanIgnoresReentrantCallWhileScanning() async {
+        let gate = ScanGate()
+        let counter = CallCounter()
+        let vm = makeLargeOldFiles(scanner: {
+            counter.bump()
+            await gate.wait()
+            return []
+        })
+
+        vm.beginScan()
+        await yieldUntil({ vm.phase == .scanning }, ".scanning")
+        vm.beginScan() // re-entrant while scanning: must be a no-op
+        await yieldUntil({ counter.count >= 1 }, "scanner invoked")
+        XCTAssertEqual(counter.count, 1)
+
+        gate.open()
+        await yieldUntil({ vm.phase != .scanning }, "scan settles")
+        XCTAssertEqual(counter.count, 1, "re-entrant beginScan must not start a second scan")
     }
 
     // MARK: - DiskScannerViewModel (Space Lens)
@@ -504,6 +553,26 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
         vm.beginScan()
         await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
         XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    func test_optimization_beginScanIgnoresReentrantCallWhileLoading() async {
+        let gate = ScanGate()
+        let counter = CallCounter()
+        let vm = makeOptimization(loadLoginItems: {
+            counter.bump()
+            await gate.wait()
+            return []
+        })
+
+        vm.beginScan()
+        await yieldUntil({ vm.phase == .loading }, ".loading")
+        vm.beginScan() // re-entrant while loading: must be a no-op
+        await yieldUntil({ counter.count >= 1 }, "loader invoked")
+        XCTAssertEqual(counter.count, 1)
+
+        gate.open()
+        await yieldUntil({ vm.phase != .loading }, "load settles")
+        XCTAssertEqual(counter.count, 1, "re-entrant beginScan must not start a second load")
     }
 
     // MARK: - Construction helpers

--- a/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
+++ b/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
@@ -1,0 +1,590 @@
+// ScanCoordinatingConformanceTests.swift
+// Pins the full Phase→ScanPresentation mapping (every rich case) and the beginScan() entrypoint for all six scannable view models conforming to ScanCoordinating.
+
+import XCTest
+import Combine
+@testable import VaderCleaner
+
+/// Each scannable view model keeps its own rich `Phase` enum; this suite
+/// verifies the coarse `ScanPresentation` projection ContentView relies on for
+/// *every* phase the spec calls out (transient ones caught by freezing an
+/// injected closure mid-flight), plus that `beginScan()` always pulls a
+/// freshly-constructed (`.idle`) view model out of `.intro`.
+@MainActor
+final class ScanCoordinatingConformanceTests: XCTestCase {
+
+    // MARK: - Test infrastructure
+
+    /// Freezes an injected scan/load/clean closure mid-flight so a test can
+    /// observe a transient projection. The closure `await`s `wait()`; because
+    /// every view model is `@MainActor` the suspension yields the main actor
+    /// back to the test, which polls for the expected phase, then calls
+    /// `open()` to let the closure (and the operation) finish. `opened` makes
+    /// the `wait()`-then-`open()` and `open()`-then-`wait()` orders both safe.
+    @MainActor
+    private final class ScanGate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var opened = false
+
+        func wait() async {
+            if opened { return }
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func open() {
+            opened = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    /// Polls `predicate` between `Task.yield()`s until it holds, failing the
+    /// test if it never does. Used instead of a fixed sleep because the phase
+    /// hop we are waiting on is an in-memory main-actor write, not wall-clock
+    /// work — yielding lets the operation's task advance with no arbitrary
+    /// delay.
+    private func yieldUntil(
+        _ predicate: () -> Bool,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0..<2000 {
+            if predicate() { return }
+            await Task.yield()
+        }
+        XCTFail("Timed out waiting for: \(message)", file: file, line: line)
+    }
+
+    private func makeFile(
+        name: String,
+        category: ScanCategory = .userCache
+    ) -> ScannedFile {
+        ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/scan-coordinating/\(name)"),
+            size: 100,
+            lastAccessDate: nil,
+            lastModifiedDate: nil,
+            category: category
+        )
+    }
+
+    private struct Boom: Error {}
+
+    // MARK: - SmartScanViewModel
+    // Mapping: .idle→.intro; .scanning→.working; .results/.cleaning/.done/.failed→.results.
+
+    func test_smartScan_idleMapsToIntro() {
+        XCTAssertEqual(makeSmartScan().scanPresentation, .intro)
+    }
+
+    func test_smartScan_scanningMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeSmartScan(junkScanner: {
+            await gate.wait()
+            return ScanResult(items: [])
+        })
+
+        let task = Task { await vm.scan() }
+        await yieldUntil({ vm.scanPresentation == .working }, ".scanning → .working")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_smartScan_resultsMapsToResults() async {
+        let vm = makeSmartScan()
+        await vm.scan()
+        if case .results = vm.phase {} else { XCTFail("expected .results, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_smartScan_cleaningMapsToResults() async {
+        let gate = ScanGate()
+        let vm = makeSmartScan(junkCleaner: { _ in
+            await gate.wait()
+            return 0
+        })
+        await vm.scan() // → .results, the only phase clean() acts from.
+
+        let task = Task { await vm.clean() }
+        await yieldUntil({ vm.phase == .cleaning }, ".cleaning")
+        XCTAssertEqual(vm.scanPresentation, .results)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_smartScan_doneMapsToResults() async {
+        let vm = makeSmartScan()
+        await vm.scan()
+        await vm.clean()
+        if case .done = vm.phase {} else { XCTFail("expected .done, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_smartScan_failedMapsToResults() async {
+        let vm = makeSmartScan(junkScanner: { throw Boom() })
+        await vm.scan()
+        if case .failed = vm.phase {} else { XCTFail("expected .failed, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_smartScan_beginScanLeavesIntro() async {
+        let vm = makeSmartScan()
+        vm.beginScan()
+        await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
+        XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - SystemJunkViewModel
+    // Mapping: .idle→.intro; .scanning/.cleaning→.working; .preview/.complete/.failed→.results.
+
+    func test_systemJunk_idleMapsToIntro() {
+        XCTAssertEqual(makeSystemJunk().scanPresentation, .intro)
+    }
+
+    func test_systemJunk_scanningMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeSystemJunk(scanner: {
+            await gate.wait()
+            return ScanResult(items: [])
+        })
+
+        let task = Task { await vm.scan() }
+        await yieldUntil({ vm.phase == .scanning }, ".scanning")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_systemJunk_previewMapsToResults() async {
+        let vm = makeSystemJunk(scanner: { ScanResult(items: [self.makeFile(name: "a")]) })
+        await vm.scan()
+        if case .preview = vm.phase {} else { XCTFail("expected .preview, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_systemJunk_cleaningMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeSystemJunk(
+            scanner: { ScanResult(items: [self.makeFile(name: "a")]) },
+            deleter: { _ in
+                await gate.wait()
+                return 100
+            }
+        )
+        await vm.scan() // → .preview with one checked category, so clean() runs.
+
+        let task = Task { await vm.clean() }
+        await yieldUntil({ vm.phase == .cleaning }, ".cleaning")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_systemJunk_completeMapsToResults() async {
+        let vm = makeSystemJunk(
+            scanner: { ScanResult(items: [self.makeFile(name: "a")]) },
+            deleter: { _ in 100 }
+        )
+        await vm.scan()
+        await vm.clean()
+        if case .complete = vm.phase {} else { XCTFail("expected .complete, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_systemJunk_failedMapsToResults() async {
+        let vm = makeSystemJunk(scanner: { throw Boom() })
+        await vm.scan()
+        if case .failed = vm.phase {} else { XCTFail("expected .failed, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_systemJunk_beginScanLeavesIntro() async {
+        let vm = makeSystemJunk()
+        vm.beginScan()
+        await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
+        XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - LargeOldFilesViewModel
+    // Mapping: .idle→.intro; .scanning→.working; .results/.empty/.failed→.results.
+
+    func test_largeOldFiles_idleMapsToIntro() {
+        XCTAssertEqual(makeLargeOldFiles().scanPresentation, .intro)
+    }
+
+    func test_largeOldFiles_scanningMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeLargeOldFiles(scanner: {
+            await gate.wait()
+            return []
+        })
+
+        let task = Task { await vm.scan() }
+        await yieldUntil({ vm.phase == .scanning }, ".scanning")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_largeOldFiles_resultsMapsToResults() async {
+        let vm = makeLargeOldFiles(scanner: { [self.makeFile(name: "big", category: .largeFile)] })
+        await vm.scan()
+        if case .results = vm.phase {} else { XCTFail("expected .results, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_largeOldFiles_emptyMapsToResults() async {
+        let vm = makeLargeOldFiles(scanner: { [] })
+        await vm.scan()
+        XCTAssertEqual(vm.phase, .empty)
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_largeOldFiles_failedMapsToResults() async {
+        let vm = makeLargeOldFiles(scanner: { throw Boom() })
+        await vm.scan()
+        if case .failed = vm.phase {} else { XCTFail("expected .failed, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_largeOldFiles_beginScanLeavesIntro() async {
+        let vm = makeLargeOldFiles()
+        vm.beginScan()
+        await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
+        XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - DiskScannerViewModel (Space Lens)
+    // Mapping: .idle→.intro; .scanning→.working; .ready/.error→.results.
+
+    private func diskNode() -> DiskNode {
+        DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root"),
+            name: "root",
+            size: 1,
+            isDirectory: true,
+            children: []
+        )
+    }
+
+    func test_diskScanner_idleMapsToIntro() {
+        let vm = DiskScannerViewModel(scanner: { _, _ in self.diskNode() })
+        XCTAssertEqual(vm.scanPresentation, .intro)
+    }
+
+    func test_diskScanner_scanningMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = DiskScannerViewModel(scanner: { _, _ in
+            await gate.wait()
+            return self.diskNode()
+        })
+
+        let task = Task {
+            await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+        }
+        await yieldUntil({ vm.phase == .scanning }, ".scanning")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_diskScanner_readyMapsToResults() async {
+        let node = diskNode()
+        let vm = DiskScannerViewModel(scanner: { _, _ in node })
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+        XCTAssertEqual(vm.phase, .ready(node))
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_diskScanner_errorMapsToResults() async {
+        struct ScanFailure: LocalizedError { var errorDescription: String? { "boom" } }
+        let vm = DiskScannerViewModel(scanner: { _, _ in throw ScanFailure() })
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+        XCTAssertEqual(vm.phase, .error("boom"))
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_diskScanner_beginScanLeavesIntro() async {
+        // `beginScan()` defaults the root to the user's home directory; the
+        // injected scanner short-circuits the walk so no real disk is read.
+        let vm = DiskScannerViewModel(scanner: { _, _ in self.diskNode() })
+        vm.beginScan()
+        await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
+        XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - MalwareViewModel
+    // Mapping: .idle→.intro; .checkingClamAV/.updatingDatabase/.scanning/.removing→.working;
+    //          .needsInstall/.results/.clean/.done/.failed→.results.
+
+    private let threat = MalwareThreat(
+        filePath: URL(fileURLWithPath: "/Users/me/Downloads/evil.bin"),
+        threatName: "Eicar-Test-Signature"
+    )
+
+    func test_malware_idleMapsToIntro() {
+        XCTAssertEqual(makeMalware().scanPresentation, .intro)
+    }
+
+    /// `.checkingClamAV` is set and left within a single synchronous run
+    /// (`checkInstalled` is a sync closure and nothing suspends before the
+    /// phase advances), so it is not transiently observable through any
+    /// injected seam without modifying VM logic. Its `.working` mapping is
+    /// instead guaranteed at compile time by the extension's exhaustive,
+    /// `default`-free switch and is identical to the other `.working` cases
+    /// exercised below.
+    func test_malware_updatingDatabaseMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeMalware(
+            checkInstalled: { true },
+            databaseLastUpdated: { nil }, // nil ⇒ stale ⇒ the .updatingDatabase path
+            updateDatabase: { _ in await gate.wait() }
+        )
+
+        let task = Task { await vm.scan() }
+        await yieldUntil({
+            if case .updatingDatabase = vm.phase { return true } else { return false }
+        }, ".updatingDatabase")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_malware_scanningMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeMalware(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _ in
+                await gate.wait()
+                return []
+            }
+        )
+
+        let task = Task { await vm.scan() }
+        await yieldUntil({
+            if case .scanning = vm.phase { return true } else { return false }
+        }, ".scanning")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_malware_removingMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeMalware(
+            scan: { _ in [self.threat] },
+            removeThreats: { _ in
+                await gate.wait()
+                return [] // no failures ⇒ .done
+            }
+        )
+        await vm.scan() // → .results([threat])
+
+        let task = Task { await vm.removeThreats() }
+        await yieldUntil({ vm.phase == .removing }, ".removing")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_malware_needsInstallMapsToResults() async {
+        // Maps to `.results` (not `.intro`) on purpose: MalwareView renders
+        // its own ClamAV install onboarding for this state.
+        let vm = makeMalware(checkInstalled: { false })
+        await vm.scan()
+        XCTAssertEqual(vm.phase, .needsInstall)
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_malware_resultsMapsToResults() async {
+        let vm = makeMalware(scan: { _ in [self.threat] })
+        await vm.scan()
+        if case .results = vm.phase {} else { XCTFail("expected .results, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_malware_cleanMapsToResults() async {
+        let vm = makeMalware(scan: { _ in [] })
+        await vm.scan()
+        XCTAssertEqual(vm.phase, .clean)
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_malware_doneMapsToResults() async {
+        let vm = makeMalware(scan: { _ in [self.threat] }, removeThreats: { _ in [] })
+        await vm.scan()
+        await vm.removeThreats()
+        if case .done = vm.phase {} else { XCTFail("expected .done, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_malware_failedMapsToResults() async {
+        let vm = makeMalware(
+            databaseLastUpdated: { Date() },
+            scan: { _ in throw Boom() }
+        )
+        await vm.scan()
+        if case .failed = vm.phase {} else { XCTFail("expected .failed, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_malware_beginScanLeavesIntro() async {
+        let vm = makeMalware(checkInstalled: { true }, databaseLastUpdated: { Date() })
+        vm.beginScan()
+        await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
+        XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - OptimizationViewModel
+    // Mapping: .idle→.intro; .loading→.working; .ready/.working/.failed→.results.
+
+    func test_optimization_idleMapsToIntro() {
+        XCTAssertEqual(makeOptimization().scanPresentation, .intro)
+    }
+
+    func test_optimization_loadingMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makeOptimization(loadLoginItems: {
+            await gate.wait()
+            return []
+        })
+
+        let task = Task { await vm.refresh() }
+        await yieldUntil({ vm.phase == .loading }, ".loading")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_optimization_readyMapsToResults() async {
+        let vm = makeOptimization()
+        await vm.refresh()
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    /// `Phase.working` (an in-progress *action*, e.g. a RAM flush) projects to
+    /// `ScanPresentation.results`, not `.working` — the name collision is the
+    /// whole reason this case is pinned: the section's own detail UI stays on
+    /// screen for action progress rather than reverting to the generic intro.
+    func test_optimization_workingPhaseMapsToResults() async {
+        let gate = ScanGate()
+        let vm = makeOptimization(flushRAM: { await gate.wait() })
+
+        let task = Task { await vm.flushRAM() }
+        await yieldUntil({ vm.phase == .working }, "Phase.working")
+        XCTAssertEqual(vm.scanPresentation, .results)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_optimization_failedMapsToResults() async {
+        let vm = makeOptimization(flushRAM: { throw Boom() })
+        await vm.flushRAM()
+        if case .failed = vm.phase {} else { XCTFail("expected .failed, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_optimization_beginScanLeavesIntro() async {
+        let vm = makeOptimization()
+        vm.beginScan()
+        await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
+        XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - Construction helpers
+    //
+    // One per view model, mirroring the defaults each VM's own
+    // *ViewModelTests use so a test only overrides the closure it exercises.
+
+    private func makeSmartScan(
+        junkScanner: @escaping SmartScanViewModel.JunkScanner = { ScanResult(items: []) },
+        malwareInstalled: @escaping SmartScanViewModel.MalwareInstalled = { true },
+        malwareScanner: @escaping SmartScanViewModel.MalwareScanner = { [] },
+        loginItemsLoader: @escaping SmartScanViewModel.LoginItemsLoader = { [] },
+        junkCleaner: @escaping SmartScanViewModel.JunkCleaner = { _ in 0 },
+        threatRemover: @escaping SmartScanViewModel.ThreatRemover = { _ in [] }
+    ) -> SmartScanViewModel {
+        SmartScanViewModel(
+            junkScanner: junkScanner,
+            malwareInstalled: malwareInstalled,
+            malwareScanner: malwareScanner,
+            loginItemsLoader: loginItemsLoader,
+            junkCleaner: junkCleaner,
+            threatRemover: threatRemover
+        )
+    }
+
+    private func makeSystemJunk(
+        scanner: @escaping SystemJunkViewModel.Scanner = { ScanResult(items: []) },
+        deleter: @escaping SystemJunkViewModel.Deleter = { _ in 0 }
+    ) -> SystemJunkViewModel {
+        SystemJunkViewModel(scanner: scanner, deleter: deleter)
+    }
+
+    private func makeLargeOldFiles(
+        scanner: @escaping () async throws -> [ScannedFile] = { [] },
+        deleter: @escaping ([URL]) async -> Set<URL> = { Set($0) }
+    ) -> LargeOldFilesViewModel {
+        LargeOldFilesViewModel(scanner: scanner, deleter: deleter)
+    }
+
+    private func makeMalware(
+        checkInstalled: @escaping MalwareViewModel.CheckInstalled = { true },
+        databaseLastUpdated: @escaping MalwareViewModel.DatabaseLastUpdated = { Date() },
+        updateDatabase: @escaping MalwareViewModel.UpdateDatabase = { _ in },
+        scan: @escaping MalwareViewModel.Scan = { _ in [] },
+        removeThreats: @escaping MalwareViewModel.RemoveThreats = { _ in [] },
+        notify: @escaping MalwareViewModel.Notify = { _ in },
+        shouldNotify: @escaping MalwareViewModel.ShouldNotify = { true }
+    ) -> MalwareViewModel {
+        MalwareViewModel(
+            checkInstalled: checkInstalled,
+            databaseLastUpdated: databaseLastUpdated,
+            updateDatabase: updateDatabase,
+            scan: scan,
+            removeThreats: removeThreats,
+            notify: notify,
+            shouldNotify: shouldNotify
+        )
+    }
+
+    private func makeOptimization(
+        loadLoginItems: @escaping OptimizationViewModel.LoadLoginItems = { [] },
+        loadUserAgents: @escaping OptimizationViewModel.LoadAgents = { [] },
+        loadSystemAgents: @escaping OptimizationViewModel.LoadAgents = { [] },
+        readMemory: @escaping OptimizationViewModel.ReadMemory = { .empty },
+        setLoginItemEnabled: @escaping OptimizationViewModel.SetLoginItemEnabled = { _, _ in },
+        disableAgent: @escaping OptimizationViewModel.DisableAgent = { _ in },
+        removeAgent: @escaping OptimizationViewModel.RemoveAgent = { _ in },
+        flushRAM: @escaping OptimizationViewModel.FlushRAM = {},
+        runMaintenance: @escaping OptimizationViewModel.RunMaintenance = { "" }
+    ) -> OptimizationViewModel {
+        OptimizationViewModel(
+            loadLoginItems: loadLoginItems,
+            loadUserAgents: loadUserAgents,
+            loadSystemAgents: loadSystemAgents,
+            readMemory: readMemory,
+            setLoginItemEnabled: setLoginItemEnabled,
+            disableAgent: disableAgent,
+            removeAgent: removeAgent,
+            flushRAM: flushRAM,
+            runMaintenance: runMaintenance,
+            launchAtLoginChanges: nil
+        )
+    }
+}

--- a/VaderCleanerTests/ScanCoordinatingTests.swift
+++ b/VaderCleanerTests/ScanCoordinatingTests.swift
@@ -5,6 +5,7 @@ import XCTest
 import Combine
 @testable import VaderCleaner
 
+@MainActor
 final class ScanCoordinatingTests: XCTestCase {
 
     /// Minimal stand-in for the real scannable view models (which conform in a

--- a/todo.md
+++ b/todo.md
@@ -56,7 +56,7 @@
 
 - [x] **Prompt 28** — Step 1/8: SectionPresentation model + `isScannable` ([#84](https://github.com/jayvicsanantonio/VaderCleaner/issues/84))
 - [x] **Prompt 29** — Step 2/8: ScanPresentation enum + ScanCoordinating protocol ([#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85))
-- [ ] **Prompt 30** — Step 3/8: Conform the 6 scannable view models (extensions) ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
+- [x] **Prompt 30** — Step 3/8: Conform the 6 scannable view models (extensions) ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
 - [ ] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
 - [ ] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
 - [ ] **Prompt 33** — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))


### PR DESCRIPTION
Closes #86. Scan-Centric Redesign **Step 3/8** — builds on #84/#85.

## What

Conforms the six scannable view models to `ScanCoordinating` **via extensions only** (each appended to its own VM file). No existing VM method, logic, or `Phase` enum is modified — the diff is purely additive (**748 insertions, 0 deletions**).

| VM | `.intro` | `.working` | `.results` | `beginScan()` |
|---|---|---|---|---|
| SmartScanViewModel | `.idle` | `.scanning` | `.results/.cleaning/.done/.failed` | `Task { await scan() }` |
| SystemJunkViewModel | `.idle` | `.scanning/.cleaning` | `.preview/.complete/.failed` | `Task { await scan() }` |
| LargeOldFilesViewModel | `.idle` | `.scanning` | `.results/.empty/.failed` | `Task { await scan() }` |
| DiskScannerViewModel | `.idle` | `.scanning` | `.ready/.error` | `Task { await startScan(root: home) }` |
| MalwareViewModel | `.idle` | `.checkingClamAV/.updatingDatabase/.scanning/.removing` | `.needsInstall/.results/.clean/.done/.failed` | `Task { await scan() }` |
| OptimizationViewModel | `.idle` | `.loading` | `.ready/.working/.failed` | `Task { await refresh() }` |

Each switch is exhaustive with **no `default:`** so a future `Phase` case fails to compile rather than silently mis-mapping. Two semantic stretches are commented in code: Space Lens defaults its root to `homeDirectoryForCurrentUser`; Optimization's "scan" is really `refresh()`/load.

## ⚠️ Divergence from the posted plan — please audit

The plan comment on #86 said the change would be confined to extensions + one new test file. In practice it **also touched `ScanCoordinating.swift` and `ScanCoordinatingTests.swift`** (from #85):

- A `@MainActor` view model witnessing a *non-isolated* `ScanCoordinating` requirement emits a "conformance crosses into main actor-isolated code … data race" warning (a hard error in Swift 6 mode). Per-extension `MainActor.assumeIsolated` workarounds (×6, no precedent in this repo) were rejected in favour of the **root-cause fix**: marking the protocol `@MainActor`. Every conformer is already `@MainActor` and the only consumer is SwiftUI (also main-actor), so this is the semantically correct isolation.
- This still satisfies #85's stated contract — *"plain `ObservableObject` protocol (no associated types)"*: `@MainActor` is an isolation attribute, not an associated type or type erasure, and ContentView still calls members directly on concrete types.
- `ScanCoordinatingTests` is annotated `@MainActor` so its non-isolated `FakeCoordinator` usage stays warning-free.

## Tests

`ScanCoordinatingConformanceTests` (41 tests) drives all six VMs through **every reachable `Phase` case** and asserts the coarse projection at each. Transient phases (`.scanning`, `.cleaning`, `.removing`, `.updatingDatabase`, Optimization `Phase.working`) are caught by freezing an injected closure on an async gate. `beginScan()` is asserted to leave `.intro` for every VM.

- Malware `.checkingClamAV` is set and left within a single synchronous run (no injected async seam suspends there), so it cannot be observed transiently without modifying VM logic. Its `.working` mapping is guaranteed by the exhaustive default-free switch and documented in the test.
- Optimization `Phase.working` → `ScanPresentation.results` is explicitly pinned (the name collision is intentional: action progress keeps the detail UI, not the generic intro).

**Full unit suite green: 666 tests, 0 failures.** Build is clean — zero new compiler warnings for the conformance.

> Note: the full scheme run also surfaced a pre-existing, unrelated XCUITest flake (`SystemJunkUITests.test_systemJunkPreviewPersistsAcrossSidebarNavigation` — `Unable to find hit point for ScrollView` at off-screen `x=-1476`, a window-placement issue). It **passes in isolation** (verified) and is untouched by this change (no UI is wired to `ScanCoordinating` until Step 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)