### PR TITLE
privacy: adopt the unified scan intro + floating Scan button

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -233,7 +233,9 @@ struct ContentView: View {
                 SpaceLensView(viewModel: spaceLensViewModel)
             }
         case .privacy:
-            PrivacyView(viewModel: privacyViewModel)
+            ScannableSectionContent(coordinator: privacyViewModel, section: section) {
+                PrivacyView(viewModel: privacyViewModel)
+            }
         case .appUninstaller:
             AppUninstallerView(viewModel: appUninstallerViewModel)
         case .appUpdater:
@@ -272,7 +274,9 @@ struct ContentView: View {
             FloatingScanOverlay(coordinator: optimizationViewModel, section: section)
         case .malwareRemoval:
             FloatingScanOverlay(coordinator: malwareViewModel, section: section)
-        case .privacy, .extensions, .appUninstaller, .appUpdater, .healthMonitor:
+        case .privacy:
+            FloatingScanOverlay(coordinator: privacyViewModel, section: section)
+        case .extensions, .appUninstaller, .appUpdater, .healthMonitor:
             EmptyView()
         }
     }

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -91,9 +91,9 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
     var isScannable: Bool {
         switch self {
         case .smartScan, .systemJunk, .largeOldFiles,
-             .spaceLens, .malwareRemoval, .optimization:
+             .spaceLens, .malwareRemoval, .optimization, .privacy:
             return true
-        case .privacy, .extensions, .appUninstaller,
+        case .extensions, .appUninstaller,
              .appUpdater, .healthMonitor:
             return false
         }
@@ -109,9 +109,9 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
     var requiresFullDiskAccess: Bool {
         switch self {
         case .smartScan, .systemJunk, .largeOldFiles,
-             .spaceLens, .malwareRemoval:
+             .spaceLens, .malwareRemoval, .privacy:
             return true
-        case .optimization, .privacy, .extensions,
+        case .optimization, .extensions,
              .appUninstaller, .appUpdater, .healthMonitor:
             return false
         }

--- a/VaderCleaner/PrivacyView.swift
+++ b/VaderCleaner/PrivacyView.swift
@@ -6,10 +6,13 @@ import SwiftUI
 /// Detail view shown when the user selects "Privacy" in the sidebar.
 /// The parent owns feature state and destructive-action coordination while
 /// dedicated subviews render each phase and preview row.
+///
+/// The `.idle` phase is not rendered here: ContentView shows the unified
+/// `SectionIntroView` plus the floating Scan button while the coordinator
+/// reports `.intro`, so the detail view is only built once a scan has started.
 struct PrivacyView: View {
 
     @ObservedObject private var viewModel: PrivacyViewModel
-    @EnvironmentObject private var appState: AppState
     @State private var showClearConfirmation = false
 
     init(viewModel: PrivacyViewModel) {
@@ -34,12 +37,11 @@ struct PrivacyView: View {
     private var content: some View {
         switch viewModel.phase {
         case .idle:
-            VStack(spacing: 16) {
-                if !appState.hasFullDiskAccess {
-                    FullDiskAccessPromptCard(onRecheck: { appState.refresh() })
-                }
-                PrivacyIdleState(onScan: startPreview)
-            }
+            // Unreachable: ContentView shows the unified SectionIntroView
+            // while the coordinator reports `.intro` (which `.idle` maps to),
+            // so the detail view is never built in this phase. The arm stays
+            // only to keep the switch exhaustive over `Phase`.
+            EmptyView()
         case .scanning:
             PrivacyProgressState(label: "Scanning…", identifier: "privacy.scanning")
         case .preview:
@@ -84,10 +86,6 @@ struct PrivacyView: View {
             localized: "This permanently removes the selected browser data. Browsers will recreate the storage on next launch but the data won't be recoverable.",
             comment: "Alert message shown when clearing selected browser data only."
         )
-    }
-
-    private func startPreview() {
-        Task { await viewModel.preview() }
     }
 }
 

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -431,3 +431,34 @@ extension PrivacyViewModel {
         )
     }
 }
+
+// MARK: - ScanCoordinating
+
+extension PrivacyViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. `.scanning`/`.clearing` are both "work in flight";
+    /// `.preview`/`.complete`/`.failed` all want the section's own detail UI,
+    /// whose internal switch renders the specifics.
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .scanning, .clearing:
+            return .working
+        case .preview, .complete, .failed:
+            return .results
+        }
+    }
+
+    /// Entrypoint for the unified floating Scan button. Privacy's scan is the
+    /// browser-detection + sizing pass that `preview()` runs.
+    func beginScan() {
+        // `preview()` cancels any in-flight operation before restarting, so a
+        // double-tapped Scan button wouldn't race — but gating on the
+        // work-in-flight phases keeps the behavior identical to the other
+        // scannable view models.
+        guard phase != .scanning, phase != .clearing else { return }
+        Task { await preview() }
+    }
+}

