### PR TITLE
feat: wire unified intro + floating Scan into ContentView (#89)

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -28,6 +28,10 @@ struct ContentView: View {
     /// system caches the answer so the second prompt is a no-op, but it's
     /// cleaner to issue exactly one.
     @State private var didRequestNotificationPermission = false
+    /// Fixed width of the navigation rail. Shared by the rail's own frame and
+    /// the floating Scan overlay so the disc centers over the detail content
+    /// area (not the full window) without the two drifting apart.
+    private let railWidth: CGFloat = 240
     init(
         systemJunkViewModel: SystemJunkViewModel,
         largeOldFilesViewModel: LargeOldFilesViewModel,
@@ -59,7 +63,7 @@ struct ContentView: View {
             // full-bleed selection bar. The rail and detail share one
             // continuous gradient — no sidebar material, no divider.
             rail
-                .frame(width: 240)
+                .frame(width: railWidth)
 
             // Hosts `.navigationTitle` / `.toolbar` for the detail screens
             // without reintroducing a split divider.
@@ -69,11 +73,14 @@ struct ContentView: View {
         }
         // The Scan CTA floats over the window's bottom edge. It is attached to
         // the OUTER HStack — outside the NavigationStack — so the detail
-        // screens' toolbars and safe-area insets can't clip it. Negative
-        // bottom padding lets the disc and its glow bleed past the edge while
-        // the disc's center stays inside the window so it remains hittable.
+        // screens' toolbars and safe-area insets can't clip it. The leading
+        // inset equal to the rail width re-centers the disc over the detail
+        // content area rather than the full window, and the negative bottom
+        // padding lets the disc and its glow bleed past the edge while its
+        // center stays inside the window so it remains hittable.
         .overlay(alignment: .bottom) {
             floatingScan(for: selectedSection ?? .smartScan)
+                .padding(.leading, railWidth)
                 .padding(.bottom, -24)
         }
         .frame(minWidth: 900, minHeight: 600)

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -67,6 +67,15 @@ struct ContentView: View {
                 detailView(for: selectedSection ?? .smartScan)
             }
         }
+        // The Scan CTA floats over the window's bottom edge. It is attached to
+        // the OUTER HStack — outside the NavigationStack — so the detail
+        // screens' toolbars and safe-area insets can't clip it. Negative
+        // bottom padding lets the disc and its glow bleed past the edge while
+        // the disc's center stays inside the window so it remains hittable.
+        .overlay(alignment: .bottom) {
+            floatingScan(for: selectedSection ?? .smartScan)
+                .padding(.bottom, -24)
+        }
         .frame(minWidth: 900, minHeight: 600)
         // Branded shell: gradient backdrop, crimson tint, forced dark
         // appearance. The toolbar background is hidden so the floating glass
@@ -190,20 +199,28 @@ struct ContentView: View {
     private func detailView(for section: NavigationSection) -> some View {
         switch section {
         case .smartScan:
-            SmartScanView(
-                viewModel: smartScanViewModel,
-                onReviewSystemJunk: { selectedSection = .systemJunk },
-                onReviewMalware: { selectedSection = .malwareRemoval },
-                onReviewOptimization: { selectedSection = .optimization }
-            )
+            ScannableSectionContent(coordinator: smartScanViewModel, section: section) {
+                SmartScanView(
+                    viewModel: smartScanViewModel,
+                    onReviewSystemJunk: { selectedSection = .systemJunk },
+                    onReviewMalware: { selectedSection = .malwareRemoval },
+                    onReviewOptimization: { selectedSection = .optimization }
+                )
+            }
         case .healthMonitor:
             HealthMonitorView(service: systemStats)
         case .systemJunk:
-            SystemJunkView(viewModel: systemJunkViewModel)
+            ScannableSectionContent(coordinator: systemJunkViewModel, section: section) {
+                SystemJunkView(viewModel: systemJunkViewModel)
+            }
         case .largeOldFiles:
-            LargeOldFilesView(viewModel: largeOldFilesViewModel)
+            ScannableSectionContent(coordinator: largeOldFilesViewModel, section: section) {
+                LargeOldFilesView(viewModel: largeOldFilesViewModel)
+            }
         case .spaceLens:
-            SpaceLensView(viewModel: spaceLensViewModel)
+            ScannableSectionContent(coordinator: spaceLensViewModel, section: section) {
+                SpaceLensView(viewModel: spaceLensViewModel)
+            }
         case .privacy:
             PrivacyView(viewModel: privacyViewModel)
         case .appUninstaller:
@@ -213,9 +230,39 @@ struct ContentView: View {
         case .extensions:
             ExtensionsManagerView(viewModel: extensionsManagerViewModel)
         case .optimization:
-            OptimizationView(viewModel: optimizationViewModel)
+            ScannableSectionContent(coordinator: optimizationViewModel, section: section) {
+                OptimizationView(viewModel: optimizationViewModel)
+            }
         case .malwareRemoval:
-            MalwareView(viewModel: malwareViewModel)
+            ScannableSectionContent(coordinator: malwareViewModel, section: section) {
+                MalwareView(viewModel: malwareViewModel)
+            }
+        }
+    }
+
+    /// The shell-level floating Scan button for the selected section. Renders
+    /// only for scannable sections and — via `FloatingScanOverlay`'s
+    /// observation of the coordinator — only while that section is at its
+    /// `.intro` phase; everything else collapses to nothing so the disc
+    /// disappears the instant a scan starts. The switch is exhaustive so a new
+    /// section is a compile-time prompt to classify it here.
+    @ViewBuilder
+    private func floatingScan(for section: NavigationSection) -> some View {
+        switch section {
+        case .smartScan:
+            FloatingScanOverlay(coordinator: smartScanViewModel, section: section)
+        case .systemJunk:
+            FloatingScanOverlay(coordinator: systemJunkViewModel, section: section)
+        case .largeOldFiles:
+            FloatingScanOverlay(coordinator: largeOldFilesViewModel, section: section)
+        case .spaceLens:
+            FloatingScanOverlay(coordinator: spaceLensViewModel, section: section)
+        case .optimization:
+            FloatingScanOverlay(coordinator: optimizationViewModel, section: section)
+        case .malwareRemoval:
+            FloatingScanOverlay(coordinator: malwareViewModel, section: section)
+        case .privacy, .extensions, .appUninstaller, .appUpdater, .healthMonitor:
+            EmptyView()
         }
     }
 
@@ -230,6 +277,51 @@ struct ContentView: View {
                 if newValue == false { onboarding.dismiss() }
             }
         )
+    }
+}
+
+/// Gates a scannable section between the unified `SectionIntroView` and its
+/// own detail view. The coordinator is held as `@ObservedObject` here — not in
+/// ContentView, where the view models are plain `let`s — so the swap is
+/// reactive: tapping the floating Scan flips `scanPresentation` off `.intro`
+/// and this view rebuilds into the detail view. The detail closure is not
+/// evaluated while at `.intro`, so the section's auto-load `.task`/`.onAppear`
+/// stays gated behind Scan rather than firing under the intro.
+private struct ScannableSectionContent<Coordinator: ScanCoordinating, Detail: View>: View {
+    @ObservedObject var coordinator: Coordinator
+    let section: NavigationSection
+    @ViewBuilder let detail: () -> Detail
+
+    var body: some View {
+        if coordinator.scanPresentation == .intro,
+           let presentation = SectionPresentation.for(section) {
+            SectionIntroView(presentation: presentation, section: section)
+        } else {
+            // `.working`/`.results`, or the defensive case of a scannable
+            // section with no presentation metadata: the section's own
+            // detail view is the source of truth for every non-intro phase.
+            detail()
+        }
+    }
+}
+
+/// The shell-level floating Scan button for one scannable section. Observes
+/// the coordinator so the disc is shown only while the section is at `.intro`
+/// and vanishes the moment a scan starts. Accent-tinted per section; the
+/// window's crimson shell is unchanged.
+private struct FloatingScanOverlay<Coordinator: ScanCoordinating>: View {
+    @ObservedObject var coordinator: Coordinator
+    let section: NavigationSection
+
+    var body: some View {
+        if coordinator.scanPresentation == .intro {
+            FloatingScanButton(
+                title: String(localized: "Scan", comment: "Floating scan button title."),
+                accent: SectionPresentation.for(section)?.accent ?? .vaderCrimson,
+                accessibilityIdentifier: section.scanAccessibilityIdentifier,
+                action: { coordinator.beginScan() }
+            )
+        }
     }
 }
 

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -54,6 +54,18 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         }
     }
 
