### PR TITLE
feat: add reusable SectionIntroView (#88)

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17B889E32D6334AED35F2BE /* LaunchAgent.swift */; };
 		1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732FA87F80DF686871220B50 /* SectionPresentationTests.swift */; };
 		FB2C7C1E2D3F4A5B6C7D8E92 /* FloatingScanButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */; };
+		FB607C1E2D3F4A5B6C7D8E96 /* SectionIntroViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB717C1E2D3F4A5B6C7D8E97 /* SectionIntroViewTests.swift */; };
 		13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */; };
 		1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */; };
 		159F0D7D84A23B27058835D6 /* BrowserDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */; };
@@ -123,6 +124,7 @@
 		892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */; };
 		89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */; };
 		FB0A7C1E2D3F4A5B6C7D8E90 /* FloatingScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */; };
+		FB4E7C1E2D3F4A5B6C7D8E94 /* SectionIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5F7C1E2D3F4A5B6C7D8E95 /* SectionIntroView.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
@@ -290,6 +292,7 @@
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
 		FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButton.swift; sourceTree = "<group>"; };
+		FB5F7C1E2D3F4A5B6C7D8E95 /* SectionIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroView.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
@@ -347,6 +350,7 @@
 		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
 		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
 		FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButtonTests.swift; sourceTree = "<group>"; };
+		FB717C1E2D3F4A5B6C7D8E97 /* SectionIntroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroViewTests.swift; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
@@ -525,6 +529,7 @@
 				6090134A72001DE6262436F3 /* FileIconCache.swift */,
 				BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */,
 				FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */,
+				FB5F7C1E2D3F4A5B6C7D8E95 /* SectionIntroView.swift */,
 				5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */,
 				AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */,
 				FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */,
@@ -656,6 +661,7 @@
 				A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */,
 				6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */,
 				FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */,
+				FB717C1E2D3F4A5B6C7D8E97 /* SectionIntroViewTests.swift */,
 				166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */,
 				E776BF468380DFF621C6063C /* HelperConnectionErrorTests.swift */,
 				0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */,
@@ -911,6 +917,7 @@
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				FB2C7C1E2D3F4A5B6C7D8E92 /* FloatingScanButtonTests.swift in Sources */,
+				FB607C1E2D3F4A5B6C7D8E96 /* SectionIntroViewTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
 				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,
 				6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */,
@@ -1039,6 +1046,7 @@
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */,
 				FB0A7C1E2D3F4A5B6C7D8E90 /* FloatingScanButton.swift in Sources */,