--- a/VaderCleaner/PrivacyViewSubviews.swift
+++ b/VaderCleaner/PrivacyViewSubviews.swift
@@ -12,36 +12,6 @@ enum PrivacyViewFormatting {
     }()
 }
 
-struct PrivacyIdleState: View {
-    let onScan: () -> Void
-
-    var body: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "lock.shield")
-                .font(.system(size: 56))
-                .foregroundStyle(.secondary)
-            Text(String(
-                localized: "Privacy",
-                comment: "Title for the Privacy cleanup feature."
-            ))
-                .font(.title2.weight(.semibold))
-            Text(String(
-                localized: "Clear browsing history, downloads, cookies, cache, saved form data across detected browsers, and the system Recent Items list.",
-                comment: "Description of what the Privacy cleanup feature can clear."
-            ))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 460)
-            Button("Scan", action: onScan)
-                .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
-                .accessibilityIdentifier("privacy.scan")
-        }
-        .padding()
-    }
-}
-
 struct PrivacyProgressState: View {
     let label: String
     let identifier: String

--- a/VaderCleaner/SectionPresentation.swift
+++ b/VaderCleaner/SectionPresentation.swift
@@ -184,7 +184,35 @@ struct SectionPresentation {
                     ),
                 ]
             )
-        case .privacy, .extensions, .appUninstaller, .appUpdater, .healthMonitor:
+        case .privacy:
+            return SectionPresentation(
+                heroSymbol: "lock.shield",
+                heroAssetName: nil,
+                accent: .vaderCrimson,
+                tagline: String(
+                    localized: "Clear browsing history, cookies, and caches across your browsers.",
+                    comment: "Privacy intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: "clock.arrow.circlepath",
+                        title: String(localized: "Browsing History", comment: "Privacy feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "arrow.down.circle",
+                        title: String(localized: "Downloads", comment: "Privacy feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "internaldrive",
+                        title: String(localized: "Cookies & Cache", comment: "Privacy feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "doc.text",
+                        title: String(localized: "Recent Items", comment: "Privacy feature row.")
+                    ),
+                ]
+            )
+        case .extensions, .appUninstaller, .appUpdater, .healthMonitor:
             return nil
         }
     }

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -91,7 +91,7 @@ final class NavigationSectionTests: XCTestCase {
             .spaceLens: true,        // home directory walk
             .malwareRemoval: true,   // ClamAV scan
             .optimization: false,    // launchctl / login items / RAM
-            .privacy: false,
+            .privacy: true,          // Safari data lives in TCC-protected paths
             .extensions: false,
             .appUninstaller: false,
             .appUpdater: false,

--- a/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
+++ b/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
@@ -1,5 +1,5 @@
 // ScanCoordinatingConformanceTests.swift
-// Pins the full Phase→ScanPresentation mapping (every rich case) and the beginScan() entrypoint for all six scannable view models conforming to ScanCoordinating.
+// Pins the full Phase→ScanPresentation mapping (every rich case) and the beginScan() entrypoint for all seven scannable view models conforming to ScanCoordinating.
 
 import XCTest
 import Combine
@@ -575,6 +575,92 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
         XCTAssertEqual(counter.count, 1, "re-entrant beginScan must not start a second load")
     }
 
