### PR TITLE
ux: surface Full Disk Access reminder when permission is missing

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		09756E0B2E09D8BF521C1141 /* MalwareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7315AD5A081B0855C316F00F /* MalwareView.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */; };
-		A1B2C3D4E5F60718293A4B5C /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B4A3928170F6E5D4C3B2A1 /* ScanCoordinatingConformanceTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
 		109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */; };
@@ -24,8 +23,6 @@
 		11C7DA0D7ECDCBF7DFB3C829 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 329FBD86F55918272AF0EF2A /* Localizable.stringsdict */; };
 		12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17B889E32D6334AED35F2BE /* LaunchAgent.swift */; };
 		1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732FA87F80DF686871220B50 /* SectionPresentationTests.swift */; };
-		FB2C7C1E2D3F4A5B6C7D8E92 /* FloatingScanButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */; };
-		FB607C1E2D3F4A5B6C7D8E96 /* SectionIntroViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB717C1E2D3F4A5B6C7D8E97 /* SectionIntroViewTests.swift */; };
 		13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */; };
 		1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */; };
 		159F0D7D84A23B27058835D6 /* BrowserDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D221A2A7BDB0CB1983DA2D72 /* BrowserDetector.swift */; };
@@ -34,6 +31,7 @@
 		196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
 		1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */; };
+		1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */; };
 		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
 		20A0A0A414E0D919060C99D2 /* MalwareThreatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */; };
 		218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46943B264F72B3753075A8C /* UpdateInfoTests.swift */; };
@@ -123,23 +121,24 @@
 		85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */; };
 		892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */; };
 		89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */; };
-		FB0A7C1E2D3F4A5B6C7D8E90 /* FloatingScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */; };
-		FB4E7C1E2D3F4A5B6C7D8E94 /* SectionIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5F7C1E2D3F4A5B6C7D8E95 /* SectionIntroView.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
 		91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */; };
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
 		9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */; };
+		99B965EE0BB2762D13896FF6 /* EmptyStateFullDiskAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */; };
 		99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC50A90E584320709971BCB /* ScanCategoryTests.swift */; };
 		9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */; };
 		9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */; };
 		9CA467B702E12F278B7BE6DC /* HelperConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43596249B222D18142F961E2 /* HelperConnectionManager.swift */; };
+		9D44F12D7502363B814F2DF9 /* SectionIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */; };
 		9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */; };
 		A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */; };
 		A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */; };
 		A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
+		A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */; };
 		ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */; };
 		AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC67B639248BC5EA1F5473 /* ScanCategory.swift */; };
 		B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */; };
@@ -190,6 +189,7 @@
 		EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */; };
 		EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */; };
 		EC99895496A545FE0F9A9222 /* FullDiskAccessPromptCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */; };
+		EE62512542BF54B5D6ADFA9D /* FloatingScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */; };
 		EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4E92A146A223EA836C156D /* ScanResultTests.swift */; };
 		F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */; };
 		F0838C9B10FFB6AD75523D0A /* PrivacyPermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */; };
@@ -198,6 +198,7 @@
 		F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8635D102B895AF349A13D /* AppUpdaterView.swift */; };
 		F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */; };
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
+		FE156E2CD69BA8F894E9078D /* FloatingScanButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A35775D85A4E890A04EE26 /* FloatingScanButtonTests.swift */; };
 		FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */; };
 		FF87A6FAB563AF43345061BB /* PreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */; };
 		FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */; };
@@ -284,18 +285,17 @@
 		2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModelTests.swift; sourceTree = "<group>"; };
 		2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModel.swift; sourceTree = "<group>"; };
 		2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManager.swift; sourceTree = "<group>"; };
+		2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButton.swift; sourceTree = "<group>"; };
 		2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanViewModelTests.swift; sourceTree = "<group>"; };
 		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
 		2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSection.swift; sourceTree = "<group>"; };
 		2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingTests.swift; sourceTree = "<group>"; };
