### PR TITLE
Float the Scan disc in a child window and gate Full Disk Access at tap

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */; };
 		28B2F4C32E608BD283DB2DE5 /* VaderCleanerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */; };
 		290DC2499AC322736E1FC7E6 /* ProcessLineStreamerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */; };
+		2A194198E5DDD324E97D99B2 /* FloatingScanOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */; };
 		2A28D67DA396B3D2B6DB13D5 /* DiskScannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */; };
 		2A46AEBD95B9E1561264D0F0 /* NotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */; };
 		2A9EFA38DAE2163D06793B46 /* PrivacyCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */; };
@@ -66,15 +67,18 @@
 		3A3C0E7B444AE96C4C2D1C8F /* HealthMonitorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */; };
 		3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */; };
 		3B8C348DB1DCBFB89771ADDC /* PrivacyPermissionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */; };
+		3D65654B589EFF2972927ED7 /* ScanAccessPopoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */; };
 		3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */; };
 		406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */; };
 		4156DAE09EB7579F22FA6959 /* MalwareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */; };
+		45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */; };
 		483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */; };
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
 		4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */; };
 		4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
+		4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */; };
 		50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */; };
 		52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */; };
 		55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
@@ -94,6 +98,7 @@
 		65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD8C98E8253953444DD99F /* NotificationManager.swift */; };
 		65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */; };
+		67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */; };
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
 		6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */; };
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
@@ -155,6 +160,7 @@
 		B9E44C0566F7DFAFAF8A6071 /* MalwareThreat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5741874005D8A34BB7D82287 /* MalwareThreat.swift */; };
 		B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */; };
 		BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2B92863509818189F46CD /* MenuBarContent.swift */; };
+		BA47B242AAAE6EAD08CC7D23 /* ScanDiscWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */; };
 		BABEDA3326E05DC3A8356E3D /* AppStoreUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */; };
 		BB6D9635C62A1D0635E2799F /* AppUpdaterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76CE861C998A697164C552 /* AppUpdaterError.swift */; };
 		BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */; };
@@ -195,6 +201,7 @@
 		EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4E92A146A223EA836C156D /* ScanResultTests.swift */; };
 		F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */; };
 		F0838C9B10FFB6AD75523D0A /* PrivacyPermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */; };
+		F106EE57A074D89D42E2872B /* ScanDiscWindowFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC72C9CBA70B1BBF45D6B8C1 /* ScanDiscWindowFrameTests.swift */; };
 		F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */; };
 		F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */; };
 		F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8635D102B895AF349A13D /* AppUpdaterView.swift */; };
@@ -291,12 +298,14 @@
 		2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButton.swift; sourceTree = "<group>"; };
 		2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanViewModelTests.swift; sourceTree = "<group>"; };
 		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
+		2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanAccessPopover.swift; sourceTree = "<group>"; };
 		2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSection.swift; sourceTree = "<group>"; };
 		2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingTests.swift; sourceTree = "<group>"; };
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
+		3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscHostView.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
 		3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingConformanceTests.swift; sourceTree = "<group>"; };
 		3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdaterTests.swift; sourceTree = "<group>"; };
@@ -309,6 +318,7 @@
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
 		46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpersTests.swift; sourceTree = "<group>"; };
 		4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsService.swift; sourceTree = "<group>"; };
+		48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscWindowController.swift; sourceTree = "<group>"; };
 		49D62624319B764770F02292 /* AppUninstallerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModel.swift; sourceTree = "<group>"; };
 		4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayout.swift; sourceTree = "<group>"; };
 		4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScanner.swift; sourceTree = "<group>"; };
@@ -360,6 +370,7 @@
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
+		88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanOverlay.swift; sourceTree = "<group>"; };
 		897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensView.swift; sourceTree = "<group>"; };
 		8A0F635D79B943130BAB15AE /* VaderCleaner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VaderCleaner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModel.swift; sourceTree = "<group>"; };
@@ -403,6 +414,7 @@
 		B79E0766E335360E04FC6A53 /* AppDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscovery.swift; sourceTree = "<group>"; };
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
 		BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateFullDiskAccessTests.swift; sourceTree = "<group>"; };
+		BC72C9CBA70B1BBF45D6B8C1 /* ScanDiscWindowFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscWindowFrameTests.swift; sourceTree = "<group>"; };
 		BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileScanner.swift; sourceTree = "<group>"; };
 		BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModelTests.swift; sourceTree = "<group>"; };
 		BF767348D39506E36221A89D /* MalwareThreatRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemover.swift; sourceTree = "<group>"; };
@@ -440,6 +452,7 @@
 		E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModel.swift; sourceTree = "<group>"; };
 		E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVDetectorTests.swift; sourceTree = "<group>"; };
 		E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskNodeTests.swift; sourceTree = "<group>"; };
+		E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscWindowFrame.swift; sourceTree = "<group>"; };
 		E776BF468380DFF621C6063C /* HelperConnectionErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionErrorTests.swift; sourceTree = "<group>"; };
 		E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearerTests.swift; sourceTree = "<group>"; };
 		EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatTests.swift; sourceTree = "<group>"; };
@@ -450,6 +463,7 @@
 		F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleterTests.swift; sourceTree = "<group>"; };
 		F421495C84A41EDEF253EBD6 /* FileCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategory.swift; sourceTree = "<group>"; };
 		F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderTheme.swift; sourceTree = "<group>"; };
+		F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanAccessPopoverTests.swift; sourceTree = "<group>"; };
 		F973B5B33642739FB9D7D004 /* HelperConnectionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionError.swift; sourceTree = "<group>"; };
 		FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VaderCleaner.entitlements; sourceTree = "<group>"; };
 		FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManagerTests.swift; sourceTree = "<group>"; };
@@ -535,6 +549,7 @@
 				6090134A72001DE6262436F3 /* FileIconCache.swift */,
 				BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */,
 				2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */,
+				88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */,
 				5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */,
 				AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */,
 				FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */,
@@ -579,8 +594,12 @@
 				7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */,
 				9D5CB08F96767D10B1271970 /* RAMManager.swift */,
 				2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */,
+				2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */,
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
 				AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */,
+				3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */,
+				48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */,
+				E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */,
 				B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */,
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
 				9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */,
@@ -698,9 +717,11 @@
 				7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */,
 				78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */,
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
+				F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
 				3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */,
 				2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */,
+				BC72C9CBA70B1BBF45D6B8C1 /* ScanDiscWindowFrameTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
 				6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
@@ -922,9 +943,11 @@
 				290DC2499AC322736E1FC7E6 /* ProcessLineStreamerTests.swift in Sources */,
 				3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */,
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
+				3D65654B589EFF2972927ED7 /* ScanAccessPopoverTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
 				1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */,
 				102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */,
+				F106EE57A074D89D42E2872B /* ScanDiscWindowFrameTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
@@ -1007,6 +1030,7 @@
 				730791446114BB6991798518 /* FileIconCache.swift in Sources */,
 				52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */,
 				EE62512542BF54B5D6ADFA9D /* FloatingScanButton.swift in Sources */,
+				2A194198E5DDD324E97D99B2 /* FloatingScanOverlay.swift in Sources */,
 				EC99895496A545FE0F9A9222 /* FullDiskAccessPromptCard.swift in Sources */,
 				E5E7952A56BA88D9CA86A1B5 /* HTTPFetching.swift in Sources */,
 				92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */,
@@ -1052,8 +1076,12 @@
 				196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */,
 				7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */,
 				567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */,
+				45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */,
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,
 				9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */,
