### PR TITLE
Skip TCC-protected media stores and unify the crimson theme accent

### DIFF
--- a/VaderCleaner/FileCategory.swift
+++ b/VaderCleaner/FileCategory.swift
@@ -27,13 +27,20 @@ enum FileCategory: Hashable {
     /// Tile color in the treemap. Held with the enum rather than at the
     /// view layer so a future use (legend, tooltip swatch) can read it
     /// directly without re-implementing the mapping.
+    ///
+    /// All five shades sit in the crimson family so the treemap stays inside
+    /// the Vader identity; they are spread bright → deep across lightness so
+    /// neighboring tiles remain distinguishable at a glance. `.media` is the
+    /// theme anchor — it is exactly `Color.vaderCrimson`. `.other` is a
+    /// desaturated dusty crimson so the fallback bucket still reads as the
+    /// quiet, neutral category.
     var color: Color {
         switch self {
-        case .documents: return .blue
-        case .media:     return .purple
-        case .apps:      return .orange
-        case .system:    return .red
-        case .other:     return .gray
+        case .documents: return Color(red: 0.95, green: 0.30, blue: 0.36)
+        case .media:     return .vaderCrimson
+        case .apps:      return Color(red: 0.66, green: 0.09, blue: 0.15)
+        case .system:    return Color(red: 0.46, green: 0.07, blue: 0.12)
+        case .other:     return Color(red: 0.40, green: 0.20, blue: 0.24)
         }
     }
 

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -32,8 +32,36 @@ struct FileScanOptions: Equatable {
 
     let packagesAsFiles: Bool
 
-    init(packagesAsFiles: Bool = false) {
+    /// When true, the walk never descends into or emits a TCC-protected
+    /// photo-library bundle (see `ProtectedMediaStoreBundle`). Reading inside
+    /// one trips a macOS Photos privacy prompt, so the Large & Old Files scan
+    /// sets this; System Junk scans (which never reach `~/Pictures`) leave it
+    /// off and keep their historical behaviour.
+    let skipsProtectedMediaStores: Bool
+
+    init(packagesAsFiles: Bool = false, skipsProtectedMediaStores: Bool = false) {
         self.packagesAsFiles = packagesAsFiles
+        self.skipsProtectedMediaStores = skipsProtectedMediaStores
+    }
+}
+
+/// Recognises the TCC-protected photo-library bundles a scan must not descend
+/// into. Reading the contents of a Photos or Photo Booth library trips a macOS
+/// Photos privacy prompt, so `FileScanner` skips these whole when
+/// `FileScanOptions.skipsProtectedMediaStores` is set.
+///
+/// The Apple Music media folder (`~/Music/Music`) is not covered here — it is a
+/// plainly-named directory at a fixed path, so callers exclude it by path
+/// instead (see `UserFilesPathProviding.protectedMediaStores()`).
+enum ProtectedMediaStoreBundle {
+    /// True when `url` names a Photos library bundle (`.photoslibrary`, any
+    /// casing) or the `Photo Booth Library` bundle. Matching is
+    /// case-insensitive to mirror the default case-insensitive APFS volume.
+    static func matches(_ url: URL) -> Bool {
+        if url.pathExtension.caseInsensitiveCompare("photoslibrary") == .orderedSame {
+            return true
+        }
+        return url.lastPathComponent.caseInsensitiveCompare("Photo Booth Library") == .orderedSame
     }
 }
 
@@ -409,6 +437,18 @@ struct FileScanner: FileScanning {
                 }
 
                 let isDirectory = resourceValues?.isDirectory == true
+
+                // Never descend into a TCC-protected photo-library bundle —
+                // reading its contents trips a macOS Photos privacy prompt.
+                // The bundle is dropped, not emitted: a photo library is not
+                // a deletable file.
+                if options.skipsProtectedMediaStores,
+                   isDirectory,
+                   ProtectedMediaStoreBundle.matches(url) {
+                    enumerator.skipDescendants()
+                    continue
+                }
+
                 if options.packagesAsFiles,
                    isDirectory,
                    resourceValues?.isPackage == true {

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -47,8 +47,9 @@ struct LargeOldFilesScanner {
         return matches
     }
 
-    /// Runs the scan and emits matching files in batches. `excluding` is
-    /// forwarded straight to the underlying `FileScanning` — the
+    /// Runs the scan and emits matching files in batches. Caller-provided
+    /// `excluding` paths are combined with `pathProvider.protectedMediaStores()`
+    /// before being forwarded to the underlying `FileScanning`; the
     /// path-component-aware match semantics covered in `FileScannerTests`
     /// apply unchanged.
     ///

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -69,15 +69,17 @@ struct LargeOldFilesScanner {
             // synthetic "unclassified" case to the public `ScanCategory` enum.
             ScanRoot(url: $0, category: .largeFile)
         }
-        // Fold the TCC-protected media stores (Photos / Apple Music) into the
-        // exclusion list so the walk never descends into them — descending
-        // would trip a macOS privacy prompt for Photos or Music access.
+        // Keep the walk out of TCC-protected media stores so it never trips a
+        // macOS Photos/Music privacy prompt. Apple Music's media folder is a
+        // plainly-named directory at a fixed path, so it is excluded by path;
+        // photo-library bundles can live anywhere, so `skipsProtectedMediaStores`
+        // has `FileScanner` recognise and skip them by name mid-walk.
         let allExclusions = excluding + pathProvider.protectedMediaStores()
         let cutoff = now().addingTimeInterval(-Self.ageThresholdSeconds)
         try await fileScanner.scan(
             roots: roots,
             excluding: allExclusions,
-            options: FileScanOptions(packagesAsFiles: true),
+            options: FileScanOptions(packagesAsFiles: true, skipsProtectedMediaStores: true),
             batchSize: batchSize
         ) { scannedBatch in
             let matchedBatch = scannedBatch.compactMap { Self.classify($0, cutoff: cutoff) }

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -68,10 +68,14 @@ struct LargeOldFilesScanner {
             // synthetic "unclassified" case to the public `ScanCategory` enum.
             ScanRoot(url: $0, category: .largeFile)
         }
+        // Fold the TCC-protected media stores (Photos / Apple Music) into the
+        // exclusion list so the walk never descends into them — descending
+        // would trip a macOS privacy prompt for Photos or Music access.
+        let allExclusions = excluding + pathProvider.protectedMediaStores()
         let cutoff = now().addingTimeInterval(-Self.ageThresholdSeconds)
         try await fileScanner.scan(
             roots: roots,
-            excluding: excluding,
+            excluding: allExclusions,
             options: FileScanOptions(packagesAsFiles: true),
             batchSize: batchSize
         ) { scannedBatch in

--- a/VaderCleaner/SectionPresentation.swift
+++ b/VaderCleaner/SectionPresentation.swift
@@ -64,7 +64,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "trash",
                 heroAssetName: nil,
-                accent: .green,
+                accent: .vaderCrimson,
                 tagline: String(
                     localized: "Clean your system to reclaim space and boost performance.",
                     comment: "System Junk intro tagline."
@@ -92,7 +92,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "doc.text.magnifyingglass",
                 heroAssetName: nil,
-                accent: .teal,
+                accent: .vaderCrimson,
                 tagline: String(
                     localized: "Find big and forgotten files taking up space.",
                     comment: "Large & Old Files intro tagline."
@@ -116,7 +116,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "square.split.2x2",
                 heroAssetName: nil,
-                accent: .indigo,
+                accent: .vaderCrimson,
                 tagline: String(
                     localized: "See what's using your storage with an interactive map.",
                     comment: "Space Lens intro tagline."
@@ -160,7 +160,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "gauge.with.needle",
                 heroAssetName: nil,
-                accent: .orange,
+                accent: .vaderCrimson,
                 tagline: String(
                     localized: "Keep your Mac in top shape with recommended maintenance.",
                     comment: "Optimization intro tagline."

--- a/VaderCleaner/UserFilesPathProviding.swift
+++ b/VaderCleaner/UserFilesPathProviding.swift
@@ -72,6 +72,11 @@ struct DefaultUserFilesPathProvider: UserFilesPathProviding {
             options: [.skipsPackageDescendants]
         ) {
             for case let url as URL in enumerator {
+                // The enclosing Large & Old Files scan can be cancelled while
+                // this pre-pass runs; bail out so a cancelled scan is not held
+                // up walking ~/Pictures. A partial result is harmless — the
+                // scan that consumes it aborts at its own next checkpoint.
+                if Task.isCancelled { break }
                 if url.pathExtension.caseInsensitiveCompare("photoslibrary") == .orderedSame {
                     stores.append(url)
                 } else if url.lastPathComponent.caseInsensitiveCompare("Photo Booth Library") == .orderedSame {

--- a/VaderCleaner/UserFilesPathProviding.swift
+++ b/VaderCleaner/UserFilesPathProviding.swift
@@ -49,11 +49,14 @@ struct DefaultUserFilesPathProvider: UserFilesPathProviding {
 
     /// Discovers the TCC-protected media stores under the user's home.
     ///
-    /// Photo libraries are found by listing `~/Pictures` — a shallow listing of
-    /// the user's own folder needs no special permission, and only descending
-    /// *into* a `.photoslibrary` / `Photo Booth Library` bundle trips the
-    /// Photos prompt. Listing catches renamed or multiple libraries that a
-    /// hard-coded default name would miss.
+    /// Photo libraries are found by walking `~/Pictures` recursively: a user
+    /// can rename the default library, keep several, or tuck one inside a
+    /// subfolder, so a shallow listing of fixed names would miss them. The
+    /// walk never descends *into* a bundle — that is what trips the Photos
+    /// prompt — because `.skipsPackageDescendants` skips `.photoslibrary`
+    /// packages and `Photo Booth Library` is skipped explicitly. Extension
+    /// and name matching is case-insensitive to mirror the default
+    /// case-insensitive APFS volume (and `FileScanner`'s exclusion matching).
     ///
     /// The Apple Music and legacy iTunes media folders sit at the fixed paths
     /// `~/Music/Music` and `~/Music/iTunes`; they are returned only when they
@@ -63,14 +66,21 @@ struct DefaultUserFilesPathProvider: UserFilesPathProviding {
         var stores: [URL] = []
 
         let pictures = homeDirectory.appendingPathComponent("Pictures", isDirectory: true)
-        if let entries = try? fileManager.contentsOfDirectory(
+        if let enumerator = fileManager.enumerator(
             at: pictures,
-            includingPropertiesForKeys: nil
+            includingPropertiesForKeys: nil,
+            options: [.skipsPackageDescendants]
         ) {
-            for entry in entries
-            where entry.pathExtension == "photoslibrary"
-                || entry.lastPathComponent == "Photo Booth Library" {
-                stores.append(entry)
+            for case let url as URL in enumerator {
+                if url.pathExtension.caseInsensitiveCompare("photoslibrary") == .orderedSame {
+                    stores.append(url)
+                } else if url.lastPathComponent.caseInsensitiveCompare("Photo Booth Library") == .orderedSame {
+                    stores.append(url)
+                    // Photo Booth's library is not a registered package type,
+                    // so `.skipsPackageDescendants` would not stop the walk
+                    // from descending into it — skip its contents explicitly.
+                    enumerator.skipDescendants()
+                }
             }
         }
 

--- a/VaderCleaner/UserFilesPathProviding.swift
+++ b/VaderCleaner/UserFilesPathProviding.swift
@@ -1,5 +1,5 @@
 // UserFilesPathProviding.swift
-// Resolves the home-directory subtrees the Large & Old Files scanner walks, plus the TCC-protected media stores (Photos / Apple Music) it must skip so the scan never trips a macOS privacy prompt.
+// Resolves the home-directory subtrees the Large & Old Files scanner walks, plus the fixed-path Apple Music media folders it excludes by path so the scan never trips a macOS privacy prompt.
 
 import Foundation
 
@@ -17,12 +17,13 @@ import Foundation
 protocol UserFilesPathProviding {
     func roots() -> [URL]
 
-    /// TCC-protected media stores that sit under `roots()` and must be folded
-    /// into the scan's exclusion list. Descending into a Photos library bundle
-    /// or the Apple Music media folder triggers a macOS privacy prompt for
-    /// Photos or Music access — skipping them outright keeps the Large & Old
-    /// Files scan silent (and avoids ever offering the user's photo library
-    /// up as a deletable "large file").
+    /// The fixed-path TCC-protected media folders under `roots()` that must be
+    /// folded into the scan's exclusion list — the Apple Music media folder and
+    /// the legacy iTunes folder. These are plainly-named directories, so they
+    /// cannot be recognised by name mid-walk and must be excluded by path.
+    /// Photo-library bundles, which can live anywhere under any root, are
+    /// skipped in-walk by `FileScanner` (see
+    /// `FileScanOptions.skipsProtectedMediaStores`) rather than listed here.
     func protectedMediaStores() -> [URL]
 }
 
@@ -47,56 +48,23 @@ struct DefaultUserFilesPathProvider: UserFilesPathProviding {
             .map { homeDirectory.appendingPathComponent($0, isDirectory: true) }
     }
 
-    /// Discovers the TCC-protected media stores under the user's home.
+    /// Returns the fixed-path Apple Music media folder (`~/Music/Music`) and the
+    /// legacy iTunes folder (`~/Music/iTunes`) when they exist.
     ///
-    /// Photo libraries are found by walking `~/Pictures` recursively: a user
-    /// can rename the default library, keep several, or tuck one inside a
-    /// subfolder, so a shallow listing of fixed names would miss them. The
-    /// walk never descends *into* a bundle — that is what trips the Photos
-    /// prompt — because `.skipsPackageDescendants` skips `.photoslibrary`
-    /// packages and `Photo Booth Library` is skipped explicitly. Extension
-    /// and name matching is case-insensitive to mirror the default
-    /// case-insensitive APFS volume (and `FileScanner`'s exclusion matching).
+    /// These are plainly-named directories at known paths, so unlike
+    /// photo-library bundles they cannot be recognised by name during the walk
+    /// and must be excluded by path. They are returned only when they actually
+    /// exist so the exclusion list never carries phantom paths.
     ///
-    /// The Apple Music and legacy iTunes media folders sit at the fixed paths
-    /// `~/Music/Music` and `~/Music/iTunes`; they are returned only when they
-    /// actually exist so the exclusion list never carries phantom paths.
+    /// Photo-library bundles are deliberately *not* listed here — they can live
+    /// at any depth under any scanned root, so `FileScanner` detects and skips
+    /// them in-walk via `FileScanOptions.skipsProtectedMediaStores`.
     func protectedMediaStores() -> [URL] {
         let fileManager = FileManager.default
-        var stores: [URL] = []
-
-        let pictures = homeDirectory.appendingPathComponent("Pictures", isDirectory: true)
-        if let enumerator = fileManager.enumerator(
-            at: pictures,
-            includingPropertiesForKeys: nil,
-            options: [.skipsPackageDescendants]
-        ) {
-            for case let url as URL in enumerator {
-                // The enclosing Large & Old Files scan can be cancelled while
-                // this pre-pass runs; bail out so a cancelled scan is not held
-                // up walking ~/Pictures. A partial result is harmless — the
-                // scan that consumes it aborts at its own next checkpoint.
-                if Task.isCancelled { break }
-                if url.pathExtension.caseInsensitiveCompare("photoslibrary") == .orderedSame {
-                    stores.append(url)
-                } else if url.lastPathComponent.caseInsensitiveCompare("Photo Booth Library") == .orderedSame {
-                    stores.append(url)
-                    // Photo Booth's library is not a registered package type,
-                    // so `.skipsPackageDescendants` would not stop the walk
-                    // from descending into it — skip its contents explicitly.
-                    enumerator.skipDescendants()
-                }
-            }
-        }
-
         let music = homeDirectory.appendingPathComponent("Music", isDirectory: true)
-        for mediaFolder in ["Music", "iTunes"] {
+        return ["Music", "iTunes"].compactMap { mediaFolder in
             let url = music.appendingPathComponent(mediaFolder, isDirectory: true)
-            if fileManager.fileExists(atPath: url.path) {
-                stores.append(url)
-            }
+            return fileManager.fileExists(atPath: url.path) ? url : nil
         }
-
-        return stores
     }
 }

--- a/VaderCleaner/UserFilesPathProviding.swift
+++ b/VaderCleaner/UserFilesPathProviding.swift
@@ -1,5 +1,5 @@
 // UserFilesPathProviding.swift
-// Resolves the home-directory subtrees that the Large & Old Files scanner walks, returned as plain root URLs (no category tag — the scanner classifies per-file by size/age).
+// Resolves the home-directory subtrees the Large & Old Files scanner walks, plus the TCC-protected media stores (Photos / Apple Music) it must skip so the scan never trips a macOS privacy prompt.
 
 import Foundation
 
@@ -16,6 +16,14 @@ import Foundation
 /// per-file tagging.
 protocol UserFilesPathProviding {
     func roots() -> [URL]
+
+    /// TCC-protected media stores that sit under `roots()` and must be folded
+    /// into the scan's exclusion list. Descending into a Photos library bundle
+    /// or the Apple Music media folder triggers a macOS privacy prompt for
+    /// Photos or Music access — skipping them outright keeps the Large & Old
+    /// Files scan silent (and avoids ever offering the user's photo library
+    /// up as a deletable "large file").
+    func protectedMediaStores() -> [URL]
 }
 
 /// Production implementation that returns the canonical user directories that
@@ -37,5 +45,43 @@ struct DefaultUserFilesPathProvider: UserFilesPathProviding {
     func roots() -> [URL] {
         ["Documents", "Downloads", "Desktop", "Movies", "Music", "Pictures", "Library"]
             .map { homeDirectory.appendingPathComponent($0, isDirectory: true) }
+    }
+
+    /// Discovers the TCC-protected media stores under the user's home.
+    ///
+    /// Photo libraries are found by listing `~/Pictures` — a shallow listing of
+    /// the user's own folder needs no special permission, and only descending
+    /// *into* a `.photoslibrary` / `Photo Booth Library` bundle trips the
+    /// Photos prompt. Listing catches renamed or multiple libraries that a
+    /// hard-coded default name would miss.
+    ///
+    /// The Apple Music and legacy iTunes media folders sit at the fixed paths
+    /// `~/Music/Music` and `~/Music/iTunes`; they are returned only when they
+    /// actually exist so the exclusion list never carries phantom paths.
+    func protectedMediaStores() -> [URL] {
+        let fileManager = FileManager.default
+        var stores: [URL] = []
+
+        let pictures = homeDirectory.appendingPathComponent("Pictures", isDirectory: true)
+        if let entries = try? fileManager.contentsOfDirectory(
+            at: pictures,
+            includingPropertiesForKeys: nil
+        ) {
+            for entry in entries
+            where entry.pathExtension == "photoslibrary"
+                || entry.lastPathComponent == "Photo Booth Library" {
+                stores.append(entry)
+            }
+        }
+
+        let music = homeDirectory.appendingPathComponent("Music", isDirectory: true)
+        for mediaFolder in ["Music", "iTunes"] {
+            let url = music.appendingPathComponent(mediaFolder, isDirectory: true)
+            if fileManager.fileExists(atPath: url.path) {
+                stores.append(url)
+            }
+        }
+
+        return stores
     }
 }

--- a/VaderCleanerTests/FileCategoryTests.swift
+++ b/VaderCleanerTests/FileCategoryTests.swift
@@ -2,6 +2,8 @@
 // Verifies FileCategory's mapping from DiskNode to one of documents/media/apps/system/other based on extension and path heuristics.
 
 import XCTest
+import SwiftUI
+import AppKit
 @testable import VaderCleaner
 
 /// Unit tests for `FileCategory`. The category drives tile color in the
@@ -110,6 +112,52 @@ final class FileCategoryTests: XCTestCase {
     func test_category_otherForUserDirectoryWithNoSpecialMarker() {
         let node = makeDirectory(path: "/Users/example/Projects")
         XCTAssertEqual(FileCategory.from(node: node), .other)
+    }
+
+    // MARK: - Tile colors
+
+    /// Every `FileCategory` case — the enum is not `CaseIterable`, so the list
+    /// is pinned here and the tile-color tests iterate it.
+    private static let allCategories: [FileCategory] = [
+        .documents, .media, .apps, .system, .other,
+    ]
+
+    /// Every category tile color must sit in the crimson family — a red-end
+    /// hue with real saturation — so the Space Lens treemap stays inside the
+    /// Vader identity. Asserted in hue/saturation rather than raw RGB so
+    /// re-tuning the ramp's lightness can't fail this for cosmetic reasons.
+    func test_everyCategoryTileColor_isInTheCrimsonFamily() {
+        for category in Self.allCategories {
+            let components = hsbComponents(of: category.color)
+            XCTAssertTrue(
+                components.hue <= 15.0 / 360.0 || components.hue >= 330.0 / 360.0,
+                "\(category) tile hue \(components.hue * 360)° must be at the red end (crimson family)"
+            )
+            XCTAssertGreaterThan(
+                components.saturation,
+                0.3,
+                "\(category) tile color must be saturated, not a washed-out neutral"
+            )
+        }
+    }
+
+    /// The five tiles must stay mutually distinguishable — a crimson family is
+    /// not a single crimson. Guards against a future "make everything
+    /// .vaderCrimson" collapse that would render the treemap unreadable.
+    func test_categoryTileColors_areAllDistinct() {
+        let colors = Self.allCategories.map(\.color)
+        XCTAssertEqual(
+            Set(colors).count,
+            colors.count,
+            "Every FileCategory must map to a distinct tile color"
+        )
+    }
+
+    private func hsbComponents(
+        of color: Color
+    ) -> (hue: CGFloat, saturation: CGFloat, brightness: CGFloat) {
+        let nsColor = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        return (nsColor.hueComponent, nsColor.saturationComponent, nsColor.brightnessComponent)
     }
 
     // MARK: - Fixtures

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -403,4 +403,96 @@ final class FileScannerTests: XCTestCase {
         XCTAssertEqual(files.count, 1)
         XCTAssertEqual(files.first?.size, 1_234)
     }
+
+    // MARK: - Protected media stores
+
+    /// `ProtectedMediaStoreBundle.matches` recognises Photos and Photo Booth
+    /// library bundles by extension / name, case-insensitively (the default
+    /// APFS volume is case-insensitive), and rejects everything else.
+    func test_protectedMediaStoreBundle_matchesPhotoAndPhotoBoothLibrariesCaseInsensitively() {
+        let matching = [
+            "/Users/x/Pictures/Photos Library.photoslibrary",
+            "/Users/x/Pictures/Family.PHOTOSLIBRARY",
+            "/Users/x/Pictures/Archive/Old.PhotosLibrary",
+            "/Users/x/Pictures/Photo Booth Library",
+            "/Users/x/Pictures/photo booth library",
+        ]
+        for path in matching {
+            XCTAssertTrue(
+                ProtectedMediaStoreBundle.matches(URL(fileURLWithPath: path)),
+                "\(path) should be recognised as a protected media store"
+            )
+        }
+
+        let nonMatching = [
+            "/Users/x/Pictures/Wallpapers",
+            "/Users/x/Pictures/vacation.jpg",
+            "/Users/x/Documents/Photo Booth Library Notes.txt",
+            "/Users/x/Music/Music",
+        ]
+        for path in nonMatching {
+            XCTAssertFalse(
+                ProtectedMediaStoreBundle.matches(URL(fileURLWithPath: path)),
+                "\(path) should not be recognised as a protected media store"
+            )
+        }
+    }
+
+    /// With `skipsProtectedMediaStores` set, the walk drops Photos library
+    /// bundles whole — at any depth — and never descends into them, so the
+    /// real scan cannot trip a macOS Photos privacy prompt.
+    func test_scan_skipsProtectedMediaStores_dropsPhotoLibraryBundlesAtAnyDepth() async throws {
+        let topLibrary = tempRoot.appendingPathComponent("Photos Library.photoslibrary", isDirectory: true)
+        let nestedLibrary = tempRoot
+            .appendingPathComponent("Archive", isDirectory: true)
+            .appendingPathComponent("Old.photoslibrary", isDirectory: true)
+        for library in [topLibrary, nestedLibrary] {
+            try FileManager.default.createDirectory(at: library, withIntermediateDirectories: true)
+            try TestHelpers.createDummyFile(named: "originals.bin", size: 64, in: library)
+        }
+        try TestHelpers.createDummyFile(named: "keep.bin", size: 32, in: tempRoot)
+
+        let scanner = FileScanner()
+        var files: [ScannedFile] = []
+        try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .largeFile)],
+            excluding: [],
+            options: FileScanOptions(packagesAsFiles: true, skipsProtectedMediaStores: true),
+            batchSize: FileScanner.defaultBatchSize
+        ) { batch in
+            files.append(contentsOf: batch)
+        }
+
+        XCTAssertEqual(
+            files.map { $0.url.lastPathComponent },
+            ["keep.bin"],
+            "Protected photo libraries must not be emitted, at any depth"
+        )
+    }
+
+    /// The skip is opt-in: with the option unset, a photo library is treated
+    /// like any other package — proving System Junk scans (which use the
+    /// default options) are unaffected.
+    func test_scan_packagesAsFiles_emitsPhotoLibraryWhenSkipOptionUnset() async throws {
+        let library = tempRoot.appendingPathComponent("Photos Library.photoslibrary", isDirectory: true)
+        try FileManager.default.createDirectory(at: library, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "originals.bin", size: 64, in: library)
+
+        let scanner = FileScanner()
+        var files: [ScannedFile] = []
+        try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .largeFile)],
+            excluding: [],
+            options: FileScanOptions(packagesAsFiles: true),
+            batchSize: FileScanner.defaultBatchSize
+        ) { batch in
+            files.append(contentsOf: batch)
+        }
+
+        XCTAssertEqual(
+            files.map { $0.url.lastPathComponent },
+            ["Photos Library.photoslibrary"],
+            "With the skip option off, a photo library is treated like any other package"
+        )
+    }
 }

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -86,9 +86,12 @@ final class LargeOldFilesScannerTests: XCTestCase {
     }
 
     func test_scan_usesPackageContentAccessDateForAgeClassification() async throws {
-        let root = try makeRoot("pictures")
-        let package = root.appendingPathComponent("PhotoLibrary.photoslibrary", isDirectory: true)
-        let contents = package.appendingPathComponent("database", isDirectory: true)
+        let root = try makeRoot("applications")
+        // A plain `.app` package — not a TCC-protected media store, so the
+        // scanner rolls it up and the package content-access-date path is
+        // actually exercised here.
+        let package = root.appendingPathComponent("LegacyArchive.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
         try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
         let innerFile = try TestHelpers.createDummyFile(named: "active.sqlite", size: 32, in: contents)
         try setAccessDate(at: innerFile, to: referenceNow.addingTimeInterval(-3_600))
@@ -333,22 +336,59 @@ final class LargeOldFilesScannerTests: XCTestCase {
 
     // MARK: - Protected media stores
 
-    /// TCC-protected media stores (Photos libraries, the Apple Music media
-    /// folder) are folded into the scan's exclusion list by the scanner, so the
-    /// walk never descends into them — descending would trip a macOS privacy
-    /// prompt for Photos or Music access. A protected store must not appear in
-    /// the results even when its rolled-up size would otherwise qualify it as
-    /// a large file.
+    /// TCC-protected photo-library bundles (`.photoslibrary`, `Photo Booth
+    /// Library`) are skipped by `FileScanner` during the walk — at any depth,
+    /// in any root — so they never surface as deletable large files and the
+    /// scan never descends into one (which would trip a macOS Photos prompt).
     func test_scan_excludesProtectedMediaStores() async throws {
         let root = try makeRoot("pictures")
 
-        let photoLibrary = root.appendingPathComponent("Photos Library.photoslibrary", isDirectory: true)
-        try FileManager.default.createDirectory(at: photoLibrary, withIntermediateDirectories: true)
-        try createSparseFile(
-            at: photoLibrary.appendingPathComponent("originals.bin"),
-            size: LargeOldFilesScanner.sizeThresholdBytes + 1
+        let topLibrary = root.appendingPathComponent("Photos Library.photoslibrary", isDirectory: true)
+        let nestedLibrary = root
+            .appendingPathComponent("Archive", isDirectory: true)
+            .appendingPathComponent("Old Trips.photoslibrary", isDirectory: true)
+        for library in [topLibrary, nestedLibrary] {
+            try FileManager.default.createDirectory(at: library, withIntermediateDirectories: true)
+            try createSparseFile(
+                at: library.appendingPathComponent("originals.bin"),
+                size: LargeOldFilesScanner.sizeThresholdBytes + 1
+            )
+        }
+
+        let keptLarge = try TestHelpers.createDummyFile(
+            named: "kept-large.bin",
+            size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
+            in: root
+        )
+        try setRecentAccessDate(at: keptLarge)
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(roots: [root]),
+            now: { self.referenceNow }
         )
 
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(
+            files.map { $0.url.lastPathComponent },
+            ["kept-large.bin"],
+            "Protected photo libraries must not surface as large files, at any depth"
+        )
+    }
+
+    /// Paths from `pathProvider.protectedMediaStores()` — the fixed-path Apple
+    /// Music / iTunes folders — are folded into the scan's exclusion list, so
+    /// nothing under them is emitted.
+    func test_scan_excludesProtectedMediaStorePaths() async throws {
+        let root = try makeRoot("music")
+        let mediaFolder = root.appendingPathComponent("Music", isDirectory: true)
+        try FileManager.default.createDirectory(at: mediaFolder, withIntermediateDirectories: true)
+        let insideMedia = try TestHelpers.createDummyFile(
+            named: "track.bin",
+            size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
+            in: mediaFolder
+        )
+        try setRecentAccessDate(at: insideMedia)
         let keptLarge = try TestHelpers.createDummyFile(
             named: "kept-large.bin",
             size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
@@ -359,48 +399,38 @@ final class LargeOldFilesScannerTests: XCTestCase {
         let scanner = LargeOldFilesScanner(
             pathProvider: StubUserFilesPathProvider(
                 roots: [root],
-                protectedMediaStores: [photoLibrary]
+                protectedMediaStores: [mediaFolder]
             ),
             now: { self.referenceNow }
         )
 
         let files = try await scanner.scan(excluding: [])
 
-        XCTAssertEqual(files.count, 1, "The protected Photos library must not be emitted")
-        XCTAssertEqual(files.first?.url.lastPathComponent, "kept-large.bin")
-        XCTAssertFalse(
-            files.contains { $0.url.lastPathComponent == "Photos Library.photoslibrary" },
-            "A protected media store must never surface as a deletable large file"
-        )
+        XCTAssertEqual(files.map { $0.url.lastPathComponent }, ["kept-large.bin"])
     }
 
     // MARK: - DefaultUserFilesPathProvider protected media stores
 
-    /// `protectedMediaStores()` must surface every Photos / Photo Booth library
-    /// bundle in `~/Pictures` plus the Apple Music and legacy iTunes media
-    /// folders, while leaving ordinary `~/Pictures` subfolders alone.
-    func test_protectedMediaStores_includesPhotoLibrariesAndAppleMusicMedia() throws {
+    /// `protectedMediaStores()` returns the fixed-path Apple Music and legacy
+    /// iTunes media folders — and *only* those. Photo-library bundles are not
+    /// pre-discovered here; `FileScanner` skips them in-walk instead.
+    func test_protectedMediaStores_returnsOnlyTheFixedPathMusicFolders() throws {
         let pictures = tempRoot.appendingPathComponent("Pictures", isDirectory: true)
         let music = tempRoot.appendingPathComponent("Music", isDirectory: true)
         let photoLibrary = pictures.appendingPathComponent("Family.photoslibrary", isDirectory: true)
-        let photoBooth = pictures.appendingPathComponent("Photo Booth Library", isDirectory: true)
-        let wallpapers = pictures.appendingPathComponent("Wallpapers", isDirectory: true)
         let appleMusic = music.appendingPathComponent("Music", isDirectory: true)
         let iTunes = music.appendingPathComponent("iTunes", isDirectory: true)
-        for directory in [photoLibrary, photoBooth, wallpapers, appleMusic, iTunes] {
+        for directory in [photoLibrary, appleMusic, iTunes] {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         }
 
         let provider = DefaultUserFilesPathProvider(homeDirectory: tempRoot)
         let stores = Set(provider.protectedMediaStores().map { $0.resolvingSymlinksInPath().path })
 
-        XCTAssertTrue(stores.contains(photoLibrary.resolvingSymlinksInPath().path))
-        XCTAssertTrue(stores.contains(photoBooth.resolvingSymlinksInPath().path))
-        XCTAssertTrue(stores.contains(appleMusic.resolvingSymlinksInPath().path))
-        XCTAssertTrue(stores.contains(iTunes.resolvingSymlinksInPath().path))
-        XCTAssertFalse(
-            stores.contains(wallpapers.resolvingSymlinksInPath().path),
-            "An ordinary ~/Pictures subfolder is not a protected media store"
+        XCTAssertEqual(
+            stores,
+            [appleMusic.resolvingSymlinksInPath().path, iTunes.resolvingSymlinksInPath().path],
+            "Only the fixed-path Music folders belong here — photo libraries are skipped in-walk"
         )
     }
 
@@ -422,33 +452,6 @@ final class LargeOldFilesScannerTests: XCTestCase {
         XCTAssertTrue(
             provider.protectedMediaStores().isEmpty,
             "An empty Pictures and Music layout has no protected media stores"
-        )
-    }
-
-    /// A photo library can be renamed (changing its extension's casing on a
-    /// case-insensitive volume) or kept inside a `~/Pictures` subfolder.
-    /// `protectedMediaStores()` must still discover it — otherwise the scan
-    /// descends into the bundle and trips the Photos prompt this guards.
-    func test_protectedMediaStores_discoversNestedAndDifferentlyCasedPhotoLibraries() throws {
-        let pictures = tempRoot.appendingPathComponent("Pictures", isDirectory: true)
-        let nestedLibrary = pictures
-            .appendingPathComponent("Archive/2024", isDirectory: true)
-            .appendingPathComponent("Old Trips.photoslibrary", isDirectory: true)
-        let upperCasedLibrary = pictures.appendingPathComponent("Family.PHOTOSLIBRARY", isDirectory: true)
-        for directory in [nestedLibrary, upperCasedLibrary] {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        }
-
-        let provider = DefaultUserFilesPathProvider(homeDirectory: tempRoot)
-        let stores = Set(provider.protectedMediaStores().map { $0.resolvingSymlinksInPath().path })
-
-        XCTAssertTrue(
-            stores.contains(nestedLibrary.resolvingSymlinksInPath().path),
-            "A photo library nested in a ~/Pictures subfolder must still be discovered"
-        )
-        XCTAssertTrue(
-            stores.contains(upperCasedLibrary.resolvingSymlinksInPath().path),
-            "Photo library detection must be case-insensitive"
         )
     }
 

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -1,5 +1,5 @@
 // LargeOldFilesScannerTests.swift
-// Drives LargeOldFilesScanner against temp directories via an injected UserFilesPathProviding stub, covering size/age classification, the both-match tiebreak, the unknown-access-date guard, and exclusion forwarding.
+// Drives LargeOldFilesScanner against temp directories via an injected UserFilesPathProviding stub, covering size/age classification, the both-match tiebreak, the unknown-access-date guard, exclusion forwarding, and protected-media-store skipping, plus DefaultUserFilesPathProvider.protectedMediaStores discovery.
 
 import XCTest
 @testable import VaderCleaner
@@ -331,6 +331,100 @@ final class LargeOldFilesScannerTests: XCTestCase {
         XCTAssertEqual(files.first?.url.lastPathComponent, "kept-large.bin")
     }
 
+    // MARK: - Protected media stores
+
+    /// TCC-protected media stores (Photos libraries, the Apple Music media
+    /// folder) are folded into the scan's exclusion list by the scanner, so the
+    /// walk never descends into them — descending would trip a macOS privacy
+    /// prompt for Photos or Music access. A protected store must not appear in
+    /// the results even when its rolled-up size would otherwise qualify it as
+    /// a large file.
+    func test_scan_excludesProtectedMediaStores() async throws {
+        let root = try makeRoot("pictures")
+
+        let photoLibrary = root.appendingPathComponent("Photos Library.photoslibrary", isDirectory: true)
+        try FileManager.default.createDirectory(at: photoLibrary, withIntermediateDirectories: true)
+        try createSparseFile(
+            at: photoLibrary.appendingPathComponent("originals.bin"),
+            size: LargeOldFilesScanner.sizeThresholdBytes + 1
+        )
+
+        let keptLarge = try TestHelpers.createDummyFile(
+            named: "kept-large.bin",
+            size: Int(LargeOldFilesScanner.sizeThresholdBytes) + 1,
+            in: root
+        )
+        try setRecentAccessDate(at: keptLarge)
+
+        let scanner = LargeOldFilesScanner(
+            pathProvider: StubUserFilesPathProvider(
+                roots: [root],
+                protectedMediaStores: [photoLibrary]
+            ),
+            now: { self.referenceNow }
+        )
+
+        let files = try await scanner.scan(excluding: [])
+
+        XCTAssertEqual(files.count, 1, "The protected Photos library must not be emitted")
+        XCTAssertEqual(files.first?.url.lastPathComponent, "kept-large.bin")
+        XCTAssertFalse(
+            files.contains { $0.url.lastPathComponent == "Photos Library.photoslibrary" },
+            "A protected media store must never surface as a deletable large file"
+        )
+    }
+
+    // MARK: - DefaultUserFilesPathProvider protected media stores
+
+    /// `protectedMediaStores()` must surface every Photos / Photo Booth library
+    /// bundle in `~/Pictures` plus the Apple Music and legacy iTunes media
+    /// folders, while leaving ordinary `~/Pictures` subfolders alone.
+    func test_protectedMediaStores_includesPhotoLibrariesAndAppleMusicMedia() throws {
+        let pictures = tempRoot.appendingPathComponent("Pictures", isDirectory: true)
+        let music = tempRoot.appendingPathComponent("Music", isDirectory: true)
+        let photoLibrary = pictures.appendingPathComponent("Family.photoslibrary", isDirectory: true)
+        let photoBooth = pictures.appendingPathComponent("Photo Booth Library", isDirectory: true)
+        let wallpapers = pictures.appendingPathComponent("Wallpapers", isDirectory: true)
+        let appleMusic = music.appendingPathComponent("Music", isDirectory: true)
+        let iTunes = music.appendingPathComponent("iTunes", isDirectory: true)
+        for directory in [photoLibrary, photoBooth, wallpapers, appleMusic, iTunes] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
+        let provider = DefaultUserFilesPathProvider(homeDirectory: tempRoot)
+        let stores = Set(provider.protectedMediaStores().map { $0.resolvingSymlinksInPath().path })
+
+        XCTAssertTrue(stores.contains(photoLibrary.resolvingSymlinksInPath().path))
+        XCTAssertTrue(stores.contains(photoBooth.resolvingSymlinksInPath().path))
+        XCTAssertTrue(stores.contains(appleMusic.resolvingSymlinksInPath().path))
+        XCTAssertTrue(stores.contains(iTunes.resolvingSymlinksInPath().path))
+        XCTAssertFalse(
+            stores.contains(wallpapers.resolvingSymlinksInPath().path),
+            "An ordinary ~/Pictures subfolder is not a protected media store"
+        )
+    }
+
+    /// The Apple Music and legacy iTunes folders sit at fixed paths but may not
+    /// exist; `protectedMediaStores()` returns only folders that are actually
+    /// present so the exclusion list never carries phantom paths.
+    func test_protectedMediaStores_omitsMusicFoldersThatDoNotExist() throws {
+        try FileManager.default.createDirectory(
+            at: tempRoot.appendingPathComponent("Pictures", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: tempRoot.appendingPathComponent("Music", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let provider = DefaultUserFilesPathProvider(homeDirectory: tempRoot)
+
+        XCTAssertTrue(
+            provider.protectedMediaStores().isEmpty,
+            "An empty Pictures and Music layout has no protected media stores"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeRoot(_ name: String) throws -> URL {
@@ -370,8 +464,15 @@ final class LargeOldFilesScannerTests: XCTestCase {
 /// temp directory rather than the real `~/Documents` etc.
 private struct StubUserFilesPathProvider: UserFilesPathProviding {
     private let stubbedRoots: [URL]
-    init(roots: [URL]) { self.stubbedRoots = roots }
+    private let stubbedProtectedMediaStores: [URL]
+
+    init(roots: [URL], protectedMediaStores: [URL] = []) {
+        self.stubbedRoots = roots
+        self.stubbedProtectedMediaStores = protectedMediaStores
+    }
+
     func roots() -> [URL] { stubbedRoots }
+    func protectedMediaStores() -> [URL] { stubbedProtectedMediaStores }
 }
 
 /// Lets `test_scan_skipsFilesWithUnknownAccessDateBelowSizeThreshold` synthesize

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -425,6 +425,33 @@ final class LargeOldFilesScannerTests: XCTestCase {
         )
     }
 
+    /// A photo library can be renamed (changing its extension's casing on a
+    /// case-insensitive volume) or kept inside a `~/Pictures` subfolder.
+    /// `protectedMediaStores()` must still discover it — otherwise the scan
+    /// descends into the bundle and trips the Photos prompt this guards.
+    func test_protectedMediaStores_discoversNestedAndDifferentlyCasedPhotoLibraries() throws {
+        let pictures = tempRoot.appendingPathComponent("Pictures", isDirectory: true)
+        let nestedLibrary = pictures
+            .appendingPathComponent("Archive/2024", isDirectory: true)
+            .appendingPathComponent("Old Trips.photoslibrary", isDirectory: true)
+        let upperCasedLibrary = pictures.appendingPathComponent("Family.PHOTOSLIBRARY", isDirectory: true)
+        for directory in [nestedLibrary, upperCasedLibrary] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
+        let provider = DefaultUserFilesPathProvider(homeDirectory: tempRoot)
+        let stores = Set(provider.protectedMediaStores().map { $0.resolvingSymlinksInPath().path })
+
+        XCTAssertTrue(
+            stores.contains(nestedLibrary.resolvingSymlinksInPath().path),
+            "A photo library nested in a ~/Pictures subfolder must still be discovered"
+        )
+        XCTAssertTrue(
+            stores.contains(upperCasedLibrary.resolvingSymlinksInPath().path),
+            "Photo library detection must be case-insensitive"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeRoot(_ name: String) throws -> URL {

--- a/VaderCleanerTests/SectionPresentationTests.swift
+++ b/VaderCleanerTests/SectionPresentationTests.swift
@@ -3,6 +3,7 @@
 
 import XCTest
 import AppKit
+import SwiftUI
 @testable import VaderCleaner
 
 final class SectionPresentationTests: XCTestCase {
@@ -91,6 +92,20 @@ final class SectionPresentationTests: XCTestCase {
                     "Feature title must be non-empty for \(section)"
                 )
             }
+        }
+    }
+
+    /// Every scannable section's intro accent must be the single Vader crimson —
+    /// the app's one brand accent. A section added with a stray accent (or an
+    /// existing one drifting back to a per-section color) fails loudly here.
+    func test_everyScannablePresentationAccent_isVaderCrimson() throws {
+        for section in scannableSections {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            XCTAssertEqual(
+                presentation.accent,
+                .vaderCrimson,
+                "Section \(section) must use the unified crimson accent"
+            )
         }
     }
 


### PR DESCRIPTION
This PR bundles two related polish changes to the macOS app.

---

## 1. Skip TCC-protected media stores in the Large & Old Files scan

### What
Stop the Large & Old Files scanner from descending into TCC-protected media stores (Photos libraries, Photo Booth Library, the Apple Music / legacy iTunes media folders).

### Why
The scanner walks `~/Pictures` and `~/Music` as scan roots. Descending **into** a `.photoslibrary` bundle, `Photo Booth Library`, or `~/Music/Music` triggers a macOS privacy prompt for Photos or Music access. Those popups surfaced during the app's permission flow even though VaderCleaner declares no `NSPhotoLibraryUsageDescription`/`NSAppleMusicUsageDescription` and uses no PhotoKit/MediaPlayer APIs — the Large & Old Files scan was the only code path touching those locations.

### How
Two mechanisms, each fit to its target:

- **Photo-library bundles** (`.photoslibrary`, `Photo Booth Library`) can be renamed or live at any depth under any scanned root, so they are detected *during the walk*. `FileScanner` recognises them via `ProtectedMediaStoreBundle.matches` (extension/name, matched case-insensitively) and skips them whole — never descending, never emitting — gated by the new `FileScanOptions.skipsProtectedMediaStores` flag. The flag defaults off, so System Junk scans are unaffected; `LargeOldFilesScanner` sets it on. No pre-discovery, no duplicate tree walk, and the skip rides the walk's existing cancellation checks.
- **The Apple Music / iTunes media folders** (`~/Music/Music`, `~/Music/iTunes`) are plainly-named directories at fixed paths — they can't be recognised by name mid-walk — so `UserFilesPathProviding.protectedMediaStores()` returns them (when present) and `LargeOldFilesScanner` folds them into the scan's exclusion list.

A protected store is never emitted, so a photo library is never offered up as a deletable "large file" (a safety win — deleting files inside a `.photoslibrary` bundle corrupts it).

### Reviewer note
Unit/integration tests prove the scanner won't descend into those stores; they can't prove macOS shows no dialog. To confirm at runtime, reset TCC state and run a Large & Old Files scan:

```sh
tccutil reset Photos com.personal.VaderCleaner
tccutil reset MediaLibrary com.personal.VaderCleaner
```

No Photos or Music prompt should appear during the scan.

---

## 2. Unify section accents and treemap tiles to one crimson

### What
Make the app's accent identity uniformly crimson.

### Why
The six section intro screens each carried a different accent (System Junk green, Large & Old Files teal, Space Lens indigo, Optimization orange; Smart Scan and Malware already crimson), and the Space Lens treemap colored file-category tiles blue/purple/orange/red/gray — the app read as a rainbow rather than the Vader identity.

### How
- All six `SectionPresentation` accents now use `Color.vaderCrimson`. Hero art, sub-feature rows, and floating Scan buttons inherit the section accent, so they unify automatically.
- `FileCategory`'s treemap palette becomes a five-shade crimson ramp spread bright → deep so tiles stay distinguishable; `.media` is anchored to `vaderCrimson` exactly and `.other` is a desaturated dusty crimson for the neutral fallback bucket.
- Health Monitor status colors (good/warning/critical) are intentionally left semantic.

### Reviewer note
Unit tests prove the five tile shades are distinct and in the crimson family (hue/saturation check), but not that they're visually distinguishable at `.opacity(0.55)` over near-black — worth an eyeball in Space Lens. The Smart Scan dashboard's System Junk (blue) and Optimization (orange) card tints are left as-is in this PR.

---

## Tests

TDD throughout — failing tests written first, then implementation.

- **Privacy — in-walk detection:** `test_protectedMediaStoreBundle_matchesPhotoAndPhotoBoothLibrariesCaseInsensitively`, `test_scan_skipsProtectedMediaStores_dropsPhotoLibraryBundlesAtAnyDepth`, `test_scan_packagesAsFiles_emitsPhotoLibraryWhenSkipOptionUnset` (gating / System Junk unchanged).
- **Privacy — integration:** `test_scan_excludesProtectedMediaStores` (nested + top-level photo libraries skipped end-to-end), `test_scan_excludesProtectedMediaStorePaths` (fixed-path Music exclusion), `test_protectedMediaStores_returnsOnlyTheFixedPathMusicFolders`, `test_protectedMediaStores_omitsMusicFoldersThatDoNotExist`.
- **Crimson:** `test_everyScannablePresentationAccent_isVaderCrimson`, `test_everyCategoryTileColor_isInTheCrimsonFamily`, `test_categoryTileColors_areAllDistinct`.

Full suite: **700/700 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scan engine now detects and excludes macOS TCC-protected media store locations (Photos and Music libraries) to prevent unnecessary privacy interruptions during file scanning.

* **Style**
  * Redesigned interface color scheme to use consistent crimson tones throughout the app for improved visual identity.

* **Tests**
  * Expanded test coverage for protected media store detection and unified color scheme validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->