-		C5B4A3928170F6E5D4C3B2A1 /* ScanCoordinatingConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingConformanceTests.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
-		FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButton.swift; sourceTree = "<group>"; };
-		FB5F7C1E2D3F4A5B6C7D8E95 /* SectionIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroView.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
+		3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingConformanceTests.swift; sourceTree = "<group>"; };
 		3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdaterTests.swift; sourceTree = "<group>"; };
 		3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerTests.swift; sourceTree = "<group>"; };
 		3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviding.swift; sourceTree = "<group>"; };
@@ -339,6 +339,7 @@
 		673CA7922445475111927C0B /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModel.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
+		6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroViewTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
 		6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerUITests.swift; sourceTree = "<group>"; };
 		6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModelTests.swift; sourceTree = "<group>"; };
@@ -349,8 +350,6 @@
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
 		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
-		FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButtonTests.swift; sourceTree = "<group>"; };
-		FB717C1E2D3F4A5B6C7D8E97 /* SectionIntroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroViewTests.swift; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
@@ -380,6 +379,7 @@
 		9D5CB08F96767D10B1271970 /* RAMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManager.swift; sourceTree = "<group>"; };
 		9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScanner.swift; sourceTree = "<group>"; };
 		9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFilesPathProviding.swift; sourceTree = "<group>"; };
+		9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroView.swift; sourceTree = "<group>"; };
 		A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareUITests.swift; sourceTree = "<group>"; };
 		A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategoryTests.swift; sourceTree = "<group>"; };
 		A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerApp.swift; sourceTree = "<group>"; };
@@ -398,11 +398,13 @@
 		B46943B264F72B3753075A8C /* UpdateInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfoTests.swift; sourceTree = "<group>"; };
 		B79E0766E335360E04FC6A53 /* AppDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscovery.swift; sourceTree = "<group>"; };
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
+		BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateFullDiskAccessTests.swift; sourceTree = "<group>"; };
 		BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScanner.swift; sourceTree = "<group>"; };
 		BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModelTests.swift; sourceTree = "<group>"; };
 		BF767348D39506E36221A89D /* MalwareThreatRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemover.swift; sourceTree = "<group>"; };
 		BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModelTests.swift; sourceTree = "<group>"; };
 		C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewSubviews.swift; sourceTree = "<group>"; };
+		C2A35775D85A4E890A04EE26 /* FloatingScanButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButtonTests.swift; sourceTree = "<group>"; };
 		C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScannerTests.swift; sourceTree = "<group>"; };
 		C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
 		C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinderTests.swift; sourceTree = "<group>"; };
@@ -528,8 +530,7 @@
 				F421495C84A41EDEF253EBD6 /* FileCategory.swift */,
 				6090134A72001DE6262436F3 /* FileIconCache.swift */,
 				BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */,
-				FB1B7C1E2D3F4A5B6C7D8E91 /* FloatingScanButton.swift */,
-				FB5F7C1E2D3F4A5B6C7D8E95 /* SectionIntroView.swift */,
+				2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */,
 				5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */,
 				AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */,
 				FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */,
@@ -578,6 +579,7 @@
 				AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */,
 				B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */,
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
+				9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */,
 				2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */,
 				3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */,
 				D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */,
@@ -654,14 +656,14 @@
 				E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */,
 				3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */,
 				BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */,
+				BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */,
 				C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */,
 				8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */,
 				DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */,
 				BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */,
 				A25898AAB0DB3AD51F22F385 /* FileCategoryTests.swift */,
 				6734EE11A5B3607B3D58EEA0 /* FileScannerTests.swift */,
-				FB3D7C1E2D3F4A5B6C7D8E93 /* FloatingScanButtonTests.swift */,
-				FB717C1E2D3F4A5B6C7D8E97 /* SectionIntroViewTests.swift */,
+				C2A35775D85A4E890A04EE26 /* FloatingScanButtonTests.swift */,
 				166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */,
 				E776BF468380DFF621C6063C /* HelperConnectionErrorTests.swift */,
 				0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */,
@@ -692,9 +694,10 @@
 				78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */,
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
+				3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */,
 				2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */,
-				C5B4A3928170F6E5D4C3B2A1 /* ScanCoordinatingConformanceTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
+				6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
 				22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */,
@@ -876,12 +879,14 @@
 				FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */,
 				82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */,
 				2A28D67DA396B3D2B6DB13D5 /* DiskScannerViewModelTests.swift in Sources */,
+				99B965EE0BB2762D13896FF6 /* EmptyStateFullDiskAccessTests.swift in Sources */,
 				A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */,
 				F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */,
 				7BB62CCBF7BE84455A11531C /* ExtensionItemTests.swift in Sources */,
 				B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */,
 				1541B5C534265E6FD9E74F7C /* FileCategoryTests.swift in Sources */,
 				823A4719C664D1125A35103C /* FileScannerTests.swift in Sources */,
+				FE156E2CD69BA8F894E9078D /* FloatingScanButtonTests.swift in Sources */,
 				2CE84E79268B4A59C5B8FACB /* HealthMonitorViewModelTests.swift in Sources */,
 				03546E424E99155428A6D25F /* HelperConnectionErrorTests.swift in Sources */,
 				6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */,
@@ -912,12 +917,11 @@
 				3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */,
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
+				1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */,
 				102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */,
