### PR TITLE
feat: extract reusable FloatingScanButton (#87)

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		11C7DA0D7ECDCBF7DFB3C829 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 329FBD86F55918272AF0EF2A /* Localizable.stringsdict */; };
 		12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17B889E32D6334AED35F2BE /* LaunchAgent.swift */; };
 		1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732FA87F80DF686871220B50 /* SectionPresentationTests.swift */; };
+		FB2C7C1E2D3F4A5B6C7D8E92 /* FloatingScanButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */; };
 		13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */; };
 		1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */; };
 		159F0D7D84A23B27058835D6 /* BrowserDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */; };
@@ -121,6 +122,7 @@
 		85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */; };
 		892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */; };
 		89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */; };
+		FB0A7C1E2D3F4A5B6C7D8E90 /* FloatingScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
@@ -287,6 +289,7 @@
 		C5B4A3928170F6E5D4C3B2A1 /* ScanCoordinatingConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingConformanceTests.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
+		FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButton.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
@@ -343,6 +346,7 @@
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
 		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
+		FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButtonTests.swift; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
@@ -520,6 +524,7 @@
 				F421495C84A41EDEF253EBD6 /* FileCategory.swift */,
 				6090134A72001DE6262436F3 /* FileIconCache.swift */,
 				BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */,
+				FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */,
 				5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */,
 				AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */,
 				FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */,
@@ -650,6 +655,7 @@
 				BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */,
 				A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */,
 				6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */,
+				FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */,
 				166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */,
 				E776BF468380DFF621C6063C /* HelperConnectionErrorTests.swift */,
 				0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */,
@@ -904,6 +910,7 @@
 				A1B2C3D4E5F60718293A4B5C /* ScanCoordinatingConformanceTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
+				FB2C7C1E2D3F4A5B6C7D8E92 /* FloatingScanButtonTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
 				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,
 				6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */,
@@ -1031,6 +1038,7 @@
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */,
+				FB0A7C1E2D3F4A5B6C7D8E90 /* FloatingScanButton.swift in Sources */,
 				FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */,
 				9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */,
 				E357AD8EDB1FA65E6D5EB59E /* SmartScanViewSubviews.swift in Sources */,

