### PR TITLE
ui: darken Scan disc centre and stop the intro hero floating

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -111,8 +111,8 @@ struct ContentView: View {
                         // screen enters from the opposite edge once the
                         // outgoing has fully cleared. The two halves run
                         // sequentially so only one section is on screen at a
-                        // time. `selectSection` updates `navigationDirection`
-                        // a tick before the selection so both halves of the
+                        // time. `selectSection` writes `navigationDirection`
+                        // alongside the selection so both halves of the
                         // transition read the same direction.
                         .id(selectedSection)
                         .transition(.sectionContent(navigationDirection))
@@ -321,25 +321,20 @@ struct ContentView: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    /// Applies a sidebar selection, recording which way the detail pane should
-    /// travel and then committing the new selection one runloop tick later.
-    /// The split matters: SwiftUI resolves a removal transition from the
-    /// outgoing view's *last* render, so writing both `@State` values in one
-    /// batch would leave the removal half stuck on the previous direction and
-    /// the two halves of the slide would disagree on a reversal. Updating
-    /// `navigationDirection` first lets the outgoing view re-render with the
-    /// new direction before the selection — and therefore the keyed animation
-    /// and the transition itself — commits.
+    /// Applies a sidebar selection, recording the travel direction alongside
+    /// the new selection so both halves of the slide transition read the same
+    /// direction. The two `@State` writes commit synchronously in one render
+    /// pass — deferring the selection would let rapid taps queue intermediate
+    /// flashes through sections the user did not intend to visit, and would
+    /// also leave `navigationDirection` open to being recomputed against a
+    /// stale `selectedSection` between taps. Every selection change — rail
+    /// taps and the Smart Scan review shortcuts — routes through here.
     private func selectSection(_ section: NavigationSection) {
         guard section != selectedSection else { return }
-        guard let current = selectedSection else {
-            selectedSection = section
-            return
+        if let current = selectedSection {
+            navigationDirection = current.transitionDirection(to: section)
         }
-        navigationDirection = current.transitionDirection(to: section)
-        DispatchQueue.main.async {
-            selectedSection = section
-        }
+        selectedSection = section
     }
 
     /// Idempotent permission-request driver. Fires the system prompt at most
@@ -422,8 +417,8 @@ private extension AnyTransition {
     /// for `.down` — and fades as it leaves. The incoming screen then enters
     /// from the opposite edge after the outgoing has finished, so a single
     /// section is on screen at a time rather than the two overlapping.
-    /// `selectSection` re-renders the outgoing view with the new direction a
-    /// tick before the selection commits so both halves agree on the edges.
+    /// `selectSection` writes the direction alongside the selection so both
+    /// halves of the transition agree on the edges.
     static func sectionContent(_ direction: SectionTransitionDirection) -> AnyTransition {
         // Halves run back-to-back: removal animates from 0 → exitDuration,
         // and the insertion's `.delay` keeps the new view at its starting

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -110,15 +110,16 @@ struct ContentView: View {
                 ZStack {
                     detailView(for: selectedSection ?? .smartScan)
                         // Slide-and-fade the detail screen as the section
-                        // changes: the outgoing screen slides out to the edge
-                        // in the direction of travel — top for an upward
-                        // move, bottom for a downward one — and the incoming
-                        // screen enters from the opposite edge once the
-                        // outgoing has fully cleared. The two halves run
-                        // sequentially so only one section is on screen at a
-                        // time. `selectSection` updates `navigationDirection`
-                        // a tick before the selection commits so both halves
-                        // of the transition read the same direction.
+                        // changes, reading as a scroll between rows: a
+                        // downward rail tap sends content sliding up (the
+                        // outgoing screen exits through the top, the incoming
+                        // follows up from the bottom), and an upward rail tap
+                        // mirrors the motion in the opposite direction. Both
+                        // halves of the transition travel the same way and
+                        // run sequentially, so only one section is on screen
+                        // at a time. `selectSection` updates
+                        // `navigationDirection` a tick before the selection
+                        // commits so both halves agree on the direction.
                         .id(selectedSection)
                         .transition(.sectionContent(navigationDirection))
                 }
@@ -432,15 +433,15 @@ struct ContentView: View {
 }
 
 private extension AnyTransition {
-    /// Slide-and-fade for the detail pane. The outgoing screen slides all the
-    /// way out through the edge it's heading toward — top for `.up`, bottom
-    /// for `.down` — and fades as it leaves. The incoming screen then enters
-    /// from the opposite edge after the outgoing has finished, so a single
-    /// section is on screen at a time rather than the two overlapping.
-    /// `selectSection` writes the direction a tick before the selection so
-    /// the outgoing view re-renders with the new direction before SwiftUI
-    /// resolves the removal half, keeping both halves in agreement on a
-    /// reversal.
+    /// Slide-and-fade for the detail pane. Both halves of the transition
+    /// travel the same way, so it reads as a continuous scroll: a `.up`
+    /// move sends the outgoing screen out through the top edge and the
+    /// incoming screen up from the bottom; a `.down` move mirrors that
+    /// through the opposite edges. The two halves run sequentially so only
+    /// one section is on screen at a time. `selectSection` writes the
+    /// direction a tick before the selection so the outgoing view
+    /// re-renders with the new direction before SwiftUI resolves the
+    /// removal half, keeping both halves in agreement on a reversal.
     static func sectionContent(_ direction: SectionTransitionDirection) -> AnyTransition {
         // Halves run back-to-back: removal animates from 0 → exitDuration,
         // and the insertion's `.delay` keeps the new view at its starting

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -21,6 +21,11 @@ struct ContentView: View {
     private let malwareViewModel: MalwareViewModel
     private let smartScanViewModel: SmartScanViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
+    /// Which way the detail pane's slide-and-fade transition should travel for
+    /// the current section change. Set by `selectSection` from the rail order
+    /// of the outgoing and incoming sections, just before the selection — and
+    /// therefore the keyed animation — commits.
+    @State private var navigationDirection: SectionTransitionDirection = .down
     /// Namespace for the sliding selection pill in the custom rail.
     @Namespace private var pillNamespace
     /// The section the pointer is currently over, if any. Drives the rail's
@@ -92,12 +97,26 @@ struct ContentView: View {
             // Hosts `.navigationTitle` / `.toolbar` for the detail screens
             // without reintroducing a split divider.
             NavigationStack {
-                detailView(for: selectedSection ?? .smartScan)
-                    // Crossfade the whole detail screen as the section
-                    // changes, so navigation reads as a soft dissolve in step
-                    // with the backdrop recolour rather than a hard cut.
-                    .id(selectedSection)
-                    .transition(.opacity)
+                // A plain ZStack hosts the section-keyed detail view so its
+                // `.id`-driven swap has a stable parent to play its transition
+                // within. NavigationStack is not a reliable transition host
+                // for its own root content; wrapping in an everyday container
+                // is the canonical SwiftUI pattern.
+                ZStack {
+                    detailView(for: selectedSection ?? .smartScan)
+                        // Slide-and-fade the incoming detail screen: it drifts
+                        // in from above for a lower rail row and from below
+                        // for a higher one, so navigation has a sense of
+                        // direction. The outgoing screen only fades — a
+                        // transition's removal half is resolved a render
+                        // before its insertion half, so a direction-free
+                        // removal avoids the two halves disagreeing on a
+                        // change of travel direction. `selectSection` sets
+                        // `navigationDirection` before the selection commits.
+                        .id(selectedSection)
+                        .transition(.sectionContent(navigationDirection))
+                }
+                .animation(.smooth(duration: 0.42), value: selectedSection)
             }
         }
         // The floating Scan disc lives in its own borderless child panel
@@ -118,9 +137,9 @@ struct ContentView: View {
         .onChange(of: selectedSection) { _, newValue in
             scanDiscController.section = newValue ?? .smartScan
         }
-        // One ambient animation drives every section-change motion in lock
-        // step: the rail's selection pill slides and the detail screen
-        // crossfades.
+        // Animates the rail's section-change motion — chiefly the selection
+        // pill sliding between rows. The detail pane and the backdrop each
+        // animate their own transition with a matching curve.
         .animation(.smooth(duration: 0.42), value: selectedSection)
         // The side-by-side section intro needs a pane wide enough for the
         // hero, the gap, and the text column; a 1000pt minimum keeps that
@@ -204,7 +223,7 @@ struct ContentView: View {
         let isSelected = selectedSection == section
         let isHovering = hoveredSection == section
         return Button {
-            selectedSection = section
+            selectSection(section)
         } label: {
             HStack(spacing: 14) {
                 Image(systemName: section.icon)
@@ -301,6 +320,20 @@ struct ContentView: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
+    /// Applies a sidebar selection, first recording which way the detail pane
+    /// should travel so its slide-and-fade transition matches the rail move.
+    /// Both `@State` writes land in one update pass, so the keyed animation
+    /// drives the transition with the direction already in place. Every
+    /// selection change — rail taps and the Smart Scan review shortcuts —
+    /// routes through here so the direction is never stale.
+    private func selectSection(_ section: NavigationSection) {
+        guard section != selectedSection else { return }
+        if let current = selectedSection {
+            navigationDirection = current.transitionDirection(to: section)
+        }
+        selectedSection = section
+    }
+
     /// Idempotent permission-request driver. Fires the system prompt at most
     /// once per session, and only once the FDA onboarding flow has reached a
     /// terminal state (granted or explicitly dismissed).
@@ -321,9 +354,9 @@ struct ContentView: View {
             ScannableSectionContent(coordinator: smartScanViewModel, section: section) {
                 SmartScanView(
                     viewModel: smartScanViewModel,
-                    onReviewSystemJunk: { selectedSection = .systemJunk },
-                    onReviewMalware: { selectedSection = .malwareRemoval },
-                    onReviewOptimization: { selectedSection = .optimization }
+                    onReviewSystemJunk: { selectSection(.systemJunk) },
+                    onReviewMalware: { selectSection(.malwareRemoval) },
+                    onReviewOptimization: { selectSection(.optimization) }
                 )
             }
         case .healthMonitor:
@@ -371,6 +404,26 @@ struct ContentView: View {
             set: { newValue in
                 if newValue == false { onboarding.dismiss() }
             }
+        )
+    }
+}
+
+private extension AnyTransition {
+    /// Slide-and-fade for the detail pane. The incoming screen drifts into
+    /// place from above for a `.down` move and from below for an `.up` one, so
+    /// the new content visibly travels the way the rail selection moved. The
+    /// outgoing screen only fades: a transition's removal half is resolved a
+    /// render before its insertion half, so a direction-free removal stops a
+    /// change of travel direction from leaving the two halves sliding opposite
+    /// ways.
+    static func sectionContent(_ direction: SectionTransitionDirection) -> AnyTransition {
+        // A modest drift — the fade carries the transition, the offset only
+        // gives it a direction.
+        let distance: CGFloat = 60
+        let travel: CGFloat = direction == .down ? distance : -distance
+        return .asymmetric(
+            insertion: .offset(y: -travel).combined(with: .opacity),
+            removal: .opacity
         )
     }
 }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -104,15 +104,16 @@ struct ContentView: View {
                 // is the canonical SwiftUI pattern.
                 ZStack {
                     detailView(for: selectedSection ?? .smartScan)
-                        // Slide-and-fade the incoming detail screen: it drifts
-                        // in from above for a lower rail row and from below
-                        // for a higher one, so navigation has a sense of
-                        // direction. The outgoing screen only fades — a
-                        // transition's removal half is resolved a render
-                        // before its insertion half, so a direction-free
-                        // removal avoids the two halves disagreeing on a
-                        // change of travel direction. `selectSection` sets
-                        // `navigationDirection` before the selection commits.
+                        // Slide-and-fade the detail screen as the section
+                        // changes: the outgoing screen slides out to the edge
+                        // in the direction of travel — top for an upward
+                        // move, bottom for a downward one — and the incoming
+                        // screen enters from the opposite edge once the
+                        // outgoing has fully cleared. The two halves run
+                        // sequentially so only one section is on screen at a
+                        // time. `selectSection` updates `navigationDirection`
+                        // a tick before the selection so both halves of the
+                        // transition read the same direction.
                         .id(selectedSection)
                         .transition(.sectionContent(navigationDirection))
                 }
@@ -320,18 +321,25 @@ struct ContentView: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    /// Applies a sidebar selection, first recording which way the detail pane
-    /// should travel so its slide-and-fade transition matches the rail move.
-    /// Both `@State` writes land in one update pass, so the keyed animation
-    /// drives the transition with the direction already in place. Every
-    /// selection change — rail taps and the Smart Scan review shortcuts —
-    /// routes through here so the direction is never stale.
+    /// Applies a sidebar selection, recording which way the detail pane should
+    /// travel and then committing the new selection one runloop tick later.
+    /// The split matters: SwiftUI resolves a removal transition from the
+    /// outgoing view's *last* render, so writing both `@State` values in one
+    /// batch would leave the removal half stuck on the previous direction and
+    /// the two halves of the slide would disagree on a reversal. Updating
+    /// `navigationDirection` first lets the outgoing view re-render with the
+    /// new direction before the selection — and therefore the keyed animation
+    /// and the transition itself — commits.
     private func selectSection(_ section: NavigationSection) {
         guard section != selectedSection else { return }
-        if let current = selectedSection {
-            navigationDirection = current.transitionDirection(to: section)
+        guard let current = selectedSection else {
+            selectedSection = section
+            return
         }
-        selectedSection = section
+        navigationDirection = current.transitionDirection(to: section)
+        DispatchQueue.main.async {
+            selectedSection = section
+        }
     }
 
     /// Idempotent permission-request driver. Fires the system prompt at most
@@ -409,21 +417,28 @@ struct ContentView: View {
 }
 
 private extension AnyTransition {
-    /// Slide-and-fade for the detail pane. The incoming screen drifts into
-    /// place from above for a `.down` move and from below for an `.up` one, so
-    /// the new content visibly travels the way the rail selection moved. The
-    /// outgoing screen only fades: a transition's removal half is resolved a
-    /// render before its insertion half, so a direction-free removal stops a
-    /// change of travel direction from leaving the two halves sliding opposite
-    /// ways.
+    /// Slide-and-fade for the detail pane. The outgoing screen slides all the
+    /// way out through the edge it's heading toward — top for `.up`, bottom
+    /// for `.down` — and fades as it leaves. The incoming screen then enters
+    /// from the opposite edge after the outgoing has finished, so a single
+    /// section is on screen at a time rather than the two overlapping.
+    /// `selectSection` re-renders the outgoing view with the new direction a
+    /// tick before the selection commits so both halves agree on the edges.
     static func sectionContent(_ direction: SectionTransitionDirection) -> AnyTransition {
-        // A modest drift — the fade carries the transition, the offset only
-        // gives it a direction.
-        let distance: CGFloat = 60
-        let travel: CGFloat = direction == .down ? distance : -distance
+        // Halves run back-to-back: removal animates from 0 → exitDuration,
+        // and the insertion's `.delay` keeps the new view at its starting
+        // edge until the outgoing has fully cleared.
+        let exitDuration: Double = 0.4
+        let entryDuration: Double = 0.4
+        let removalEdge: Edge = direction == .down ? .bottom : .top
+        let insertionEdge: Edge = direction == .down ? .top : .bottom
         return .asymmetric(
-            insertion: .offset(y: -travel).combined(with: .opacity),
-            removal: .opacity
+            insertion: .move(edge: insertionEdge)
+                .combined(with: .opacity)
+                .animation(.smooth(duration: entryDuration).delay(exitDuration)),
+            removal: .move(edge: removalEdge)
+                .combined(with: .opacity)
+                .animation(.smooth(duration: exitDuration))
         )
     }
 }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -123,7 +123,13 @@ struct ContentView: View {
                         .id(selectedSection)
                         .transition(.sectionContent(navigationDirection))
                 }
-                .animation(.smooth(duration: 0.42), value: selectedSection)
+                // The transaction has to span the full sequential transition
+                // (exit + entry delay + entry = ~1.1s). If it's shorter than
+                // the insertion's `.delay`, SwiftUI cancels the deferred entry
+                // animation and the incoming view snaps to its rest position
+                // instead of sliding in. Slightly longer than the actual
+                // total just gives a margin of safety.
+                .animation(.smooth(duration: 1.2), value: selectedSection)
             }
         }
         // The floating Scan disc lives in its own borderless child panel

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -422,9 +422,13 @@ private extension AnyTransition {
     static func sectionContent(_ direction: SectionTransitionDirection) -> AnyTransition {
         // Halves run back-to-back: removal animates from 0 → exitDuration,
         // and the insertion's `.delay` keeps the new view at its starting
-        // edge until the outgoing has fully cleared.
-        let exitDuration: Double = 0.4
-        let entryDuration: Double = 0.4
+        // edge until the outgoing has fully cleared. The durations are
+        // generous enough that the long edge-to-edge travel reads as a
+        // fluid glide rather than a sharp slide, and `exitDuration`
+        // matches the backdrop's own crossfade so the new section begins
+        // entering exactly when the backdrop has finished recolouring.
+        let exitDuration: Double = 0.55
+        let entryDuration: Double = 0.55
         let removalEdge: Edge = direction == .down ? .bottom : .top
         let insertionEdge: Edge = direction == .down ? .top : .bottom
         return .asymmetric(

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -26,6 +26,11 @@ struct ContentView: View {
     /// of the outgoing and incoming sections, just before the selection — and
     /// therefore the keyed animation — commits.
     @State private var navigationDirection: SectionTransitionDirection = .down
+    /// The latest section a rail tap is steering toward while a previous
+    /// `selectSection` is still waiting on its deferred commit. Coalesces
+    /// rapid taps into one pending dispatch so the navigation lands on the
+    /// final target — never an intermediate one — with the matching direction.
+    @State private var pendingSelection: NavigationSection?
     /// Namespace for the sliding selection pill in the custom rail.
     @Namespace private var pillNamespace
     /// The section the pointer is currently over, if any. Drives the rail's
@@ -111,9 +116,9 @@ struct ContentView: View {
                         // screen enters from the opposite edge once the
                         // outgoing has fully cleared. The two halves run
                         // sequentially so only one section is on screen at a
-                        // time. `selectSection` writes `navigationDirection`
-                        // alongside the selection so both halves of the
-                        // transition read the same direction.
+                        // time. `selectSection` updates `navigationDirection`
+                        // a tick before the selection commits so both halves
+                        // of the transition read the same direction.
                         .id(selectedSection)
                         .transition(.sectionContent(navigationDirection))
                 }
@@ -321,20 +326,35 @@ struct ContentView: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    /// Applies a sidebar selection, recording the travel direction alongside
-    /// the new selection so both halves of the slide transition read the same
-    /// direction. The two `@State` writes commit synchronously in one render
-    /// pass — deferring the selection would let rapid taps queue intermediate
-    /// flashes through sections the user did not intend to visit, and would
-    /// also leave `navigationDirection` open to being recomputed against a
-    /// stale `selectedSection` between taps. Every selection change — rail
-    /// taps and the Smart Scan review shortcuts — routes through here.
+    /// Applies a sidebar selection, recording the travel direction first and
+    /// then committing the selection on the next runloop tick. The deferral
+    /// matters: SwiftUI resolves a removal transition from the outgoing
+    /// view's last render, so a same-batch write of both `@State` values
+    /// would leave the removal half stuck on the previous direction and the
+    /// two halves of the slide would disagree on a reversal. To avoid the
+    /// race condition that a naive dispatch would open up (rapid taps
+    /// queuing intermediate selections, each animating with a later tap's
+    /// direction), we coalesce: only one pending commit is ever in flight,
+    /// and any further taps simply re-target it. The user always lands on
+    /// the final tapped section, with the direction computed against the
+    /// section they're actually leaving.
     private func selectSection(_ section: NavigationSection) {
         guard section != selectedSection else { return }
-        if let current = selectedSection {
-            navigationDirection = current.transitionDirection(to: section)
+        guard let current = selectedSection else {
+            selectedSection = section
+            return
         }
-        selectedSection = section
+        navigationDirection = current.transitionDirection(to: section)
+        let wasIdle = pendingSelection == nil
+        pendingSelection = section
+        if wasIdle {
+            DispatchQueue.main.async {
+                if let target = pendingSelection {
+                    pendingSelection = nil
+                    selectedSection = target
+                }
+            }
+        }
     }
 
     /// Idempotent permission-request driver. Fires the system prompt at most
@@ -417,8 +437,10 @@ private extension AnyTransition {
     /// for `.down` — and fades as it leaves. The incoming screen then enters
     /// from the opposite edge after the outgoing has finished, so a single
     /// section is on screen at a time rather than the two overlapping.
-    /// `selectSection` writes the direction alongside the selection so both
-    /// halves of the transition agree on the edges.
+    /// `selectSection` writes the direction a tick before the selection so
+    /// the outgoing view re-renders with the new direction before SwiftUI
+    /// resolves the removal half, keeping both halves in agreement on a
+    /// reversal.
     static func sectionContent(_ direction: SectionTransitionDirection) -> AnyTransition {
         // Halves run back-to-back: removal animates from 0 → exitDuration,
         // and the insertion's `.delay` keeps the new view at its starting

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -441,12 +441,19 @@ private struct ScannableSectionContent<Coordinator: ScanCoordinating, Detail: Vi
     @ViewBuilder let detail: () -> Detail
 
     var body: some View {
-        content
-            // Reuse SmartScanView's phase-transition pattern so the
-            // intro → scan swap crossfades instead of hard-cutting.
-            .id(phaseTransitionID)
-            .transition(.opacity)
-            .animation(.smooth(duration: 0.35), value: phaseTransitionID)
+        // A plain ZStack so the body's root carries no `.transition` of its
+        // own. The intro↔scan crossfade lives one level in, on `content`;
+        // keeping it off the root lets the outer section-navigation slide
+        // (applied to this view by `ContentView`) act on a clean container
+        // instead of colliding with this wrapper's own transition.
+        ZStack {
+            content
+                // Reuse SmartScanView's phase-transition pattern so the
+                // intro → scan swap crossfades instead of hard-cutting.
+                .id(phaseTransitionID)
+                .transition(.opacity)
+                .animation(.smooth(duration: 0.35), value: phaseTransitionID)
+        }
     }
 
     /// Binary token: only the intro ↔ detail boundary crossfades. It is

--- a/VaderCleaner/FloatingScanButton.swift
+++ b/VaderCleaner/FloatingScanButton.swift
@@ -49,12 +49,26 @@ struct FloatingScanButton: View {
                 .font(.system(size: diameter * 0.17, weight: .semibold))
                 .foregroundStyle(.white)
                 .frame(width: diameter, height: diameter)
-                // A flat, fully opaque accent fill — not a glass material and
-                // not a fading gradient — so the disc reads as a solid section-
-                // coloured button even where it floats over the desktop,
-                // beyond any window backdrop glass could tint against.
+                // An opaque accent fill darkened toward the centre by a radial
+                // black-to-clear wash, so the white title sits on a deeper
+                // backdrop and stays legible while the rim keeps the vivid
+                // section colour. The wash only darkens — it never fades to
+                // transparent — so the disc still reads as solid where it
+                // floats over the desktop, beyond any window backdrop glass
+                // could tint against.
                 .background(
-                    Circle().fill(accent)
+                    Circle()
+                        .fill(accent)
+                        .overlay(
+                            Circle().fill(
+                                RadialGradient(
+                                    colors: [.black.opacity(0.55), .clear],
+                                    center: .center,
+                                    startRadius: 0,
+                                    endRadius: diameter * 0.5
+                                )
+                            )
+                        )
                 )
                 // Crisp white ring, echoing the reference's lit disc.
                 .overlay(

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -117,3 +117,25 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         }
     }
 }
+
+/// Which way the detail pane's content travels during a section change —
+/// derived from the rail order of the outgoing and incoming sections.
+enum SectionTransitionDirection {
+    case up
+    case down
+}
+
+extension NavigationSection {
+    /// The direction the main detail content should travel when the rail
+    /// selection moves from this section to `target`, decided by their order
+    /// in `allCases` (the rail's top-to-bottom order). A move to a lower row
+    /// travels `.down`; a move to a higher row travels `.up`.
+    func transitionDirection(to target: NavigationSection) -> SectionTransitionDirection {
+        let order = NavigationSection.allCases
+        guard
+            let fromIndex = order.firstIndex(of: self),
+            let toIndex = order.firstIndex(of: target)
+        else { return .down }
+        return toIndex > fromIndex ? .down : .up
+    }
+}

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -128,14 +128,16 @@ enum SectionTransitionDirection {
 extension NavigationSection {
     /// The direction the main detail content should travel when the rail
     /// selection moves from this section to `target`, decided by their order
-    /// in `allCases` (the rail's top-to-bottom order). A move to a lower row
-    /// travels `.down`; a move to a higher row travels `.up`.
+    /// in `allCases` (the rail's top-to-bottom order). The motion reads as a
+    /// scroll between rows: a move to a lower row scrolls the content `.up`
+    /// (outgoing exits the top edge, incoming follows up from the bottom),
+    /// and a move to a higher row mirrors it the other way as `.down`.
     func transitionDirection(to target: NavigationSection) -> SectionTransitionDirection {
         let order = NavigationSection.allCases
         guard
             let fromIndex = order.firstIndex(of: self),
             let toIndex = order.firstIndex(of: target)
         else { return .down }
-        return toIndex > fromIndex ? .down : .up
+        return toIndex > fromIndex ? .up : .down
     }
 }

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -13,10 +13,6 @@ struct SectionIntroView: View {
     let presentation: SectionPresentation
     let section: NavigationSection
 
-    /// Drives the hero's slow vertical drift. Flipped true on appear so the
-    /// repeating float animation has a value to oscillate between.
-    @State private var heroFloating = false
-
     /// Localized section title for display. A computed accessor so the
     /// rendered heading tracks the UI language while the identifiers below
     /// stay fixed regardless of locale.
@@ -80,8 +76,7 @@ struct SectionIntroView: View {
     // MARK: Hero
 
     /// Designer art when supplied, otherwise the accent-tinted SF Symbol,
-    /// over a soft accent orb. Slowly drifts so it floats like the reference's
-    /// lit 3D illustration. Decorative — hidden from accessibility.
+    /// over a soft accent orb. Decorative — hidden from accessibility.
     @ViewBuilder
     private var hero: some View {
         ZStack {
@@ -111,13 +106,6 @@ struct SectionIntroView: View {
         // A soft bloom behind the hero, recoloured to the section accent so
         // the intro feels like part of one family.
         .shadow(color: presentation.accent.opacity(0.30), radius: 22)
-        // A slow vertical drift so the hero gently floats in place.
-        .offset(y: heroFloating ? -7 : 5)
-        .animation(
-            .easeInOut(duration: 3.6).repeatForever(autoreverses: true),
-            value: heroFloating
-        )
-        .onAppear { heroFloating = true }
         // The art is decorative, but a sighted user gets a clear section
         // anchor here, so VoiceOver gets one too. The label is qualified as
         // an "illustration" rather than the bare section name so it does not

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -76,7 +76,8 @@ struct SectionIntroView: View {
     // MARK: Hero
 
     /// Designer art when supplied, otherwise the accent-tinted SF Symbol,
-    /// over a soft accent orb. Decorative — hidden from accessibility.
+    /// over a soft accent orb. Exposed to accessibility as a labelled
+    /// illustration (see the `.accessibilityLabel`/`.isImage` below).
     @ViewBuilder
     private var hero: some View {
         ZStack {

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -106,33 +106,36 @@ final class NavigationSectionTests: XCTestCase {
         }
     }
 
-    func test_transitionDirection_toLowerRailRow_isDown() {
-        // Smart Scan sits above System Junk in the rail, so moving the
-        // selection to System Junk sends the detail content downward.
+    func test_transitionDirection_toLowerRailRow_isUp() {
+        // Smart Scan sits above System Junk in the rail. The transition
+        // reads as a scroll toward the lower row: the outgoing section
+        // exits the top and the incoming follows up from the bottom, so
+        // the content travels `.up`.
         XCTAssertEqual(
             NavigationSection.smartScan.transitionDirection(to: .systemJunk),
-            .down
+            .up
         )
     }
 
-    func test_transitionDirection_toHigherRailRow_isUp() {
-        // The reverse move — back up to a higher row — travels upward.
+    func test_transitionDirection_toHigherRailRow_isDown() {
+        // The reverse move — back up to a higher row — mirrors the scroll
+        // in the other direction, sending content `.down`.
         XCTAssertEqual(
             NavigationSection.systemJunk.transitionDirection(to: .smartScan),
-            .up
+            .down
         )
     }
 
     func test_transitionDirection_acrossMultipleRows_followsRailOrder() {
         // Distance doesn't matter, only order: jumping from the first row to
-        // the last is still `.down`, and the return jump is `.up`.
+        // the last still scrolls `.up`, and the return jump scrolls `.down`.
         XCTAssertEqual(
             NavigationSection.smartScan.transitionDirection(to: .healthMonitor),
-            .down
+            .up
         )
         XCTAssertEqual(
             NavigationSection.healthMonitor.transitionDirection(to: .smartScan),
-            .up
+            .down
         )
     }
 

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -106,6 +106,36 @@ final class NavigationSectionTests: XCTestCase {
         }
     }
 
+    func test_transitionDirection_toLowerRailRow_isDown() {
+        // Smart Scan sits above System Junk in the rail, so moving the
+        // selection to System Junk sends the detail content downward.
+        XCTAssertEqual(
+            NavigationSection.smartScan.transitionDirection(to: .systemJunk),
+            .down
+        )
+    }
+
+    func test_transitionDirection_toHigherRailRow_isUp() {
+        // The reverse move — back up to a higher row — travels upward.
+        XCTAssertEqual(
+            NavigationSection.systemJunk.transitionDirection(to: .smartScan),
+            .up
+        )
+    }
+
+    func test_transitionDirection_acrossMultipleRows_followsRailOrder() {
+        // Distance doesn't matter, only order: jumping from the first row to
+        // the last is still `.down`, and the return jump is `.up`.
+        XCTAssertEqual(
+            NavigationSection.smartScan.transitionDirection(to: .healthMonitor),
+            .down
+        )
+        XCTAssertEqual(
+            NavigationSection.healthMonitor.transitionDirection(to: .smartScan),
+            .up
+        )
+    }
+
     func test_eachSection_hasValidSFSymbol() throws {
         guard #available(macOS 14.0, *) else {
             throw XCTSkip("SF Symbol validation requires macOS 14.0 (the app's minimum deployment target)")


### PR DESCRIPTION
## What changed

Two readability/polish tweaks to the section landing UI.

### Scan disc — darker centre for legible text
`FloatingScanButton` now layers a radial black-to-clear wash over its opaque accent fill, so the disc darkens toward the centre. The white **Scan** title sits on a deeper backdrop and reads more clearly, while the rim keeps the vivid section accent. The darkening radius scales with `diameter`, so it stays proportionate on both the compact in-window CTAs (108pt) and the larger floating disc (130pt).

Because `FloatingScanButton` is the shared component every section uses for its Scan disc, this applies across all sections at once.

### Intro hero — no longer floats
`SectionIntroView`'s hero illustration had a slow, continuous vertical drift. It is now static. Removed the `heroFloating` state, its `.onAppear` trigger, and the repeating `.offset`/`.animation`.

## Why

- The flat accent fill made the white disc title harder to read; a darker centre raises contrast where the text actually sits.
- The drifting hero icon was a distraction on the section landing screen.

## Reviewer notes

- The disc wash **only darkens** — it never fades to transparent — so the disc stays fully opaque even where it floats over the desktop beyond the window backdrop (the original design constraint).
- The static hero affects **every** section's intro screen, since the hero is shared.
- No logic changed: both are pure visual tweaks. Existing `FloatingScanButton` contract tests (title, accent, diameter, accessibility) are unaffected; the removed hero state was `private`. App builds clean (`xcodebuild build`).
- The `xcuserdata` scheme-management plist was intentionally left out of this PR — it is personal Xcode state, not part of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved floating scan button contrast with a subtle radial shading for better title legibility
  * Removed floating animation from hero artwork for a steadier presentation

* **New Features**
  * Detail pane now animates with directional slide-and-fade transitions when switching sections

* **Tests**
  * Added tests validating correct transition directions between sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->