-				A1B2C3D4E5F60718293A4B5C /* ScanCoordinatingConformanceTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
+				A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
-				FB2C7C1E2D3F4A5B6C7D8E92 /* FloatingScanButtonTests.swift in Sources */,
-				FB607C1E2D3F4A5B6C7D8E96 /* SectionIntroViewTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
 				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,
 				6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */,
@@ -995,6 +999,7 @@
 				60DBED2582B50DA009B180C4 /* FileCategory.swift in Sources */,
 				730791446114BB6991798518 /* FileIconCache.swift in Sources */,
 				52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */,
+				EE62512542BF54B5D6ADFA9D /* FloatingScanButton.swift in Sources */,
 				EC99895496A545FE0F9A9222 /* FullDiskAccessPromptCard.swift in Sources */,
 				E5E7952A56BA88D9CA86A1B5 /* HTTPFetching.swift in Sources */,
 				92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */,
@@ -1044,9 +1049,8 @@
 				9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */,
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
+				9D44F12D7502363B814F2DF9 /* SectionIntroView.swift in Sources */,
 				89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */,
-				FB0A7C1E2D3F4A5B6C7D8E90 /* FloatingScanButton.swift in Sources */,
-				FB4E7C1E2D3F4A5B6C7D8E94 /* SectionIntroView.swift in Sources */,
 				FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */,
 				9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */,
 				E357AD8EDB1FA65E6D5EB59E /* SmartScanViewSubviews.swift in Sources */,

--- a/VaderCleaner/FullDiskAccessPromptCard.swift
+++ b/VaderCleaner/FullDiskAccessPromptCard.swift
@@ -1,20 +1,27 @@
 // FullDiskAccessPromptCard.swift
-// Inline banner shown in FDA-sensitive scanner idle states when Full Disk Access is missing, so the user gets an actionable prompt instead of silently empty or incomplete scan results.
+// Inline accent-tinted reminder shown on a section's intro when Full Disk Access is missing, so the user is told up front that scans here will be incomplete and can grant access without leaving the flow.
 
 import SwiftUI
 import AppKit
 
-/// Non-blocking inline prompt rendered above a scanner's Scan call-to-action
-/// when Full Disk Access has not been granted. The app-wide onboarding sheet
-/// (`PermissionOnboardingView`) covers first run; once the user dismisses it
-/// with "Continue Without Access" this card is the persistent, per-feature
-/// reminder that scans here will be incomplete until access is granted.
+/// Non-blocking inline prompt rendered inside a scannable section's intro
+/// (and in `PrivacyView`'s idle state) when Full Disk Access has not been
+/// granted. The app-wide onboarding sheet (`PermissionOnboardingView`) covers
+/// first run; once the user dismisses it with "Continue Without Access" this
+/// card is the persistent, per-section reminder that scans here will be
+/// incomplete until access is granted.
 ///
-/// The owning view supplies only the recheck action (typically
+/// `accent` tints the lock symbol and the primary CTA so the card reads as
+/// part of the section it sits in (System Junk green, Large & Old Files teal,
+/// etc.). The owning view supplies the recheck action (typically
 /// `AppState.refresh`). Opening System Settings reuses the same deep-link as
 /// the onboarding sheet so the Full Disk Access pane URL lives in one place.
 struct FullDiskAccessPromptCard: View {
 
+    /// Section-aware tint applied to the lock symbol and the primary button.
+    /// Defaults to crimson so existing call sites (PrivacyView) stay on the
+    /// Vader palette without a code change.
+    var accent: Color = .vaderCrimson
     let onRecheck: () -> Void
 
     private func openSettings() {
@@ -25,7 +32,8 @@ struct FullDiskAccessPromptCard: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: "lock.shield")
                 .font(.title2)
-                .foregroundStyle(.tint)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(accent)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Full Disk Access needed")
                     .font(.callout.weight(.semibold))
@@ -37,6 +45,7 @@ struct FullDiskAccessPromptCard: View {
                     Button("Open System Settings", action: openSettings)
                         .controlSize(.small)
                         .buttonStyle(.borderedProminent)
+                        .tint(accent)
                         .accessibilityIdentifier("fda.openSettings")
                     Button("Check Again", action: onRecheck)
                         .controlSize(.small)
@@ -49,13 +58,17 @@ struct FullDiskAccessPromptCard: View {
         }
         .padding(12)
         .glassEffect(.regular, in: .rect(cornerRadius: 8))
+        // Soft accent halo so the card feels native to the section without
+        // overpowering the hero — sits beneath the glass so the surface still
+        // reads as a quiet reminder, not an alert.
+        .shadow(color: accent.opacity(0.25), radius: 14, y: 4)
         .frame(maxWidth: 420)
         .accessibilityIdentifier("fda.inlinePrompt")
     }
 }
 
 #Preview {
