### PR TITLE
ui: per-section color theming and a redesigned navigation rail

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2CE84E79268B4A59C5B8FACB /* HealthMonitorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */; };
 		2CF8285ADDBEB285A1DB56AC /* LoginItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F1DC062C52C51730548216 /* LoginItem.swift */; };
 		2D5B0C45DB5F5EA679AF4131 /* SmartScanUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B18E28D449EF4D5FB1D6E0B /* SmartScanUITests.swift */; };
+		2D8DAC3191BC1733AE762C03 /* SectionThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */; };
 		2DD748D16E344D435A5C3E24 /* HelperRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */; };
 		2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CA7922445475111927C0B /* AppInfo.swift */; };
 		3328707476CC1411FA1270D0 /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D92F45290B56030CBFA83D3 /* Browser.swift */; };
@@ -167,6 +168,7 @@
 		C2F35144C0139C8829C4BB8A /* MenuBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */; };
 		C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */; };
 		C3F9A86A896DAD3A63EB8F9F /* ExclusionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6085B6A39985DFF334821551 /* ExclusionsStore.swift */; };
+		C75E96295ED70F91F6B2A0F1 /* SectionTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */; };
 		C9DB75A7B6E045D306393638 /* PrivacyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */; };
 		CF68F2891382E3F3D4CA5474 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */; };
 		D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */; };
@@ -253,6 +255,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTheme.swift; sourceTree = "<group>"; };
 		02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsFormatters.swift; sourceTree = "<group>"; };
 		02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicy.swift; sourceTree = "<group>"; };
 		04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerView.swift; sourceTree = "<group>"; };
@@ -373,6 +376,7 @@
 		92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResult.swift; sourceTree = "<group>"; };
 		93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesView.swift; sourceTree = "<group>"; };
 		9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearer.swift; sourceTree = "<group>"; };
+		9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionThemeTests.swift; sourceTree = "<group>"; };
 		98D7B18095634307C5D7223D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItem.swift; sourceTree = "<group>"; };
@@ -581,6 +585,7 @@
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
 				9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */,
 				2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */,
+				01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */,
 				3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */,
 				D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */,
 				DEB9C7A07E62C19FD94824B5 /* SmartScanViewSubviews.swift */,
@@ -699,6 +704,7 @@
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
 				6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
+				9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
 				22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */,
 				F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */,
@@ -922,6 +928,7 @@
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
+				2D8DAC3191BC1733AE762C03 /* SectionThemeTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
 				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,
 				6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */,
@@ -1051,6 +1058,7 @@
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				9D44F12D7502363B814F2DF9 /* SectionIntroView.swift in Sources */,
 				89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */,
