### PR TITLE
ui: reorder sidebar and keep Scan disc fully inside the window

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -32,6 +32,10 @@ struct ContentView: View {
     /// the floating Scan overlay so the disc centers over the detail content
     /// area (not the full window) without the two drifting apart.
     private let railWidth: CGFloat = 240
+    /// Bottom inset for the floating Scan overlay. Sized so the 108pt disc
+    /// and its breathing glow sit fully inside the window above the bottom
+    /// edge instead of being clipped by it.
+    private let floatingScanBottomPadding: CGFloat = 32
     init(
         systemJunkViewModel: SystemJunkViewModel,
         largeOldFilesViewModel: LargeOldFilesViewModel,
@@ -81,7 +85,7 @@ struct ContentView: View {
         .overlay(alignment: .bottom) {
             floatingScan(for: selectedSection ?? .smartScan)
                 .padding(.leading, railWidth)
-                .padding(.bottom, 32)
+                .padding(.bottom, floatingScanBottomPadding)
         }
         .frame(minWidth: 900, minHeight: 600)
         // Branded shell: gradient backdrop, crimson tint, forced dark

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -75,13 +75,13 @@ struct ContentView: View {
         // the OUTER HStack — outside the NavigationStack — so the detail
         // screens' toolbars and safe-area insets can't clip it. The leading
         // inset equal to the rail width re-centers the disc over the detail
-        // content area rather than the full window, and the negative bottom
-        // padding lets the disc and its glow bleed past the edge while its
-        // center stays inside the window so it remains hittable.
+        // content area rather than the full window, and the bottom padding
+        // keeps the whole disc and its glow inside the window above the
+        // bottom edge.
         .overlay(alignment: .bottom) {
             floatingScan(for: selectedSection ?? .smartScan)
                 .padding(.leading, railWidth)
-                .padding(.bottom, -24)
+                .padding(.bottom, 32)
         }
         .frame(minWidth: 900, minHeight: 600)
         // Branded shell: gradient backdrop, crimson tint, forced dark

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -9,11 +9,11 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
     case largeOldFiles
     case spaceLens
     case malwareRemoval
+    case optimization
     case privacy
     case extensions
     case appUninstaller
     case appUpdater
-    case optimization
     case healthMonitor
 
     var id: Self { self }
@@ -25,11 +25,11 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .largeOldFiles:   return String(localized: "Large & Old Files")
         case .spaceLens:       return String(localized: "Space Lens")
         case .malwareRemoval:  return String(localized: "Malware Removal")
+        case .optimization:    return String(localized: "Optimization")
         case .privacy:         return String(localized: "Privacy")
         case .extensions:      return String(localized: "Extensions")
         case .appUninstaller:  return String(localized: "App Uninstaller")
         case .appUpdater:      return String(localized: "App Updater")
-        case .optimization:    return String(localized: "Optimization")
         case .healthMonitor:   return String(localized: "Health Monitor")
         }
     }
@@ -45,11 +45,11 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .largeOldFiles:   return "sidebar.largeOldFiles"
         case .spaceLens:       return "sidebar.spaceLens"
         case .malwareRemoval:  return "sidebar.malwareRemoval"
+        case .optimization:    return "sidebar.optimization"
         case .privacy:         return "sidebar.privacy"
         case .extensions:      return "sidebar.extensions"
         case .appUninstaller:  return "sidebar.appUninstaller"
         case .appUpdater:      return "sidebar.appUpdater"
-        case .optimization:    return "sidebar.optimization"
         case .healthMonitor:   return "sidebar.healthMonitor"
         }
     }
@@ -74,11 +74,11 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .largeOldFiles:   return "doc.text.magnifyingglass"
         case .spaceLens:       return "square.split.2x2"
         case .malwareRemoval:  return "shield.lefthalf.filled"
+        case .optimization:    return "gauge.with.needle"
         case .privacy:         return "lock.shield"
         case .extensions:      return "puzzlepiece.extension"
         case .appUninstaller:  return "xmark.app"
         case .appUpdater:      return "arrow.triangle.2.circlepath.circle"
-        case .optimization:    return "gauge.with.needle"
         case .healthMonitor:   return "heart.text.square"
         }
     }


### PR DESCRIPTION
## What changed

Two small UI tweaks to the scan-centric shell:

1. **Sidebar order** — `Optimization` now sits directly after `Malware Removal` instead of after `App Updater`.
2. **Floating Scan disc** — the entire 108pt circle (plus its glow) now renders inside the window. Previously the overlay used a negative bottom inset that intentionally pushed the disc past the window's bottom edge, which read as the button being clipped.

## Why

- Grouping `Malware Removal` and `Optimization` together puts the two protect/tune sections next to each other, before the management-style screens (Privacy, Extensions, App Uninstaller, App Updater, Health Monitor).
- The bleed-past-the-edge styling on the Scan disc was a deliberate design choice, but in practice it looked like the button was being clipped by the window chrome — moving it fully inside the window removes that ambiguity.

## How

- `VaderCleaner/NavigationSection.swift`: move `case optimization` to follow `case malwareRemoval` in the enum declaration (this is what `NavigationSection.allCases` — and therefore the sidebar `ForEach` in `ContentView` — iterates). Reorder the matching `title`, `accessibilityIdentifier`, and `icon` switches to keep the file internally consistent. `isScannable` already grouped the two cases together, so no change there.
- `VaderCleaner/ContentView.swift`: flip the floating Scan overlay's `.padding(.bottom, -24)` → `.padding(.bottom, 32)` and update the adjacent comment to describe the disc staying fully inside the window rather than bleeding past it.

## Tests

`NavigationSectionTests` already pins the contract that matters:

- `test_firstCase_isSmartScan` — still passes (`smartScan` is unchanged as the first case).
- `test_allCasesCount_is11` — still passes (still 11 cases).
- The identifier-pinning tests are dictionary-based, so they're order-independent.

No new tests were added — the sidebar order is data-driven from `allCases` and is already covered by the existing pinning tests, and the Scan disc padding is a single layout constant.

## Reviewer notes

- UI tests target the stable `sidebar.<case>` / `section.<case>.scan` identifiers, which are unchanged, so existing UI-test selectors continue to work.
- The `floatingScan` overlay is attached to the outer `HStack` (outside the `NavigationStack`), so the toolbar / safe-area inset behavior the surrounding comment block describes is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating Scan overlay positioning to ensure visual elements remain fully within the window bounds instead of extending beyond the screen edge

* **Navigation**
  * Reorganized sidebar navigation section ordering for improved structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->