-    FullDiskAccessPromptCard(onRecheck: {})
+    FullDiskAccessPromptCard(accent: .green, onRecheck: {})
         .padding()
         .frame(width: 560)
 }

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -80,7 +80,11 @@ struct LargeOldFilesView: View {
                 onAddToExclusions: { exclusions.add(path: $0.url.path) }
             )
         case .empty:
-            LargeOldFilesEmptyState(onScanAgain: viewModel.scanAgain)
+            LargeOldFilesEmptyState(
+                onScanAgain: viewModel.scanAgain,
+                hasFullDiskAccess: appState.hasFullDiskAccess,
+                onRefreshAccess: { appState.refresh() }
+            )
         case .failed(let stage, let message):
             LargeOldFilesFailedState(stage: stage, message: message, onTryAgain: viewModel.scanAgain)
         }

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -267,6 +267,19 @@ struct LargeOldFilesFooter: View {
 
 struct LargeOldFilesEmptyState: View {
     let onScanAgain: () -> Void
+    /// Current Full Disk Access state. Drives whether the inline reminder
+    /// appears under the "Scan Again" CTA — without it the user can't tell
+    /// whether the empty result is genuine or just FDA-blocked.
+    let hasFullDiskAccess: Bool
+    /// Re-runs the FDA check. Wired to `AppState.refresh()` so the card can
+    /// fade out the moment the user grants access in System Settings.
+    let onRefreshAccess: () -> Void
+
+    /// Pure predicate so the gate is unit-testable without rendering. The
+    /// per-section "this scan needs FDA" decision lives in
+    /// `NavigationSection.requiresFullDiskAccess`; here it is unconditional
+    /// because Large & Old Files always requires FDA to read ~/Library.
+    var shouldShowFullDiskAccessReminder: Bool { !hasFullDiskAccess }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -285,8 +298,18 @@ struct LargeOldFilesEmptyState: View {
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("large-old.scanAgain")
+
+            if shouldShowFullDiskAccessReminder {
+                FullDiskAccessPromptCard(
+                    accent: .teal,
+                    onRecheck: onRefreshAccess
+                )
+                .padding(.top, 8)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
         }
         .padding()
+        .animation(.smooth(duration: 0.4), value: hasFullDiskAccess)
     }
 }
 

--- a/VaderCleaner/MalwareView.swift
+++ b/VaderCleaner/MalwareView.swift
@@ -11,6 +11,9 @@ struct MalwareView: View {
     @ObservedObject private var viewModel: MalwareViewModel
     @StateObject private var onboardingViewModel = MalwareOnboardingViewModel()
     @State private var confirmingRemoval = false
+    /// Observed so the clean state's inline FDA reminder card can fade out
+    /// the moment access is granted (scenePhase refresh flips the flag).
+    @EnvironmentObject private var appState: AppState
 
     init(viewModel: MalwareViewModel) {
         self.viewModel = viewModel
@@ -100,7 +103,9 @@ struct MalwareView: View {
         case .clean:
             MalwareCleanState(
                 lastScanDate: viewModel.lastScanDate,
-                onScanAgain: { viewModel.startScan() }
+                onScanAgain: { viewModel.startScan() },
+                hasFullDiskAccess: appState.hasFullDiskAccess,
+                onRefreshAccess: { appState.refresh() }
             )
         case .results(let threats):
             MalwareResultsState(
@@ -148,5 +153,6 @@ struct MalwareView: View {
     )
     return MalwareView(viewModel: vm)
         .frame(width: 900, height: 600)
+        .environmentObject(AppState(checker: { true }))
         .task { await vm.scan() }
 }

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -93,6 +93,19 @@ struct MalwareFailedState: View {
 struct MalwareCleanState: View {
     let lastScanDate: Date?
     let onScanAgain: () -> Void
+    /// Current Full Disk Access state. Without FDA, ClamAV can't read
+    /// system-protected paths, so a "clean" result can be misleading — the
+    /// reminder card surfaces here so the user knows the scan was partial.
+    let hasFullDiskAccess: Bool
+    /// Re-runs the FDA check, wired to `AppState.refresh()` so the card can
+    /// fade out the moment the user grants access in System Settings.
+    let onRefreshAccess: () -> Void
+
+    /// Pure predicate so the gate is unit-testable without rendering. The
+    /// per-section "this scan needs FDA" decision lives in
+    /// `NavigationSection.requiresFullDiskAccess`; here it is unconditional
+    /// because Malware Removal always requires FDA for a complete scan.
+    var shouldShowFullDiskAccessReminder: Bool { !hasFullDiskAccess }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -120,9 +133,19 @@ struct MalwareCleanState: View {
             ), action: onScanAgain)
                 .controlSize(.large)
                 .accessibilityIdentifier("malware.scanAgain")
+
+            if shouldShowFullDiskAccessReminder {
+                FullDiskAccessPromptCard(
+                    accent: .vaderCrimson,
+                    onRecheck: onRefreshAccess
+                )
+                .padding(.top, 8)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
+        .animation(.smooth(duration: 0.4), value: hasFullDiskAccess)
     }
 }
 

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -98,4 +98,22 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
             return false
         }
     }
+
+    /// Whether this section's scan reads paths that are gated by Full Disk
+    /// Access. Drives whether the intro screen shows the inline FDA reminder
+    /// card — sections that don't touch FDA-protected paths (Optimization, the
+    /// management screens) intentionally never warn so the prompt is reserved
+    /// for cases where missing the permission really would yield empty or
+    /// incomplete results. Exhaustive switch so a future section is a
+    /// compile-time prompt to classify it here.
+    var requiresFullDiskAccess: Bool {
+        switch self {
+        case .smartScan, .systemJunk, .largeOldFiles,
+             .spaceLens, .malwareRemoval:
+            return true
+        case .optimization, .privacy, .extensions,
+             .appUninstaller, .appUpdater, .healthMonitor:
+            return false
+        }
+    }
 }

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -13,10 +13,24 @@ struct SectionIntroView: View {
     let presentation: SectionPresentation
     let section: NavigationSection
 
+    /// Observed for the inline FDA reminder. When access flips on (the user
+    /// granted it in System Settings; scenePhase refreshes the flag on
+    /// foreground), the card animates out so the intro returns to its
+    /// uncluttered landing without a relaunch.
+    @EnvironmentObject private var appState: AppState
+
     /// Localized section title for display. A computed accessor so the
     /// rendered heading tracks the UI language while the identifiers below
     /// stay fixed regardless of locale.
     var title: String { section.title }
+
+    /// Whether the inline Full Disk Access reminder should render for this
+    /// section given the supplied access flag. Pulled out as a pure predicate
+    /// so tests can pin the behaviour without rendering the body — the only
+    /// inputs are `section.requiresFullDiskAccess` and the flag itself.
+    func shouldShowFullDiskAccessReminder(hasFullDiskAccess: Bool) -> Bool {
+        section.requiresFullDiskAccess && !hasFullDiskAccess
+    }
 
     // MARK: Accessibility identifiers
 
@@ -126,8 +140,8 @@ struct SectionIntroView: View {
 
     // MARK: Text + features
 
-    /// Title, tagline, and the descriptive feature rows, grouped under the
-    /// per-section accessibility identifier.
+    /// Title, tagline, the inline FDA reminder (when needed), and the
+    /// descriptive feature rows, grouped under the per-section identifier.
     private var textColumn: some View {
         VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 10) {
@@ -146,12 +160,32 @@ struct SectionIntroView: View {
                     .frame(maxWidth: 420, alignment: .leading)
             }
 
+            // Inline reminder, sized to align with the tagline column. Sits
+            // between tagline and features so it reads as context for "what
+            // this scan can see" rather than an alarm above the title. Slides
+            // in/out smoothly when access flips, which is the moment of
+            // delight: granting access in System Settings and watching the
+            // card retract on return.
+            if shouldShowFullDiskAccessReminder(hasFullDiskAccess: appState.hasFullDiskAccess) {
+                FullDiskAccessPromptCard(
+                    accent: presentation.accent,
+                    onRecheck: { appState.refresh() }
+                )
+                .transition(
+                    .asymmetric(
+                        insertion: .opacity.combined(with: .move(edge: .top)),
+                        removal: .opacity.combined(with: .scale(scale: 0.96))
+                    )
+                )
+            }
+
             VStack(alignment: .leading, spacing: 14) {
                 ForEach(Array(presentation.features.enumerated()), id: \.offset) { index, feature in
                     featureRow(feature, index: index)
                 }
             }
         }
+        .animation(.smooth(duration: 0.4), value: appState.hasFullDiskAccess)
         // Combine the title + tagline + rows under the per-section id without
         // hiding the rows: .contain keeps each row independently queryable by
         // its own identifier while still pinning "this is section X's intro".

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -62,11 +62,25 @@ struct SystemJunkView: View {
         .accessibilityIdentifier(identifier)
     }
 
+    @ViewBuilder
     private func previewState(result: ScanResult) -> some View {
-        VStack(spacing: 0) {
-            previewList(result: result)
-            Divider()
-            previewFooter
+        if result.items.isEmpty {
+            // A scan that found nothing collapses to the dedicated empty
+            // subview — the regular preview list + disabled Clean footer
+            // reads as "you did something wrong" when the truth is "nothing
+            // qualified." The empty subview also carries the FDA reminder
+            // for the silent-failure case.
+            SystemJunkEmptyPreviewState(
+                onScanAgain: viewModel.scanAgain,
+                hasFullDiskAccess: appState.hasFullDiskAccess,
+                onRefreshAccess: { appState.refresh() }
+            )
+        } else {
+            VStack(spacing: 0) {
+                previewList(result: result)
+                Divider()
+                previewFooter
+            }
         }
     }
 
@@ -200,6 +214,61 @@ private struct CategoryRow: View {
                 .foregroundStyle(.secondary)
         }
         .padding(.vertical, 4)
+    }
+}
+
+/// Empty-result variant of the preview state. Surfaces when a scan returns
+/// zero items — without it, the user would land on the regular preview list
+/// with a disabled Clean button, reading as "I did something wrong" when the
+/// truth is "nothing qualified or FDA blocked the reads." The inline FDA
+/// reminder card surfaces under the CTA whenever access is missing, so the
+/// silent-failure case is always explained.
+struct SystemJunkEmptyPreviewState: View {
+    let onScanAgain: () -> Void
+    /// Current Full Disk Access state. Drives whether the inline reminder
+    /// appears under the "Scan Again" CTA.
+    let hasFullDiskAccess: Bool
+    /// Re-runs the FDA check, wired to `AppState.refresh()` so the card can
+    /// fade out the moment the user grants access in System Settings.
+    let onRefreshAccess: () -> Void
+
+    /// Pure predicate so the gate is unit-testable without rendering. The
+    /// per-section "this scan needs FDA" decision lives in
+    /// `NavigationSection.requiresFullDiskAccess`; here it is unconditional
+    /// because System Junk always requires FDA to read /Library/Caches and
+    /// /Library/Logs.
+    var shouldShowFullDiskAccessReminder: Bool { !hasFullDiskAccess }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.green)
+            Text("Nothing to clean up")
+                .font(.title2.weight(.semibold))
+                .accessibilityIdentifier("system-junk.emptyTitle")
+            Text("No junk caches, logs, or mail attachments were found this time.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+            Button("Scan Again", action: onScanAgain)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("system-junk.emptyScanAgain")
+
+            if shouldShowFullDiskAccessReminder {
+                FullDiskAccessPromptCard(
+                    accent: .green,
+                    onRecheck: onRefreshAccess
+                )
+                .padding(.top, 8)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .animation(.smooth(duration: 0.4), value: hasFullDiskAccess)
     }
 }
 

--- a/VaderCleanerTests/EmptyStateFullDiskAccessTests.swift
+++ b/VaderCleanerTests/EmptyStateFullDiskAccessTests.swift
@@ -1,0 +1,77 @@
+// EmptyStateFullDiskAccessTests.swift
+// Pins that each FDA-sensitive section's empty/clean detail state surfaces the inline Full Disk Access reminder when access is missing, so a user who tapped Scan before reading the intro reminder still sees why the result looks like "nothing found."
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class EmptyStateFullDiskAccessTests: XCTestCase {
+
+    func test_largeOldFilesEmptyState_showsReminderOnlyWhenAccessIsMissing() {
+        let missing = LargeOldFilesEmptyState(
+            onScanAgain: {},
+            hasFullDiskAccess: false,
+            onRefreshAccess: {}
+        )
+        XCTAssertTrue(
+            missing.shouldShowFullDiskAccessReminder,
+            "The empty state must surface the reminder when Full Disk Access is missing"
+        )
+
+        let granted = LargeOldFilesEmptyState(
+            onScanAgain: {},
+            hasFullDiskAccess: true,
+            onRefreshAccess: {}
+        )
+        XCTAssertFalse(
+            granted.shouldShowFullDiskAccessReminder,
+            "The empty state must hide the reminder once Full Disk Access is granted"
+        )
+    }
+
+    func test_malwareCleanState_showsReminderOnlyWhenAccessIsMissing() {
+        let missing = MalwareCleanState(
+            lastScanDate: nil,
+            onScanAgain: {},
+            hasFullDiskAccess: false,
+            onRefreshAccess: {}
+        )
+        XCTAssertTrue(
+            missing.shouldShowFullDiskAccessReminder,
+            "The clean state must surface the reminder when Full Disk Access is missing"
+        )
+
+        let granted = MalwareCleanState(
+            lastScanDate: nil,
+            onScanAgain: {},
+            hasFullDiskAccess: true,
+            onRefreshAccess: {}
+        )
+        XCTAssertFalse(
+            granted.shouldShowFullDiskAccessReminder,
+            "The clean state must hide the reminder once Full Disk Access is granted"
+        )
+    }
+
+    func test_systemJunkEmptyPreviewState_showsReminderOnlyWhenAccessIsMissing() {
+        let missing = SystemJunkEmptyPreviewState(
+            onScanAgain: {},
+            hasFullDiskAccess: false,
+            onRefreshAccess: {}
+        )
+        XCTAssertTrue(
+            missing.shouldShowFullDiskAccessReminder,
+            "The empty preview state must surface the reminder when Full Disk Access is missing"
+        )
+
+        let granted = SystemJunkEmptyPreviewState(
+            onScanAgain: {},
+            hasFullDiskAccess: true,
+            onRefreshAccess: {}
+        )
+        XCTAssertFalse(
+            granted.shouldShowFullDiskAccessReminder,
+            "The empty preview state must hide the reminder once Full Disk Access is granted"
+        )
+    }
+}

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -80,6 +80,32 @@ final class NavigationSectionTests: XCTestCase {
         XCTAssertEqual(Set(ids).count, ids.count, "Scan identifiers must be unique")
     }
 
+    func test_requiresFullDiskAccess_isPinned() {
+        // The reminder card surfaces on a section's intro only when its scan
+        // actually needs Full Disk Access. Pinned per case so a future
+        // section can't silently slip through with the wrong default.
+        let expected: [NavigationSection: Bool] = [
+            .smartScan: true,        // composes System Junk + Malware
+            .systemJunk: true,       // /Library/Caches, /Library/Logs, mail
+            .largeOldFiles: true,    // walks ~/Library
+            .spaceLens: true,        // home directory walk
+            .malwareRemoval: true,   // ClamAV scan
+            .optimization: false,    // launchctl / login items / RAM
+            .privacy: false,
+            .extensions: false,
+            .appUninstaller: false,
+            .appUpdater: false,
+            .healthMonitor: false,
+        ]
+        for section in NavigationSection.allCases {
+            XCTAssertEqual(
+                section.requiresFullDiskAccess,
+                expected[section],
+                "requiresFullDiskAccess for \(section) drifted — reclassify here intentionally."
+            )
+        }
+    }
+
     func test_eachSection_hasValidSFSymbol() throws {
         guard #available(macOS 14.0, *) else {
             throw XCTSkip("SF Symbol validation requires macOS 14.0 (the app's minimum deployment target)")

--- a/VaderCleanerTests/SectionIntroViewTests.swift
+++ b/VaderCleanerTests/SectionIntroViewTests.swift
@@ -91,6 +91,52 @@ final class SectionIntroViewTests: XCTestCase {
         }
     }
 
+    func test_reminderShows_whenSectionRequiresFDAAndAccessIsMissing() throws {
+        // The reminder card surfaces on the intro of every FDA-sensitive
+        // section whenever Full Disk Access has not been granted. Tested via
+        // the view's pure predicate so we don't need to render the body.
+        for section in NavigationSection.allCases where section.isScannable && section.requiresFullDiskAccess {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let view = SectionIntroView(presentation: presentation, section: section)
+
+            XCTAssertTrue(
+                view.shouldShowFullDiskAccessReminder(hasFullDiskAccess: false),
+                "\(section) requires FDA — the reminder must show when access is missing"
+            )
+        }
+    }
+
+    func test_reminderHides_whenFullDiskAccessIsGranted() throws {
+        // Granting access takes the card away on the next state flip, so the
+        // intro returns to its uncluttered landing.
+        for section in NavigationSection.allCases where section.isScannable {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let view = SectionIntroView(presentation: presentation, section: section)
+
+            XCTAssertFalse(
+                view.shouldShowFullDiskAccessReminder(hasFullDiskAccess: true),
+                "\(section) must not show the reminder once Full Disk Access is granted"
+            )
+        }
+    }
+
+    func test_reminderHides_whenSectionDoesNotRequireFDA() throws {
+        // Sections whose scans don't read FDA-gated paths never warn, even
+        // when access is missing — the reminder is reserved for cases where
+        // missing FDA actually yields empty or incomplete results.
+        for section in NavigationSection.allCases
+            where section.isScannable && !section.requiresFullDiskAccess
+        {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            let view = SectionIntroView(presentation: presentation, section: section)
+
+            XCTAssertFalse(
+                view.shouldShowFullDiskAccessReminder(hasFullDiskAccess: false),
+                "\(section) does not require FDA — the reminder must stay hidden"
+            )
+        }
+    }
+
     func test_eachFeatureExposesItsIndexedAccessibilityIdentifier() throws {
         for section in NavigationSection.allCases where section.isScannable {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))


### PR DESCRIPTION
## What and why

Users who clicked **Continue Without Access** on the first-run FDA onboarding had no on-screen indication that subsequent scans would return empty or incomplete results. Tapping the floating **Scan** disc looked like a broken button: the press fired, the scan ran, and the result surface said "Nothing to clean up" / "No threats found" without ever explaining that Full Disk Access was the real reason.

This PR closes that loop in two stages:

1. **On every FDA-sensitive section's intro** — surface an inline reminder so the user is told up front that the scan they're about to run will be incomplete.
2. **On the three silent-failure result surfaces** — render the same reminder under "Nothing to clean up" / "No threats found" / System Junk's empty preview, so a user who skipped the intro card still sees the explanation when the result looks misleadingly "all good."

The floating Scan disc itself stays **fully enabled and full-opacity** in both flows. Pure Option A: educate the user, don't paternalize the affordance.

## Commits

Split for review:

| Commit | Scope |
|---|---|
| [`55d5e9e`](https://github.com/jayvicsanantonio/VaderCleaner/commit/55d5e9e) — "surface FDA reminder on every FDA-sensitive section intro" | The intro-card wiring. Reusable foundations: ` requiresFullDiskAccess`, `accent: Color` param on the card, predicate + render in `SectionIntroView`. |
| [`574b27d`](https://github.com/jayvicsanantonio/VaderCleaner/commit/574b27d) — "extend FDA reminder into the three silent-failure result states" | Propagates the same card into Large & Old Files empty / Malware clean / System Junk empty preview. |

Each commit builds and tests pass independently.

## Design choices

- **Placement on the intro: between tagline and features.** Reads as context for "what this scan can see" rather than an alarm above the title. The advisor pass weighed three placements; this one integrated best with the natural reading flow.
- **Card accent matches the section.** Lock symbol and primary CTA pick up the section's tint (green System Junk, teal Large & Old Files, indigo Space Lens, crimson Malware/Smart Scan). Soft accent halo under the glass keeps the surface quiet, not alert-y. The default stays crimson so the existing `PrivacyView` call site is unchanged.
- **Smooth slide-out on grant.** Granting access in System Settings → returning to the app → `scenePhase` refresh → `appState.hasFullDiskAccess` flips → the card retracts via `.smooth(duration: 0.4)`. That's the delight beat.
- **Disc stays fully enabled.** Considered dimming/disabling, rejected. The user's earlier feedback locked Option A: warn, don't gate.
- **`NavigationSection.requiresFullDiskAccess`** lives in one exhaustive switch so a future section is a compile-time prompt to classify it. Optimization opts out (launchctl / login items / RAM need no FDA).
- **Plain-param forwarding into leaf subviews, not new `@EnvironmentObject`.** Matches the existing pattern (`onScanAgain`, `lastScanDate`); keeps `#Preview` blocks buildable without injection. Parent views hold the env object and forward.
- **System Junk: branch on empty result, don't blanket the preview.** Showing the reminder on a preview that *did* find items would nag. Only the empty case (the actual silent-failure surface) gets the new dedicated `SystemJunkEmptyPreviewState`.

## Sections intentionally not covered (advisor confirmed)

- **Space Lens `.ready`** — renders a treemap with real folders, so the user always sees *something*. Not a "checkmark says all good" lie.
- **Smart Scan dashboard** — composes the others. The "Review" buttons funnel users into per-section detail views where the new cards surface. Adding another card on the dashboard would be redundant.

Both are one-line additions if usage suggests otherwise.

## Tests

- `NavigationSection.requiresFullDiskAccess` pinned per case in [NavigationSectionTests.swift](VaderCleanerTests/NavigationSectionTests.swift).
- `SectionIntroView.shouldShowFullDiskAccessReminder(hasFullDiskAccess:)` pinned across all scannable sections in [SectionIntroViewTests.swift](VaderCleanerTests/SectionIntroViewTests.swift).
- New [EmptyStateFullDiskAccessTests.swift](VaderCleanerTests/EmptyStateFullDiskAccessTests.swift) pins the predicate on each of the three empty-state subviews.

**Local run:**
- `xcodebuild build` ✅
- Full unit suite: **690/690 passing** (6 new across both commits).
- UI tests for `SmartScan`, `SystemJunk`, `Optimization`, `SpaceLens`, `Malware`, `FinalPolish`: all passing — existing identifiers and layouts untouched.

## Reviewer caveat

The UI tests run on a machine where Full Disk Access is granted, so the new card rendering paths are unit-tested but **not exercised end-to-end** in UI tests. Manual smoke check — toggle FDA off in System Settings and click through each FDA-sensitive section's intro + force an empty scan — is the real verification for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Full Disk Access reminders to scan result and empty state screens, displayed when access is not granted.
  * Full Disk Access prompt cards now support customizable accent colors for enhanced visual consistency across sections.

* **Tests**
  * Added tests to verify Full Disk Access reminder visibility in empty and clean states.
  * Added tests to validate Full Disk Access requirements per scan section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->