--- a/VaderCleaner/FloatingScanButton.swift
+++ b/VaderCleaner/FloatingScanButton.swift
@@ -1,0 +1,58 @@
+// FloatingScanButton.swift
+// The reusable hero call-to-action: a large floating interactive-glass disc with a breathing glow and press feedback, tinted by an accent (crimson by default).
+
+import SwiftUI
+
+/// The hero / dashboard call to action — an interactive-glass disc echoing the
+/// reference's circular button. Interactive glass gives it the system
+/// press-scale and shimmer; the `accent` tint marks it as the primary action
+/// (crimson by default, so unspecified call sites stay on the Vader palette).
+/// Shared across sections so every "Scan"/"Clean" CTA stays visually identical.
+struct FloatingScanButton: View {
+    let title: String
+    var accent: Color = .vaderCrimson
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    @State private var hovering = false
+    @State private var pulsing = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 108, height: 108)
+        }
+        .buttonStyle(PressableCircleButtonStyle())
+        .glassEffect(
+            .regular.tint(accent).interactive(),
+            in: .circle
+        )
+        // Ambient glow that breathes so the primary action keeps drawing the
+        // eye even when the rest of the screen is still.
+        .shadow(
+            color: accent.opacity(pulsing ? 0.65 : 0.4),
+            radius: pulsing ? 30 : 18,
+            y: 8
+        )
+        .scaleEffect(hovering ? 1.06 : 1.0)
+        .animation(.spring(response: 0.32, dampingFraction: 0.6), value: hovering)
+        .animation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true), value: pulsing)
+        .onHover { hovering = $0 }
+        .onAppear { pulsing = true }
+        .keyboardShortcut(.defaultAction)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
+/// Press feedback for the circular CTAs — a quick spring scale-down while
+/// pressed so the button feels physical rather than flat.
+private struct PressableCircleButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.93 : 1.0)
+            .animation(.spring(response: 0.25, dampingFraction: 0.55),
+                       value: configuration.isPressed)
+    }
+}

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -59,7 +59,7 @@ struct SmartScanIdleState: View {
 
             Spacer(minLength: 0)
 
-            CircularActionButton(
+            FloatingScanButton(
                 title: String(
                     localized: "Scan",
                     comment: "Primary button that starts the Smart Scan."
@@ -71,59 +71,6 @@ struct SmartScanIdleState: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
-    }
-}
-
-/// The hero / dashboard call to action — a crimson interactive-glass disc
-/// echoing the reference's circular button. Interactive glass gives it the
-/// system press-scale and shimmer; the crimson tint marks it as the primary
-/// action. Shared by the welcome screen ("Scan") and the results dashboard
-/// ("Clean") so the two CTAs stay visually identical.
-private struct CircularActionButton: View {
-    let title: String
-    let accessibilityIdentifier: String
-    let action: () -> Void
-
-    @State private var hovering = false
-    @State private var pulsing = false
-
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .font(.title3.weight(.semibold))
-                .foregroundStyle(.white)
-                .frame(width: 108, height: 108)
-        }
-        .buttonStyle(PressableCircleButtonStyle())
-        .glassEffect(
-            .regular.tint(Color.vaderCrimson).interactive(),
-            in: .circle
-        )
-        // Ambient glow that breathes so the primary action keeps drawing the
-        // eye even when the rest of the screen is still.
-        .shadow(
-            color: Color.vaderCrimson.opacity(pulsing ? 0.65 : 0.4),
-            radius: pulsing ? 30 : 18,
-            y: 8
-        )
-        .scaleEffect(hovering ? 1.06 : 1.0)
-        .animation(.spring(response: 0.32, dampingFraction: 0.6), value: hovering)
-        .animation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true), value: pulsing)
-        .onHover { hovering = $0 }
-        .onAppear { pulsing = true }
-        .keyboardShortcut(.defaultAction)
-        .accessibilityIdentifier(accessibilityIdentifier)
-    }
-}
-
-/// Press feedback for the circular CTAs — a quick spring scale-down while
-/// pressed so the button feels physical rather than flat.
-private struct PressableCircleButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .scaleEffect(configuration.isPressed ? 0.93 : 1.0)
-            .animation(.spring(response: 0.25, dampingFraction: 0.55),
-                       value: configuration.isPressed)
     }
 }
 