+    /// Stable automation identifier for this section's floating Scan button.
+    /// Mirrors `accessibilityIdentifier`'s suffix so the rail row and the scan
+    /// trigger for the same section share a recognizable stem
+    /// (`sidebar.systemJunk` ↔ `section.systemJunk.scan`). Derived by dropping
+    /// the `sidebar.` prefix so the two identifiers can't drift apart. Only
+    /// scannable sections render this button, but it is defined for every case
+    /// so the contract is uniform. Pinned by `NavigationSectionTests`; the
+    /// scan-centric UI tests target this identifier.
+    var scanAccessibilityIdentifier: String {
+        "section.\(accessibilityIdentifier.dropFirst("sidebar.".count)).scan"
+    }
+
     var icon: String {
         switch self {
         case .smartScan:       return "sparkles"

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -55,15 +55,16 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
     }
 
     /// Stable automation identifier for this section's floating Scan button.
-    /// Mirrors `accessibilityIdentifier`'s suffix so the rail row and the scan
-    /// trigger for the same section share a recognizable stem
-    /// (`sidebar.systemJunk` ↔ `section.systemJunk.scan`). Derived by dropping
-    /// the `sidebar.` prefix so the two identifiers can't drift apart. Only
-    /// scannable sections render this button, but it is defined for every case
-    /// so the contract is uniform. Pinned by `NavigationSectionTests`; the
-    /// scan-centric UI tests target this identifier.
+    /// Built from the enum case name so it shares a recognizable stem with the
+    /// `accessibilityIdentifier` suffix (`sidebar.systemJunk` ↔
+    /// `section.systemJunk.scan`) without depending on that string's format.
+    /// `String(describing:)` on a no-payload case yields the case name and is
+    /// the same locale-independent source `SectionIntroView` already uses.
+    /// Only scannable sections render this button, but it is defined for every
+    /// case so the contract is uniform. Pinned by `NavigationSectionTests`;
+    /// the scan-centric UI tests target this identifier.
     var scanAccessibilityIdentifier: String {
-        "section.\(accessibilityIdentifier.dropFirst("sidebar.".count)).scan"
+        "section.\(String(describing: self)).scan"
     }
 
     var icon: String {

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -52,6 +52,34 @@ final class NavigationSectionTests: XCTestCase {
         XCTAssertEqual(Set(ids).count, ids.count, "Sidebar identifiers must be unique")
     }
 
+    func test_scanAccessibilityIdentifiers_areStableAndPinned() {
+        let expected: [NavigationSection: String] = [
+            .smartScan: "section.smartScan.scan",
+            .systemJunk: "section.systemJunk.scan",
+            .largeOldFiles: "section.largeOldFiles.scan",
+            .spaceLens: "section.spaceLens.scan",
+            .malwareRemoval: "section.malwareRemoval.scan",
+            .privacy: "section.privacy.scan",
+            .extensions: "section.extensions.scan",
+            .appUninstaller: "section.appUninstaller.scan",
+            .appUpdater: "section.appUpdater.scan",
+            .optimization: "section.optimization.scan",
+            .healthMonitor: "section.healthMonitor.scan",
+        ]
+        for section in NavigationSection.allCases {
+            XCTAssertEqual(
+                section.scanAccessibilityIdentifier,
+                expected[section],
+                "Scan identifier for \(section) drifted — update the UI-test locators too"
+            )
+        }
+    }
+
+    func test_scanAccessibilityIdentifiers_areUnique() {
+        let ids = NavigationSection.allCases.map(\.scanAccessibilityIdentifier)
+        XCTAssertEqual(Set(ids).count, ids.count, "Scan identifiers must be unique")
+    }
+
     func test_eachSection_hasValidSFSymbol() throws {
         guard #available(macOS 14.0, *) else {
             throw XCTSkip("SF Symbol validation requires macOS 14.0 (the app's minimum deployment target)")

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -140,9 +140,14 @@ final class FinalPolishUITests: XCTestCase {
                       "Expected Large & Old Files row in sidebar")
         row.click()
 
-        let scan = app.buttons["large-old.scan"]
+        // Scannable sections land on the unified intro first; the scan trigger
+        // is the single shell-level floating button.
+        let intro = app.descendants(matching: .any)["section.intro"]
+        XCTAssertTrue(intro.waitForExistence(timeout: 5),
+                      "Expected the unified intro screen for Large & Old Files")
+        let scan = app.buttons["section.largeOldFiles.scan"]
         XCTAssertTrue(scan.waitForExistence(timeout: 5),
-                      "Expected Scan button in Large & Old Files idle state")
+                      "Expected the floating Scan button on the Large & Old Files intro")
         scan.click()
 
         // Prefer a terminal state; allow a generous window for the walk.

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -1,5 +1,5 @@
 // MalwareUITests.swift
-// End-to-end UI test for Malware Removal — navigates to the section and asserts it renders either the idle scan screen or the ClamAV onboarding (depending on whether ClamAV is installed on the test host), exercising the sidebar → view-model → view wiring against the real app process.
+// End-to-end UI test for Malware Removal — navigates to the section, taps the floating Scan on the unified intro, and asserts it renders either the scan screen or the ClamAV onboarding (depending on whether ClamAV is installed on the test host), exercising the sidebar → view-model → view wiring against the real app process.
 
 import XCTest
 
@@ -24,7 +24,7 @@ final class MalwareUITests: XCTestCase {
         app = nil
     }
 
-    func test_navigateToMalware_revealsIdleOrOnboarding() throws {
+    func test_navigateToMalware_scan_revealsScanScreenOrOnboarding() throws {
         dismissOnboardingIfNeeded()
 
         let sidebarRow = app.buttons["sidebar.malwareRemoval"].firstMatch
@@ -32,9 +32,20 @@ final class MalwareUITests: XCTestCase {
                       "Expected Malware Removal row in sidebar")
         sidebarRow.click()
 
-        // Either ClamAV is installed (idle "Scan for Malware" button) or it is
-        // not (the onboarding's "Check Again" button). Whichever the host
-        // produces, one of the two must appear — proving the view rendered.
+        // Malware lands on the unified intro first; the scan trigger is the
+        // single shell-level floating button.
+        let intro = app.descendants(matching: .any)["section.intro"]
+        XCTAssertTrue(intro.waitForExistence(timeout: 5),
+                      "Expected the unified intro screen for Malware Removal")
+        let floatingScan = app.buttons["section.malwareRemoval.scan"]
+        XCTAssertTrue(floatingScan.waitForExistence(timeout: 5),
+                      "Expected the floating Scan button on the Malware Removal intro")
+        floatingScan.click()
+
+        // After Scan, MalwareView takes over: either ClamAV is installed (its
+        // own "Scan for Malware" button) or it is not (the onboarding's "Check
+        // Again" button). Whichever the host produces, one of the two must
+        // appear — proving the section's detail view rendered.
         let scanButton = app.buttons["malware.scan"]
         let onboardingRecheck = app.buttons["Check Again"]
 

--- a/VaderCleanerUITests/OptimizationUITests.swift
+++ b/VaderCleanerUITests/OptimizationUITests.swift
@@ -1,5 +1,5 @@
 // OptimizationUITests.swift
-// End-to-end UI test for Optimization — navigates to the section and asserts the view renders (toolbar + a ready-state section) so the sidebar → view-model → view wiring is exercised against the real app process.
+// End-to-end UI test for Optimization — navigates to the section, taps the floating Scan on the unified intro, and asserts the view renders (toolbar + a ready-state section) so the sidebar → view-model → view wiring is exercised against the real app process.
 
 import XCTest
 
@@ -24,13 +24,23 @@ final class OptimizationUITests: XCTestCase {
         app = nil
     }
 
-    func test_navigateToOptimization_revealsToolbarAndContent() throws {
+    func test_navigateToOptimization_scan_revealsToolbarAndContent() throws {
         dismissOnboardingIfNeeded()
 
         let sidebarRow = app.buttons["sidebar.optimization"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Optimization row in sidebar")
         sidebarRow.click()
+
+        // Optimization lands on the unified intro first; tapping the floating
+        // Scan kicks off the load that previously ran automatically on appear.
+        let intro = app.descendants(matching: .any)["section.intro"]
+        XCTAssertTrue(intro.waitForExistence(timeout: 5),
+                      "Expected the unified intro screen for Optimization")
+        let floatingScan = app.buttons["section.optimization.scan"]
+        XCTAssertTrue(floatingScan.waitForExistence(timeout: 5),
+                      "Expected the floating Scan button on the Optimization intro")
+        floatingScan.click()
 
         // The refresh toolbar button is present whenever the view renders,
         // independent of phase — strongest "view did not crash" signal.

--- a/VaderCleanerUITests/SmartScanUITests.swift
+++ b/VaderCleanerUITests/SmartScanUITests.swift
@@ -1,5 +1,5 @@
 // SmartScanUITests.swift
-// End-to-end UI test for Smart Scan — asserts the default landing section renders its idle Scan screen, exercising the App → ContentView → SmartScanView wiring against the real app process.
+// End-to-end UI test for Smart Scan — asserts the default landing section renders the unified intro screen and its floating Scan button, exercising the App → ContentView → SectionIntroView wiring against the real app process.
 
 import XCTest
 
@@ -25,19 +25,24 @@ final class SmartScanUITests: XCTestCase {
         app = nil
     }
 
-    func test_smartScanIsDefaultLanding_revealsIdleScanScreen() throws {
+    func test_smartScanIsDefaultLanding_revealsIntroScreen() throws {
         dismissOnboardingIfNeeded()
 
-        // Smart Scan is the default selected section, so its idle Scan button
-        // should be present without any navigation.
-        let scanButton = app.buttons["smartScan.scan"]
+        // Smart Scan is the default selected section, so the unified intro and
+        // its floating Scan button should be present without any navigation.
+        let intro = app.descendants(matching: .any)["section.intro"]
         XCTAssertTrue(
-            scanButton.waitForExistence(timeout: 10),
-            "Expected the Smart Scan idle screen to be the default landing view"
+            intro.waitForExistence(timeout: 10),
+            "Expected the Smart Scan intro screen to be the default landing view"
+        )
+        let scanButton = app.buttons["section.smartScan.scan"]
+        XCTAssertTrue(
+            scanButton.waitForExistence(timeout: 5),
+            "Expected the floating Scan button on the Smart Scan intro"
         )
     }
 
-    func test_navigateToSmartScan_revealsIdleScanScreen() throws {
+    func test_navigateToSmartScan_revealsIntroScreen() throws {
         dismissOnboardingIfNeeded()
 
         // Navigate away and back to prove the sidebar → view wiring works
@@ -54,10 +59,15 @@ final class SmartScanUITests: XCTestCase {
                       "Expected Smart Scan row in sidebar")
         smartScanRow.click()
 
-        let scanButton = app.buttons["smartScan.scan"]
+        let intro = app.descendants(matching: .any)["section.intro"]
         XCTAssertTrue(
-            scanButton.waitForExistence(timeout: 10),
-            "Expected Smart Scan to render its idle Scan screen"
+            intro.waitForExistence(timeout: 10),
+            "Expected Smart Scan to render its intro screen"
+        )
+        let scanButton = app.buttons["section.smartScan.scan"]
+        XCTAssertTrue(
+            scanButton.waitForExistence(timeout: 5),
+            "Expected the floating Scan button on the Smart Scan intro"
         )
     }
 

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -1,5 +1,5 @@
 // SpaceLensUITests.swift
-// End-to-end UI test for Space Lens — navigates to the section and waits for either the in-progress scan or the post-scan treemap, asserting that the wiring between sidebar selection, view-model, and view reaches the user's home directory.
+// End-to-end UI test for Space Lens — navigates to the section, taps the floating Scan on the unified intro, and waits for either the in-progress scan or the post-scan treemap, asserting that the wiring between sidebar selection, view-model, and view reaches the user's home directory.
 
 import XCTest
 
@@ -28,7 +28,7 @@ final class SpaceLensUITests: XCTestCase {
     /// directory, the error banner). Any of these is evidence that the
     /// view-model is alive and the scan kicked off — anything else is a
     /// wiring regression.
-    func test_navigateToSpaceLens_revealsScanningOrTreemap() throws {
+    func test_navigateToSpaceLens_scan_revealsScanningOrTreemap() throws {
         dismissOnboardingIfNeeded()
 
         let sidebarRow = app.buttons["sidebar.spaceLens"].firstMatch
@@ -36,11 +36,21 @@ final class SpaceLensUITests: XCTestCase {
                       "Expected Space Lens row in sidebar")
         sidebarRow.click()
 
-        // The scan starts automatically on first appearance, so we expect either
-        // the scanning indicator or — on tiny home folders / fast machines —
-        // the treemap to land before our timeout. The error banner is
-        // accepted as well: a CI runner without home-folder access should
-        // still surface a recognizable state, not hang on a blank canvas.
+        // Space Lens lands on the unified intro first; tapping the floating
+        // Scan kicks off the walk that previously ran automatically on appear.
+        let intro = app.descendants(matching: .any)["section.intro"]
+        XCTAssertTrue(intro.waitForExistence(timeout: 5),
+                      "Expected the unified intro screen for Space Lens")
+        let floatingScan = app.buttons["section.spaceLens.scan"]
+        XCTAssertTrue(floatingScan.waitForExistence(timeout: 5),
+                      "Expected the floating Scan button on the Space Lens intro")
+        floatingScan.click()
+
+        // After Scan we expect either the scanning indicator or — on tiny home
+        // folders / fast machines — the treemap to land before our timeout.
+        // The error banner is accepted as well: a CI runner without
+        // home-folder access should still surface a recognizable state, not
+        // hang on a blank canvas.
         let appeared = waitForAnySpaceLensState(timeout: 30)
         XCTAssertTrue(appeared,
                       "Expected to land on a recognizable Space Lens state after selection")

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -41,10 +41,15 @@ final class SystemJunkUITests: XCTestCase {
                       "Expected System Junk row in sidebar")
         sidebarRow.click()
 
-        // Idle state should expose the Scan button by accessibility identifier.
-        let scanButton = app.buttons["system-junk.scan"]
+        // Scannable sections land on the unified intro screen first.
+        let intro = app.descendants(matching: .any)["section.intro"]
+        XCTAssertTrue(intro.waitForExistence(timeout: 5),
+                      "Expected the unified intro screen for System Junk")
+
+        // The scan trigger is now the single shell-level floating button.
+        let scanButton = app.buttons["section.systemJunk.scan"]
         XCTAssertTrue(scanButton.waitForExistence(timeout: 5),
-                      "Expected Scan button in System Junk idle state")
+                      "Expected the floating Scan button on the System Junk intro")
         scanButton.click()
 
         // The scan completes once we land on either the preview footer
@@ -70,9 +75,9 @@ final class SystemJunkUITests: XCTestCase {
                       "Expected System Junk row in sidebar")
         sidebarRow.click()
 
-        let scanButton = app.buttons["system-junk.scan"]
+        let scanButton = app.buttons["section.systemJunk.scan"]
         XCTAssertTrue(scanButton.waitForExistence(timeout: 5),
-                      "Expected Scan button in System Junk idle state")
+                      "Expected the floating Scan button on the System Junk intro")
         scanButton.click()
 
         let totalSelected = app.staticTexts["system-junk.totalSelected"]
@@ -93,8 +98,8 @@ final class SystemJunkUITests: XCTestCase {
             || cleanButton.waitForExistence(timeout: 1)
         XCTAssertTrue(previewStillVisible,
                       "Expected System Junk preview state to persist after sidebar navigation")
-        XCTAssertFalse(app.buttons["system-junk.scan"].exists,
-                       "Expected System Junk not to reset to idle after sidebar navigation")
+        XCTAssertFalse(app.buttons["section.systemJunk.scan"].exists,
+                       "Expected System Junk not to reset to its intro after sidebar navigation")
     }
 
     // MARK: - Helpers

--- a/todo.md
+++ b/todo.md
@@ -59,6 +59,6 @@
 - [x] **Prompt 30** — Step 3/8: Conform the 6 scannable view models (extensions) ([#86](https://github.com/jayvicsanantonio/VaderCleaner/issues/86))
 - [x] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
 - [x] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
-- [ ] **Prompt 33** — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))
+- [x] **Prompt 33** — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))
 - [ ] **Prompt 34** — Step 7/8: Retire per-section bespoke idle states ([#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90))
 - [ ] **Prompt 35** — Step 8/8: Transitions, accessibility, E2E, README ([#91](https://github.com/jayvicsanantonio/VaderCleaner/issues/91))


### PR DESCRIPTION
Closes #89 — Scan-Centric Redesign, Step 6/8.

## What

Wires the unified intro + floating Scan into `ContentView` for the six scannable sections, **replacing** (not overlaying) each section's bespoke idle state.

- For a scannable section at `.intro`, ContentView renders `SectionIntroView`; for `.working`/`.results` it renders the section's existing detail view **unchanged** (its internal switch still owns working/results/done/failed/needs-install).
- One shell-level `FloatingScanButton` is attached as an `.overlay(alignment: .bottom)` on the **outer HStack** (outside the NavigationStack, so toolbars/safe-area can't clip it), with negative bottom padding so the disc + glow bleed past the window edge while the center stays hittable. It is accent-tinted per section and visible only for scannable sections at `.intro`; tapping it calls `coordinator.beginScan()`.
- Non-scannable sections (Privacy, Extensions, App Uninstaller, App Updater, Health Monitor) are completely unchanged.

## Reactivity

ContentView holds the view models as plain `let`s, so reading `scanPresentation` directly in `body` would not re-render when a scan starts. Two small `private` generic subviews hold the concrete coordinator as `@ObservedObject`:

- `ScannableSectionContent` — swaps intro ↔ detail reactively (and does not build the detail closure under `.intro`, so each section's auto-load `.task`/`.onAppear` stays gated behind Scan; all are already phase-guarded, no double-scan).
- `FloatingScanOverlay` — shows/hides the disc as the phase changes.

## Identifiers & tests

- Added `NavigationSection.scanAccessibilityIdentifier` (mirrors the existing `sidebar.*` suffix → `section.<id>.scan`), pinned by new `NavigationSectionTests` cases.
- Repointed the affected UI tests: assert the unified intro (`section.intro`), tap `section.<id>.scan`, then assert the section's working/results UI. `SpaceLens`/`Optimization`/`Malware` tests now drive the scan explicitly because their auto-load no longer fires under the intro. Verified `MalwareViewModel` maps `.needsInstall → .results`, so the ClamAV onboarding still shows (not hidden behind the generic intro).

Dead per-section idle code is intentionally left in the detail views (Step 7 deletes it).

## Verification

- `xcodebuild test` — **VaderCleanerTests: 681 passed, 0 failures**
- `xcodebuild test` — **VaderCleanerUITests: 15 passed, 0 failures** (the post-scan assertions in the Malware/Optimization/SpaceLens/SystemJunk/Large&Old tests prove the detail UI renders after Scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)