+    // MARK: - PrivacyViewModel
+    // Mapping: .idle→.intro; .scanning/.clearing→.working; .preview/.complete/.failed→.results.
+
+    func test_privacy_idleMapsToIntro() {
+        XCTAssertEqual(makePrivacy().scanPresentation, .intro)
+    }
+
+    func test_privacy_scanningMapsToWorking() async {
+        let gate = ScanGate()
+        let vm = makePrivacy(detector: {
+            await gate.wait()
+            return []
+        })
+
+        let task = Task { await vm.preview() }
+        await yieldUntil({ vm.phase == .scanning }, ".scanning")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_privacy_previewMapsToResults() async {
+        let vm = makePrivacy()
+        await vm.preview()
+        XCTAssertEqual(vm.phase, .preview)
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_privacy_clearingMapsToWorking() async {
+        let gate = ScanGate()
+        // The recents clearer runs first inside `clear()`; gating it freezes
+        // the VM in `.clearing` long enough to observe the projection.
+        let vm = makePrivacy(clearRecentFiles: { await gate.wait() })
+        await vm.preview() // → .preview, the only phase clear() acts from.
+
+        let task = Task { await vm.clear() }
+        await yieldUntil({ vm.phase == .clearing }, ".clearing")
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        gate.open()
+        await task.value
+    }
+
+    func test_privacy_completeMapsToResults() async {
+        let vm = makePrivacy()
+        await vm.preview()
+        await vm.clear()
+        if case .complete = vm.phase {} else { XCTFail("expected .complete, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_privacy_failedMapsToResults() async {
+        let vm = makePrivacy(detector: { throw Boom() })
+        await vm.preview()
+        if case .failed = vm.phase {} else { XCTFail("expected .failed, got \(vm.phase)") }
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_privacy_beginScanLeavesIntro() async {
+        let vm = makePrivacy()
+        vm.beginScan()
+        await yieldUntil({ vm.scanPresentation != .intro }, "beginScan() leaves .intro")
+        XCTAssertNotEqual(vm.scanPresentation, .intro)
+    }
+
+    func test_privacy_beginScanIgnoresReentrantCallWhileScanning() async {
+        let gate = ScanGate()
+        let counter = CallCounter()
+        let vm = makePrivacy(detector: {
+            await counter.bump()
+            await gate.wait()
+            return []
+        })
+
+        vm.beginScan()
+        await yieldUntil({ vm.phase == .scanning }, ".scanning")
+        vm.beginScan() // re-entrant while scanning: must be a no-op
+        await yieldUntil({ counter.count >= 1 }, "detector invoked")
+        XCTAssertEqual(counter.count, 1)
+
+        gate.open()
+        await yieldUntil({ vm.phase != .scanning }, "scan settles")
+        XCTAssertEqual(counter.count, 1, "re-entrant beginScan must not start a second scan")
+    }
+
     // MARK: - Construction helpers
     //
     // One per view model, mirroring the defaults each VM's own
@@ -654,6 +740,22 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
             flushRAM: flushRAM,
             runMaintenance: runMaintenance,
             launchAtLoginChanges: nil
+        )
+    }
+
+    private func makePrivacy(
+        detector: @escaping PrivacyViewModel.Detector = { [] },
+        sizer: @escaping PrivacyViewModel.Sizer = { _, _ in 0 },
+        pathsFor: @escaping PrivacyViewModel.PathsResolver = { _, _ in [] },
+        clearer: @escaping PrivacyViewModel.Clearer = { _, _ in },
+        clearRecentFiles: @escaping PrivacyViewModel.RecentFilesClearer = { }
+    ) -> PrivacyViewModel {
+        PrivacyViewModel(
+            detector: detector,
+            sizer: sizer,
+            pathsFor: pathsFor,
+            clearer: clearer,
+            clearRecentFiles: clearRecentFiles
         )
     }
 }

--- a/VaderCleanerTests/SectionIntroViewTests.swift
+++ b/VaderCleanerTests/SectionIntroViewTests.swift
@@ -8,7 +8,7 @@ import SwiftUI
 @MainActor
 final class SectionIntroViewTests: XCTestCase {
 
-    /// The six scannable sections, each paired with the per-section
+    /// The seven scannable sections, each paired with the per-section
     /// accessibility-id slug it must derive from its `NavigationSection` case
     /// name (locale-independent). Hardcoded — not re-derived through the
     /// view's own slug helper — so a regression in that helper fails this
@@ -20,6 +20,7 @@ final class SectionIntroViewTests: XCTestCase {
         .spaceLens: "spacelens",
         .malwareRemoval: "malwareremoval",
         .optimization: "optimization",
+        .privacy: "privacy",
     ]
 
     func test_buildsFromEveryScannableSectionPresentation() throws {

--- a/VaderCleanerTests/SectionPresentationTests.swift
+++ b/VaderCleanerTests/SectionPresentationTests.swift
@@ -8,15 +8,15 @@ import SwiftUI
 
 final class SectionPresentationTests: XCTestCase {
 
-    /// The six sections that drive a scan/load and therefore get the unified
+    /// The seven sections that drive a scan/load and therefore get the unified
     /// intro screen + floating Scan button. Pinned here so a drift in
     /// `isScannable` or `SectionPresentation.for(_:)` fails loudly.
     private let scannableSections: Set<NavigationSection> = [
         .smartScan, .systemJunk, .largeOldFiles,
-        .spaceLens, .malwareRemoval, .optimization,
+        .spaceLens, .malwareRemoval, .optimization, .privacy,
     ]
 
-    func test_isScannable_isTrueForExactlyTheSixScannableSections() {
+    func test_isScannable_isTrueForExactlyTheSevenScannableSections() {
         for section in NavigationSection.allCases {
             let expected = scannableSections.contains(section)
             XCTAssertEqual(
@@ -27,9 +27,9 @@ final class SectionPresentationTests: XCTestCase {
         }
     }
 
-    func test_isScannable_countIsExactlySix() {
+    func test_isScannable_countIsExactlySeven() {
         let count = NavigationSection.allCases.filter(\.isScannable).count
-        XCTAssertEqual(count, 6, "Exactly six sections must be scannable")
+        XCTAssertEqual(count, 7, "Exactly seven sections must be scannable")
     }
 
     func test_presentationFor_isNonNilForScannableAndNilOtherwise() {


### PR DESCRIPTION
## What

Make the Privacy section's layout and UX consistent with the six other scannable sections. Privacy previously had a bespoke idle screen (`PrivacyIdleState`) with an inline "Scan" button and its own Full Disk Access card. It now adopts the shared pattern: the accent-tinted `SectionIntroView` hero + the shell-level floating crimson Scan disc.

## Why

Every other scannable section (Smart Scan, System Junk, Large & Old Files, Space Lens, Malware Removal, Optimization) already routes through `ScannableSectionContent` → `SectionIntroView` + `FloatingScanOverlay`. Privacy was the odd one out. The codebase already had explicit placeholders for this (`return nil` in `SectionPresentation.for(_:)`, `EmptyView()` in `ContentView.floatingScan(for:)`).

## Changes

- **NavigationSection** — `.privacy` is now `isScannable`; `requiresFullDiskAccess` flips `false → true` so the unified FDA reminder card still surfaces.
- **SectionPresentation** — added Privacy's presentation: `lock.shield` hero, tagline, four feature rows (Browsing History, Downloads, Cookies & Cache, Recent Items).
- **PrivacyViewModel** — conforms to `ScanCoordinating`: `scanPresentation` projects `Phase` onto intro/working/results, `beginScan()` runs `preview()`.
- **ContentView** — Privacy wrapped in `ScannableSectionContent`; `FloatingScanOverlay` wired.
- **PrivacyView** — `.idle` arm is now an unreachable `EmptyView()` (mirrors `SystemJunkView`); dropped the unused `appState` dependency and `startPreview()`.
- **PrivacyViewSubviews** — removed the now-dead `PrivacyIdleState`.
- **Tests** — `SectionPresentationTests`, `NavigationSectionTests`, `SectionIntroViewTests` updated for the seventh scannable section; `ScanCoordinatingConformanceTests` gains a full Privacy block pinning every `Phase`→`ScanPresentation` transition and the `beginScan()` entrypoint.

## Reviewer notes

- **`requiresFullDiskAccess` flip (`false → true`) is an intentional reclassification** of a pinned contract. The old bespoke idle screen already showed an FDA card; this keeps that reminder appearing via the unified `SectionIntroView` mechanism. Safari's data lives in TCC-protected paths, so it is genuinely FDA-relevant.
- **"Re-scan" / "Scan Again" behavior shift** — those buttons call `scanAgain()` → `.idle` → `.intro`, so they now return to the intro screen requiring another tap on the floating disc, rather than rescanning immediately. This matches System Junk's existing behavior (consistency, not a regression).

## Testing

All 708 unit tests pass; the app target builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Privacy is now fully integrated as a scannable feature, enabling cleanup of browsing history, downloads, cookies & cache, and recent items with the unified scanning experience.

* **Tests**
  * Updated test coverage to validate Privacy scanning functionality and full disk access requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->