@@ -329,7 +276,7 @@ struct SmartScanResultsState: View {
             .onAppear { appeared = true }
 
             if hasCleanableWork {
-                CircularActionButton(
+                FloatingScanButton(
                     title: String(
                         localized: "Clean",
                         comment: "Circular button on the Smart Scan dashboard that cleans junk and removes threats."

--- a/VaderCleanerTests/FloatingScanButtonTests.swift
+++ b/VaderCleanerTests/FloatingScanButtonTests.swift
@@ -1,0 +1,80 @@
+// FloatingScanButtonTests.swift
+// Pins the reusable FloatingScanButton contract: stored title/accent/accessibility identifier and that triggering it invokes the supplied action.
+
+import XCTest
+import SwiftUI
+@testable import VaderCleaner
+
+@MainActor
+final class FloatingScanButtonTests: XCTestCase {
+
+    func test_exposesPassedAccessibilityIdentifier() {
+        let button = FloatingScanButton(
+            title: "Scan",
+            accessibilityIdentifier: "section.scan",
+            action: {}
+        )
+
+        XCTAssertEqual(
+            button.accessibilityIdentifier,
+            "section.scan",
+            "FloatingScanButton must surface the accessibility identifier it was given"
+        )
+    }
+
+    func test_storesPassedTitle() {
+        let button = FloatingScanButton(
+            title: "Clean",
+            accessibilityIdentifier: "section.clean",
+            action: {}
+        )
+
+        XCTAssertEqual(button.title, "Clean")
+    }
+
+    func test_invokesActionOnTrigger() {
+        var fired = false
+        let button = FloatingScanButton(
+            title: "Scan",
+            accessibilityIdentifier: "section.scan",
+            action: { fired = true }
+        )
+
+        XCTAssertFalse(fired, "Action must not fire on construction")
+
+        button.action()
+
+        XCTAssertTrue(fired, "Triggering the button must invoke the supplied action")
+    }
+
+    func test_defaultAccentIsVaderCrimson() {
+        // The default keeps existing SmartScan call sites visually unchanged
+        // after the extraction — they pass no accent and must stay crimson.
+        let button = FloatingScanButton(
+            title: "Scan",
+            accessibilityIdentifier: "section.scan",
+            action: {}
+        )
+
+        XCTAssertEqual(
+            button.accent,
+            .vaderCrimson,
+            "FloatingScanButton must default its tint to VaderTheme crimson"
+        )
+    }
+
+    func test_customAccentIsStored() {
+        let button = FloatingScanButton(
+            title: "Scan",
+            accent: .blue,
+            accessibilityIdentifier: "section.scan",
+            action: {}
+        )
+
+        XCTAssertEqual(
+            button.accent,
+            .blue,
+            "A caller-supplied accent must override the crimson default"
+        )
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -57,7 +57,7 @@
 - [x] **Prompt 28** — Step 1/8: SectionPresentation model + `isScannable` ([#84](https://github.com/jayvicsanantonio/VaderCleaner/issues/84))
 - [x] **Prompt 29** — Step 2/8: ScanPresentation enum + ScanCoordinating protocol ([#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85))
 - [x] **Prompt 30** — Step 3/8: Conform the 6 scannable view models (extensions) ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
-- [ ] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
+- [x] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
 - [ ] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
 - [ ] **Prompt 33** — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))
 - [ ] **Prompt 34** — Step 7/8: Retire per-section bespoke idle states ([#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90))


### PR DESCRIPTION
Closes #87 — Scan-Centric Redesign, **Step 4 of 8**.

## What

Relocate the floating circular CTA out of `SmartScanViewSubviews.swift` into a reusable `VaderCleaner/FloatingScanButton.swift`, so later steps can drop the same disc into any scannable section's generic intro.

- `CircularActionButton` → generalized into `struct FloatingScanButton: View` with `title`, `accent: Color = .vaderCrimson`, `accessibilityIdentifier`, `action`.
- `PressableCircleButtonStyle` relocated alongside it, still `private`.
- **Relocate, not rewrite** (global CLAUDE.md rule): every modifier and magic number copied verbatim — 108×108 frame, shadow opacities 0.65/0.4, radii 30/18, `y: 8`, hover scale 1.06, spring 0.32/0.6, easeInOut 1.8 `repeatForever`, `.keyboardShortcut(.defaultAction)`. The only in-button change is `Color.vaderCrimson` → `accent` in the glass tint and the breathing shadow.
- SmartScan's two CTAs (idle **Scan**, results **Clean**) switched to `FloatingScanButton` with no `accent`, inheriting the crimson default → SmartScan renders and behaves identically.

## Tests

`VaderCleanerTests/FloatingScanButtonTests.swift` — the repo has no ViewInspector/hosting view-unit pattern, so per the issue this asserts the stored contract via a `@MainActor` harness: exposes the passed `accessibilityIdentifier`, stores `title`, default `accent == .vaderCrimson`, custom accent overrides the default, and invoking `action()` fires the closure. The real SwiftUI wiring stays covered end-to-end by the existing `SmartScanUITests` (`app.buttons["smartScan.scan"]`).

## Verification

- Full unit suite: **674 passed, 0 failures** (incl. 5 new `FloatingScanButtonTests`), no new warnings.
- `SmartScanUITests` green on the branch across repeated runs — no SmartScan visual or behavioral regression.

## Acceptance criteria

- [x] `FloatingScanButton` is a reusable component (title/accent/a11y id/action); old private structs relocated, not reimplemented.
- [x] SmartScan call sites updated; SmartScan looks and behaves identically (existing SmartScan UI tests still pass).
- [x] `FloatingScanButtonTests` pass; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned scan button with glass-morphism styling, animated pulsing glow, and hover scaling effects.
  * Added keyboard shortcut support for the scan action.
  * Customizable accent colors for the button.

* **Tests**
  * Added comprehensive test coverage for the new scan button component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->