+				67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */,
+				BA47B242AAAE6EAD08CC7D23 /* ScanDiscWindowController.swift in Sources */,
+				4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */,
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				9D44F12D7502363B814F2DF9 /* SectionIntroView.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -2,6 +2,7 @@
 // Root view — NavigationSplitView with sidebar listing all 11 sections and placeholder detail views.
 
 import SwiftUI
+import AppKit
 
 struct ContentView: View {
     @EnvironmentObject private var appState: AppState
@@ -32,13 +33,13 @@ struct ContentView: View {
     /// cleaner to issue exactly one.
     @State private var didRequestNotificationPermission = false
     /// Fixed width of the navigation rail. Shared by the rail's own frame and
-    /// the floating Scan overlay so the disc centers over the detail content
-    /// area (not the full window) without the two drifting apart.
+    /// the Scan disc panel so the disc centers over the detail content area
+    /// (not the full window) without the two drifting apart.
     private let railWidth: CGFloat = 240
-    /// Bottom inset for the floating Scan overlay. Sized so the 108pt disc
-    /// and its breathing glow sit fully inside the window above the bottom
-    /// edge instead of being clipped by it.
-    private let floatingScanBottomPadding: CGFloat = 32
+    /// Owns the borderless child panel that hosts the floating Scan disc so it
+    /// can straddle the window's bottom edge. Created with the scannable view
+    /// models; attached once the host window resolves.
+    @StateObject private var scanDiscController: ScanDiscWindowController
     init(
         systemJunkViewModel: SystemJunkViewModel,
         largeOldFilesViewModel: LargeOldFilesViewModel,
@@ -61,6 +62,15 @@ struct ContentView: View {
         self.optimizationViewModel = optimizationViewModel
         self.malwareViewModel = malwareViewModel
         self.smartScanViewModel = smartScanViewModel
+        _scanDiscController = StateObject(wrappedValue: ScanDiscWindowController(
+            smartScanViewModel: smartScanViewModel,
+            systemJunkViewModel: systemJunkViewModel,
+            largeOldFilesViewModel: largeOldFilesViewModel,
+            spaceLensViewModel: spaceLensViewModel,
+            optimizationViewModel: optimizationViewModel,
+            malwareViewModel: malwareViewModel,
+            privacyViewModel: privacyViewModel
+        ))
     }
 
     /// Colour identity of the section currently on screen. Drives the window
@@ -90,21 +100,27 @@ struct ContentView: View {
                     .transition(.opacity)
             }
         }
-        // The Scan CTA floats over the window's bottom edge. It is attached to
-        // the OUTER HStack — outside the NavigationStack — so the detail
-        // screens' toolbars and safe-area insets can't clip it. The leading
-        // inset equal to the rail width re-centers the disc over the detail
-        // content area rather than the full window, and the bottom padding
-        // keeps the whole disc and its glow inside the window above the
-        // bottom edge.
-        .overlay(alignment: .bottom) {
-            floatingScan(for: selectedSection ?? .smartScan)
-                .padding(.leading, railWidth)
-                .padding(.bottom, floatingScanBottomPadding)
+        // The floating Scan disc lives in its own borderless child panel
+        // (`ScanDiscWindowController`) so it can straddle the window's bottom
+        // edge — a plain overlay cannot, because a window clips its content.
+        // Resolve the host window, then hand it to the controller.
+        .background(
+            WindowAccessor { window in
+                scanDiscController.attach(
+                    to: window,
+                    railWidth: railWidth,
+                    appState: appState
+                )
+            }
+        )
+        // Mirror the sidebar selection onto the disc panel so it shows the
+        // matching section's disc.
+        .onChange(of: selectedSection) { _, newValue in
+            scanDiscController.section = newValue ?? .smartScan
         }
         // One ambient animation drives every section-change motion in lock
-        // step: the rail's selection pill slides, the detail screen
-        // crossfades, and the floating Scan disc recolours.
+        // step: the rail's selection pill slides and the detail screen
+        // crossfades.
         .animation(.smooth(duration: 0.42), value: selectedSection)
         // The side-by-side section intro needs a pane wide enough for the
         // hero, the gap, and the text column; a 1000pt minimum keeps that
@@ -345,34 +361,6 @@ struct ContentView: View {
         }
     }
 
-    /// The shell-level floating Scan button for the selected section. Renders
-    /// only for scannable sections and — via `FloatingScanOverlay`'s
-    /// observation of the coordinator — only while that section is at its
-    /// `.intro` phase; everything else collapses to nothing so the disc
-    /// disappears the instant a scan starts. The switch is exhaustive so a new
-    /// section is a compile-time prompt to classify it here.
-    @ViewBuilder
-    private func floatingScan(for section: NavigationSection) -> some View {
-        switch section {
-        case .smartScan:
-            FloatingScanOverlay(coordinator: smartScanViewModel, section: section)
-        case .systemJunk:
-            FloatingScanOverlay(coordinator: systemJunkViewModel, section: section)
-        case .largeOldFiles:
-            FloatingScanOverlay(coordinator: largeOldFilesViewModel, section: section)
-        case .spaceLens:
-            FloatingScanOverlay(coordinator: spaceLensViewModel, section: section)
-        case .optimization:
-            FloatingScanOverlay(coordinator: optimizationViewModel, section: section)
-        case .malwareRemoval:
-            FloatingScanOverlay(coordinator: malwareViewModel, section: section)
-        case .privacy:
-            FloatingScanOverlay(coordinator: privacyViewModel, section: section)
-        case .extensions, .appUninstaller, .appUpdater, .healthMonitor:
-            EmptyView()
-        }
-    }
-
     /// Shown until either FDA is granted (which the foreground refresh will detect)
     /// or the user dismisses for the session — either via the explicit "Continue
     /// Without Access" button or via Esc / programmatic sheet dismissal, both of
@@ -434,34 +422,26 @@ private struct ScannableSectionContent<Coordinator: ScanCoordinating, Detail: Vi
     }
 }
 
-/// The shell-level floating Scan button for one scannable section. Observes
-/// the coordinator so the disc is shown only while the section is at `.intro`
-/// and vanishes the moment a scan starts. Accent-tinted per section; the
-/// window's crimson shell is unchanged.
-private struct FloatingScanOverlay<Coordinator: ScanCoordinating>: View {
-    @ObservedObject var coordinator: Coordinator
-    let section: NavigationSection
+/// Resolves the `NSWindow` hosting a SwiftUI view. SwiftUI exposes no direct
+/// handle to its window, so this zero-size representable reads `view.window`
+/// once the view joins the hierarchy and hands it to `onResolve`. `onResolve`
+/// can be called more than once — across a window close/reopen, or on a later
+/// layout pass — so callers must treat it as idempotent.
+private struct WindowAccessor: NSViewRepresentable {
+    let onResolve: (NSWindow) -> Void
 
-    var body: some View {
-        Group {
-            if coordinator.scanPresentation == .intro {
-                FloatingScanButton(
-                    title: String(localized: "Scan", comment: "Floating scan button title."),
-                    accent: SectionPresentation.for(section)?.accent ?? .vaderCrimson,
-                    accessibilityIdentifier: section.scanAccessibilityIdentifier,
-                    accessibilityLabel: String(
-                        localized: "Scan \(section.title)",
-                        comment: "VoiceOver label for a section's floating scan button, e.g. \"Scan System Junk\"."
-                    ),
-                    action: { coordinator.beginScan() }
-                )
-                .transition(.opacity)
-            }
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        // `view.window` is nil until the view joins the hierarchy; resolve on
+        // the next runloop tick, once it has a window.
+        DispatchQueue.main.async {
+            if let window = view.window { onResolve(window) }
         }
-        // The disc fades out as the section leaves `.intro` instead of
-        // popping, staying in lock-step with the intro → detail crossfade
-        // `ScannableSectionContent` runs on the same value.
-        .animation(.smooth(duration: 0.35), value: coordinator.scanPresentation)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        if let window = nsView.window { onResolve(window) }
     }
 }
 

--- a/VaderCleaner/FloatingScanButton.swift
+++ b/VaderCleaner/FloatingScanButton.swift
@@ -1,16 +1,30 @@
 // FloatingScanButton.swift
-// The reusable hero call-to-action: a large floating interactive-glass disc with a breathing glow and press feedback, tinted by an accent (crimson by default).
+// The reusable hero call-to-action: a large circular accent-filled disc with a white ring, a breathing glow, and press feedback.
 
 import SwiftUI
 
-/// The hero / dashboard call to action — an interactive-glass disc echoing the
-/// reference's circular button. Interactive glass gives it the system
-/// press-scale and shimmer; the `accent` tint marks it as the primary action
-/// (crimson by default, so unspecified call sites stay on the Vader palette).
-/// Shared across sections so every "Scan"/"Clean" CTA stays visually identical.
+/// The hero / dashboard call to action — a circular button echoing the
+/// reference's Scan disc. A saturated `accent` fill (crimson by default, so
+/// unspecified call sites stay on the Vader palette) marks it as the primary
+/// action, and a white ring lifts it off the backdrop. Shared across sections
+/// so every "Scan"/"Clean" CTA stays visually identical.
+///
+/// The fill is a solid colour rather than a Liquid Glass material on purpose:
+/// the floating Scan disc is hosted in a child panel that straddles the window
+/// edge, so for its lower half there is no window backdrop for glass to tint
+/// against — a glass disc reads as dark grey over the desktop.
 struct FloatingScanButton: View {
+
+    /// Diameter of the floating Scan disc. Shared as one constant so the disc,
+    /// its host panel, and the panel's placement maths all agree on one size.
+    static let floatingDiameter: CGFloat = 130
+
     let title: String
     var accent: Color = .vaderCrimson
+    /// Diameter of the circular button. Defaults to the compact size used by
+    /// in-window CTAs such as the Smart Scan "Clean" button; the floating Scan
+    /// disc passes `floatingDiameter`.
+    var diameter: CGFloat = 108
     let accessibilityIdentifier: String
     /// VoiceOver label. `nil` falls back to `title` so existing call sites
     /// keep announcing "Scan"; the scan-centric shell passes
@@ -26,20 +40,35 @@ struct FloatingScanButton: View {
     /// unit-testable without rendering.
     var resolvedAccessibilityLabel: String { accessibilityLabel ?? title }
 
+    /// White ring width, scaled to the disc so it stays proportionate.
+    private var borderWidth: CGFloat { max(1.5, diameter * 0.018) }
+
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.title3.weight(.semibold))
+                .font(.system(size: diameter * 0.17, weight: .semibold))
                 .foregroundStyle(.white)
-                .frame(width: 108, height: 108)
+                .frame(width: diameter, height: diameter)
+                // A flat, fully opaque accent fill — not a glass material and
+                // not a fading gradient — so the disc reads as a solid section-
+                // coloured button even where it floats over the desktop,
+                // beyond any window backdrop glass could tint against.
+                .background(
+                    Circle().fill(accent)
+                )
+                // Crisp white ring, echoing the reference's lit disc.
+                .overlay(
+                    Circle().strokeBorder(.white, lineWidth: borderWidth)
+                )
+                // The frame is only transparent layout padding around the
+                // text; without an explicit content shape the button's hit
+                // region would collapse to the glyphs. Make the whole circle
+                // the tappable surface.
+                .contentShape(Circle())
         }
         .buttonStyle(PressableCircleButtonStyle())
-        .glassEffect(
-            .regular.tint(accent).interactive(),
-            in: .circle
-        )
-        // Ambient glow that breathes so the primary action keeps drawing the
-        // eye even when the rest of the screen is still.
+        // Ambient accent glow that breathes so the primary action keeps drawing
+        // the eye even when the rest of the screen is still.
         .shadow(
             color: accent.opacity(pulsing ? 0.65 : 0.4),
             radius: pulsing ? 30 : 18,

--- a/VaderCleaner/FloatingScanOverlay.swift
+++ b/VaderCleaner/FloatingScanOverlay.swift
@@ -1,0 +1,95 @@
+// FloatingScanOverlay.swift
+// The floating Scan disc for one scannable section — shown only at the `.intro` phase, accent-tinted, and gated behind the Full Disk Access popover when access is missing.
+
+import SwiftUI
+import AppKit
+
+/// The floating Scan button for one scannable section. Observes the coordinator
+/// so the disc is shown only while the section is at `.intro` and vanishes the
+/// moment a scan starts. Accent-tinted per section.
+///
+/// Hosted inside `ScanDiscWindowController`'s child panel so the disc can
+/// straddle the main window's bottom edge. `onIntroPresenceChanged` reports
+/// whether the disc is currently on screen so the controller can show or hide
+/// that panel in step.
+struct FloatingScanOverlay<Coordinator: ScanCoordinating>: View {
+    @ObservedObject var coordinator: Coordinator
+    let section: NavigationSection
+    /// Called whenever the disc's `.intro`-phase presence changes, so the
+    /// owning window controller can order its panel in or out to match.
+    var onIntroPresenceChanged: (Bool) -> Void = { _ in }
+
+    /// Observed so a Scan tap can be gated on the live Full Disk Access flag.
+    @EnvironmentObject private var appState: AppState
+
+    /// Drives the Full Disk Access popover anchored to the Scan disc. Set true
+    /// when the user taps Scan on an FDA-sensitive section without access; the
+    /// scan is held until they choose "Open System Settings" or "Scan Anyway".
+    @State private var showFullDiskAccessPrompt = false
+
+    /// Section-aware tint shared by the disc and the popover raised from it.
+    private var accent: Color {
+        SectionPresentation.for(section)?.accent ?? .vaderCrimson
+    }
+
+    /// Whether the disc should currently be on screen.
+    private var isAtIntro: Bool {
+        coordinator.scanPresentation == .intro
+    }
+
+    var body: some View {
+        Group {
+            if isAtIntro {
+                FloatingScanButton(
+                    title: String(localized: "Scan", comment: "Floating scan button title."),
+                    accent: accent,
+                    diameter: FloatingScanButton.floatingDiameter,
+                    accessibilityIdentifier: section.scanAccessibilityIdentifier,
+                    accessibilityLabel: String(
+                        localized: "Scan \(section.title)",
+                        comment: "VoiceOver label for a section's floating scan button, e.g. \"Scan System Junk\"."
+                    ),
+                    action: handleScanTap
+                )
+                .transition(.opacity)
+                // The Full Disk Access warning is anchored to the disc and
+                // raised only at the moment of action — tapping Scan on an
+                // FDA-sensitive section without access — so it never sits as
+                // permanent furniture on the intro screen.
+                .popover(isPresented: $showFullDiskAccessPrompt, arrowEdge: .top) {
+                    ScanAccessPopover(
+                        accent: accent,
+                        onOpenSettings: {
+                            NSWorkspace.shared.open(PermissionOnboardingViewModel.systemSettingsURL)
+                        },
+                        onScanAnyway: {
+                            showFullDiskAccessPrompt = false
+                            coordinator.beginScan()
+                        }
+                    )
+                }
+            }
+        }
+        // The disc fades out as the section leaves `.intro` instead of
+        // popping, staying in lock-step with the intro → detail crossfade.
+        .animation(.smooth(duration: 0.35), value: coordinator.scanPresentation)
+        .onAppear { onIntroPresenceChanged(isAtIntro) }
+        .onChange(of: coordinator.scanPresentation) { _, _ in
+            onIntroPresenceChanged(isAtIntro)
+        }
+    }
+
+    /// Routes a Scan tap: FDA-sensitive sections without access raise the
+    /// access popover; everything else starts the scan immediately.
+    private func handleScanTap() {
+        switch ScanTapOutcome.evaluate(
+            requiresFullDiskAccess: section.requiresFullDiskAccess,
+            hasFullDiskAccess: appState.hasFullDiskAccess
+        ) {
+        case .beginScan:
+            coordinator.beginScan()
+        case .promptForFullDiskAccess:
+            showFullDiskAccessPrompt = true
+        }
+    }
+}

--- a/VaderCleaner/FloatingScanOverlay.swift
+++ b/VaderCleaner/FloatingScanOverlay.swift
@@ -60,6 +60,10 @@ struct FloatingScanOverlay<Coordinator: ScanCoordinating>: View {
                     ScanAccessPopover(
                         accent: accent,
                         onOpenSettings: {
+                            // Dismiss the popover before handing focus to
+                            // System Settings so no stale popover lingers when
+                            // the app comes back forward.
+                            showFullDiskAccessPrompt = false
                             NSWorkspace.shared.open(PermissionOnboardingViewModel.systemSettingsURL)
                         },
                         onScanAnyway: {

--- a/VaderCleaner/FullDiskAccessPromptCard.swift
+++ b/VaderCleaner/FullDiskAccessPromptCard.swift
@@ -1,15 +1,16 @@
 // FullDiskAccessPromptCard.swift
-// Inline accent-tinted reminder shown on a section's intro when Full Disk Access is missing, so the user is told up front that scans here will be incomplete and can grant access without leaving the flow.
+// Inline accent-tinted reminder shown in a scannable section's empty/clean detail state when Full Disk Access is missing, so a user who scanned without access sees why the result looks like "nothing found" and can grant access without leaving the flow.
 
 import SwiftUI
 import AppKit
 
-/// Non-blocking inline prompt rendered inside a scannable section's intro
-/// (and in `PrivacyView`'s idle state) when Full Disk Access has not been
-/// granted. The app-wide onboarding sheet (`PermissionOnboardingView`) covers
-/// first run; once the user dismisses it with "Continue Without Access" this
-/// card is the persistent, per-section reminder that scans here will be
-/// incomplete until access is granted.
+/// Non-blocking inline prompt rendered in a scannable section's empty or clean
+/// detail state (System Junk, Large & Old Files, Malware Removal) when Full
+/// Disk Access has not been granted. The app-wide onboarding sheet
+/// (`PermissionOnboardingView`) covers first run, and the floating Scan button
+/// raises a `ScanAccessPopover` at the point of action; this card is the
+/// post-scan explanation — it tells a user who scanned anyway why an empty
+/// result may just be missing permission, and lets them fix it and re-scan.
 ///
 /// `accent` tints the lock symbol and the primary CTA so the card reads as
 /// part of the section it sits in (System Junk green, Large & Old Files teal,

--- a/VaderCleaner/ScanAccessPopover.swift
+++ b/VaderCleaner/ScanAccessPopover.swift
@@ -1,0 +1,87 @@
+// ScanAccessPopover.swift
+// The Full Disk Access gate for the floating Scan button: a pure decision for whether a Scan tap should prompt, plus the popover shown at the point of action.
+
+import SwiftUI
+
+/// What tapping a scannable section's floating Scan button should do, decided
+/// purely from the section's FDA sensitivity and the current access state.
+///
+/// Replaces the always-on inline reminder card: instead of warning on every
+/// intro screen, the gate evaluates at the moment the user actually taps Scan.
+enum ScanTapOutcome: Equatable {
+    /// Start the section's scan immediately.
+    case beginScan
+    /// Hold the scan and show the Full Disk Access popover first.
+    case promptForFullDiskAccess
+
+    /// Pure decision used by the floating Scan button. A scan is gated only
+    /// when the section genuinely reads FDA-protected paths *and* access is
+    /// missing; every other combination scans straight away.
+    static func evaluate(
+        requiresFullDiskAccess: Bool,
+        hasFullDiskAccess: Bool
+    ) -> ScanTapOutcome {
+        requiresFullDiskAccess && !hasFullDiskAccess
+            ? .promptForFullDiskAccess
+            : .beginScan
+    }
+}
+
+/// Popover anchored to the floating Scan button, shown the moment a user taps
+/// Scan on an FDA-sensitive section without access granted. Action-anchored, so
+/// it offers an escape hatch ("Scan Anyway") rather than only telling the user
+/// to fix the permission — the user asked for a scan, so they can have one.
+///
+/// `accent` tints the lock symbol and the primary button so the popover reads
+/// as part of the section it was raised from (System Junk green, etc.); it
+/// defaults to crimson so unspecified call sites stay on the Vader palette.
+struct ScanAccessPopover: View {
+
+    /// Section-aware tint applied to the lock symbol and the primary button.
+    var accent: Color = .vaderCrimson
+    /// Opens System Settings on the Full Disk Access pane.
+    let onOpenSettings: () -> Void
+    /// Dismisses the popover and starts the scan with whatever is accessible.
+    let onScanAnyway: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: "lock.shield")
+                    .font(.title2)
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(accent)
+                Text("Full Disk Access needed")
+                    .font(.callout.weight(.semibold))
+            }
+            Text("Without it, this scan can only see unprotected files. Grant access for complete results, or scan what's reachable now.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                Button("Open System Settings", action: onOpenSettings)
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
+                    .tint(accent)
+                    .accessibilityIdentifier("fda.popover.openSettings")
+                Button("Scan Anyway", action: onScanAnyway)
+                    .controlSize(.small)
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("fda.popover.scanAnyway")
+            }
+            .padding(.top, 2)
+        }
+        .padding(16)
+        .frame(width: 300)
+        // `.contain` keeps the two buttons independently queryable by their
+        // own identifiers; without it the container identifier propagates
+        // down and overwrites every child's, matching the pattern
+        // `SectionIntroView` uses for its per-section / per-feature ids.
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("fda.popover")
+    }
+}
+
+#Preview {
+    ScanAccessPopover(accent: .green, onOpenSettings: {}, onScanAnyway: {})
+}

--- a/VaderCleaner/ScanAccessPopover.swift
+++ b/VaderCleaner/ScanAccessPopover.swift
@@ -51,20 +51,38 @@ struct ScanAccessPopover: View {
                     .font(.title2)
                     .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(accent)
-                Text("Full Disk Access needed")
+                Text(String(
+                    localized: "Full Disk Access needed",
+                    comment: "Title of the popover shown when the user taps Scan on a section whose scan needs Full Disk Access."
+                ))
                     .font(.callout.weight(.semibold))
             }
-            Text("Without it, this scan can only see unprotected files. Grant access for complete results, or scan what's reachable now.")
+            Text(String(
+                localized: "Without it, this scan can only see unprotected files. Grant access for complete results, or scan what's reachable now.",
+                comment: "Body of the Scan access popover, explaining why Full Disk Access matters."
+            ))
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 8) {
-                Button("Open System Settings", action: onOpenSettings)
+                Button(
+                    String(
+                        localized: "Open System Settings",
+                        comment: "Scan access popover button that opens the Full Disk Access pane in System Settings."
+                    ),
+                    action: onOpenSettings
+                )
                     .controlSize(.small)
                     .buttonStyle(.borderedProminent)
                     .tint(accent)
                     .accessibilityIdentifier("fda.popover.openSettings")
-                Button("Scan Anyway", action: onScanAnyway)
+                Button(
+                    String(
+                        localized: "Scan Anyway",
+                        comment: "Scan access popover button that starts the scan despite missing Full Disk Access."
+                    ),
+                    action: onScanAnyway
+                )
                     .controlSize(.small)
                     .buttonStyle(.bordered)
                     .accessibilityIdentifier("fda.popover.scanAnyway")

--- a/VaderCleaner/ScanDiscHostView.swift
+++ b/VaderCleaner/ScanDiscHostView.swift
@@ -1,0 +1,57 @@
+// ScanDiscHostView.swift
+// SwiftUI root hosted inside the Scan disc's child panel — picks the selected section's coordinator, renders the floating disc, and reports its visibility back to the window controller.
+
+import SwiftUI
+
+/// The content of `ScanDiscWindowController`'s child panel. It mirrors the
+/// section ContentView is showing (pushed onto `controller.section`) and renders
+/// that section's floating Scan disc, centered in the panel.
+///
+/// Non-scannable sections have no disc; they hide the panel outright so its
+/// transparent area never sits over — and intercepts clicks for — the main
+/// window.
+struct ScanDiscHostView: View {
+    @ObservedObject var controller: ScanDiscWindowController
+
+    var body: some View {
+        content
+            // Center the disc within the panel, which is sized larger than the
+            // disc so its accent glow is not clipped.
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch controller.section {
+        case .smartScan:
+            overlay(controller.smartScanViewModel, .smartScan)
+        case .systemJunk:
+            overlay(controller.systemJunkViewModel, .systemJunk)
+        case .largeOldFiles:
+            overlay(controller.largeOldFilesViewModel, .largeOldFiles)
+        case .spaceLens:
+            overlay(controller.spaceLensViewModel, .spaceLens)
+        case .optimization:
+            overlay(controller.optimizationViewModel, .optimization)
+        case .malwareRemoval:
+            overlay(controller.malwareViewModel, .malwareRemoval)
+        case .privacy:
+            overlay(controller.privacyViewModel, .privacy)
+        case .extensions, .appUninstaller, .appUpdater, .healthMonitor:
+            // Non-scannable sections never show a disc — keep the panel hidden.
+            Color.clear
+                .onAppear { controller.setDiscVisible(false) }
+        }
+    }
+
+    private func overlay<Coordinator: ScanCoordinating>(
+        _ coordinator: Coordinator,
+        _ section: NavigationSection
+    ) -> some View {
+        FloatingScanOverlay(
+            coordinator: coordinator,
+            section: section,
+            onIntroPresenceChanged: { controller.setDiscVisible($0) }
+        )
+    }
+}

--- a/VaderCleaner/ScanDiscWindowController.swift
+++ b/VaderCleaner/ScanDiscWindowController.swift
@@ -1,0 +1,197 @@
+// ScanDiscWindowController.swift
+// Owns the borderless child panel that hosts the floating Scan disc, so the disc can straddle the main window's bottom edge — top half on the window, bottom half over the desktop.
+
+import AppKit
+import SwiftUI
+
+/// Manages a borderless `NSPanel`, attached as a child of the app's main
+/// window, that hosts the floating Scan disc. A child panel is the only way to
+/// render the disc outside the main window's bounds: a window clips all of its
+/// own content, so a plain SwiftUI overlay can never cross the bottom edge.
+///
+/// ContentView pushes the sidebar selection onto `section`; the panel's SwiftUI
+/// root (`ScanDiscHostView`) mirrors it and reports, via `setDiscVisible(_:)`,
+/// whether a disc is currently on screen so the panel is ordered in or out to
+/// match.
+@MainActor
+final class ScanDiscWindowController: ObservableObject {
+
+    /// The section whose disc the panel currently shows — driven by ContentView.
+    @Published var section: NavigationSection = .smartScan
+
+    // The seven scannable sections' coordinators. `ScanDiscHostView` switches
+    // on `section` to drive the matching one.
+    let smartScanViewModel: SmartScanViewModel
+    let systemJunkViewModel: SystemJunkViewModel
+    let largeOldFilesViewModel: LargeOldFilesViewModel
+    let spaceLensViewModel: DiskScannerViewModel
+    let optimizationViewModel: OptimizationViewModel
+    let malwareViewModel: MalwareViewModel
+    let privacyViewModel: PrivacyViewModel
+
+    /// Diameter of the disc itself — the single shared constant the disc, this
+    /// panel, and the placement maths all key off.
+    private let discDiameter = FloatingScanButton.floatingDiameter
+    /// Side length of the square panel. Wider than the disc so its breathing
+    /// accent glow is not clipped by the panel bounds.
+    private let panelSize = FloatingScanButton.floatingDiameter + 100
+    /// Gap kept below the disc when it is tucked fully inside (fullscreen,
+    /// where there is no desktop below the window to straddle into).
+    private let fullScreenMargin: CGFloat = 36
+
+    private var panel: NSPanel?
+    private weak var parentWindow: NSWindow?
+    private var appState: AppState?
+    private var railWidth: CGFloat = 0
+    private var isFullScreen = false
+    private var observers: [NSObjectProtocol] = []
+
+    init(
+        smartScanViewModel: SmartScanViewModel,
+        systemJunkViewModel: SystemJunkViewModel,
+        largeOldFilesViewModel: LargeOldFilesViewModel,
+        spaceLensViewModel: DiskScannerViewModel,
+        optimizationViewModel: OptimizationViewModel,
+        malwareViewModel: MalwareViewModel,
+        privacyViewModel: PrivacyViewModel
+    ) {
+        self.smartScanViewModel = smartScanViewModel
+        self.systemJunkViewModel = systemJunkViewModel
+        self.largeOldFilesViewModel = largeOldFilesViewModel
+        self.spaceLensViewModel = spaceLensViewModel
+        self.optimizationViewModel = optimizationViewModel
+        self.malwareViewModel = malwareViewModel
+        self.privacyViewModel = privacyViewModel
+    }
+
+    /// Attaches the disc panel as a child of the app's main window. Idempotent:
+    /// re-attaching to the same window only re-positions, and attaching to a
+    /// different window detaches the old one first — `ContentView.onAppear` can
+    /// fire more than once across a window close/reopen.
+    func attach(to window: NSWindow, railWidth: CGFloat, appState: AppState) {
+        self.railWidth = railWidth
+        self.appState = appState
+
+        if parentWindow === window, panel != nil {
+            reposition()
+            return
+        }
+        if parentWindow != nil { detach() }
+
+        parentWindow = window
+        let panel = makePanel(appState: appState)
+        self.panel = panel
+        window.addChildWindow(panel, ordered: .above)
+        isFullScreen = window.styleMask.contains(.fullScreen)
+        installObservers(for: window)
+        reposition()
+    }
+
+    /// Shows or hides the panel. The panel is ordered in only while a scannable
+    /// section's disc should be on screen, so its transparent margin never
+    /// intercepts clicks meant for the main window behind it.
+    func setDiscVisible(_ visible: Bool) {
+        guard let panel, let parentWindow else { return }
+        if visible {
+            if panel.parent == nil {
+                parentWindow.addChildWindow(panel, ordered: .above)
+            }
+            reposition()
+            panel.orderFront(nil)
+        } else {
+            panel.orderOut(nil)
+        }
+    }
+
+    // MARK: - Panel construction
+
+    private func makePanel(appState: AppState) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: panelSize, height: panelSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        // A floating, non-activating accessory: clicking the disc must not
+        // steal key status from the main window or dim its traffic lights.
+        panel.isFloatingPanel = true
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.hidesOnDeactivate = false
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        // The disc draws its own glow in SwiftUI; a system window shadow would
+        // wrap the whole transparent panel.
+        panel.hasShadow = false
+        // An NSHostingView in a borderless panel does not inherit the main
+        // window's appearance — force the dark scheme the app runs in so
+        // Liquid Glass adopts its light-on-dark treatment.
+        panel.appearance = NSAppearance(named: .darkAqua)
+        // Let the panel ride along when the main window enters fullscreen.
+        panel.collectionBehavior = [.fullScreenAuxiliary]
+
+        panel.contentView = NSHostingView(
+            rootView: ScanDiscHostView(controller: self)
+                .environmentObject(appState)
+        )
+        return panel
+    }
+
+    // MARK: - Positioning
+
+    private func reposition() {
+        guard let panel, let parentWindow else { return }
+        let placement: ScanDiscWindowFrame.Placement = isFullScreen
+            ? .tuckedInside(margin: fullScreenMargin)
+            : .straddleBottomEdge
+        let frame = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parentWindow.frame,
+            railWidth: railWidth,
+            panelSize: panelSize,
+            discDiameter: discDiameter,
+            placement: placement
+        )
+        panel.setFrame(frame, display: true)
+    }
+
+    // MARK: - Parent window observation
+
+    private func installObservers(for window: NSWindow) {
+        let center = NotificationCenter.default
+
+        func observe(_ name: NSNotification.Name, _ handler: @escaping () -> Void) {
+            let token = center.addObserver(
+                forName: name, object: window, queue: .main
+            ) { _ in
+                // The `.main` queue guarantees the main thread; bridge that to
+                // main-actor isolation so the controller's methods are callable.
+                MainActor.assumeIsolated(handler)
+            }
+            observers.append(token)
+        }
+
+        // A child window moves with its parent automatically, but a resize
+        // leaves it pinned to its old origin — recenter on both.
+        observe(NSWindow.didResizeNotification) { [weak self] in self?.reposition() }
+        observe(NSWindow.didMoveNotification) { [weak self] in self?.reposition() }
+        observe(NSWindow.didEnterFullScreenNotification) { [weak self] in
+            self?.isFullScreen = true
+            self?.reposition()
+        }
+        observe(NSWindow.didExitFullScreenNotification) { [weak self] in
+            self?.isFullScreen = false
+            self?.reposition()
+        }
+        observe(NSWindow.willCloseNotification) { [weak self] in self?.detach() }
+    }
+
+    private func detach() {
+        observers.forEach(NotificationCenter.default.removeObserver)
+        observers.removeAll()
+        if let panel, let parentWindow, panel.parent != nil {
+            parentWindow.removeChildWindow(panel)
+        }
+        panel?.orderOut(nil)
+        panel = nil
+        parentWindow = nil
+    }
+}

--- a/VaderCleaner/ScanDiscWindowController.swift
+++ b/VaderCleaner/ScanDiscWindowController.swift
@@ -35,8 +35,9 @@ final class ScanDiscWindowController: ObservableObject {
     /// Side length of the square panel. Wider than the disc so its breathing
     /// accent glow is not clipped by the panel bounds.
     private let panelSize = FloatingScanButton.floatingDiameter + 100
-    /// Gap kept below the disc when it is tucked fully inside (fullscreen,
-    /// where there is no desktop below the window to straddle into).
+    /// Gap kept below the disc panel when it is tucked fully inside
+    /// (fullscreen, where there is no desktop below the window to straddle
+    /// into).
     private let fullScreenMargin: CGFloat = 36
 
     private var panel: NSPanel?

--- a/VaderCleaner/ScanDiscWindowController.swift
+++ b/VaderCleaner/ScanDiscWindowController.swift
@@ -148,7 +148,10 @@ final class ScanDiscWindowController: ObservableObject {
             railWidth: railWidth,
             panelSize: panelSize,
             discDiameter: discDiameter,
-            placement: placement
+            placement: placement,
+            // Hold the disc on the visible screen even when the window is
+            // dragged against the bottom edge.
+            screenVisibleFrame: parentWindow.screen?.visibleFrame
         )
         panel.setFrame(frame, display: true)
     }

--- a/VaderCleaner/ScanDiscWindowFrame.swift
+++ b/VaderCleaner/ScanDiscWindowFrame.swift
@@ -37,7 +37,8 @@ enum ScanDiscWindowFrame {
         railWidth: CGFloat,
         panelSize: CGFloat,
         discDiameter: CGFloat,
-        placement: Placement
+        placement: Placement,
+        screenVisibleFrame: CGRect? = nil
     ) -> CGRect {
         let detailMidX = parentFrame.minX + railWidth + (parentFrame.width - railWidth) / 2
         let originX = detailMidX - panelSize / 2
@@ -52,8 +53,39 @@ enum ScanDiscWindowFrame {
             // by `margin`.
             centerY = parentFrame.minY + margin + discDiameter / 2
         }
-        let originY = centerY - panelSize / 2
+        var originY = centerY - panelSize / 2
+
+        // Keep the disc itself fully on the visible screen: when the main
+        // window sits against the screen's bottom edge, an unclamped straddle
+        // would drop the disc's lower half behind the Dock or off-screen,
+        // hiding the primary CTA. Only the disc is held in — the transparent
+        // panel margin around it may still spill past the screen edge.
+        if let screenVisibleFrame {
+            originY = clampedOriginY(
+                originY,
+                panelSize: panelSize,
+                discDiameter: discDiameter,
+                screenVisibleFrame: screenVisibleFrame
+            )
+        }
 
         return CGRect(x: originX, y: originY, width: panelSize, height: panelSize)
+    }
+
+    /// Clamps the panel's vertical origin so the disc centered within it stays
+    /// fully inside `screenVisibleFrame`. A degenerate screen smaller than the
+    /// disc is left unclamped rather than producing an inverted range.
+    private static func clampedOriginY(
+        _ originY: CGFloat,
+        panelSize: CGFloat,
+        discDiameter: CGFloat,
+        screenVisibleFrame: CGRect
+    ) -> CGFloat {
+        // Gap between the panel's edge and the disc's edge.
+        let discInset = (panelSize - discDiameter) / 2
+        let lowerBound = screenVisibleFrame.minY - discInset
+        let upperBound = screenVisibleFrame.maxY - discDiameter - discInset
+        guard lowerBound <= upperBound else { return originY }
+        return min(max(originY, lowerBound), upperBound)
     }
 }

--- a/VaderCleaner/ScanDiscWindowFrame.swift
+++ b/VaderCleaner/ScanDiscWindowFrame.swift
@@ -16,7 +16,7 @@ enum ScanDiscWindowFrame {
         /// The disc's center rests on the bottom edge — top half on the
         /// window, bottom half over the desktop. The standard windowed look.
         case straddleBottomEdge
-        /// The whole disc sits on the window, its bottom edge `margin` points
+        /// The whole panel sits inside the window, its bottom edge `margin`
         /// above the window's bottom edge. Used in fullscreen, where there is
         /// no desktop below the window to straddle into.
         case tuckedInside(margin: CGFloat)
@@ -49,9 +49,11 @@ enum ScanDiscWindowFrame {
             // Panel center on the edge → disc center on the edge.
             centerY = parentFrame.minY
         case .tuckedInside(let margin):
-            // Lift the panel so the disc's bottom edge clears the window edge
-            // by `margin`.
-            centerY = parentFrame.minY + margin + discDiameter / 2
+            // Sit the whole panel inside the window, its bottom edge `margin`
+            // above the window's edge. Keyed off `panelSize` — not the disc —
+            // so the transparent panel margin never hangs past the edge and
+            // intercepts bottom-edge clicks.
+            centerY = parentFrame.minY + margin + panelSize / 2
         }
         var originY = centerY - panelSize / 2
 

--- a/VaderCleaner/ScanDiscWindowFrame.swift
+++ b/VaderCleaner/ScanDiscWindowFrame.swift
@@ -1,0 +1,59 @@
+// ScanDiscWindowFrame.swift
+// Pure geometry for the floating Scan disc's child panel — where to place it relative to the main window so the disc straddles (or, in fullscreen, tucks above) the bottom edge.
+
+import CoreGraphics
+
+/// Computes the screen-coordinate frame of the borderless panel that hosts the
+/// floating Scan disc. Kept free of AppKit so the placement maths can be
+/// unit-tested without a window.
+///
+/// All rectangles use macOS screen coordinates: the origin is bottom-left and
+/// `minY` is a window's bottom edge.
+enum ScanDiscWindowFrame {
+
+    /// How the disc sits relative to the main window's bottom edge.
+    enum Placement: Equatable {
+        /// The disc's center rests on the bottom edge — top half on the
+        /// window, bottom half over the desktop. The standard windowed look.
+        case straddleBottomEdge
+        /// The whole disc sits on the window, its bottom edge `margin` points
+        /// above the window's bottom edge. Used in fullscreen, where there is
+        /// no desktop below the window to straddle into.
+        case tuckedInside(margin: CGFloat)
+    }
+
+    /// Frame for the disc panel.
+    ///
+    /// - Parameters:
+    ///   - parentFrame: the main window's frame, in screen coordinates.
+    ///   - railWidth: width of the navigation rail; the disc centers over the
+    ///     detail area (the window minus the rail), not the whole window.
+    ///   - panelSize: side length of the square panel.
+    ///   - discDiameter: diameter of the disc centered within the panel; only
+    ///     affects `.tuckedInside`, which positions by the disc's own edge.
+    ///   - placement: straddle the bottom edge, or tuck fully inside.
+    static func panelFrame(
+        parentFrame: CGRect,
+        railWidth: CGFloat,
+        panelSize: CGFloat,
+        discDiameter: CGFloat,
+        placement: Placement
+    ) -> CGRect {
+        let detailMidX = parentFrame.minX + railWidth + (parentFrame.width - railWidth) / 2
+        let originX = detailMidX - panelSize / 2
+
+        let centerY: CGFloat
+        switch placement {
+        case .straddleBottomEdge:
+            // Panel center on the edge → disc center on the edge.
+            centerY = parentFrame.minY
+        case .tuckedInside(let margin):
+            // Lift the panel so the disc's bottom edge clears the window edge
+            // by `margin`.
+            centerY = parentFrame.minY + margin + discDiameter / 2
+        }
+        let originY = centerY - panelSize / 2
+
+        return CGRect(x: originX, y: originY, width: panelSize, height: panelSize)
+    }
+}

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -13,12 +13,6 @@ struct SectionIntroView: View {
     let presentation: SectionPresentation
     let section: NavigationSection
 
-    /// Observed for the inline FDA reminder. When access flips on (the user
-    /// granted it in System Settings; scenePhase refreshes the flag on
-    /// foreground), the card animates out so the intro returns to its
-    /// uncluttered landing without a relaunch.
-    @EnvironmentObject private var appState: AppState
-
     /// Drives the hero's slow vertical drift. Flipped true on appear so the
     /// repeating float animation has a value to oscillate between.
     @State private var heroFloating = false
@@ -27,14 +21,6 @@ struct SectionIntroView: View {
     /// rendered heading tracks the UI language while the identifiers below
     /// stay fixed regardless of locale.
     var title: String { section.title }
-
-    /// Whether the inline Full Disk Access reminder should render for this
-    /// section given the supplied access flag. Pulled out as a pure predicate
-    /// so tests can pin the behaviour without rendering the body — the only
-    /// inputs are `section.requiresFullDiskAccess` and the flag itself.
-    func shouldShowFullDiskAccessReminder(hasFullDiskAccess: Bool) -> Bool {
-        section.requiresFullDiskAccess && !hasFullDiskAccess
-    }
 
     // MARK: Accessibility identifiers
 
@@ -81,8 +67,14 @@ struct SectionIntroView: View {
         // Reserve the bottom band for the floating Scan disc, so the centred
         // cluster sits clear of it and the landing never needs to scroll.
         .padding(.bottom, 168)
-        .accessibilityIdentifier(rootAccessibilityIdentifier)
+        // Seal the intro as a container *before* naming it: applied in this
+        // order, `section.intro` labels the container element itself. The
+        // reverse order would instead propagate `section.intro` down onto
+        // every descendant — overwriting `textColumn`'s own
+        // `section.intro.<slug>` identifier so the per-section intro could no
+        // longer be located.
         .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(rootAccessibilityIdentifier)
     }
 
     // MARK: Hero
@@ -142,8 +134,8 @@ struct SectionIntroView: View {
 
     // MARK: Text + features
 
-    /// Title, tagline, the inline FDA reminder (when needed), and the
-    /// descriptive feature rows, grouped under the per-section identifier.
+    /// Title, tagline, and the descriptive feature rows, grouped under the
+    /// per-section identifier.
     private var textColumn: some View {
         VStack(alignment: .leading, spacing: 22) {
             VStack(alignment: .leading, spacing: 10) {
@@ -163,25 +155,6 @@ struct SectionIntroView: View {
                     .frame(maxWidth: 360, alignment: .leading)
             }
 
-            // Inline reminder, sized to align with the tagline column. Sits
-            // between tagline and features so it reads as context for "what
-            // this scan can see" rather than an alarm above the title. Slides
-            // in/out smoothly when access flips, which is the moment of
-            // delight: granting access in System Settings and watching the
-            // card retract on return.
-            if shouldShowFullDiskAccessReminder(hasFullDiskAccess: appState.hasFullDiskAccess) {
-                FullDiskAccessPromptCard(
-                    accent: presentation.accent,
-                    onRecheck: { appState.refresh() }
-                )
-                .transition(
-                    .asymmetric(
-                        insertion: .opacity.combined(with: .move(edge: .top)),
-                        removal: .opacity.combined(with: .scale(scale: 0.96))
-                    )
-                )
-            }
-
             VStack(alignment: .leading, spacing: 14) {
                 ForEach(Array(presentation.features.enumerated()), id: \.offset) { index, feature in
                     featureRow(feature, index: index)
@@ -189,7 +162,6 @@ struct SectionIntroView: View {
             }
         }
         .frame(maxWidth: 380, alignment: .leading)
-        .animation(.smooth(duration: 0.4), value: appState.hasFullDiskAccess)
         // Combine the title + tagline + rows under the per-section id without
         // hiding the rows: .contain keeps each row independently queryable by
         // its own identifier while still pinning "this is section X's intro".

--- a/VaderCleanerTests/FloatingScanButtonTests.swift
+++ b/VaderCleanerTests/FloatingScanButtonTests.swift
@@ -78,6 +78,45 @@ final class FloatingScanButtonTests: XCTestCase {
         )
     }
 
+    func test_defaultDiameterIsCompact() {
+        // In-window CTAs (e.g. the Smart Scan "Clean" button) pass no diameter
+        // and must keep the compact size.
+        let button = FloatingScanButton(
+            title: "Clean",
+            accessibilityIdentifier: "section.clean",
+            action: {}
+        )
+
+        XCTAssertEqual(button.diameter, 108)
+    }
+
+    func test_customDiameterIsStored() {
+        let button = FloatingScanButton(
+            title: "Scan",
+            diameter: 150,
+            accessibilityIdentifier: "section.scan",
+            action: {}
+        )
+
+        XCTAssertEqual(button.diameter, 150)
+    }
+
+    func test_floatingDiameterIsLargerThanTheCompactDefault() {
+        // The floating Scan disc is deliberately a lot bigger than the
+        // in-window default so it reads as the screen's hero action.
+        let compact = FloatingScanButton(
+            title: "Clean",
+            accessibilityIdentifier: "section.clean",
+            action: {}
+        )
+
+        XCTAssertGreaterThan(
+            FloatingScanButton.floatingDiameter,
+            compact.diameter,
+            "The floating Scan disc must be larger than the compact CTA default"
+        )
+    }
+
     func test_accessibilityLabelDefaultsToTitle() {
         // Call sites that don't pass a label keep VoiceOver announcing the
         // visible title, so the disc still reads as "Scan" by default.

--- a/VaderCleanerTests/ScanAccessPopoverTests.swift
+++ b/VaderCleanerTests/ScanAccessPopoverTests.swift
@@ -1,0 +1,111 @@
+// ScanAccessPopoverTests.swift
+// Pins the Scan-tap Full Disk Access gate: which sections raise the access popover, and the ScanAccessPopover view's accent + callback contract.
+
+import XCTest
+import SwiftUI
+@testable import VaderCleaner
+
+@MainActor
+final class ScanAccessPopoverTests: XCTestCase {
+
+    // MARK: ScanTapOutcome.evaluate
+
+    func test_evaluate_requiresFDAWithoutAccess_promptsForAccess() {
+        XCTAssertEqual(
+            ScanTapOutcome.evaluate(requiresFullDiskAccess: true, hasFullDiskAccess: false),
+            .promptForFullDiskAccess,
+            "An FDA-sensitive section with access missing must hold the scan and prompt"
+        )
+    }
+
+    func test_evaluate_requiresFDAWithAccess_beginsScan() {
+        XCTAssertEqual(
+            ScanTapOutcome.evaluate(requiresFullDiskAccess: true, hasFullDiskAccess: true),
+            .beginScan,
+            "Once Full Disk Access is granted the scan must start straight away"
+        )
+    }
+
+    func test_evaluate_noFDARequirement_alwaysBeginsScan() {
+        // Sections whose scans don't read FDA-protected paths never gate,
+        // regardless of the current access state.
+        XCTAssertEqual(
+            ScanTapOutcome.evaluate(requiresFullDiskAccess: false, hasFullDiskAccess: false),
+            .beginScan,
+            "A section that doesn't require FDA must scan even when access is missing"
+        )
+        XCTAssertEqual(
+            ScanTapOutcome.evaluate(requiresFullDiskAccess: false, hasFullDiskAccess: true),
+            .beginScan,
+            "A section that doesn't require FDA must scan when access is present"
+        )
+    }
+
+    func test_evaluate_acrossEveryScannableSection() {
+        // The gate only ever fires for sections that genuinely require FDA,
+        // and only while access is missing — pinned against the real
+        // NavigationSection metadata so a reclassification can't slip past.
+        for section in NavigationSection.allCases where section.isScannable {
+            let missing = ScanTapOutcome.evaluate(
+                requiresFullDiskAccess: section.requiresFullDiskAccess,
+                hasFullDiskAccess: false
+            )
+            let granted = ScanTapOutcome.evaluate(
+                requiresFullDiskAccess: section.requiresFullDiskAccess,
+                hasFullDiskAccess: true
+            )
+
+            if section.requiresFullDiskAccess {
+                XCTAssertEqual(missing, .promptForFullDiskAccess,
+                               "\(section) requires FDA — a Scan tap must prompt when access is missing")
+            } else {
+                XCTAssertEqual(missing, .beginScan,
+                               "\(section) does not require FDA — a Scan tap must never prompt")
+            }
+            XCTAssertEqual(granted, .beginScan,
+                           "\(section) must scan immediately once access is granted")
+        }
+    }
+
+    // MARK: ScanAccessPopover
+
+    func test_defaultAccentIsVaderCrimson() {
+        // Unspecified call sites stay on the Vader palette, matching the
+        // FloatingScanButton / FullDiskAccessPromptCard defaults.
+        let popover = ScanAccessPopover(onOpenSettings: {}, onScanAnyway: {})
+
+        XCTAssertEqual(
+            popover.accent,
+            .vaderCrimson,
+            "ScanAccessPopover must default its tint to VaderTheme crimson"
+        )
+    }
+
+    func test_customAccentIsStored() {
+        let popover = ScanAccessPopover(accent: .green, onOpenSettings: {}, onScanAnyway: {})
+
+        XCTAssertEqual(
+            popover.accent,
+            .green,
+            "A caller-supplied accent must override the crimson default"
+        )
+    }
+
+    func test_invokesOpenSettingsCallback() {
+        var fired = false
+        let popover = ScanAccessPopover(onOpenSettings: { fired = true }, onScanAnyway: {})
+
+        XCTAssertFalse(fired, "Callback must not fire on construction")
+        popover.onOpenSettings()
+        XCTAssertTrue(fired, "Triggering Open System Settings must invoke the supplied callback")
+    }
+
+    func test_invokesScanAnywayCallback() {
+        var fired = false
+        let popover = ScanAccessPopover(onOpenSettings: {}, onScanAnyway: { fired = true })
+
+        XCTAssertFalse(fired, "Callback must not fire on construction")
+        popover.onScanAnyway()
+        XCTAssertTrue(fired, "Triggering Scan Anyway must invoke the supplied callback")
+    }
+}

--- a/VaderCleanerTests/ScanDiscWindowFrameTests.swift
+++ b/VaderCleanerTests/ScanDiscWindowFrameTests.swift
@@ -59,7 +59,7 @@ final class ScanDiscWindowFrameTests: XCTestCase {
 
     // MARK: Tucked inside (fullscreen)
 
-    func test_tucked_placesDiscFullyInsideAboveTheEdge() {
+    func test_tucked_placesPanelFullyInsideAboveTheEdge() {
         let margin: CGFloat = 40
         let frame = ScanDiscWindowFrame.panelFrame(
             parentFrame: parent,
@@ -68,12 +68,14 @@ final class ScanDiscWindowFrameTests: XCTestCase {
             discDiameter: discDiameter,
             placement: .tuckedInside(margin: margin)
         )
-        // The disc's bottom edge must sit `margin` above the window's bottom
-        // edge, so the whole disc is on-window (used in fullscreen, where
-        // there is no "outside" to straddle into).
-        let discBottom = frame.midY - discDiameter / 2
-        XCTAssertEqual(discBottom, parent.minY + margin, accuracy: 0.001,
-                       "Tucked disc bottom must sit `margin` above the window edge")
+        // The whole panel — not just the disc — must sit inside the window,
+        // its bottom edge `margin` above the window's bottom edge. In
+        // fullscreen there is no desktop below the window to overhang into,
+        // so even the transparent panel margin must stay on-window.
+        XCTAssertEqual(frame.minY, parent.minY + margin, accuracy: 0.001,
+                       "Tucked panel bottom must sit `margin` above the window edge")
+        XCTAssertGreaterThanOrEqual(frame.minY, parent.minY,
+                                    "The tucked panel must not hang below the window")
     }
 
     func test_tucked_keepsDiscWithinParentVerticalBounds() {

--- a/VaderCleanerTests/ScanDiscWindowFrameTests.swift
+++ b/VaderCleanerTests/ScanDiscWindowFrameTests.swift
@@ -104,4 +104,43 @@ final class ScanDiscWindowFrameTests: XCTestCase {
         XCTAssertEqual(straddle.midX, tucked.midX, accuracy: 0.001,
                        "Placement must change only the vertical position")
     }
+
+    // MARK: Screen clamping
+
+    private let screen = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+
+    func test_straddle_clampsDiscAboveTheScreenBottom() {
+        // A window pushed against the screen's bottom edge — an unclamped
+        // straddle would drop the disc's lower half off-screen / behind the
+        // Dock. The disc must stay fully on the visible screen.
+        let lowWindow = CGRect(x: 100, y: 24, width: 1000, height: 800)
+        let frame = ScanDiscWindowFrame.panelFrame(
+            parentFrame: lowWindow,
+            railWidth: railWidth,
+            panelSize: panelSize,
+            discDiameter: discDiameter,
+            placement: .straddleBottomEdge,
+            screenVisibleFrame: screen
+        )
+        let discInset = (panelSize - discDiameter) / 2
+        let discBottom = frame.minY + discInset
+        XCTAssertGreaterThanOrEqual(discBottom, screen.minY,
+                                    "The disc must not drop below the visible screen")
+    }
+
+    func test_straddle_doesNotClampWhenWindowIsWellWithinScreen() {
+        // A normally-placed window: clamping must be a no-op so the disc still
+        // straddles the bottom edge exactly.
+        let unclamped = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent, railWidth: railWidth, panelSize: panelSize,
+            discDiameter: discDiameter, placement: .straddleBottomEdge
+        )
+        let clamped = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent, railWidth: railWidth, panelSize: panelSize,
+            discDiameter: discDiameter, placement: .straddleBottomEdge,
+            screenVisibleFrame: screen
+        )
+        XCTAssertEqual(clamped, unclamped,
+                       "A window clear of the screen edge must not be clamped")
+    }
 }

--- a/VaderCleanerTests/ScanDiscWindowFrameTests.swift
+++ b/VaderCleanerTests/ScanDiscWindowFrameTests.swift
@@ -1,0 +1,107 @@
+// ScanDiscWindowFrameTests.swift
+// Pins the pure geometry that positions the floating Scan disc's child panel: centered over the detail area and either straddling or tucked above the main window's bottom edge.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ScanDiscWindowFrameTests: XCTestCase {
+
+    private let parent = CGRect(x: 100, y: 200, width: 1000, height: 800)
+    private let railWidth: CGFloat = 240
+    private let panelSize: CGFloat = 190
+    private let discDiameter: CGFloat = 108
+
+    // MARK: Straddle
+
+    func test_straddle_centersPanelVerticallyOnBottomEdge() {
+        let frame = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent,
+            railWidth: railWidth,
+            panelSize: panelSize,
+            discDiameter: discDiameter,
+            placement: .straddleBottomEdge
+        )
+        // The disc is centered in its panel, so a panel centered on the
+        // parent's bottom edge puts the disc's center exactly on the edge —
+        // top half inside the window, bottom half over the desktop.
+        XCTAssertEqual(frame.midY, parent.minY, accuracy: 0.001,
+                       "Panel center must sit on the parent window's bottom edge")
+        XCTAssertEqual(frame.height, panelSize, accuracy: 0.001)
+        XCTAssertEqual(frame.width, panelSize, accuracy: 0.001)
+    }
+
+    func test_straddle_centersPanelHorizontallyOverDetailArea() {
+        let frame = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent,
+            railWidth: railWidth,
+            panelSize: panelSize,
+            discDiameter: discDiameter,
+            placement: .straddleBottomEdge
+        )
+        // The disc centers over the detail content area — the window minus the
+        // navigation rail — not the full window.
+        let detailMidX = parent.minX + railWidth + (parent.width - railWidth) / 2
+        XCTAssertEqual(frame.midX, detailMidX, accuracy: 0.001,
+                       "Panel must center over the detail area, clear of the rail")
+    }
+
+    func test_horizontalCentering_withoutRail_matchesWindowCenter() {
+        let frame = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent,
+            railWidth: 0,
+            panelSize: panelSize,
+            discDiameter: discDiameter,
+            placement: .straddleBottomEdge
+        )
+        XCTAssertEqual(frame.midX, parent.midX, accuracy: 0.001,
+                       "With no rail the disc centers on the whole window")
+    }
+
+    // MARK: Tucked inside (fullscreen)
+
+    func test_tucked_placesDiscFullyInsideAboveTheEdge() {
+        let margin: CGFloat = 40
+        let frame = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent,
+            railWidth: railWidth,
+            panelSize: panelSize,
+            discDiameter: discDiameter,
+            placement: .tuckedInside(margin: margin)
+        )
+        // The disc's bottom edge must sit `margin` above the window's bottom
+        // edge, so the whole disc is on-window (used in fullscreen, where
+        // there is no "outside" to straddle into).
+        let discBottom = frame.midY - discDiameter / 2
+        XCTAssertEqual(discBottom, parent.minY + margin, accuracy: 0.001,
+                       "Tucked disc bottom must sit `margin` above the window edge")
+    }
+
+    func test_tucked_keepsDiscWithinParentVerticalBounds() {
+        let frame = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent,
+            railWidth: railWidth,
+            panelSize: panelSize,
+            discDiameter: discDiameter,
+            placement: .tuckedInside(margin: 40)
+        )
+        let discBottom = frame.midY - discDiameter / 2
+        let discTop = frame.midY + discDiameter / 2
+        XCTAssertGreaterThanOrEqual(discBottom, parent.minY,
+                                    "Tucked disc must not cross below the window")
+        XCTAssertLessThanOrEqual(discTop, parent.maxY,
+                                 "Tucked disc must stay within the window")
+    }
+
+    func test_tucked_keepsTheSameHorizontalCentering() {
+        let straddle = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent, railWidth: railWidth, panelSize: panelSize,
+            discDiameter: discDiameter, placement: .straddleBottomEdge
+        )
+        let tucked = ScanDiscWindowFrame.panelFrame(
+            parentFrame: parent, railWidth: railWidth, panelSize: panelSize,
+            discDiameter: discDiameter, placement: .tuckedInside(margin: 40)
+        )
+        XCTAssertEqual(straddle.midX, tucked.midX, accuracy: 0.001,
+                       "Placement must change only the vertical position")
+    }
+}

--- a/VaderCleanerTests/SectionIntroViewTests.swift
+++ b/VaderCleanerTests/SectionIntroViewTests.swift
@@ -92,51 +92,9 @@ final class SectionIntroViewTests: XCTestCase {
         }
     }
 
-    func test_reminderShows_whenSectionRequiresFDAAndAccessIsMissing() throws {
-        // The reminder card surfaces on the intro of every FDA-sensitive
-        // section whenever Full Disk Access has not been granted. Tested via
-        // the view's pure predicate so we don't need to render the body.
-        for section in NavigationSection.allCases where section.isScannable && section.requiresFullDiskAccess {
-            let presentation = try XCTUnwrap(SectionPresentation.for(section))
-            let view = SectionIntroView(presentation: presentation, section: section)
-
-            XCTAssertTrue(
-                view.shouldShowFullDiskAccessReminder(hasFullDiskAccess: false),
-                "\(section) requires FDA — the reminder must show when access is missing"
-            )
-        }
-    }
-
-    func test_reminderHides_whenFullDiskAccessIsGranted() throws {
-        // Granting access takes the card away on the next state flip, so the
-        // intro returns to its uncluttered landing.
-        for section in NavigationSection.allCases where section.isScannable {
-            let presentation = try XCTUnwrap(SectionPresentation.for(section))
-            let view = SectionIntroView(presentation: presentation, section: section)
-
-            XCTAssertFalse(
-                view.shouldShowFullDiskAccessReminder(hasFullDiskAccess: true),
-                "\(section) must not show the reminder once Full Disk Access is granted"
-            )
-        }
-    }
-
-    func test_reminderHides_whenSectionDoesNotRequireFDA() throws {
-        // Sections whose scans don't read FDA-gated paths never warn, even
-        // when access is missing — the reminder is reserved for cases where
-        // missing FDA actually yields empty or incomplete results.
-        for section in NavigationSection.allCases
-            where section.isScannable && !section.requiresFullDiskAccess
-        {
-            let presentation = try XCTUnwrap(SectionPresentation.for(section))
-            let view = SectionIntroView(presentation: presentation, section: section)
-
-            XCTAssertFalse(
-                view.shouldShowFullDiskAccessReminder(hasFullDiskAccess: false),
-                "\(section) does not require FDA — the reminder must stay hidden"
-            )
-        }
-    }
+    // The Scan-tap Full Disk Access gate that the intro reminder card was
+    // replaced by is covered by `ScanAccessPopoverTests` — the intro screen
+    // itself no longer renders an FDA reminder.
 
     func test_eachFeatureExposesItsIndexedAccessibilityIdentifier() throws {
         for section in NavigationSection.allCases where section.isScannable {

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -183,6 +183,7 @@ final class FinalPolishUITests: XCTestCase {
         XCTAssertTrue(scan.waitForExistence(timeout: 5),
                       "Expected the floating Scan button on the Large & Old Files intro")
         scan.click()
+        proceedPastScanAccessPopoverIfNeeded()
 
         // Prefer a terminal state; allow a generous window for the walk.
         // One combined query so an early empty/failed state short-circuits
@@ -337,6 +338,17 @@ final class FinalPolishUITests: XCTestCase {
         let continueWithout = app.buttons["Continue Without Access"]
         if continueWithout.waitForExistence(timeout: 2) {
             continueWithout.click()
+        }
+    }
+
+    /// The floating Scan button gates FDA-sensitive sections behind an access
+    /// popover when Full Disk Access is missing — which it is on a test host
+    /// that dismissed onboarding via "Continue Without Access". Tap "Scan
+    /// Anyway" so the scan proceeds and the wiring under test still runs.
+    private func proceedPastScanAccessPopoverIfNeeded() {
+        let scanAnyway = app.buttons["fda.popover.scanAnyway"]
+        if scanAnyway.waitForExistence(timeout: 2) {
+            scanAnyway.click()
         }
     }
 

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -347,7 +347,7 @@ final class FinalPolishUITests: XCTestCase {
     /// Anyway" so the scan proceeds and the wiring under test still runs.
     private func proceedPastScanAccessPopoverIfNeeded() {
         let scanAnyway = app.buttons["fda.popover.scanAnyway"]
-        if scanAnyway.waitForExistence(timeout: 2) {
+        if scanAnyway.waitForExistence(timeout: 5) {
             scanAnyway.click()
         }
     }

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -95,7 +95,7 @@ final class MalwareUITests: XCTestCase {
     /// Anyway" so the scan proceeds and the wiring under test still runs.
     private func proceedPastScanAccessPopoverIfNeeded() {
         let scanAnyway = app.buttons["fda.popover.scanAnyway"]
-        if scanAnyway.waitForExistence(timeout: 2) {
+        if scanAnyway.waitForExistence(timeout: 5) {
             scanAnyway.click()
         }
     }

--- a/VaderCleanerUITests/MalwareUITests.swift
+++ b/VaderCleanerUITests/MalwareUITests.swift
@@ -46,6 +46,7 @@ final class MalwareUITests: XCTestCase {
         XCTAssertTrue(floatingScan.waitForExistence(timeout: 5),
                       "Expected the floating Scan button on the Malware Removal intro")
         floatingScan.click()
+        proceedPastScanAccessPopoverIfNeeded()
 
         // After Scan, MalwareView takes over and the unified intro is gone.
         // `scan()` first enters `.checkingClamAV`, then branches per host:
@@ -85,6 +86,17 @@ final class MalwareUITests: XCTestCase {
         let continueWithout = app.buttons["Continue Without Access"]
         if continueWithout.waitForExistence(timeout: 2) {
             continueWithout.click()
+        }
+    }
+
+    /// The floating Scan button gates FDA-sensitive sections behind an access
+    /// popover when Full Disk Access is missing — which it is on a test host
+    /// that dismissed onboarding via "Continue Without Access". Tap "Scan
+    /// Anyway" so the scan proceeds and the wiring under test still runs.
+    private func proceedPastScanAccessPopoverIfNeeded() {
+        let scanAnyway = app.buttons["fda.popover.scanAnyway"]
+        if scanAnyway.waitForExistence(timeout: 2) {
+            scanAnyway.click()
         }
     }
 }

--- a/VaderCleanerUITests/SmartScanUITests.swift
+++ b/VaderCleanerUITests/SmartScanUITests.swift
@@ -75,11 +75,11 @@ final class SmartScanUITests: XCTestCase {
         )
     }
 
-    /// The Scan disc is 108pt of interactive glass, but its label is only the
-    /// centered "Scan" text. Without an explicit content shape the button's
-    /// hit region collapses to the text glyphs, so clicking the glass around
-    /// the word does nothing. The button element must report (close to) the
-    /// full 108pt disc, not the ~37x20pt text bounds.
+    /// The Scan disc's label is only the centered "Scan" text. Without an
+    /// explicit content shape the button's hit region collapses to the text
+    /// glyphs, so clicking the disc around the word does nothing. The button
+    /// element must report (close to) the full disc, not the ~37x20pt text
+    /// bounds.
     func test_smartScan_scanDiscIsFullyInteractive() throws {
         dismissOnboardingIfNeeded()
 
@@ -97,6 +97,34 @@ final class SmartScanUITests: XCTestCase {
         XCTAssertGreaterThan(
             frame.height, 100,
             "The Scan button must span the whole disc, not just its text label"
+        )
+    }
+
+    /// The Scan disc straddles the window's bottom edge, so the FDA popover
+    /// must open upward — above the disc. A downward popover would be clipped
+    /// off the bottom of the window, making "Scan Anyway" hard to reach.
+    func test_smartScan_fdaPopover_opensAboveTheDisc() throws {
+        dismissOnboardingIfNeeded()
+
+        let scanButton = app.buttons["section.smartScan.scan"]
+        XCTAssertTrue(
+            scanButton.waitForExistence(timeout: 10),
+            "Expected the floating Scan button on the Smart Scan intro"
+        )
+        let discFrame = scanButton.frame
+        scanButton.click()
+
+        let popover = app.descendants(matching: .any)["fda.popover"]
+        guard popover.waitForExistence(timeout: 5) else {
+            throw XCTSkip(
+                "Full Disk Access is granted on this host — no FDA popover to position-check."
+            )
+        }
+        // XCUITest frames are top-left origin, so a smaller midY is higher on
+        // screen: the popover's center must sit above the disc's center.
+        XCTAssertLessThan(
+            popover.frame.midY, discFrame.midY,
+            "The FDA popover must open above the Scan disc, not below it"
         )
     }
 

--- a/VaderCleanerUITests/SmartScanUITests.swift
+++ b/VaderCleanerUITests/SmartScanUITests.swift
@@ -144,7 +144,7 @@ final class SmartScanUITests: XCTestCase {
     /// Anyway" so the scan proceeds and the wiring under test still runs.
     private func proceedPastScanAccessPopoverIfNeeded() {
         let scanAnyway = app.buttons["fda.popover.scanAnyway"]
-        if scanAnyway.waitForExistence(timeout: 2) {
+        if scanAnyway.waitForExistence(timeout: 5) {
             scanAnyway.click()
         }
     }

--- a/VaderCleanerUITests/SmartScanUITests.swift
+++ b/VaderCleanerUITests/SmartScanUITests.swift
@@ -62,6 +62,7 @@ final class SmartScanUITests: XCTestCase {
             "Expected the floating Scan button on the Smart Scan intro"
         )
         scanButton.click()
+        proceedPastScanAccessPopoverIfNeeded()
 
         // `smartScan.scanning` is `SmartScanView`'s progress-state identifier
         // — reaching it proves intro → working. Type-agnostic query, matching
@@ -71,6 +72,31 @@ final class SmartScanUITests: XCTestCase {
         XCTAssertTrue(
             scanning.waitForExistence(timeout: 10),
             "Expected Smart Scan to enter its scanning (working) state after Scan"
+        )
+    }
+
+    /// The Scan disc is 108pt of interactive glass, but its label is only the
+    /// centered "Scan" text. Without an explicit content shape the button's
+    /// hit region collapses to the text glyphs, so clicking the glass around
+    /// the word does nothing. The button element must report (close to) the
+    /// full 108pt disc, not the ~37x20pt text bounds.
+    func test_smartScan_scanDiscIsFullyInteractive() throws {
+        dismissOnboardingIfNeeded()
+
+        let scanButton = app.buttons["section.smartScan.scan"]
+        XCTAssertTrue(
+            scanButton.waitForExistence(timeout: 10),
+            "Expected the floating Scan button on the Smart Scan intro"
+        )
+
+        let frame = scanButton.frame
+        XCTAssertGreaterThan(
+            frame.width, 100,
+            "The Scan button must span the whole disc, not just its text label"
+        )
+        XCTAssertGreaterThan(
+            frame.height, 100,
+            "The Scan button must span the whole disc, not just its text label"
         )
     }
 
@@ -109,6 +135,17 @@ final class SmartScanUITests: XCTestCase {
         let continueWithout = app.buttons["Continue Without Access"]
         if continueWithout.waitForExistence(timeout: 2) {
             continueWithout.click()
+        }
+    }
+
+    /// The floating Scan button gates FDA-sensitive sections behind an access
+    /// popover when Full Disk Access is missing — which it is on a test host
+    /// that dismissed onboarding via "Continue Without Access". Tap "Scan
+    /// Anyway" so the scan proceeds and the wiring under test still runs.
+    private func proceedPastScanAccessPopoverIfNeeded() {
+        let scanAnyway = app.buttons["fda.popover.scanAnyway"]
+        if scanAnyway.waitForExistence(timeout: 2) {
+            scanAnyway.click()
         }
     }
 }

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -77,7 +77,7 @@ final class SpaceLensUITests: XCTestCase {
     /// Anyway" so the scan proceeds and the wiring under test still runs.
     private func proceedPastScanAccessPopoverIfNeeded() {
         let scanAnyway = app.buttons["fda.popover.scanAnyway"]
-        if scanAnyway.waitForExistence(timeout: 2) {
+        if scanAnyway.waitForExistence(timeout: 5) {
             scanAnyway.click()
         }
     }

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -50,6 +50,7 @@ final class SpaceLensUITests: XCTestCase {
         XCTAssertTrue(floatingScan.waitForExistence(timeout: 5),
                       "Expected the floating Scan button on the Space Lens intro")
         floatingScan.click()
+        proceedPastScanAccessPopoverIfNeeded()
 
         // After Scan we expect either the scanning indicator or — on tiny home
         // folders / fast machines — the treemap to land before our timeout.
@@ -67,6 +68,17 @@ final class SpaceLensUITests: XCTestCase {
         let continueWithout = app.buttons["Continue Without Access"]
         if continueWithout.waitForExistence(timeout: 2) {
             continueWithout.click()
+        }
+    }
+
+    /// The floating Scan button gates FDA-sensitive sections behind an access
+    /// popover when Full Disk Access is missing — which it is on a test host
+    /// that dismissed onboarding via "Continue Without Access". Tap "Scan
+    /// Anyway" so the scan proceeds and the wiring under test still runs.
+    private func proceedPastScanAccessPopoverIfNeeded() {
+        let scanAnyway = app.buttons["fda.popover.scanAnyway"]
+        if scanAnyway.waitForExistence(timeout: 2) {
+            scanAnyway.click()
         }
     }
 

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -56,6 +56,7 @@ final class SystemJunkUITests: XCTestCase {
         XCTAssertTrue(scanButton.waitForExistence(timeout: 5),
                       "Expected the floating Scan button on the System Junk intro")
         scanButton.click()
+        proceedPastScanAccessPopoverIfNeeded()
 
         // The scan completes once we land on the preview footer (Total
         // selected label / Clean button), or — if no junk files were found —
@@ -115,6 +116,7 @@ final class SystemJunkUITests: XCTestCase {
         XCTAssertTrue(scanButton.waitForExistence(timeout: 5),
                       "Expected the floating Scan button on the System Junk intro")
         scanButton.click()
+        proceedPastScanAccessPopoverIfNeeded()
 
         // The section has left `.intro` once it shows any non-intro state:
         // the in-progress scanning indicator, or the preview footer (which
@@ -157,6 +159,17 @@ final class SystemJunkUITests: XCTestCase {
         let continueWithout = app.buttons["Continue Without Access"]
         if continueWithout.waitForExistence(timeout: 2) {
             continueWithout.click()
+        }
+    }
+
+    /// The floating Scan button gates FDA-sensitive sections behind an access
+    /// popover when Full Disk Access is missing — which it is on a test host
+    /// that dismissed onboarding via "Continue Without Access". Tap "Scan
+    /// Anyway" so the scan proceeds and the wiring under test still runs.
+    private func proceedPastScanAccessPopoverIfNeeded() {
+        let scanAnyway = app.buttons["fda.popover.scanAnyway"]
+        if scanAnyway.waitForExistence(timeout: 2) {
+            scanAnyway.click()
         }
     }
 }

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -168,7 +168,7 @@ final class SystemJunkUITests: XCTestCase {
     /// Anyway" so the scan proceeds and the wiring under test still runs.
     private func proceedPastScanAccessPopoverIfNeeded() {
         let scanAnyway = app.buttons["fda.popover.scanAnyway"]
-        if scanAnyway.waitForExistence(timeout: 2) {
+        if scanAnyway.waitForExistence(timeout: 5) {
             scanAnyway.click()
         }
     }


### PR DESCRIPTION
## What changed

Reworks the floating **Scan** disc — how it's surfaced, where it lives, and how it looks.

### Full Disk Access popover
The always-on `FullDiskAccessPromptCard` is gone from every section's intro screen. The FDA warning is now **action-anchored**: a popover (`ScanAccessPopover`) raised from the Scan disc only when the user taps Scan on an FDA-sensitive section *without* access. It offers **Open System Settings** and **Scan Anyway** — a warning at the moment of consequence with an escape hatch, instead of permanent furniture on every screen. The card is retained for the post-scan empty/clean detail states, where it still explains an empty result.

### Child-window Scan disc
The disc now lives in a borderless `NSPanel` (`ScanDiscWindowController`), attached as a child of the main window, so it can **straddle the window's bottom edge** — top half on the window, bottom half over the desktop. A plain SwiftUI overlay cannot do this: a window clips its own content. The panel tracks the parent on move/resize, tucks fully inside in fullscreen, and is ordered out whenever no disc should show.

### Disc styling
- Flat, fully opaque **accent fill** — Liquid Glass has no window backdrop to tint against once the disc overhangs the window, so a glass disc read as dark grey.
- A thin **white ring**.
- Larger than the in-window default — size is parameterised so the shared Smart Scan **"Clean"** CTA keeps the compact 108pt size.

## Fixes found while testing

- **`section.intro.<slug>` identifier** — `SectionIntroView` applied `.accessibilityIdentifier` *before* `.accessibilityElement(children: .contain)`, so the root `section.intro` id propagated down and overwrote the per-section id. Sealing the container first fixes it. This was failing four section UI tests on `main`, independent of this PR's feature work.
- **Scan disc hit target** — the disc's click region had collapsed to its text label (a `.frame` adds only transparent padding). `.contentShape(Circle())` makes the whole disc clickable.

## Testing

- **723 unit tests pass**, including new coverage: `ScanAccessPopoverTests` (FDA gate + popover), `ScanDiscWindowFrameTests` (panel placement maths), and `FloatingScanButtonTests` (diameter + hit target).
- All scannable-section **UI tests pass** against the child-panel disc — disc clickability, the FDA popover, and section-switching, across popover and non-popover sections.

## Reviewer notes

- The Scan disc is an `NSPanel` (`.nonactivatingPanel`) — clicking it does not steal key focus from the main window.
- The disc's transparent glow-margin (within the panel) absorbs clicks; harmless, and the panel is ordered out whenever the disc isn't shown.
- `FloatingScanButton` is shared with the Smart Scan "Clean" button, so that CTA picks up the new accent fill + white ring (kept visually consistent by design) but stays the compact size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an inline Full Disk Access gating popover to guide users when scanning protected areas.
  * Moved the floating Scan disc into a dedicated floating panel for consistent behavior across windows.

* **Improvements**
  * Restyled the floating Scan button for consistent sizing, hit area, and visuals.
  * Improved disc positioning, fullscreen handling, and visibility transitions.
  * Accessibility grouping refinements.

* **Tests**
  * Added unit and UI tests covering scan gating, geometry, and button sizing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->