### PR TITLE
refactor: retire per-section bespoke idle states (#90)

### DIFF
--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -57,12 +57,11 @@ struct LargeOldFilesView: View {
     private var content: some View {
         switch viewModel.phase {
         case .idle:
-            VStack(spacing: 16) {
-                if !appState.hasFullDiskAccess {
-                    FullDiskAccessPromptCard(onRecheck: { appState.refresh() })
-                }
-                LargeOldFilesIdleState(onScan: startScan)
-            }
+            // Unreachable: ContentView shows the unified SectionIntroView
+            // while the coordinator reports `.intro` (which `.idle` maps to),
+            // so the detail view is never built in this phase. The arm stays
+            // only to keep the switch exhaustive over `Phase`.
+            EmptyView()
         case .scanning:
             LargeOldFilesProgressState(label: "Scanning…", identifier: "large-old.scanning")
         case .results:

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -39,36 +39,6 @@ enum LargeOldFilesActions {
     }
 }
 
-struct LargeOldFilesIdleState: View {
-    let onScan: () -> Void
-
-    var body: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "doc.text.magnifyingglass")
-                .font(.system(size: 56))
-                .foregroundStyle(.secondary)
-            Text(String(
-                localized: "Large & Old Files",
-                comment: "Title for the Large & Old Files scan feature."
-            ))
-                .font(.title2.weight(.semibold))
-            Text(String(
-                localized: "Scan your home folder for files larger than 50 MB or not accessed in the past six months.",
-                comment: "Description of what the Large & Old Files scan checks."
-            ))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 460)
-            Button("Scan", action: onScan)
-                .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
-                .accessibilityIdentifier("large-old.scan")
-        }
-        .padding()
-    }
-}
-
 struct LargeOldFilesProgressState: View {
     let label: String
     let identifier: String

--- a/VaderCleaner/MalwareView.swift
+++ b/VaderCleaner/MalwareView.swift
@@ -64,12 +64,11 @@ struct MalwareView: View {
         case .needsInstall:
             MalwareOnboardingView(viewModel: onboardingViewModel)
         case .idle:
-            MalwareIdleState(
-                lastScanDate: viewModel.lastScanDate,
-                databaseUpdatedDate: viewModel.databaseUpdatedDate,
-                onScan: { viewModel.startScan() },
-                onUpdateDatabase: { Task { await viewModel.updateDatabaseManually() } }
-            )
+            // Unreachable: ContentView shows the unified SectionIntroView
+            // while the coordinator reports `.intro` (which `.idle` maps to),
+            // so the detail view is never built in this phase. The arm stays
+            // only to keep the switch exhaustive over `Phase`.
+            EmptyView()
         case .checkingClamAV:
             MalwareProgressState(
                 label: String(

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -1,5 +1,5 @@
 // MalwareViewSubviews.swift
-// Dedicated subviews for the Malware Removal screen — idle, progress, clean, results list, done, and failed states.
+// Dedicated subviews for the Malware Removal screen — progress, clean, results list, done, and failed states.
 
 import SwiftUI
 
@@ -82,77 +82,6 @@ struct MalwareFailedState: View {
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("malware.failurePrimary")
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
-    }
-}
-
-// MARK: - Idle
-
-struct MalwareIdleState: View {
-    let lastScanDate: Date?
-    let databaseUpdatedDate: Date?
-    let onScan: () -> Void
-    let onUpdateDatabase: () -> Void
-
-    var body: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "shield.lefthalf.filled")
-                .font(.system(size: 56))
-                .foregroundStyle(.tint)
-            Text(String(
-                localized: "Scan for Malware",
-                comment: "Title on the idle Malware Removal screen."
-            ))
-                .font(.title.weight(.semibold))
-            Text(String(
-                localized: "VaderCleaner uses ClamAV to scan your home folder for malware, adware, and ransomware.",
-                comment: "Explanatory subtitle on the idle Malware Removal screen."
-            ))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 460)
-
-            VStack(alignment: .leading, spacing: 8) {
-                LabeledContent(String(
-                    localized: "Last scan",
-                    comment: "Row label for the most recent malware scan time."
-                )) {
-                    Text(relativeOrNever(lastScanDate))
-                        .accessibilityIdentifier("malware.lastScanDate")
-                }
-                Divider()
-                LabeledContent(String(
-                    localized: "Signature database updated",
-                    comment: "Row label for the ClamAV signature database's last update time."
-                )) {
-                    Text(relativeOrNever(databaseUpdatedDate))
-                        .accessibilityIdentifier("malware.databaseUpdatedDate")
-                }
-            }
-            .font(.callout)
-            .padding()
-            .frame(maxWidth: 460)
-            .glassEffect(.regular, in: .rect(cornerRadius: 8))
-
-            HStack(spacing: 12) {
-                Button(String(
-                    localized: "Update Database",
-                    comment: "Button that refreshes the ClamAV signature database via freshclam."
-                ), action: onUpdateDatabase)
-                    .buttonStyle(.bordered)
-                    .accessibilityIdentifier("malware.updateDatabase")
-
-                Button(String(
-                    localized: "Scan for Malware",
-                    comment: "Primary button that starts a malware scan."
-                ), action: onScan)
-                    .buttonStyle(.glassProminent)
-                    .keyboardShortcut(.defaultAction)
-                    .accessibilityIdentifier("malware.scan")
-            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()

--- a/VaderCleaner/OptimizationView.swift
+++ b/VaderCleaner/OptimizationView.swift
@@ -71,7 +71,13 @@ struct OptimizationView: View {
     @ViewBuilder
     private var content: some View {
         switch viewModel.phase {
-        case .idle, .loading:
+        case .idle:
+            // Unreachable: ContentView shows the unified SectionIntroView
+            // while the coordinator reports `.intro` (which `.idle` maps to),
+            // so the detail view is never built in this phase. The arm stays
+            // only to keep the switch exhaustive over `Phase`.
+            EmptyView()
+        case .loading:
             OptimizationProgressState(
                 label: String(
                     localized: "Loading optimization data…",

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -94,8 +94,8 @@ struct SectionIntroView: View {
                     .frame(width: 160, height: 160)
             }
         }
-        // Same soft bloom SmartScanIdleState puts behind its hero, recoloured
-        // to the section accent so the intro feels like part of one family.
+        // A soft bloom behind the hero, recoloured to the section accent so
+        // the intro feels like part of one family.
         .shadow(color: presentation.accent.opacity(0.45), radius: 32)
         .accessibilityHidden(true)
     }

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -54,7 +54,11 @@ struct SmartScanView: View {
     private var content: some View {
         switch viewModel.phase {
         case .idle:
-            SmartScanIdleState(onScan: { Task { await viewModel.scan() } })
+            // Unreachable: ContentView shows the unified SectionIntroView
+            // while the coordinator reports `.intro` (which `.idle` maps to),
+            // so the detail view is never built in this phase. The arm stays
+            // only to keep the switch exhaustive over `Phase`.
+            EmptyView()
         case .scanning(let phase):
             SmartScanProgressState(
                 label: phase,

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -1,8 +1,7 @@
 // SmartScanViewSubviews.swift
-// Dedicated subviews for the Smart Scan screen — idle, progress, the three-card results summary, done, and failed states.
+// Dedicated subviews for the Smart Scan screen — progress, the three-card results summary, done, and failed states.
 
 import SwiftUI
-import AppKit
 
 // MARK: - Shared byte formatting
 
@@ -15,64 +14,6 @@ private let smartScanByteFormatter: ByteCountFormatter = {
     f.countStyle = .file
     return f
 }()
-
-// MARK: - Idle
-
-struct SmartScanIdleState: View {
-    let onScan: () -> Void
-
-    @State private var breathing = false
-
-    var body: some View {
-        VStack(spacing: 16) {
-            Spacer(minLength: 0)
-
-            // The app icon is VaderCleaner's own artwork, so it doubles as the
-            // hero render; the crimson bloom behind it ties it to the backdrop.
-            // A slow scale breath keeps the welcome screen feeling alive while
-            // it waits for the user to start a scan.
-            Image(nsImage: NSApp.applicationIconImage)
-                .resizable()
-                .interpolation(.high)
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 168, height: 168)
-                .shadow(color: Color.vaderCrimson.opacity(0.45), radius: 32)
-                .scaleEffect(breathing ? 1.03 : 1.0)
-                .animation(.easeInOut(duration: 3.2).repeatForever(autoreverses: true),
-                           value: breathing)
-                .onAppear { breathing = true }
-
-            Text(String(
-                localized: "Welcome to VaderCleaner",
-                comment: "Hero title on the idle Smart Scan welcome screen."
-            ))
-                .font(.system(size: 34, weight: .semibold))
-
-            Text(String(
-                localized: "Start with a quick and extensive scan of your Mac.",
-                comment: "Subtitle on the idle Smart Scan welcome screen."
-            ))
-                .font(.title3)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 460)
-
-            Spacer(minLength: 0)
-
-            FloatingScanButton(
-                title: String(
-                    localized: "Scan",
-                    comment: "Primary button that starts the Smart Scan."
-                ),
-                accessibilityIdentifier: "smartScan.scan",
-                action: onScan
-            )
-            .padding(.bottom, 36)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
-    }
-}
 
 // MARK: - Progress
 

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -5,9 +5,10 @@ import SwiftUI
 
 /// Detail view for the Space Lens sidebar section. Owns nothing of its
 /// own — every piece of state lives on `DiskScannerViewModel`. Each
-/// `Phase` maps to a dedicated subview (idle → scan call-to-action,
-/// scanning → progress bar, ready → breadcrumb + treemap + footer,
-/// error → message + try again). The empty case is implicit: a `.ready`
+/// `Phase` maps to a dedicated subview (idle → not rendered, ContentView
+/// shows the unified intro instead, scanning → progress bar, ready →
+/// breadcrumb + treemap + footer, error → message + try again). The
+/// empty case is implicit: a `.ready`
 /// node whose subtree has no displayable children renders the empty
 /// placeholder inside the same layout, so the breadcrumb stays in
 /// reach for navigating back up.
@@ -29,7 +30,13 @@ struct SpaceLensView: View {
         Group {
             switch viewModel.phase {
             case .idle:
-                idleState
+                // Unreachable: ContentView shows the unified SectionIntroView
+                // while the coordinator reports `.intro` (which `.idle` maps
+                // to), so the detail view is never built in this phase. The
+                // arm stays only to keep the switch exhaustive over `Phase`.
+                // `idleState` itself is retained — the `.ready` branch below
+                // still falls back to it defensively when `currentNode` is nil.
+                EmptyView()
             case .scanning:
                 scanningState
             case .ready:

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 /// Detail view shown when the user selects "System Junk" in the sidebar.
 /// Each phase of `SystemJunkViewModel.Phase` maps to a dedicated subview:
-///   - `.idle` — centered Scan call-to-action.
+///   - `.idle` — not rendered here; ContentView shows the unified intro.
 ///   - `.scanning` — progress spinner.
 ///   - `.preview` — list of categories with checkboxes plus Clean/Re-scan.
 ///   - `.cleaning` — progress spinner.
@@ -27,7 +27,11 @@ struct SystemJunkView: View {
         Group {
             switch viewModel.phase {
             case .idle:
-                idleState
+                // Unreachable: ContentView shows the unified SectionIntroView
+                // while the coordinator reports `.intro` (which `.idle` maps
+                // to), so the detail view is never built in this phase. The
+                // arm stays only to keep the switch exhaustive over `Phase`.
+                EmptyView()
             case .scanning:
                 progressState(label: "Scanning…", identifier: "system-junk.scanning")
             case .preview(let result):
@@ -45,31 +49,6 @@ struct SystemJunkView: View {
     }
 
     // MARK: - States
-
-    private var idleState: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "trash")
-                .font(.system(size: 56))
-                .foregroundStyle(.secondary)
-            Text("System Junk")
-                .font(.title2.weight(.semibold))
-            Text("Scan caches, logs, mail attachments, iOS backups, trash, and stale language files.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 420)
-            if !appState.hasFullDiskAccess {
-                FullDiskAccessPromptCard(onRecheck: { appState.refresh() })
-            }
-            Button("Scan") {
-                Task { await viewModel.scan() }
-            }
-            .controlSize(.large)
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("system-junk.scan")
-        }
-        .padding()
-    }
 
     private func progressState(label: String, identifier: String) -> some View {
         VStack(spacing: 16) {

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -1,5 +1,5 @@
 // MalwareUITests.swift
-// End-to-end UI test for Malware Removal — navigates to the section, taps the floating Scan on the unified intro, and asserts it renders either the scan screen or the ClamAV onboarding (depending on whether ClamAV is installed on the test host), exercising the sidebar → view-model → view wiring against the real app process.
+// End-to-end UI test for Malware Removal — navigates to the section, taps the floating Scan on the unified intro, and asserts it renders either the scan progress or the ClamAV onboarding (depending on whether ClamAV is installed on the test host), exercising the sidebar → view-model → view wiring against the real app process.
 
 import XCTest
 
@@ -42,22 +42,31 @@ final class MalwareUITests: XCTestCase {
                       "Expected the floating Scan button on the Malware Removal intro")
         floatingScan.click()
 
-        // After Scan, MalwareView takes over: either ClamAV is installed (its
-        // own "Scan for Malware" button) or it is not (the onboarding's "Check
-        // Again" button). Whichever the host produces, one of the two must
-        // appear — proving the section's detail view rendered.
-        let scanButton = app.buttons["malware.scan"]
+        // After Scan, MalwareView takes over and the unified intro is gone.
+        // `scan()` first enters `.checkingClamAV`, then branches per host:
+        // without ClamAV it lands durably on the install onboarding ("Check
+        // Again"); with ClamAV it progresses into the database-update /
+        // scanning progress states, which stay on screen for the tens of
+        // seconds `clamscan` walks the home directory. Either way one of these
+        // must appear — proving the section's detail view rendered. The old
+        // in-view "Scan for Malware" idle button no longer exists; the scan
+        // trigger is the shell's floating button tapped above.
         let onboardingRecheck = app.buttons["Check Again"]
+        let progress = app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier IN {'malware.checking', 'malware.updatingDatabase', 'malware.scanning'}"
+            ))
+            .firstMatch
 
         let deadline = Date().addingTimeInterval(10)
         while Date() < deadline {
-            if scanButton.exists || onboardingRecheck.exists { break }
+            if onboardingRecheck.exists || progress.exists { break }
             usleep(200_000)
         }
 
         XCTAssertTrue(
-            scanButton.exists || onboardingRecheck.exists,
-            "Expected Malware Removal to render either the scan screen or the ClamAV onboarding"
+            onboardingRecheck.exists || progress.exists,
+            "Expected Malware Removal to render either the ClamAV onboarding or the scan progress"
         )
     }
 

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -52,6 +52,10 @@ final class MalwareUITests: XCTestCase {
         // in-view "Scan for Malware" idle button no longer exists; the scan
         // trigger is the shell's floating button tapped above.
         let onboardingRecheck = app.buttons["Check Again"]
+        // Type-agnostic query (matching this suite's sibling pattern in
+        // `FinalPolishUITests`): `MalwareProgressState`'s identifier sits on a
+        // SwiftUI container whose XCUITest element type is not reliably
+        // predictable across OS versions, so we do not narrow to a class.
         let progress = app.descendants(matching: .any)
             .matching(NSPredicate(
                 format: "identifier IN {'malware.checking', 'malware.updatingDatabase', 'malware.scanning'}"

--- a/todo.md
+++ b/todo.md
@@ -60,5 +60,5 @@
 - [x] **Prompt 31** — Step 4/8: Extract reusable FloatingScanButton ([#87](https://github.com/jayvicsanantonio/VaderCleaner/issues/87))
 - [x] **Prompt 32** — Step 5/8: SectionIntroView (hero + description + sub-features) ([#88](https://github.com/jayvicsanantonio/VaderCleaner/issues/88))
 - [x] **Prompt 33** — Step 6/8: Wire intro + floating Scan into ContentView ([#89](https://github.com/jayvicsanantonio/VaderCleaner/issues/89))
-- [ ] **Prompt 34** — Step 7/8: Retire per-section bespoke idle states ([#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90))
+- [x] **Prompt 34** — Step 7/8: Retire per-section bespoke idle states ([#90](https://github.com/jayvicsanantonio/VaderCleaner/issues/90))
 - [ ] **Prompt 35** — Step 8/8: Transitions, accessibility, E2E, README ([#91](https://github.com/jayvicsanantonio/VaderCleaner/issues/91))


### PR DESCRIPTION
**Epic:** Scan-Centric Redesign (Phase 6). **Step 7 of 8.** Closes #90.

Pure deletion-only cleanup. After Step 6, `ContentView` shows the unified `SectionIntroView` whenever a scannable section's coordinator reports `.intro` — which maps **only** from each view model's `.idle` phase — so every detail view's `.idle` switch arm is unreachable. This removes the now-dead idle UI; the app behaves identically to the end of Step 6.

## Changes

- **SmartScan / SystemJunk / LargeOldFiles / SpaceLens / Malware**: the `.idle` switch arm now renders `EmptyView()` (retained so the switch stays exhaustive over `Phase`).
- **Optimization**: split the combined `case .idle, .loading:` so `.idle` → `EmptyView()` while `.loading` (a working state) keeps rendering `OptimizationProgressState` **unchanged**.
- Deleted orphaned subviews: `SmartScanIdleState`, `LargeOldFilesIdleState`, `MalwareIdleState`, and `SystemJunkView.idleState` (plus the `import AppKit` orphaned with `SmartScanIdleState`).
- `SpaceLensView.idleState` is **kept** — the `.ready` nil-node defensive fallback (a results-mapped branch, untouched) still uses it.
- Updated only comments made provably stale by the deletions: `SectionIntroView` (named the removed struct), the `.idle` phase-map lines in `SystemJunkView`/`SpaceLensView`, and the `SmartScanViewSubviews`/`MalwareViewSubviews` file headers. All other comments and the 2-line headers are preserved.
- No view model `Phase` enum or working/results/done/failed branch changed.

## Tests

`MalwareUITests` asserted on `malware.scan` — a button inside the deleted `MalwareIdleState`. The post-floating-scan assertion is repointed to host-independent **live** signals: the ClamAV install onboarding (`Check Again`) or the `malware.checking` / `malware.updatingDatabase` / `malware.scanning` progress states. This keeps both the ClamAV-present and ClamAV-absent paths covered without referencing deleted idle UI, and does not weaken working/results coverage. No other test referenced deleted idle UI.

## Verification

- Full unit + UI suite green (`** TEST SUCCEEDED **`); `MalwareUITests` passes.
- Zero new compiler warnings introduced.

## Acceptance criteria

- [x] Dead idle/landing UI removed from all six scannable section views; no orphaned subviews.
- [x] No view model Phase enum or working/results branch changed.
- [x] Tests asserting deleted idle UI removed/updated; working/results coverage intact.
- [x] App behaves identically to end of Step 6; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated intro state handling across scanner sections for more consistent and cohesive presentation throughout the app

* **Tests**
  * Updated scanner automation tests to verify updated onboarding flows and detection logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->