+				FB4E7C1E2D3F4A5B6C7D8E94 /* SectionIntroView.swift in Sources */,
 				FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */,
 				9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */,
 				E357AD8EDB1FA65E6D5EB59E /* SmartScanViewSubviews.swift in Sources */,

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -11,7 +11,12 @@ import SwiftUI
 /// the window edge.
 struct SectionIntroView: View {
     let presentation: SectionPresentation
-    let title: String
+    let section: NavigationSection
+
+    /// Localized section title for display. A computed accessor so the
+    /// rendered heading tracks the UI language while the identifiers below
+    /// stay fixed regardless of locale.
+    var title: String { section.title }
 
     // MARK: Accessibility identifiers
 
@@ -20,13 +25,12 @@ struct SectionIntroView: View {
     var rootAccessibilityIdentifier: String { "section.intro" }
 
     /// Per-section identifier so a test/automation can assert *which* section's
-    /// intro is on screen. Derived from the English `title` (the prompt's
-    /// "derive from title" option) — stable as long as the English titles are;
-    /// Step 6 call sites pass `NavigationSection.title`. Not localized on
-    /// purpose: an accessibility *identifier* must not move with the UI
-    /// language.
+    /// intro is on screen. Derived from the `NavigationSection` case name —
+    /// not the localized title — so the identifier is identical in every
+    /// locale. An accessibility *identifier* must not move with the UI
+    /// language or UI automation breaks when the app is run translated.
     var sectionAccessibilityIdentifier: String {
-        "section.intro.\(titleSlug)"
+        "section.intro.\(sectionSlug)"
     }
 
     /// Stable identifier for the descriptive feature row at `index`.
@@ -37,14 +41,15 @@ struct SectionIntroView: View {
     /// Number of descriptive rows this intro renders.
     var featureCount: Int { presentation.features.count }
 
-    /// Lowercased, letters/digits-only reduction of the title, e.g.
-    /// "Large & Old Files" → "largeoldfiles".
-    private var titleSlug: String {
-        String(title.lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) })
+    /// Locale-independent slug from the enum case name, e.g.
+    /// `.largeOldFiles` → "largeoldfiles".
+    private var sectionSlug: String {
+        String(describing: section).lowercased()
     }
 
     // MARK: Body
 
+    /// Hero + text laid side by side on wide panes, stacked when narrow.
     var body: some View {
         // Wide layout (hero beside the text) is preferred; ViewThatFits drops
         // to the stacked layout when the detail pane is too narrow for both
@@ -68,6 +73,8 @@ struct SectionIntroView: View {
 
     // MARK: Hero
 
+    /// Designer art when supplied, otherwise the accent-tinted SF Symbol,
+    /// behind the shared accent bloom. Decorative — hidden from accessibility.
     @ViewBuilder
     private var hero: some View {
         Group {
@@ -95,6 +102,8 @@ struct SectionIntroView: View {
 
     // MARK: Text + features
 
+    /// Title, tagline, and the descriptive feature rows, grouped under the
+    /// per-section accessibility identifier.
     private var textColumn: some View {
         VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 10) {

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -1,0 +1,141 @@
+// SectionIntroView.swift
+// The reusable per-section landing screen: accent-tinted hero, title + tagline, and descriptive sub-feature rows — no Scan button (ContentView floats that separately).
+
+import SwiftUI
+
+/// A scannable section's intro screen. Renders the section's hero, title,
+/// one-line tagline, and the descriptive feature rows summarizing what the
+/// upcoming scan covers. `presentation.accent` tints only these intro elements
+/// — the window's crimson `vaderShell()` is unchanged. The floating Scan
+/// button is intentionally NOT here: ContentView adds it so it can float over
+/// the window edge.
+struct SectionIntroView: View {
+    let presentation: SectionPresentation
+    let title: String
+
+    // MARK: Accessibility identifiers
+
+    /// Shared by every section's intro so automation can locate "an intro
+    /// screen" regardless of which section is showing.
+    var rootAccessibilityIdentifier: String { "section.intro" }
+
+    /// Per-section identifier so a test/automation can assert *which* section's
+    /// intro is on screen. Derived from the English `title` (the prompt's
+    /// "derive from title" option) — stable as long as the English titles are;
+    /// Step 6 call sites pass `NavigationSection.title`. Not localized on
+    /// purpose: an accessibility *identifier* must not move with the UI
+    /// language.
+    var sectionAccessibilityIdentifier: String {
+        "section.intro.\(titleSlug)"
+    }
+
+    /// Stable identifier for the descriptive feature row at `index`.
+    func featureAccessibilityIdentifier(at index: Int) -> String {
+        "section.intro.feature.\(index)"
+    }
+
+    /// Number of descriptive rows this intro renders.
+    var featureCount: Int { presentation.features.count }
+
+    /// Lowercased, letters/digits-only reduction of the title, e.g.
+    /// "Large & Old Files" → "largeoldfiles".
+    private var titleSlug: String {
+        String(title.lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) })
+    }
+
+    // MARK: Body
+
+    var body: some View {
+        // Wide layout (hero beside the text) is preferred; ViewThatFits drops
+        // to the stacked layout when the detail pane is too narrow for both
+        // side by side, so the screen degrades gracefully at the 900pt min
+        // window without a manual breakpoint.
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .center, spacing: 48) {
+                hero
+                textColumn
+            }
+            VStack(spacing: 28) {
+                hero
+                textColumn
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(40)
+        .accessibilityIdentifier(rootAccessibilityIdentifier)
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: Hero
+
+    @ViewBuilder
+    private var hero: some View {
+        Group {
+            if let asset = presentation.heroAssetName, !asset.isEmpty {
+                // Designer-supplied art is pre-coloured, so it is not accent
+                // tinted — only the bloom carries the accent.
+                Image(asset)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 160, height: 160)
+            } else {
+                Image(systemName: presentation.heroSymbol)
+                    .font(.system(size: 120))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(presentation.accent)
+                    .frame(width: 160, height: 160)
+            }
+        }
+        // Same soft bloom SmartScanIdleState puts behind its hero, recoloured
+        // to the section accent so the intro feels like part of one family.
+        .shadow(color: presentation.accent.opacity(0.45), radius: 32)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: Text + features
+
+    private var textColumn: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.system(size: 34, weight: .semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(presentation.tagline)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 420, alignment: .leading)
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                ForEach(Array(presentation.features.enumerated()), id: \.offset) { index, feature in
+                    featureRow(feature, index: index)
+                }
+            }
+        }
+        // Combine the title + tagline + rows under the per-section id without
+        // hiding the rows: .contain keeps each row independently queryable by
+        // its own identifier while still pinning "this is section X's intro".
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(sectionAccessibilityIdentifier)
+    }
+
+    /// One descriptive row: accent icon + label. Purely informational — no
+    /// checkbox, no action (matches the reference design).
+    private func featureRow(_ feature: SectionFeature, index: Int) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: feature.symbol)
+                .font(.title3)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(presentation.accent)
+                .frame(width: 28, alignment: .center)
+            Text(feature.title)
+                .font(.body)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(featureAccessibilityIdentifier(at: index))
+    }
+}

--- a/VaderCleanerTests/SectionIntroViewTests.swift
+++ b/VaderCleanerTests/SectionIntroViewTests.swift
@@ -9,9 +9,10 @@ import SwiftUI
 final class SectionIntroViewTests: XCTestCase {
 
     /// The six scannable sections, each paired with the per-section
-    /// accessibility-id slug it must derive from its English title. Hardcoded
-    /// (not re-derived through the view's own slug helper) so a regression in
-    /// that helper fails this test loudly instead of silently agreeing.
+    /// accessibility-id slug it must derive from its `NavigationSection` case
+    /// name (locale-independent). Hardcoded — not re-derived through the
+    /// view's own slug helper — so a regression in that helper fails this
+    /// test loudly instead of silently agreeing.
     private let expectedSlugs: [NavigationSection: String] = [
         .smartScan: "smartscan",
         .systemJunk: "systemjunk",
@@ -27,7 +28,7 @@ final class SectionIntroViewTests: XCTestCase {
                 SectionPresentation.for(section),
                 "Scannable section \(section) must have a presentation"
             )
-            let view = SectionIntroView(presentation: presentation, title: section.title)
+            let view = SectionIntroView(presentation: presentation, section: section)
 
             XCTAssertEqual(
                 view.title,
@@ -45,7 +46,7 @@ final class SectionIntroViewTests: XCTestCase {
     func test_rootAccessibilityIdentifierIsStable() throws {
         for section in NavigationSection.allCases where section.isScannable {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))
-            let view = SectionIntroView(presentation: presentation, title: section.title)
+            let view = SectionIntroView(presentation: presentation, section: section)
 
             XCTAssertEqual(
                 view.rootAccessibilityIdentifier,
@@ -58,7 +59,7 @@ final class SectionIntroViewTests: XCTestCase {
     func test_perSectionAccessibilityIdentifierMatchesExpectedSlug() throws {
         for section in NavigationSection.allCases where section.isScannable {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))
-            let view = SectionIntroView(presentation: presentation, title: section.title)
+            let view = SectionIntroView(presentation: presentation, section: section)
             let expectedSlug = try XCTUnwrap(
                 expectedSlugs[section],
                 "Missing expected slug for \(section) — update the test map"
@@ -75,7 +76,7 @@ final class SectionIntroViewTests: XCTestCase {
     func test_featureCountMatchesPresentation() throws {
         for section in NavigationSection.allCases where section.isScannable {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))
-            let view = SectionIntroView(presentation: presentation, title: section.title)
+            let view = SectionIntroView(presentation: presentation, section: section)
 
             XCTAssertEqual(
                 view.featureCount,
@@ -93,7 +94,7 @@ final class SectionIntroViewTests: XCTestCase {
     func test_eachFeatureExposesItsIndexedAccessibilityIdentifier() throws {
         for section in NavigationSection.allCases where section.isScannable {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))
-            let view = SectionIntroView(presentation: presentation, title: section.title)
+            let view = SectionIntroView(presentation: presentation, section: section)
 
             for index in 0..<view.featureCount {
                 XCTAssertEqual(

--- a/VaderCleanerTests/SectionIntroViewTests.swift
+++ b/VaderCleanerTests/SectionIntroViewTests.swift
@@ -1,0 +1,107 @@
+// SectionIntroViewTests.swift
+// Pins the SectionIntroView contract: it builds from every scannable section's real presentation and exposes the stable section.intro / per-feature accessibility identifiers.
+
+import XCTest
+import SwiftUI
+@testable import VaderCleaner
+
+@MainActor
+final class SectionIntroViewTests: XCTestCase {
+
+    /// The six scannable sections, each paired with the per-section
+    /// accessibility-id slug it must derive from its English title. Hardcoded
+    /// (not re-derived through the view's own slug helper) so a regression in
+    /// that helper fails this test loudly instead of silently agreeing.
+    private let expectedSlugs: [NavigationSection: String] = [
+        .smartScan: "smartscan",
+        .systemJunk: "systemjunk",
+        .largeOldFiles: "largeoldfiles",
+        .spaceLens: "spacelens",
+        .malwareRemoval: "malwareremoval",
+        .optimization: "optimization",
+    ]
+
+    func test_buildsFromEveryScannableSectionPresentation() throws {
+        for section in NavigationSection.allCases where section.isScannable {
+            let presentation = try XCTUnwrap(
+                SectionPresentation.for(section),
+                "Scannable section \(section) must have a presentation"
+            )
+            let view = SectionIntroView(presentation: presentation, title: section.title)
+
+            XCTAssertEqual(
+                view.title,
+                section.title,
+                "SectionIntroView must surface the title it was given for \(section)"
+            )
+            XCTAssertEqual(
+                view.presentation.features.count,
+                presentation.features.count,
+                "SectionIntroView must carry the presentation it was given for \(section)"
+            )
+        }
+    }
+
+    func test_rootAccessibilityIdentifierIsStable() throws {
+        for section in NavigationSection.allCases where section.isScannable {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let view = SectionIntroView(presentation: presentation, title: section.title)
+
+            XCTAssertEqual(
+                view.rootAccessibilityIdentifier,
+                "section.intro",
+                "Every section's intro must share the stable root identifier"
+            )
+        }
+    }
+
+    func test_perSectionAccessibilityIdentifierMatchesExpectedSlug() throws {
+        for section in NavigationSection.allCases where section.isScannable {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let view = SectionIntroView(presentation: presentation, title: section.title)
+            let expectedSlug = try XCTUnwrap(
+                expectedSlugs[section],
+                "Missing expected slug for \(section) — update the test map"
+            )
+
+            XCTAssertEqual(
+                view.sectionAccessibilityIdentifier,
+                "section.intro.\(expectedSlug)",
+                "Per-section identifier for \(section) drifted from its pinned slug"
+            )
+        }
+    }
+
+    func test_featureCountMatchesPresentation() throws {
+        for section in NavigationSection.allCases where section.isScannable {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let view = SectionIntroView(presentation: presentation, title: section.title)
+
+            XCTAssertEqual(
+                view.featureCount,
+                presentation.features.count,
+                "featureCount must equal presentation.features.count for \(section)"
+            )
+            XCTAssertGreaterThan(
+                view.featureCount,
+                0,
+                "Every scannable section ships at least one descriptive feature row"
+            )
+        }
+    }
+
+    func test_eachFeatureExposesItsIndexedAccessibilityIdentifier() throws {
+        for section in NavigationSection.allCases where section.isScannable {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let view = SectionIntroView(presentation: presentation, title: section.title)
+
+            for index in 0..<view.featureCount {
+                XCTAssertEqual(
+                    view.featureAccessibilityIdentifier(at: index),
+                    "section.intro.feature.\(index)",
+                    "Feature row \(index) of \(section) must expose its indexed identifier"
+                )
+            }
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -58,7 +58,7 @@
 - [x] **Prompt 29** — Step 2/8: ScanPresentation enum + ScanCoordinating protocol ([#85](https://github.com/jayvicsanantonio/VaderCleaner/issues/85))
 - [x] **Prompt 30** — Step 3/8: Conform the 6 scannable view models (extensions) ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
 - [x] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
-- [ ] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
+- [x] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
 - [ ] **Prompt 33** — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))
 - [ ] **Prompt 34** — Step 7/8: Retire per-section bespoke idle states ([#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90))
 - [ ] **Prompt 35** — Step 8/8: Transitions, accessibility, E2E, README ([#91](https://github.com/jayvicsanantonio/VaderCleaner/issues/91))


### PR DESCRIPTION
Closes #88 — **Scan-Centric Redesign, Step 5/8.**

## What

Adds `VaderCleaner/SectionIntroView.swift`: the reusable per-section landing screen.

- **Hero** — `presentation.heroAssetName` art when supplied, otherwise a ~120pt hierarchical `Image(systemName: presentation.heroSymbol)` tinted with `presentation.accent`, behind the same soft bloom `SmartScanIdleState` uses (`accent.opacity(0.45)`, `radius: 32`). Bloom only — not the breathing scale (the spec says reuse the bloom, not the whole hero treatment).
- **Title + tagline** — `title` at 34pt semibold; `presentation.tagline` in secondary `.title3`, `maxWidth: 420`, multiline.
- **Feature rows** — vertical list of `presentation.features`: accent-tinted SF Symbol + label. Purely descriptive — no checkboxes, no actions.
- **Layout** — `ViewThatFits(in: .horizontal)` puts the hero beside the text at wide widths and stacks gracefully at the 900pt min window (detail pane ≥660pt).
- **No Scan button** — ContentView owns the floating button (Step 6) so it can sit over the window edge.
- The crimson `vaderShell()` window is untouched; the accent tints only intro elements. No other view modified.

## Accessibility

- Root: `section.intro` (`.accessibilityElement(children: .contain)` so children stay queryable).
- Per-section: `section.intro.<slug>`, slug derived from the **English** title (the prompt's "derive from title" option) — documented inline as English-stable; Step 6 callers pass `NavigationSection.title`.
- Each feature row: `section.intro.feature.<index>`, `.accessibilityElement(children: .combine)`.

## Tests

`VaderCleanerTests/SectionIntroViewTests.swift` — for every one of the 6 scannable sections, asserts the view builds from real `SectionPresentation.for(_:)` data and exposes the expected root / per-section / per-feature identifiers and a feature count matching the presentation. Per-section slugs are a hardcoded map (not re-derived) so a slug-helper regression fails loudly.

Authored test-first (TDD); confirmed failing, then implemented.

## Verification

- `xcodebuild test` scheme `VaderCleaner` → **679 tests, 0 failures**.
- 5 new `SectionIntroViewTests` pass; no other view touched.
- `todo.md` Prompt 32 checked off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated section introduction screens displaying hero images or symbols, titles, and feature highlights to provide an overview of each content section.

* **Tests**
  * Added comprehensive test coverage for section intro screens to ensure consistent functionality across all section types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->