+				C75E96295ED70F91F6B2A0F1 /* SectionTheme.swift in Sources */,
 				FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */,
 				9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */,
 				E357AD8EDB1FA65E6D5EB59E /* SmartScanViewSubviews.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -106,7 +106,10 @@ struct ContentView: View {
         // step: the rail's selection pill slides, the detail screen
         // crossfades, and the floating Scan disc recolours.
         .animation(.smooth(duration: 0.42), value: selectedSection)
-        .frame(minWidth: 900, minHeight: 600)
+        // The side-by-side section intro needs a pane wide enough for the
+        // hero, the gap, and the text column; a 1000pt minimum keeps that
+        // fixed layout from clipping at the smallest allowed window width.
+        .frame(minWidth: 1000, minHeight: 600)
         // Per-section gradient backdrop, keyed to the selection and crossfaded
         // on change so moving between sections recolours the whole window. The
         // toolbar background is hidden so the floating glass toolbar items sit

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -22,6 +22,9 @@ struct ContentView: View {
     @State private var selectedSection: NavigationSection? = .smartScan
     /// Namespace for the sliding selection pill in the custom rail.
     @Namespace private var pillNamespace
+    /// The section the pointer is currently over, if any. Drives the rail's
+    /// hover highlight — a quieter pill than the selection's.
+    @State private var hoveredSection: NavigationSection?
     /// Latched once the notification permission prompt has been issued for the
     /// session. Without this, an `.onChange` flurry (FDA refresh tick + sheet
     /// dismissal in the same cycle) would request authorization twice — the
@@ -60,6 +63,13 @@ struct ContentView: View {
         self.smartScanViewModel = smartScanViewModel
     }
 
+    /// Colour identity of the section currently on screen. Drives the window
+    /// backdrop and the control tint; falls back to Smart Scan's theme before
+    /// a selection exists.
+    private var theme: SectionTheme {
+        (selectedSection ?? .smartScan).theme
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             // A custom rail of buttons (not a List) so selection can be a soft
@@ -73,6 +83,11 @@ struct ContentView: View {
             // without reintroducing a split divider.
             NavigationStack {
                 detailView(for: selectedSection ?? .smartScan)
+                    // Crossfade the whole detail screen as the section
+                    // changes, so navigation reads as a soft dissolve in step
+                    // with the backdrop recolour rather than a hard cut.
+                    .id(selectedSection)
+                    .transition(.opacity)
             }
         }
         // The Scan CTA floats over the window's bottom edge. It is attached to
@@ -87,11 +102,22 @@ struct ContentView: View {
                 .padding(.leading, railWidth)
                 .padding(.bottom, floatingScanBottomPadding)
         }
+        // One ambient animation drives every section-change motion in lock
+        // step: the rail's selection pill slides, the detail screen
+        // crossfades, and the floating Scan disc recolours.
+        .animation(.smooth(duration: 0.42), value: selectedSection)
         .frame(minWidth: 900, minHeight: 600)
-        // Branded shell: gradient backdrop, crimson tint, forced dark
-        // appearance. The toolbar background is hidden so the floating glass
-        // toolbar items sit directly over the gradient instead of on a band.
-        .vaderShell()
+        // Per-section gradient backdrop, keyed to the selection and crossfaded
+        // on change so moving between sections recolours the whole window. The
+        // toolbar background is hidden so the floating glass toolbar items sit
+        // directly over the gradient instead of on a band.
+        .background {
+            VaderBackground(theme: theme)
+                .id(selectedSection)
+                .transition(.opacity)
+                .animation(.smooth(duration: 0.55), value: selectedSection)
+        }
+        .vaderShell(accent: theme.accent)
         .toolbarBackground(.hidden, for: .windowToolbar)
         .sheet(isPresented: shouldShowOnboarding) {
             PermissionOnboardingView()
@@ -128,22 +154,24 @@ struct ContentView: View {
     /// still work.
     private var rail: some View {
         ScrollView {
-            VStack(spacing: 4) {
+            VStack(spacing: 6) {
                 ForEach(NavigationSection.allCases) { section in
                     railRow(section)
                 }
             }
             .padding(.horizontal, 10)
             // The content extends under the hidden title bar, so inset the
-            // first row clear of the window's traffic-light controls.
-            .padding(.top, 44)
-            .padding(.bottom, 16)
+            // first row clear of the window's traffic-light controls. The top
+            // and bottom insets, the row gap, and the row height are tuned
+            // together so all eleven rows fit a default-height window without
+            // scrolling.
+            .padding(.top, 58)
+            .padding(.bottom, 12)
         }
-        // No scroll indicator: all eleven rows fit within the window's
-        // minimum height at default text sizes, so the rail reads as a
-        // static list with no visible scrolling. The ScrollView is retained
-        // only so the bottom rows stay reachable when a larger Dynamic Type
-        // size overflows the column.
+        // No scroll indicator: at a typical window height the eleven rows sit
+        // statically with no visible scrolling. The ScrollView is retained so
+        // the bottom rows stay reachable when a short window or a larger
+        // Dynamic Type size overflows the column.
         .scrollIndicators(.hidden)
         // Anchor the rail to the true window top. Detail screens declare
         // different toolbars, which changes the window's top safe-area inset;
@@ -155,6 +183,7 @@ struct ContentView: View {
 
     private func railRow(_ section: NavigationSection) -> some View {
         let isSelected = selectedSection == section
+        let isHovering = hoveredSection == section
         return Button {
             selectedSection = section
         } label: {
@@ -162,32 +191,92 @@ struct ContentView: View {
                 Image(systemName: section.icon)
                     .symbolRenderingMode(.hierarchical)
                     .font(.title3)
+                    // The icon stays neutral — matching the inactive label —
+                    // until the row is active or hovered, when it lights up in
+                    // the section's accent.
+                    .foregroundStyle(
+                        isSelected || isHovering
+                            ? section.theme.accent
+                            : Color.white.opacity(0.62)
+                    )
                     .frame(width: 26)
                 Text(section.title)
                     .font(.body)
                 Spacer(minLength: 0)
             }
-            .foregroundStyle(isSelected ? Color.white : Color.white.opacity(0.62))
+            .foregroundStyle(isSelected || isHovering ? Color.white : Color.white.opacity(0.62))
             .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, minHeight: 50, alignment: .leading)
             .background {
                 if isSelected {
-                    Color.clear
-                        .glassEffect(
-                            .regular.tint(Color.vaderCrimson),
-                            in: .rect(cornerRadius: 12)
+                    // A translucent pill — the dark page shows through, lifted
+                    // by a soft horizontal sheen that is brightest at the left
+                    // and right edges and dims behind the label in the centre.
+                    // No accent tint: a saturated glass fill reads as a solid
+                    // button, not the see-through surface the reference uses.
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    .white.opacity(0.22),
+                                    .white.opacity(0.07),
+                                    .white.opacity(0.22),
+                                ],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
                         )
+                        .overlay {
+                            // A hairline rim in the section's accent, brightest
+                            // along the leading edge and fading across to the
+                            // trailing edge, so the active pill reads as a lit,
+                            // colour-keyed glass surface.
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .strokeBorder(
+                                    LinearGradient(
+                                        colors: [
+                                            section.theme.accent.opacity(0.85),
+                                            section.theme.accent.opacity(0.25),
+                                        ],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    ),
+                                    lineWidth: 1
+                                )
+                        }
                         .matchedGeometryEffect(id: "selectionPill", in: pillNamespace)
+                } else if isHovering {
+                    // Hover highlight — a quieter pill than the selection: a
+                    // fainter flat fill and a dim hairline border, no top-lit
+                    // sheen, so the hover and active states stay clearly
+                    // distinct.
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(Color.white.opacity(0.08))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.16), lineWidth: 1)
+                        }
                 }
             }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         // Suppress the macOS keyboard focus ring. Without this the first
-        // focusable row wears the system's blue halo on launch; the crimson
-        // selection pill is the rail's own state indicator.
+        // focusable row wears the system's blue halo on launch; the rail's
+        // selection pill is its own state indicator.
         .focusEffectDisabled()
+        // Track the pointer so the row can show its hover highlight. Clearing
+        // only when *this* section is the one being left avoids a stale value
+        // when the pointer crosses straight from one row to the next.
+        .onHover { hovering in
+            if hovering {
+                hoveredSection = section
+            } else if hoveredSection == section {
+                hoveredSection = nil
+            }
+        }
+        .animation(.easeOut(duration: 0.15), value: isHovering)
         .accessibilityIdentifier(section.accessibilityIdentifier)
         .accessibilityLabel(section.title)
         .accessibilityAddTraits(isSelected ? .isSelected : [])

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -19,6 +19,10 @@ struct SectionIntroView: View {
     /// uncluttered landing without a relaunch.
     @EnvironmentObject private var appState: AppState
 
+    /// Drives the hero's slow vertical drift. Flipped true on appear so the
+    /// repeating float animation has a value to oscillate between.
+    @State private var heroFloating = false
+
     /// Localized section title for display. A computed accessor so the
     /// rendered heading tracks the UI language while the identifiers below
     /// stay fixed regardless of locale.
@@ -63,37 +67,20 @@ struct SectionIntroView: View {
 
     // MARK: Body
 
-    /// Hero + text laid side by side on wide panes, stacked when narrow.
-    /// Wrapped in a `ScrollView` so the largest Dynamic Type sizes scroll
-    /// instead of clipping; the `minHeight` keyed to the available height
-    /// keeps the content vertically centered whenever it still fits, so the
-    /// landing looks unchanged at default text sizes.
+    /// Hero and text laid side by side, centred in the pane above the floating
+    /// Scan disc. No `ScrollView`: the landing is a single static composition,
+    /// kept compact so it fits without scrolling, and the bottom inset reserves
+    /// a clear band for the Scan disc so the two never collide.
     var body: some View {
-        GeometryReader { proxy in
-            ScrollView {
-                // Wide layout (hero beside the text) is preferred;
-                // ViewThatFits drops to the stacked layout when the detail
-                // pane is too narrow for both side by side, so the screen
-                // degrades gracefully at the 900pt min window without a
-                // manual breakpoint.
-                ViewThatFits(in: .horizontal) {
-                    HStack(alignment: .center, spacing: 48) {
-                        hero
-                        textColumn
-                    }
-                    VStack(spacing: 28) {
-                        hero
-                        textColumn
-                    }
-                }
-                .padding(40)
-                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
-            }
-            // No bounce when the content already fits — the intro should feel
-            // like a static landing, not a scroll surface, until Dynamic Type
-            // actually overflows it.
-            .scrollBounceBehavior(.basedOnSize)
+        HStack(alignment: .center, spacing: 44) {
+            hero
+            textColumn
         }
+        .padding(.horizontal, 44)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Reserve the bottom band for the floating Scan disc, so the centred
+        // cluster sits clear of it and the landing never needs to scroll.
+        .padding(.bottom, 168)
         .accessibilityIdentifier(rootAccessibilityIdentifier)
         .accessibilityElement(children: .contain)
     }
@@ -101,10 +88,18 @@ struct SectionIntroView: View {
     // MARK: Hero
 
     /// Designer art when supplied, otherwise the accent-tinted SF Symbol,
-    /// behind the shared accent bloom. Decorative — hidden from accessibility.
+    /// over a soft accent orb. Slowly drifts so it floats like the reference's
+    /// lit 3D illustration. Decorative — hidden from accessibility.
     @ViewBuilder
     private var hero: some View {
-        Group {
+        ZStack {
+            // A blurred accent orb behind the artwork so the hero glows from
+            // within rather than reading as a flat icon.
+            Circle()
+                .fill(presentation.accent.opacity(0.42))
+                .frame(width: 132, height: 132)
+                .blur(radius: 50)
+
             if let asset = presentation.heroAssetName, !asset.isEmpty {
                 // Designer-supplied art is pre-coloured, so it is not accent
                 // tinted — only the bloom carries the accent.
@@ -112,18 +107,25 @@ struct SectionIntroView: View {
                     .resizable()
                     .interpolation(.high)
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 160, height: 160)
+                    .frame(width: 168, height: 168)
             } else {
                 Image(systemName: presentation.heroSymbol)
-                    .font(.system(size: 120))
+                    .font(.system(size: 108, weight: .regular))
                     .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(presentation.accent)
-                    .frame(width: 160, height: 160)
             }
         }
+        .frame(width: 200, height: 200)
         // A soft bloom behind the hero, recoloured to the section accent so
         // the intro feels like part of one family.
-        .shadow(color: presentation.accent.opacity(0.45), radius: 32)
+        .shadow(color: presentation.accent.opacity(0.30), radius: 22)
+        // A slow vertical drift so the hero gently floats in place.
+        .offset(y: heroFloating ? -7 : 5)
+        .animation(
+            .easeInOut(duration: 3.6).repeatForever(autoreverses: true),
+            value: heroFloating
+        )
+        .onAppear { heroFloating = true }
         // The art is decorative, but a sighted user gets a clear section
         // anchor here, so VoiceOver gets one too. The label is qualified as
         // an "illustration" rather than the bare section name so it does not
@@ -143,21 +145,22 @@ struct SectionIntroView: View {
     /// Title, tagline, the inline FDA reminder (when needed), and the
     /// descriptive feature rows, grouped under the per-section identifier.
     private var textColumn: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: 22) {
             VStack(alignment: .leading, spacing: 10) {
                 Text(title)
-                    .font(.system(size: 34, weight: .semibold))
+                    .font(.system(size: 40, weight: .regular))
                     .fixedSize(horizontal: false, vertical: true)
                     // Marks the section name as a heading so VoiceOver's
                     // rotor lets users jump straight to it.
                     .accessibilityAddTraits(.isHeader)
 
                 Text(presentation.tagline)
-                    .font(.title3)
+                    .font(.system(size: 16, weight: .regular))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.leading)
+                    .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: 420, alignment: .leading)
+                    .frame(maxWidth: 360, alignment: .leading)
             }
 
             // Inline reminder, sized to align with the tagline column. Sits
@@ -185,6 +188,7 @@ struct SectionIntroView: View {
                 }
             }
         }
+        .frame(maxWidth: 380, alignment: .leading)
         .animation(.smooth(duration: 0.4), value: appState.hasFullDiskAccess)
         // Combine the title + tagline + rows under the per-section id without
         // hiding the rows: .contain keeps each row independently queryable by
@@ -193,17 +197,31 @@ struct SectionIntroView: View {
         .accessibilityIdentifier(sectionAccessibilityIdentifier)
     }
 
-    /// One descriptive row: accent icon + label. Purely informational — no
+    /// One descriptive row: an accent badge + label. Purely informational — no
     /// checkbox, no action (matches the reference design).
     private func featureRow(_ feature: SectionFeature, index: Int) -> some View {
-        HStack(spacing: 14) {
-            Image(systemName: feature.symbol)
-                .font(.title3)
-                .symbolRenderingMode(.hierarchical)
-                .foregroundStyle(presentation.accent)
-                .frame(width: 28, alignment: .center)
+        HStack(spacing: 13) {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            presentation.accent,
+                            presentation.accent.opacity(0.72),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 36, height: 36)
+                .overlay {
+                    Image(systemName: feature.symbol)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.white)
+                }
+                .shadow(color: presentation.accent.opacity(0.4), radius: 7, y: 3)
             Text(feature.title)
-                .font(.body)
+                .font(.system(size: 15, weight: .regular))
+            Spacer(minLength: 0)
         }
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier(featureAccessibilityIdentifier(at: index))

--- a/VaderCleaner/SectionPresentation.swift
+++ b/VaderCleaner/SectionPresentation.swift
@@ -11,9 +11,9 @@ struct SectionFeature: Equatable {
     let title: String
 }
 
-/// The visual identity for a scannable section's intro screen. The window's
-/// crimson `vaderShell()` is unchanged — `accent` tints only the hero,
-/// sub-feature icons, and (in a later step) the floating Scan button.
+/// The content for a scannable section's intro screen. The section's colour
+/// identity lives in `NavigationSection.theme`; `accent` mirrors that hue so
+/// the hero, feature badges, and floating Scan disc match the window backdrop.
 struct SectionPresentation {
     /// SF Symbol used as the hero when no bespoke art is supplied.
     let heroSymbol: String
@@ -21,7 +21,8 @@ struct SectionPresentation {
     /// back to `heroSymbol`; wired now so art can land later with no code
     /// change.
     let heroAssetName: String?
-    /// Accent applied to intro elements only — not the window gradient.
+    /// The section's vivid hue — mirrors `NavigationSection.theme.accent` so
+    /// the intro elements match the window backdrop.
     let accent: Color
     /// One-line description shown under the section title.
     let tagline: String
@@ -40,7 +41,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "sparkles",
                 heroAssetName: nil,
-                accent: .vaderCrimson,
+                accent: section.theme.accent,
                 tagline: String(
                     localized: "Quick maintenance that takes care of the essentials.",
                     comment: "Smart Scan intro tagline."
@@ -64,7 +65,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "trash",
                 heroAssetName: nil,
-                accent: .vaderCrimson,
+                accent: section.theme.accent,
                 tagline: String(
                     localized: "Clean your system to reclaim space and boost performance.",
                     comment: "System Junk intro tagline."
@@ -92,7 +93,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "doc.text.magnifyingglass",
                 heroAssetName: nil,
-                accent: .vaderCrimson,
+                accent: section.theme.accent,
                 tagline: String(
                     localized: "Find big and forgotten files taking up space.",
                     comment: "Large & Old Files intro tagline."
@@ -116,7 +117,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "square.split.2x2",
                 heroAssetName: nil,
-                accent: .vaderCrimson,
+                accent: section.theme.accent,
                 tagline: String(
                     localized: "See what's using your storage with an interactive map.",
                     comment: "Space Lens intro tagline."
@@ -136,7 +137,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "shield.lefthalf.filled",
                 heroAssetName: nil,
-                accent: .vaderCrimson,
+                accent: section.theme.accent,
                 tagline: String(
                     localized: "Check your Mac for threats and vulnerabilities.",
                     comment: "Malware Removal intro tagline."
@@ -160,7 +161,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "gauge.with.needle",
                 heroAssetName: nil,
-                accent: .vaderCrimson,
+                accent: section.theme.accent,
                 tagline: String(
                     localized: "Keep your Mac in top shape with recommended maintenance.",
                     comment: "Optimization intro tagline."
@@ -188,7 +189,7 @@ struct SectionPresentation {
             return SectionPresentation(
                 heroSymbol: "lock.shield",
                 heroAssetName: nil,
-                accent: .vaderCrimson,
+                accent: section.theme.accent,
                 tagline: String(
                     localized: "Clear browsing history, cookies, and caches across your browsers.",
                     comment: "Privacy intro tagline."

--- a/VaderCleaner/SectionTheme.swift
+++ b/VaderCleaner/SectionTheme.swift
@@ -1,0 +1,96 @@
+// SectionTheme.swift
+// Per-section color identity — the accent and backdrop gradient that retint the whole window as the user moves between sections.
+
+import SwiftUI
+
+/// The color identity for one navigation section. `accent` is the vivid hue
+/// shared by the hero glow, the feature badges, the floating Scan disc, and the
+/// section's sidebar icon. `backdropTop`/`backdropBottom` are the dark base of
+/// the window gradient; the accent also blooms up through it as a radial glow.
+struct SectionTheme: Equatable {
+    /// The vivid section hue — hero glow, feature badges, Scan disc, rail icon.
+    let accent: Color
+    /// Top of the window gradient: the darkest corner tone.
+    let backdropTop: Color
+    /// Bottom of the window gradient: a deeper, more saturated base that the
+    /// accent bloom sits over.
+    let backdropBottom: Color
+}
+
+extension NavigationSection {
+    /// This section's color identity. Defined for every case — the window
+    /// backdrop is keyed to the section, so the non-scannable management
+    /// screens need a theme too. Exhaustive switch with no `default` so a new
+    /// section is a compile-time prompt to give it a hue.
+    var theme: SectionTheme {
+        switch self {
+        case .smartScan:
+            // The brand-crimson hero section — the app's Vader identity.
+            return SectionTheme(
+                accent: .vaderCrimson,
+                backdropTop: Color(red: 0.12, green: 0.02, blue: 0.04),
+                backdropBottom: Color(red: 0.30, green: 0.05, blue: 0.10)
+            )
+        case .systemJunk:
+            return SectionTheme(
+                accent: Color(red: 0.36, green: 0.83, blue: 0.42),
+                backdropTop: Color(red: 0.04, green: 0.11, blue: 0.06),
+                backdropBottom: Color(red: 0.07, green: 0.28, blue: 0.13)
+            )
+        case .largeOldFiles:
+            return SectionTheme(
+                accent: Color(red: 0.24, green: 0.81, blue: 0.74),
+                backdropTop: Color(red: 0.03, green: 0.11, blue: 0.11),
+                backdropBottom: Color(red: 0.05, green: 0.26, blue: 0.26)
+            )
+        case .spaceLens:
+            return SectionTheme(
+                accent: Color(red: 0.46, green: 0.44, blue: 0.99),
+                backdropTop: Color(red: 0.06, green: 0.06, blue: 0.18),
+                backdropBottom: Color(red: 0.13, green: 0.13, blue: 0.40)
+            )
+        case .malwareRemoval:
+            return SectionTheme(
+                accent: Color(red: 0.92, green: 0.22, blue: 0.32),
+                backdropTop: Color(red: 0.13, green: 0.03, blue: 0.05),
+                backdropBottom: Color(red: 0.34, green: 0.05, blue: 0.11)
+            )
+        case .optimization:
+            return SectionTheme(
+                accent: Color(red: 0.98, green: 0.60, blue: 0.20),
+                backdropTop: Color(red: 0.13, green: 0.07, blue: 0.02),
+                backdropBottom: Color(red: 0.34, green: 0.17, blue: 0.04)
+            )
+        case .privacy:
+            return SectionTheme(
+                accent: Color(red: 0.96, green: 0.30, blue: 0.64),
+                backdropTop: Color(red: 0.13, green: 0.04, blue: 0.09),
+                backdropBottom: Color(red: 0.33, green: 0.08, blue: 0.21)
+            )
+        case .extensions:
+            return SectionTheme(
+                accent: Color(red: 0.30, green: 0.59, blue: 0.99),
+                backdropTop: Color(red: 0.04, green: 0.07, blue: 0.15),
+                backdropBottom: Color(red: 0.07, green: 0.17, blue: 0.39)
+            )
+        case .appUninstaller:
+            return SectionTheme(
+                accent: Color(red: 0.52, green: 0.50, blue: 0.95),
+                backdropTop: Color(red: 0.07, green: 0.06, blue: 0.16),
+                backdropBottom: Color(red: 0.16, green: 0.14, blue: 0.37)
+            )
+        case .appUpdater:
+            return SectionTheme(
+                accent: Color(red: 0.24, green: 0.76, blue: 0.93),
+                backdropTop: Color(red: 0.03, green: 0.09, blue: 0.13),
+                backdropBottom: Color(red: 0.05, green: 0.23, blue: 0.33)
+            )
+        case .healthMonitor:
+            return SectionTheme(
+                accent: Color(red: 0.30, green: 0.86, blue: 0.64),
+                backdropTop: Color(red: 0.03, green: 0.11, blue: 0.09),
+                backdropBottom: Color(red: 0.06, green: 0.27, blue: 0.20)
+            )
+        }
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -205,6 +205,14 @@ struct VaderCleanerApp: App {
                 .environmentObject(systemStats)
                 .environmentObject(notificationMonitor)
         }
+        // Hide the title bar so no section title is drawn beside the traffic
+        // lights; the controls float over the section's gradient and each
+        // screen reads as one continuous surface.
+        .windowStyle(.hiddenTitleBar)
+        // Open wide and tall enough for the side-by-side section intro (hero
+        // beside the text) to show on first launch, with the vertically
+        // centred cluster sitting clear of the floating Scan disc.
+        .defaultSize(width: 1200, height: 800)
         .commands {
             // Replace SwiftUI's default "About VaderCleaner" item so the
             // panel carries our copyright credits instead of an empty one.

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -5,8 +5,8 @@ import SwiftUI
 
 /// Palette for the Vader identity. Deep near-black base with a vivid crimson
 /// accent — retained as the default control tint for surfaces that have no
-/// section context (e.g. the Full Disk Access prompt card) and as the Malware
-/// Removal section's hue.
+/// section context (e.g. the Full Disk Access prompt card) and as the Smart
+/// Scan section's hue.
 extension Color {
     /// A near-black with a faint cool cast — the darkest base tone.
     static let vaderSpaceBlack = Color(red: 0.039, green: 0.039, blue: 0.055)

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -1,42 +1,45 @@
 // VaderTheme.swift
-// VaderCleaner's branded visual identity: the space-black to Sith-red palette, the gradient backdrop, and the app-wide shell modifier that hosts Liquid Glass surfaces.
+// VaderCleaner's visual identity: the space-black to Sith-red palette and the per-section gradient backdrop that hosts the app's Liquid Glass surfaces.
 
 import SwiftUI
 
 /// Palette for the Vader identity. Deep near-black base with a vivid crimson
-/// accent — chosen so translucent Liquid Glass surfaces layered on top pick up
-/// a warm refraction without washing out white foreground text.
+/// accent — retained as the default control tint for surfaces that have no
+/// section context (e.g. the Full Disk Access prompt card) and as the Malware
+/// Removal section's hue.
 extension Color {
-    /// Top of the window gradient — near-black with a faint cool cast.
+    /// A near-black with a faint cool cast — the darkest base tone.
     static let vaderSpaceBlack = Color(red: 0.039, green: 0.039, blue: 0.055)
-    /// Bottom of the window gradient — a very dark crimson so the base reads
-    /// "Vader" rather than a neutral dark theme.
+    /// A very dark crimson.
     static let vaderDeepRed = Color(red: 0.149, green: 0.027, blue: 0.055)
-    /// Accent / tint — the lightsaber crimson used for the primary call to
-    /// action, the sidebar selection, and control tinting.
+    /// Accent / tint — the lightsaber crimson used as the default control tint.
     static let vaderCrimson = Color(red: 0.851, green: 0.102, blue: 0.176)
 }
 
-/// Full-bleed branded backdrop: a vertical space-black → deep-crimson gradient
-/// with a soft crimson bloom centred slightly below the window's middle, so the
-/// hero content sits in the brightest part of the glow like the reference.
+/// Full-bleed branded backdrop: a vertical dark → rich gradient in the active
+/// section's hue, with a soft accent bloom centred low so the brightest part of
+/// the glow pools behind the hero cluster and the floating Scan disc. Driven by
+/// the section theme so navigating between sections recolours the whole window.
 struct VaderBackground: View {
+    /// The active section's colour identity. The whole backdrop is built from
+    /// this, so the caller crossfades it as the selection changes.
+    let theme: SectionTheme
+
     var body: some View {
         ZStack {
             LinearGradient(
-                colors: [.vaderSpaceBlack, .vaderDeepRed],
+                colors: [theme.backdropTop, theme.backdropBottom],
                 startPoint: .top,
                 endPoint: .bottom
             )
             RadialGradient(
-                colors: [Color.vaderCrimson.opacity(0.34), .clear],
-                // y is biased just below the vertical centre (rather than 0.5)
-                // so the brightest part of the bloom falls under the hero
-                // icon/title cluster on the welcome screen, not the empty
-                // middle of the window.
-                center: UnitPoint(x: 0.5, y: 0.58),
+                colors: [theme.accent.opacity(0.5), .clear],
+                // y is biased well below centre so the bloom pools behind the
+                // hero/title cluster and the floating Scan disc rather than the
+                // empty middle of the window.
+                center: UnitPoint(x: 0.5, y: 0.74),
                 startRadius: 0,
-                endRadius: 620
+                endRadius: 760
             )
         }
         .ignoresSafeArea()
@@ -44,17 +47,14 @@ struct VaderBackground: View {
 }
 
 extension View {
-    /// Hosts a scene in the Vader shell: the gradient backdrop behind
-    /// everything, a forced dark appearance so system chrome and Liquid Glass
-    /// adopt the light-on-dark vibrant treatment, and the crimson accent tint.
-    ///
-    /// Applied at the `NavigationSplitView` root. List and scroll backgrounds
-    /// are cleared per-view so the gradient shows through the sidebar and
-    /// detail panes while their glass surfaces float on top.
-    func vaderShell() -> some View {
+    /// Hosts a scene in the Vader shell: a forced dark appearance so system
+    /// chrome and Liquid Glass adopt the light-on-dark vibrant treatment, and
+    /// the supplied accent as the control tint. The per-section gradient
+    /// backdrop is applied separately by `ContentView` so it can crossfade as
+    /// the selection changes.
+    func vaderShell(accent: Color) -> some View {
         self
-            .background(VaderBackground())
-            .tint(Color.vaderCrimson)
+            .tint(accent)
             .preferredColorScheme(.dark)
     }
 }

--- a/VaderCleanerTests/SectionPresentationTests.swift
+++ b/VaderCleanerTests/SectionPresentationTests.swift
@@ -95,16 +95,17 @@ final class SectionPresentationTests: XCTestCase {
         }
     }
 
-    /// Every scannable section's intro accent must be the single Vader crimson —
-    /// the app's one brand accent. A section added with a stray accent (or an
-    /// existing one drifting back to a per-section color) fails loudly here.
-    func test_everyScannablePresentationAccent_isVaderCrimson() throws {
+    /// Every scannable section's intro accent must mirror its
+    /// `NavigationSection.theme` accent, so the hero, feature badges, and
+    /// floating Scan disc match the per-section window backdrop. A section that
+    /// hardcodes a stray accent instead of its theme fails loudly here.
+    func test_everyScannablePresentationAccent_matchesSectionTheme() throws {
         for section in scannableSections {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))
             XCTAssertEqual(
                 presentation.accent,
-                .vaderCrimson,
-                "Section \(section) must use the unified crimson accent"
+                section.theme.accent,
+                "Section \(section)'s presentation accent must mirror its theme accent"
             )
         }
     }

--- a/VaderCleanerTests/SectionThemeTests.swift
+++ b/VaderCleanerTests/SectionThemeTests.swift
@@ -1,0 +1,56 @@
+// SectionThemeTests.swift
+// Pins the per-section color identity contract: every section has a theme, and the accents are distinct so the window visibly retints as the user moves between sections.
+
+import XCTest
+import SwiftUI
+@testable import VaderCleaner
+
+final class SectionThemeTests: XCTestCase {
+
+    func test_everySection_hasATheme() {
+        // The window backdrop is keyed to the section, so every case — not
+        // just the scannable ones — must carry a theme.
+        for section in NavigationSection.allCases {
+            let theme = section.theme
+            XCTAssertNotEqual(
+                theme.accent,
+                .clear,
+                "Section \(section) must have a visible accent"
+            )
+        }
+    }
+
+    func test_accentsAreDistinctAcrossSections() {
+        // A distinct accent per section is what makes the window visibly
+        // retint on navigation — the whole point of the per-section backdrop.
+        let accents = NavigationSection.allCases.map(\.theme.accent)
+        XCTAssertEqual(
+            Set(accents).count,
+            NavigationSection.allCases.count,
+            "Each section must have a distinct accent so navigation retints the UI"
+        )
+    }
+
+    func test_backdropGradient_hasTwoDistinctStops() {
+        // Top and bottom of the window gradient must differ or the backdrop
+        // reads as a flat fill instead of the reference's dark-to-rich ramp.
+        for section in NavigationSection.allCases {
+            let theme = section.theme
+            XCTAssertNotEqual(
+                theme.backdropTop,
+                theme.backdropBottom,
+                "Section \(section) backdrop must ramp between two distinct tones"
+            )
+        }
+    }
+
+    func test_accentDiffersFromBackdrop() {
+        // The accent blooms over the backdrop; if it equalled a backdrop stop
+        // the hero glow and Scan disc would vanish into the background.
+        for section in NavigationSection.allCases {
+            let theme = section.theme
+            XCTAssertNotEqual(theme.accent, theme.backdropTop, "\(section) accent must stand out from backdropTop")
+            XCTAssertNotEqual(theme.accent, theme.backdropBottom, "\(section) accent must stand out from backdropBottom")
+        }
+    }
+}


### PR DESCRIPTION
## What

Reworks the section landing screens and the sidebar navigation toward a CleanMyMac-style layout, with a distinct color identity per section.

### Per-section color identity
- New `SectionTheme` — an accent + backdrop gradient defined for **all 11 sections**.
- `VaderBackground` is now driven by the active section's theme; `ContentView` **crossfades the whole window backdrop** as the selection changes.
- Smart Scan keeps the brand crimson; the other sections take distinct hues (green, teal, indigo, amber, magenta, blue, …).
- `SectionPresentation.accent` now mirrors the section theme so the hero, feature badges, and floating Scan disc match the backdrop.

### Section intro screens
- Hero beside the text, **centered in the pane with no `ScrollView`** — sized to fit without scrolling and to clear the floating Scan disc.
- Larger title, a gentle hero float, and badge-style feature rows.

### Navigation rail
- **Active pill** — translucent fill with a soft horizontal sheen and an **accent-colored hairline rim** (leading→trailing gradient).
- **New hover state** — a quieter flat pill with a dim neutral border, so hover and active stay clearly distinct.
- Row icons stay neutral until hovered/active, then take the section accent.
- Fatter rows with tuned spacing/insets so **all 11 rows fit a default-height window** without scrolling.

### Window
- Hidden title bar (`.windowStyle(.hiddenTitleBar)`) so no section title is drawn beside the traffic lights.

## Why

Adopts the layout, spacing, proportion, and motion of a reference design while keeping VaderCleaner's identity — Smart Scan stays crimson, every other section gets its own hue so navigation visibly retints the UI.

## Notes for reviewers

- `SectionPresentationTests.test_everyScannablePresentationAccent_isVaderCrimson` deliberately pinned the all-crimson identity as a past decision. This PR reverses that decision, so the test is rewritten to `test_everyScannablePresentationAccent_matchesSectionTheme` (asserts each accent mirrors `SectionTheme`).
- New `SectionThemeTests` pins the theme contract: every section has a theme, accents are distinct, backdrop stops differ.
- Layout sizing in `SectionIntroView` and the rail is tuned for a ~1030×710 window; on smaller windows content may clip rather than scroll (intentional — the section landing is a non-scrolling composition).
- All affected test classes pass (`SectionThemeTests`, `SectionPresentationTests`, `SectionIntroViewTests`, `NavigationSectionTests`, `FloatingScanButtonTests` — 35 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added section-specific color themes throughout the app with distinct accent colors and gradients for each navigation section.

* **UI & Visual Improvements**
  * Enhanced window appearance with a hidden title bar and optimized dimensions.
  * Redesigned intro screens with animated floating hero elements and new accent color badges.
  * Improved navigation rail with refined hover highlighting and updated selection styling.
  * Added smooth animations and crossfades when switching between sections.
  * Updated backdrop gradients to dynamically reflect each section's theme.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->