### PR TITLE
Live scan progress feedback (+ two SwiftUI perf fixes)

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		4156DAE09EB7579F22FA6959 /* MalwareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */; };
 		4453CD1C9BEA6DFD3C62E054 /* FloatingRunOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */; };
 		4536F93FC837F56C61CDD236 /* spaceLens.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 785EECE3C6B84ECB7D0A3384 /* spaceLens.usdz */; };
+		45825BEE32AC83FC8B685E28 /* ScanProgressFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A3AE9EED81844B80CF3A1A /* ScanProgressFormatting.swift */; };
 		45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */; };
 		472FECDAABC513309987AA5E /* SmartScanJunkReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67824DA18085247812F6E08 /* SmartScanJunkReview.swift */; };
 		483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */; };
@@ -301,6 +302,7 @@
 		133467A06193C406B027D97C /* NavigationSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSectionTests.swift; sourceTree = "<group>"; };
 		13A5713F5928025F9FE34A43 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDiscovery.swift; sourceTree = "<group>"; };
+		14A3AE9EED81844B80CF3A1A /* ScanProgressFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanProgressFormatting.swift; sourceTree = "<group>"; };
 		166C78AD4798A02F30D94BF4 /* HealthMonitorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorViewModelTests.swift; sourceTree = "<group>"; };
 		168266DA7B9E9A25E0B56A8C /* systemJunk.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = systemJunk.usdz; sourceTree = "<group>"; };
 		1683C13B4837D58AD519341C /* largeOldFiles.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = largeOldFiles.usdz; sourceTree = "<group>"; };
@@ -655,6 +657,7 @@
 				E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */,
 				374A11FF89347AF05A14498B /* ScannableSectionContent.swift */,
 				B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */,
+				14A3AE9EED81844B80CF3A1A /* ScanProgressFormatting.swift */,
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
 				9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */,
 				2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */,
@@ -1200,6 +1203,7 @@
 				67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */,
 				BA47B242AAAE6EAD08CC7D23 /* ScanDiscWindowController.swift in Sources */,
 				4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */,
+				45825BEE32AC83FC8B685E28 /* ScanProgressFormatting.swift in Sources */,
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
 				80111FB2EC8ED204B993FC21 /* ScannableSectionContent.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,

--- a/VaderCleaner.xcodeproj/xcuserdata/jayvicsanantonio.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/VaderCleaner.xcodeproj/xcuserdata/jayvicsanantonio.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>VaderCleaner.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>VaderCleanerHelper.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -534,9 +534,22 @@ struct FileScanner: FileScanning {
                         continue
                     }
 
+                    // Forward progress through the package walk too. Without
+                    // this, sizing a large bundle (an `.app`, a photo library
+                    // in package-as-file mode) emits no interim ticks and the
+                    // final walked count omits everything inside it — so a scan
+                    // dominated by one big package would look stalled. Each
+                    // descendant counts toward the same `visitedCount`, fired on
+                    // the shared cancellation cadence.
                     let packageResult = try await PackageDirectorySizer.recursiveSizeResult(
                         of: url,
-                        excluding: canonicalExclusions
+                        excluding: canonicalExclusions,
+                        progress: {
+                            visitedCount += 1
+                            if visitedCount.isMultiple(of: Self.cancellationCheckInterval) {
+                                onProgress?(visitedCount)
+                            }
+                        }
                     )
                     batch.append(
                         ScannedFile(

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -25,6 +25,23 @@ protocol FileScanning {
         batchSize: Int,
         onBatch: ([ScannedFile]) async throws -> Void
     ) async throws
+
+    /// Progress-aware variant. `onProgress` receives the cumulative count of
+    /// filesystem items *walked* (not just matched), fired periodically so a
+    /// UI can show that an open-ended scan is advancing rather than hung.
+    ///
+    /// A default implementation in the extension below bridges this to the
+    /// non-progress method, dropping `onProgress`. Conformers that don't care
+    /// — including the test fakes — need not implement it; only `FileScanner`
+    /// overrides it to actually emit ticks.
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        options: FileScanOptions,
+        batchSize: Int,
+        onProgress: (@Sendable (Int) -> Void)?,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws
 }
 
 struct FileScanOptions: Equatable {
@@ -66,13 +83,47 @@ enum ProtectedMediaStoreBundle {
 }
 
 extension FileScanning {
+    /// Bridges the progress-aware requirement to the plain one for conformers
+    /// that don't emit progress. Keeping this here means existing fakes — which
+    /// implement only the non-progress method — satisfy the new requirement for
+    /// free, and a `FileScanning` existential still dispatches to `FileScanner`'s
+    /// real implementation when it has one.
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        options: FileScanOptions,
+        batchSize: Int,
+        onProgress: (@Sendable (Int) -> Void)?,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
+        try await scan(
+            roots: roots,
+            excluding: excluding,
+            options: options,
+            batchSize: batchSize,
+            onBatch: onBatch
+        )
+    }
+
     func scan(roots: [ScanRoot], excluding: [URL]) async throws -> [ScannedFile] {
+        try await scan(roots: roots, excluding: excluding, onProgress: nil)
+    }
+
+    /// Accumulating convenience that also forwards a walked-count progress
+    /// callback. Used by feature scanners that want the whole result array but
+    /// still need to surface "still scanning" feedback while the walk runs.
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        onProgress: (@Sendable (Int) -> Void)?
+    ) async throws -> [ScannedFile] {
         var results: [ScannedFile] = []
         try await scan(
             roots: roots,
             excluding: excluding,
             options: .default,
-            batchSize: FileScanner.defaultBatchSize
+            batchSize: FileScanner.defaultBatchSize,
+            onProgress: onProgress
         ) { batch in
             results.append(contentsOf: batch)
         }
@@ -358,6 +409,24 @@ struct FileScanner: FileScanning {
         batchSize: Int = defaultBatchSize,
         onBatch: ([ScannedFile]) async throws -> Void
     ) async throws {
+        try await scan(
+            roots: roots,
+            excluding: excluding,
+            options: options,
+            batchSize: batchSize,
+            onProgress: nil,
+            onBatch: onBatch
+        )
+    }
+
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        options: FileScanOptions = .default,
+        batchSize: Int = defaultBatchSize,
+        onProgress: (@Sendable (Int) -> Void)?,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
         let batchLimit = max(1, batchSize)
         let canonicalExclusions = excluding.map(PathExclusionMatcher.canonicalize)
         let hasExclusions = !canonicalExclusions.isEmpty
@@ -411,6 +480,11 @@ struct FileScanner: FileScanning {
                 visitedCount += 1
                 if visitedCount.isMultiple(of: Self.cancellationCheckInterval) {
                     try Task.checkCancellation()
+                    // Publish the running walked-count on the same cadence we
+                    // already check cancellation, so a UI can show the scan is
+                    // advancing. Piggy-backing on the existing interval keeps
+                    // this free of any extra per-file cost.
+                    onProgress?(visitedCount)
                 }
 
                 let resourceValues = try? url.resourceValues(forKeys: Self.resourceKeySet)
@@ -500,5 +574,9 @@ struct FileScanner: FileScanning {
         }
 
         try await flushBatch()
+        // Final tick so a short scan (fewer items than the cancellation
+        // interval) still reports a count, and a long one ends on its true
+        // total rather than the last interval boundary.
+        onProgress?(visitedCount)
     }
 }

--- a/VaderCleaner/FloatingScanButton.swift
+++ b/VaderCleaner/FloatingScanButton.swift
@@ -82,12 +82,20 @@ struct FloatingScanButton: View {
         }
         .buttonStyle(PressableCircleButtonStyle())
         // Ambient accent glow that breathes so the primary action keeps drawing
-        // the eye even when the rest of the screen is still.
-        .shadow(
-            color: accent.opacity(pulsing ? 0.65 : 0.4),
-            radius: pulsing ? 30 : 18,
-            y: 8
-        )
+        // the eye even when the rest of the screen is still. The glow is a
+        // fixed-radius blurred disc whose *opacity* pulses: animating opacity
+        // composites the cached blur on the GPU, whereas animating a shadow's
+        // blur radius — the earlier approach — forced the gaussian blur to be
+        // re-rasterized every frame for as long as the disc was on screen.
+        .background {
+            Circle()
+                .fill(accent)
+                .frame(width: diameter, height: diameter)
+                .blur(radius: 24)
+                .opacity(pulsing ? 0.65 : 0.4)
+                .offset(y: 8)
+                .allowsHitTesting(false)
+        }
         .scaleEffect(hovering ? 1.06 : 1.0)
         .animation(.spring(response: 0.32, dampingFraction: 0.6), value: hovering)
         .animation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true), value: pulsing)

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -36,11 +36,15 @@ struct LargeOldFilesScanner {
         self.now = now
     }
 
-    func scan(excluding: [URL]) async throws -> [ScannedFile] {
+    func scan(
+        excluding: [URL],
+        onProgress: (@Sendable (Int) -> Void)? = nil
+    ) async throws -> [ScannedFile] {
         var matches: [ScannedFile] = []
         try await scan(
             excluding: excluding,
-            batchSize: FileScanner.defaultBatchSize
+            batchSize: FileScanner.defaultBatchSize,
+            onProgress: onProgress
         ) { matchedBatch in
             matches.append(contentsOf: matchedBatch)
         }
@@ -60,6 +64,7 @@ struct LargeOldFilesScanner {
     func scan(
         excluding: [URL],
         batchSize: Int = FileScanner.defaultBatchSize,
+        onProgress: (@Sendable (Int) -> Void)? = nil,
         onBatch: ([ScannedFile]) async throws -> Void
     ) async throws {
         let roots = pathProvider.roots().map {
@@ -80,7 +85,8 @@ struct LargeOldFilesScanner {
             roots: roots,
             excluding: allExclusions,
             options: FileScanOptions(packagesAsFiles: true, skipsProtectedMediaStores: true),
-            batchSize: batchSize
+            batchSize: batchSize,
+            onProgress: onProgress
         ) { scannedBatch in
             let matchedBatch = scannedBatch.compactMap { Self.classify($0, cutoff: cutoff) }
             guard !matchedBatch.isEmpty else { return }

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -63,7 +63,11 @@ struct LargeOldFilesView: View {
             // only to keep the switch exhaustive over `Phase`.
             EmptyView()
         case .scanning:
-            LargeOldFilesProgressState(label: "Scanning…", identifier: "large-old.scanning")
+            LargeOldFilesProgressState(
+                label: "Scanning…",
+                identifier: "large-old.scanning",
+                detail: ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount)
+            )
         case .results:
             LargeOldFilesResultsContent(
                 files: viewModel.displayedFiles,
@@ -157,7 +161,7 @@ private struct PendingDeletion: Identifiable {
 
 #Preview("Idle") {
     LargeOldFilesView(viewModel: LargeOldFilesViewModel(
-        scanner: { [] },
+        scanner: { _ in [] },
         deleter: { _ in [] }
     ))
     .frame(width: 800, height: 520)

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -154,11 +154,15 @@ final class LargeOldFilesViewModel {
                 // touching the observable count. Drop the update if a newer
                 // scan has since started.
                 Task { @MainActor in
-                    guard let self, self.scanGeneration == generation else { return }
-                    // These hops are unstructured, so they can land out of
-                    // order; the walked count is monotonic, so ignore any tick
-                    // that would move it backwards rather than let it jitter.
-                    guard count > self.scannedItemCount else { return }
+                    // Drop the tick if a newer scan started, if the scan has
+                    // already left `.scanning` (a late tick must not re-trigger
+                    // observation once results are showing), or if it would move
+                    // the monotonic walked count backwards (the hops are
+                    // unstructured, so they can land out of order).
+                    guard let self,
+                          self.scanGeneration == generation,
+                          case .scanning = self.phase,
+                          count > self.scannedItemCount else { return }
                     self.scannedItemCount = count
                 }
             }

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -155,6 +155,10 @@ final class LargeOldFilesViewModel {
                 // scan has since started.
                 Task { @MainActor in
                     guard let self, self.scanGeneration == generation else { return }
+                    // These hops are unstructured, so they can land out of
+                    // order; the walked count is monotonic, so ignore any tick
+                    // that would move it backwards rather than let it jitter.
+                    guard count > self.scannedItemCount else { return }
                     self.scannedItemCount = count
                 }
             }

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -57,9 +57,12 @@ final class LargeOldFilesViewModel {
     }
 
     /// Closure type for the scan source. Async + throwing so production can
-    /// wrap `LargeOldFilesScanner.scan(excluding:)` and tests can supply an
-    /// in-memory `[ScannedFile]` (or throw to exercise the failure path).
-    typealias Scanner = () async throws -> [ScannedFile]
+    /// wrap `LargeOldFilesScanner.scan(excluding:onProgress:)` and tests can
+    /// supply an in-memory `[ScannedFile]` (or throw to exercise the failure
+    /// path). The `@Sendable (Int) -> Void` parameter receives the running
+    /// walked-item count so the scanning screen can show the scan advancing;
+    /// callers that don't report progress simply never invoke it.
+    typealias Scanner = (@escaping @Sendable (Int) -> Void) async throws -> [ScannedFile]
 
     /// Closure type for the deletion sink. Returns the set of URLs that were
     /// **actually** removed — partial-failure cases (some files locked,
@@ -69,6 +72,12 @@ final class LargeOldFilesViewModel {
 
     private(set) var phase: Phase = .idle
     private(set) var selectedURLs: Set<URL> = []
+
+    /// Running count of filesystem items the in-flight scan has walked. Reset
+    /// to 0 at the start of each scan and fed by the scanner's progress
+    /// callback so the scanning screen can show "Scanned N items…" — proof the
+    /// open-ended walk is advancing rather than hung.
+    private(set) var scannedItemCount: Int = 0
 
     /// Current sort axis. The setter recomputes `displayedFiles` so the view
     /// table re-orders without the caller doing the work. Defaults to size-
@@ -88,6 +97,12 @@ final class LargeOldFilesViewModel {
 
     @ObservationIgnored private let scanner: Scanner
     @ObservationIgnored private let deleter: Deleter
+
+    /// Incremented at the start of every scan. The progress callback hops back
+    /// to the main actor asynchronously, so a tick from a superseded scan could
+    /// otherwise land after a newer scan reset the counter; the generation
+    /// check drops those stale updates.
+    @ObservationIgnored private var scanGeneration = 0
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "LargeOldFilesViewModel")
 
@@ -127,11 +142,22 @@ final class LargeOldFilesViewModel {
     /// `.failed`. Selection is cleared because the previous list is no
     /// longer valid.
     func scan() async {
+        scanGeneration &+= 1
+        let generation = scanGeneration
         phase = .scanning
+        scannedItemCount = 0
         selectedURLs = []
         totalSelectedSize = 0
         do {
-            let files = try await scanner()
+            let files = try await scanner { [weak self] count in
+                // The scanner runs off the main actor, so hop back before
+                // touching the observable count. Drop the update if a newer
+                // scan has since started.
+                Task { @MainActor in
+                    guard let self, self.scanGeneration == generation else { return }
+                    self.scannedItemCount = count
+                }
+            }
             applyScanResult(files)
         } catch {
             log.error("Large & Old Files scan failed: \(String(describing: error), privacy: .private(mask: .hash))")
@@ -176,6 +202,7 @@ final class LargeOldFilesViewModel {
         displayedFiles = []
         selectedURLs = []
         totalSelectedSize = 0
+        scannedItemCount = 0
         phase = .idle
     }
 
@@ -254,9 +281,9 @@ extension LargeOldFilesViewModel {
     @MainActor
     static func live(exclusions: ExclusionsStore) -> LargeOldFilesViewModel {
         LargeOldFilesViewModel(
-            scanner: { [weak exclusions] in
+            scanner: { [weak exclusions] onProgress in
                 let excluded = (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
-                return try await LargeOldFilesScanner().scan(excluding: excluded)
+                return try await LargeOldFilesScanner().scan(excluding: excluded, onProgress: onProgress)
             },
             deleter: { urls in
                 await Self.removeUserFiles(at: urls)

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -42,6 +42,9 @@ enum LargeOldFilesActions {
 struct LargeOldFilesProgressState: View {
     let label: String
     let identifier: String
+    /// Optional live progress line (e.g. "Scanned 12,431 items…") shown beneath
+    /// the label so the user can see an open-ended scan advancing.
+    var detail: String? = nil
 
     var body: some View {
         VStack(spacing: 16) {
@@ -50,6 +53,13 @@ struct LargeOldFilesProgressState: View {
             Text(label)
                 .font(.callout)
                 .foregroundStyle(.secondary)
+            if let detail {
+                Text(detail)
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+                    .accessibilityIdentifier("\(identifier).count")
+            }
         }
         .padding()
         .accessibilityIdentifier(identifier)

--- a/VaderCleaner/MalwareView.swift
+++ b/VaderCleaner/MalwareView.swift
@@ -98,6 +98,7 @@ struct MalwareView: View {
                 ),
                 detail: progress,
                 identifier: "malware.scanning",
+                countDetail: ScanProgressFormatting.filesScanned(viewModel.scannedItemCount),
                 onCancel: { viewModel.cancel() }
             )
         case .clean:

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -55,6 +55,13 @@ final class MalwareViewModel {
     private static let databaseMaxAge: TimeInterval = 24 * 60 * 60
 
     private(set) var phase: Phase = .idle
+
+    /// Running count of files ClamAV has reported on during the in-flight scan,
+    /// derived from the per-line progress stream (clamscan prints one line per
+    /// file it checks). Reset to 0 when a scan starts and surfaced as
+    /// "Scanned N files…" so the user sees the scan advancing.
+    private(set) var scannedItemCount: Int = 0
+
     private(set) var lastScanDate: Date?
     private(set) var databaseUpdatedDate: Date?
 
@@ -185,6 +192,7 @@ final class MalwareViewModel {
         if Task.isCancelled { return }
 
         phase = .scanning(progress: "")
+        scannedItemCount = 0
         let found: [MalwareThreat]
         // Pick the closure that matches the requested mode. The two
         // are wired in `MalwareViewModel.live()` to two ClamAVScanner
@@ -198,6 +206,10 @@ final class MalwareViewModel {
                 // superseded this one.
                 Task { @MainActor in
                     guard let self, self.scanGeneration == generation else { return }
+                    // Each clamscan stdout line corresponds to a file it
+                    // checked, so the line count is a faithful "files scanned"
+                    // tally for the live progress readout.
+                    self.scannedItemCount += 1
                     self.phase = .scanning(progress: line)
                 }
             }

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -139,8 +139,15 @@ final class MalwareViewModel {
     /// orphaning and continuing to walk the home directory after the
     /// user has moved on (or after the app itself quits).
     func cancel() {
+        // Advance the generation so any streamed stdout line or thrown error
+        // still in flight is dropped by the `scanGeneration == generation`
+        // guards below — otherwise a late line could flip the phase back to
+        // `.scanning` or a late `catch` could land `.failed` after we've
+        // returned to idle.
+        scanGeneration &+= 1
         scanTask?.cancel()
         scanTask = nil
+        scannedItemCount = 0
         phase = .idle
     }
 
@@ -183,6 +190,10 @@ final class MalwareViewModel {
                     }
                 }
             } catch {
+                // Drop the failure if this scan was cancelled or superseded
+                // (cancel() advances the generation) so a late error can't
+                // overwrite the idle state the user asked for.
+                guard scanGeneration == generation else { return }
                 log.error("Database update failed: \(error.localizedDescription, privacy: .public)")
                 phase = .failed(message: error.localizedDescription)
                 return
@@ -214,6 +225,10 @@ final class MalwareViewModel {
                 }
             }
         } catch {
+            // Drop the failure if this scan was cancelled or superseded so a
+            // late error (e.g. clamscan SIGTERMed by cancel()) can't overwrite
+            // the idle state the user asked for.
+            guard scanGeneration == generation else { return }
             log.error("Scan failed: \(error.localizedDescription, privacy: .public)")
             phase = .failed(message: error.localizedDescription)
             return

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -23,6 +23,10 @@ struct MalwareProgressState: View {
     let label: String
     let detail: String?
     let identifier: String
+    /// Optional live count line (e.g. "Scanned 3,201 files…") shown above the
+    /// streamed path so the user sees the scan advancing even as individual
+    /// path lines flicker past.
+    var countDetail: String? = nil
     var onCancel: (() -> Void)?
 
     var body: some View {
@@ -32,6 +36,13 @@ struct MalwareProgressState: View {
             Text(label)
                 .font(.callout)
                 .foregroundStyle(.secondary)
+            if let countDetail {
+                Text(countDetail)
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+                    .accessibilityIdentifier("\(identifier).count")
+            }
             if let detail, !detail.isEmpty {
                 Text(detail)
                     .font(.caption.monospaced())

--- a/VaderCleaner/PrivacyView.swift
+++ b/VaderCleaner/PrivacyView.swift
@@ -43,7 +43,11 @@ struct PrivacyView: View {
             // only to keep the switch exhaustive over `Phase`.
             EmptyView()
         case .scanning:
-            PrivacyProgressState(label: "Scanning…", identifier: "privacy.scanning")
+            PrivacyProgressState(
+                label: "Scanning…",
+                identifier: "privacy.scanning",
+                detail: ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount)
+            )
         case .preview:
             PrivacyPreviewContent(
                 browsers: viewModel.detectedBrowsers,

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -56,6 +56,12 @@ final class PrivacyViewModel {
     typealias RecentFilesClearer   = @MainActor @Sendable () async throws -> Void
 
     private(set) var phase: Phase = .idle
+
+    /// Running count of `(browser, category)` locations sized so far during the
+    /// in-flight scan. Reset to 0 when a scan starts and surfaced as
+    /// "Scanned N items…" so the user sees the scan advancing.
+    private(set) var scannedItemCount: Int = 0
+
     private(set) var detectedBrowsers: [Browser] = []
     private(set) var checkedSelections: Set<Selection> = []
     private(set) var isClearRecentsChecked: Bool = true
@@ -210,6 +216,7 @@ final class PrivacyViewModel {
     func preview() async {
         let generation = beginOperation()
         phase = .scanning
+        scannedItemCount = 0
         let detector = detector
         let sizer = sizer
         let pathsFor = pathsFor
@@ -221,6 +228,7 @@ final class PrivacyViewModel {
                 var sizes: [Selection: Int64] = [:]
                 var pathsBySelection: [Selection: [URL]] = [:]
                 var checked: Set<Selection> = []
+                var processed = 0
                 for browser in browsers {
                     for category in PrivacyCategory.allCases {
                         try Task.checkCancellation()
@@ -228,6 +236,15 @@ final class PrivacyViewModel {
                         sizes[selection] = try await sizer(browser, category)
                         pathsBySelection[selection] = pathsFor(browser, category)
                         checked.insert(selection)
+                        // Surface the running tally so the scanning screen shows
+                        // the scan advancing. Hop to the main actor and drop the
+                        // update if a newer operation has superseded this one.
+                        processed += 1
+                        let current = processed
+                        await MainActor.run { [weak self] in
+                            guard let self, self.operationGeneration == generation else { return }
+                            self.scannedItemCount = current
+                        }
                     }
                 }
                 try Task.checkCancellation()

--- a/VaderCleaner/PrivacyViewSubviews.swift
+++ b/VaderCleaner/PrivacyViewSubviews.swift
@@ -15,6 +15,9 @@ enum PrivacyViewFormatting {
 struct PrivacyProgressState: View {
     let label: String
     let identifier: String
+    /// Optional live progress line (e.g. "Scanned 24 items…") shown beneath the
+    /// label so the user can see the scan advancing.
+    var detail: String? = nil
 
     var body: some View {
         VStack(spacing: 16) {
@@ -23,6 +26,13 @@ struct PrivacyProgressState: View {
             Text(label)
                 .font(.callout)
                 .foregroundStyle(.secondary)
+            if let detail {
+                Text(detail)
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+                    .accessibilityIdentifier("\(identifier).count")
+            }
         }
         .padding()
         .accessibilityIdentifier(identifier)

--- a/VaderCleaner/ScanProgressFormatting.swift
+++ b/VaderCleaner/ScanProgressFormatting.swift
@@ -1,0 +1,42 @@
+// ScanProgressFormatting.swift
+// Shared, localized copy + number formatting for the live "it's still scanning" feedback shown under each scan's progress indicator.
+
+import Foundation
+
+/// One place for the strings and number formatting the scanning screens use to
+/// reassure the user a scan is advancing. Centralised so every section reads
+/// identically and locale grouping (`Int.formatted()`) is applied consistently.
+enum ScanProgressFormatting {
+
+    /// "Scanned 12,431 items…" — the live walked-count line shown under the
+    /// spinner on the open-ended file-walk scans (Large & Old Files, System
+    /// Junk, Smart Scan, Privacy). Grouping separators come from the user's
+    /// locale via `Int.formatted()`.
+    static func itemsScanned(_ count: Int) -> String {
+        let formatted = count.formatted()
+        let template = String(
+            localized: "Scanned %@ items…",
+            comment: "Live progress line shown while an open-ended scan walks the file system; %@ is a localized item count."
+        )
+        return String.localizedStringWithFormat(template, formatted)
+    }
+
+    /// "Scanned 12,431 files…" — the Malware variant, where each counted unit is
+    /// a file ClamAV reported on rather than a generic filesystem item.
+    static func filesScanned(_ count: Int) -> String {
+        let formatted = count.formatted()
+        let template = String(
+            localized: "Scanned %@ files…",
+            comment: "Live progress line shown while the malware scanner checks files; %@ is a localized file count."
+        )
+        return String.localizedStringWithFormat(template, formatted)
+    }
+
+    /// "47%" — the determinate variant for Space Lens, whose scan reports a real
+    /// completion fraction. `ratio` is clamped to `[0, 1]` so a transient
+    /// out-of-range value can't render "−3%" or "120%".
+    static func percent(_ ratio: Double) -> String {
+        let clamped = max(0.0, min(1.0, ratio))
+        return clamped.formatted(.percent.precision(.fractionLength(0)))
+    }
+}

--- a/VaderCleaner/ScanProgressFormatting.swift
+++ b/VaderCleaner/ScanProgressFormatting.swift
@@ -14,10 +14,18 @@ enum ScanProgressFormatting {
     /// locale via `Int.formatted()`.
     static func itemsScanned(_ count: Int) -> String {
         let formatted = count.formatted()
-        let template = String(
-            localized: "Scanned %@ items…",
-            comment: "Live progress line shown while an open-ended scan walks the file system; %@ is a localized item count."
-        )
+        // Pick a singular template at count == 1 — Privacy and the early
+        // ticks of any scan can land there — so the readout never says
+        // "Scanned 1 items…".
+        let template = count == 1
+            ? String(
+                localized: "Scanned %@ item…",
+                comment: "Live progress line, singular, shown while an open-ended scan walks the file system; %@ is a localized item count of one."
+            )
+            : String(
+                localized: "Scanned %@ items…",
+                comment: "Live progress line shown while an open-ended scan walks the file system; %@ is a localized item count."
+            )
         return String.localizedStringWithFormat(template, formatted)
     }
 
@@ -25,10 +33,17 @@ enum ScanProgressFormatting {
     /// a file ClamAV reported on rather than a generic filesystem item.
     static func filesScanned(_ count: Int) -> String {
         let formatted = count.formatted()
-        let template = String(
-            localized: "Scanned %@ files…",
-            comment: "Live progress line shown while the malware scanner checks files; %@ is a localized file count."
-        )
+        // Malware counts one file per ClamAV line, so the very first tick is
+        // count == 1 — use the singular template there.
+        let template = count == 1
+            ? String(
+                localized: "Scanned %@ file…",
+                comment: "Live progress line, singular, shown while the malware scanner checks files; %@ is a localized file count of one."
+            )
+            : String(
+                localized: "Scanned %@ files…",
+                comment: "Live progress line shown while the malware scanner checks files; %@ is a localized file count."
+            )
         return String.localizedStringWithFormat(template, formatted)
     }
 

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -80,7 +80,8 @@ struct SmartScanView: View {
         case .scanning(let phase):
             SmartScanProgressState(
                 label: phase,
-                identifier: "smartScan.scanning"
+                identifier: "smartScan.scanning",
+                detail: ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount)
             )
         case .results(let result):
             resultsContent(result: result)
@@ -154,7 +155,7 @@ struct SmartScanView: View {
 
 #Preview("Results") {
     let vm = SmartScanViewModel(
-        junkScanner: {
+        junkScanner: { _ in
             ScanResult(items: [
                 ScannedFile(
                     url: URL(fileURLWithPath: "/Users/me/Library/Caches/big"),
@@ -177,7 +178,7 @@ struct SmartScanView: View {
         loginItemsLoader: {
             [LoginItem(id: "com.example.helper", name: "Example Helper", isEnabled: true)]
         },
-        largeOldFilesScanner: { [] },
+        largeOldFilesScanner: { _ in [] },
         updatesChecker: { [] },
         junkCleaner: { _ in 1_500_000_000 },
         threatRemover: { _ in [] },

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -301,16 +301,24 @@ final class SmartScanViewModel {
         // move its counter backwards rather than let the combined total jitter.
         let onJunkProgress: @Sendable (Int) -> Void = { [weak self] count in
             Task { @MainActor in
-                guard let self, self.scanGeneration == generation else { return }
-                guard count > self.junkWalkCount else { return }
+                // Drop the tick if a newer scan started, if it would move the
+                // count backwards, or if the scan has already left `.scanning`
+                // (a tick enqueued just before the terminal phase must not
+                // re-trigger observation once the dashboard is showing).
+                guard let self,
+                      self.scanGeneration == generation,
+                      case .scanning = self.phase,
+                      count > self.junkWalkCount else { return }
                 self.junkWalkCount = count
                 self.scannedItemCount = self.junkWalkCount + self.clutterWalkCount
             }
         }
         let onClutterProgress: @Sendable (Int) -> Void = { [weak self] count in
             Task { @MainActor in
-                guard let self, self.scanGeneration == generation else { return }
-                guard count > self.clutterWalkCount else { return }
+                guard let self,
+                      self.scanGeneration == generation,
+                      case .scanning = self.phase,
+                      count > self.clutterWalkCount else { return }
                 self.clutterWalkCount = count
                 self.scannedItemCount = self.junkWalkCount + self.clutterWalkCount
             }

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -123,8 +123,10 @@ final class SmartScanViewModel {
     }
 
     /// System Junk scan source. Throwing: a failed junk scan fails the whole
-    /// Smart Scan, mirroring `SystemJunkViewModel.Scanner`.
-    typealias JunkScanner = () async throws -> ScanResult
+    /// Smart Scan, mirroring `SystemJunkViewModel.Scanner`. The
+    /// `@Sendable (Int) -> Void` parameter receives the running walked-item
+    /// count so Smart Scan can show its sub-scans advancing.
+    typealias JunkScanner = (@escaping @Sendable (Int) -> Void) async throws -> ScanResult
     /// Whether ClamAV is installed. When `false` the malware scan is skipped
     /// entirely and the Malware card hides its action.
     typealias MalwareInstalled = () -> Bool
@@ -139,8 +141,10 @@ final class SmartScanViewModel {
     /// fail the whole Smart Scan, so the live wiring catches and yields `[]`
     /// (same shape as the malware sub-scan). Named `ClutterScanner` rather
     /// than `LargeOldFilesScanner` to keep the typealias from colliding
-    /// with the underlying `LargeOldFilesScanner` *class* in `.live`.
-    typealias ClutterScanner = () async -> [ScannedFile]
+    /// with the underlying `LargeOldFilesScanner` *class* in `.live`. The
+    /// `@Sendable (Int) -> Void` parameter receives the running walked-item
+    /// count so Smart Scan can show its sub-scans advancing.
+    typealias ClutterScanner = (@escaping @Sendable (Int) -> Void) async -> [ScannedFile]
     /// App-update check source, fronting the Applications tile. Non-throwing
     /// and best-effort for the same reason as `ClutterScanner` — a
     /// network blip can't sink an otherwise-useful Smart Scan.
@@ -166,6 +170,12 @@ final class SmartScanViewModel {
     typealias LargeFileDeleter = ([URL]) async -> Set<URL>
 
     private(set) var phase: Phase = .idle
+
+    /// Combined count of filesystem items walked by the two file-walk sub-scans
+    /// (System Junk + My Clutter) during the in-flight Smart Scan. Reset to 0
+    /// at scan start and surfaced as "Scanned N items…" beneath the stage label
+    /// so the user sees the composite scan advancing.
+    private(set) var scannedItemCount: Int = 0
 
     /// Which tiles on the dashboard are checked. Empty at `.idle`; seeded on
     /// the `.scanning → .results` transition to "every module that has
@@ -200,6 +210,16 @@ final class SmartScanViewModel {
     /// the view re-sorting on every body re-evaluation. Recomputed once
     /// when results land; cleared on `reset()`.
     private(set) var sortedLargeOldFiles: [ScannedFile] = []
+
+    /// Per-source walked counts for the two concurrent file-walk sub-scans.
+    /// `scannedItemCount` is their sum; tracking them separately lets each
+    /// scanner's monotonic count update the combined total independently.
+    @ObservationIgnored private var junkWalkCount = 0
+    @ObservationIgnored private var clutterWalkCount = 0
+
+    /// Incremented at the start of every scan so a progress tick that hops back
+    /// to the main actor after a newer scan began is dropped.
+    @ObservationIgnored private var scanGeneration = 0
 
     @ObservationIgnored private let junkScanner: JunkScanner
     @ObservationIgnored private let malwareInstalled: MalwareInstalled
@@ -266,12 +286,37 @@ final class SmartScanViewModel {
             comment: "Progress label shown while the Smart Scan runs all five sub-scans — uses the user-facing tile names from the results dashboard."
         ))
 
+        scanGeneration &+= 1
+        let generation = scanGeneration
+        scannedItemCount = 0
+        junkWalkCount = 0
+        clutterWalkCount = 0
+
+        // The two file-walk sub-scans run concurrently and each report their own
+        // monotonic walked count; sum them into one "Scanned N items…" tally.
+        // The scanners run off the main actor, so hop back before touching the
+        // observable count, and drop ticks from a superseded scan.
+        let onJunkProgress: @Sendable (Int) -> Void = { [weak self] count in
+            Task { @MainActor in
+                guard let self, self.scanGeneration == generation else { return }
+                self.junkWalkCount = count
+                self.scannedItemCount = self.junkWalkCount + self.clutterWalkCount
+            }
+        }
+        let onClutterProgress: @Sendable (Int) -> Void = { [weak self] count in
+            Task { @MainActor in
+                guard let self, self.scanGeneration == generation else { return }
+                self.clutterWalkCount = count
+                self.scannedItemCount = self.junkWalkCount + self.clutterWalkCount
+            }
+        }
+
         let clamAVAvailable = malwareInstalled()
 
-        async let junk = junkScanner()
+        async let junk = junkScanner(onJunkProgress)
         async let threats = scanForThreatsIfPossible(clamAVAvailable: clamAVAvailable)
         async let login = loginItemsLoader()
-        async let large = largeOldFilesScanner()
+        async let large = largeOldFilesScanner(onClutterProgress)
         async let updates = updatesChecker()
 
         do {
@@ -573,6 +618,7 @@ final class SmartScanViewModel {
         updateSelection = []
         largeFileSelection = []
         sortedLargeOldFiles = []
+        scannedItemCount = 0
     }
 }
 
@@ -601,9 +647,9 @@ extension SmartScanViewModel {
                          category: "SmartScanViewModel.live")
 
         return SmartScanViewModel(
-            junkScanner: { [weak exclusions] in
+            junkScanner: { [weak exclusions] onProgress in
                 let excluded = (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
-                return try await SystemJunkScanner().scan(excluding: excluded)
+                return try await SystemJunkScanner().scan(excluding: excluded, onProgress: onProgress)
             },
             malwareInstalled: { detector.isInstalled() },
             // Best-effort: a missing signature database or a broken clamscan
@@ -631,10 +677,10 @@ extension SmartScanViewModel {
             // the whole Smart Scan, so failures are logged and degraded to
             // an empty list (same partial-degradation contract as the
             // malware scanner above).
-            largeOldFilesScanner: { [weak exclusions] in
+            largeOldFilesScanner: { [weak exclusions] onProgress in
                 let excluded = (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
                 do {
-                    return try await LargeOldFilesScanner().scan(excluding: excluded)
+                    return try await LargeOldFilesScanner().scan(excluding: excluded, onProgress: onProgress)
                 } catch {
                     log.error("Smart Scan large/old files sub-scan failed, treating as no files: \(String(describing: error), privacy: .public)")
                     return []

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -296,9 +296,13 @@ final class SmartScanViewModel {
         // monotonic walked count; sum them into one "Scanned N items…" tally.
         // The scanners run off the main actor, so hop back before touching the
         // observable count, and drop ticks from a superseded scan.
+        // These hops are unstructured, so they can land out of order; each
+        // sub-scan's walked count is monotonic, so ignore any tick that would
+        // move its counter backwards rather than let the combined total jitter.
         let onJunkProgress: @Sendable (Int) -> Void = { [weak self] count in
             Task { @MainActor in
                 guard let self, self.scanGeneration == generation else { return }
+                guard count > self.junkWalkCount else { return }
                 self.junkWalkCount = count
                 self.scannedItemCount = self.junkWalkCount + self.clutterWalkCount
             }
@@ -306,6 +310,7 @@ final class SmartScanViewModel {
         let onClutterProgress: @Sendable (Int) -> Void = { [weak self] count in
             Task { @MainActor in
                 guard let self, self.scanGeneration == generation else { return }
+                guard count > self.clutterWalkCount else { return }
                 self.clutterWalkCount = count
                 self.scannedItemCount = self.junkWalkCount + self.clutterWalkCount
             }

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -8,6 +8,9 @@ import SwiftUI
 struct SmartScanProgressState: View {
     let label: String
     let identifier: String
+    /// Optional live progress line (e.g. "Scanned 12,431 items…") shown beneath
+    /// the stage label so the user sees the composite scan advancing.
+    var detail: String? = nil
 
     var body: some View {
         VStack(spacing: 16) {
@@ -18,6 +21,13 @@ struct SmartScanProgressState: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 460)
+            if let detail {
+                Text(detail)
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+                    .accessibilityIdentifier("\(identifier).count")
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier(identifier)

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -99,6 +99,13 @@ struct SpaceLensView: View {
             ProgressView(value: viewModel.scanProgress)
                 .progressViewStyle(.linear)
                 .frame(maxWidth: 360)
+            // Space Lens reports a real completion fraction, so show the live
+            // percentage — proof to the user the scan is moving toward done.
+            Text(ScanProgressFormatting.percent(viewModel.scanProgress))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .contentTransition(.numericText())
+                .accessibilityIdentifier("space-lens.scanning.percent")
             Text("Scanning…")
                 .font(.callout)
                 .foregroundStyle(.secondary)

--- a/VaderCleaner/SystemJunkScanner.swift
+++ b/VaderCleaner/SystemJunkScanner.swift
@@ -37,9 +37,12 @@ struct SystemJunkScanner {
     /// (covered in `FileScannerTests`) apply unchanged here, so a user who
     /// excluded `~/Library/Caches/com.apple.Safari` will see Safari's caches
     /// disappear from every category their parent path falls under.
-    func scan(excluding: [URL]) async throws -> ScanResult {
+    func scan(
+        excluding: [URL],
+        onProgress: (@Sendable (Int) -> Void)? = nil
+    ) async throws -> ScanResult {
         let roots = pathProvider.roots()
-        let files = try await fileScanner.scan(roots: roots, excluding: excluding)
+        let files = try await fileScanner.scan(roots: roots, excluding: excluding, onProgress: onProgress)
         return ScanResult(items: files)
     }
 }

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -33,7 +33,11 @@ struct SystemJunkView: View {
                 // arm stays only to keep the switch exhaustive over `Phase`.
                 EmptyView()
             case .scanning:
-                progressState(label: "Scanning…", identifier: "system-junk.scanning")
+                progressState(
+                    label: "Scanning…",
+                    identifier: "system-junk.scanning",
+                    detail: ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount)
+                )
             case .preview(let result):
                 previewState(result: result)
             case .cleaning:
@@ -50,13 +54,20 @@ struct SystemJunkView: View {
 
     // MARK: - States
 
-    private func progressState(label: String, identifier: String) -> some View {
+    private func progressState(label: String, identifier: String, detail: String? = nil) -> some View {
         VStack(spacing: 16) {
             ProgressView()
                 .controlSize(.large)
             Text(label)
                 .font(.callout)
                 .foregroundStyle(.secondary)
+            if let detail {
+                Text(detail)
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+                    .accessibilityIdentifier("\(identifier).count")
+            }
         }
         .padding()
         .accessibilityIdentifier(identifier)
@@ -274,7 +285,7 @@ struct SystemJunkEmptyPreviewState: View {
 
 #Preview("Idle") {
     SystemJunkView(viewModel: SystemJunkViewModel(
-        scanner: { ScanResult(items: []) },
+        scanner: { _ in ScanResult(items: []) },
         deleter: { _ in 0 }
     ))
     .frame(width: 700, height: 480)

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -128,6 +128,10 @@ final class SystemJunkViewModel {
                 // the observable count, and drop ticks from a superseded scan.
                 Task { @MainActor in
                     guard let self, self.scanGeneration == generation else { return }
+                    // These hops are unstructured, so they can land out of
+                    // order; the walked count is monotonic, so ignore any tick
+                    // that would move it backwards rather than let it jitter.
+                    guard count > self.scannedItemCount else { return }
                     self.scannedItemCount = count
                 }
             }

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -46,12 +46,13 @@ final class SystemJunkViewModel {
     }
 
     /// Closure type for the scan source. Async + throwing so production can
-    /// wrap `SystemJunkScanner.scan(excluding:)` and tests can supply an
-    /// in-memory `ScanResult` (or throw to exercise the failure path).
-    /// Kept non-Sendable: every invocation flows through `@MainActor scan()`,
-    /// so the closure body inherits main-actor isolation and there is nothing
-    /// to gain by widening the contract.
-    typealias Scanner = () async throws -> ScanResult
+    /// wrap `SystemJunkScanner.scan(excluding:onProgress:)` and tests can
+    /// supply an in-memory `ScanResult` (or throw to exercise the failure
+    /// path). The outer closure stays non-Sendable — every invocation flows
+    /// through `@MainActor scan()` — while the `@Sendable (Int) -> Void`
+    /// parameter receives the running walked-item count from the scanner's
+    /// background walk so the scanning screen can show it advancing.
+    typealias Scanner = (@escaping @Sendable (Int) -> Void) async throws -> ScanResult
 
     /// Closure type for the deletion sink. Returns the number of bytes that
     /// were actually freed (not the byte sum of the input) so partial-failure
@@ -62,8 +63,19 @@ final class SystemJunkViewModel {
     private(set) var phase: Phase = .idle
     private(set) var checkedCategories: Set<ScanCategory> = []
 
+    /// Running count of filesystem items the in-flight scan has walked. Reset
+    /// to 0 at the start of each scan and fed by the scanner's progress
+    /// callback so the scanning screen can show "Scanned N items…" — proof the
+    /// open-ended walk is advancing rather than hung.
+    private(set) var scannedItemCount: Int = 0
+
     @ObservationIgnored private let scanner: Scanner
     @ObservationIgnored private let deleter: Deleter
+
+    /// Incremented at the start of every scan so a progress tick that hops back
+    /// to the main actor after a newer scan began is dropped rather than
+    /// corrupting the fresh count.
+    @ObservationIgnored private var scanGeneration = 0
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "SystemJunkViewModel")
 
@@ -106,9 +118,19 @@ final class SystemJunkViewModel {
     /// Marks every category present in the result as checked so the user is
     /// at "select all" by default.
     func scan() async {
+        scanGeneration &+= 1
+        let generation = scanGeneration
         phase = .scanning
+        scannedItemCount = 0
         do {
-            let result = try await scanner()
+            let result = try await scanner { [weak self] count in
+                // The scanner runs off the main actor; hop back before touching
+                // the observable count, and drop ticks from a superseded scan.
+                Task { @MainActor in
+                    guard let self, self.scanGeneration == generation else { return }
+                    self.scannedItemCount = count
+                }
+            }
             self.latestResult = result
             self.checkedCategories = Set(result.itemsByCategory.keys)
             self.phase = .preview(result)
@@ -153,6 +175,7 @@ final class SystemJunkViewModel {
     func scanAgain() {
         latestResult = nil
         checkedCategories = []
+        scannedItemCount = 0
         phase = .idle
     }
 
@@ -182,15 +205,17 @@ extension SystemJunkViewModel {
     @MainActor
     static func live(exclusions: ExclusionsStore) -> SystemJunkViewModel {
         SystemJunkViewModel(
-            scanner: { [weak exclusions] in
+            scanner: { [weak exclusions] onProgress in
                 // Both `scan()` (the caller) and this closure inherit the
                 // enclosing `@MainActor` isolation, so the `exclusions`
                 // snapshot can be read directly without an explicit
                 // `MainActor.run` hop. The actual file walk happens inside
-                // `SystemJunkScanner.scan(excluding:)`, which is async and
-                // yields the main actor at its first internal `await`.
+                // `SystemJunkScanner.scan(excluding:onProgress:)`, which is
+                // async and yields the main actor at its first internal
+                // `await`; `onProgress` is forwarded so the walked-item count
+                // reaches the scanning screen.
                 let excluded = (exclusions?.exclusions ?? []).map { URL(fileURLWithPath: $0) }
-                return try await SystemJunkScanner().scan(excluding: excluded)
+                return try await SystemJunkScanner().scan(excluding: excluded, onProgress: onProgress)
             },
             deleter: { files in
                 try await SystemJunkDeleter().delete(files)

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -127,11 +127,15 @@ final class SystemJunkViewModel {
                 // The scanner runs off the main actor; hop back before touching
                 // the observable count, and drop ticks from a superseded scan.
                 Task { @MainActor in
-                    guard let self, self.scanGeneration == generation else { return }
-                    // These hops are unstructured, so they can land out of
-                    // order; the walked count is monotonic, so ignore any tick
-                    // that would move it backwards rather than let it jitter.
-                    guard count > self.scannedItemCount else { return }
+                    // Drop the tick if a newer scan started, if the scan has
+                    // already left `.scanning` (a late tick must not re-trigger
+                    // observation once the preview is showing), or if it would
+                    // move the monotonic walked count backwards (the hops are
+                    // unstructured, so they can land out of order).
+                    guard let self,
+                          self.scanGeneration == generation,
+                          case .scanning = self.phase,
+                          count > self.scannedItemCount else { return }
                     self.scannedItemCount = count
                 }
             }

--- a/VaderCleaner/TreemapView.swift
+++ b/VaderCleaner/TreemapView.swift
@@ -46,7 +46,10 @@ struct TreemapView: View {
         // layout, which genuinely depends on the bounds, runs per pass.
         let models = tileModels
         let weightedItems = models.map { (id: $0.id, weight: $0.weight) }
-        let modelsByID = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0) })
+        // Defend against duplicate ids (a corrupt scan record, or an
+        // unexpected id collision) rather than trapping: keep the first model
+        // for a given id. `uniqueKeysWithValues:` would crash on a duplicate.
+        let modelsByID = Dictionary(models.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         GeometryReader { geometry in
             let bounds = CGRect(origin: .zero, size: geometry.size)

--- a/VaderCleaner/TreemapView.swift
+++ b/VaderCleaner/TreemapView.swift
@@ -37,11 +37,22 @@ struct TreemapView: View {
     private static let tileStroke: CGFloat = 1
 
     var body: some View {
+        // Everything that depends only on `node` is derived once here, off
+        // the resize path. `GeometryReader`'s closure below re-runs on every
+        // layout pass (continuously while the window is dragged), but `body`
+        // does not — so the child filter, the weighted-item list, the id
+        // lookup, and the per-tile `formattedSize` strings survive a resize
+        // unchanged instead of being rebuilt each frame. Only the squarified
+        // layout, which genuinely depends on the bounds, runs per pass.
+        let models = tileModels
+        let weightedItems = models.map { (id: $0.id, weight: $0.weight) }
+        let modelsByID = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0) })
+
         GeometryReader { geometry in
             let bounds = CGRect(origin: .zero, size: geometry.size)
-            let tiles = computeTiles(in: bounds)
+            let tiles = placeTiles(weightedItems: weightedItems, modelsByID: modelsByID, in: bounds)
             ZStack(alignment: .topLeading) {
-                ForEach(tiles, id: \.node.id) { entry in
+                ForEach(tiles) { entry in
                     tileView(for: entry)
                 }
             }
@@ -53,52 +64,83 @@ struct TreemapView: View {
 
     // MARK: - Tile rendering
 
-    /// Layout output paired back to the source node. Held as a struct so the
-    /// `ForEach` body can reach both the tile rect and the `DiskNode` it
-    /// came from in one keyed pass.
-    private struct TileEntry {
+    /// Size-independent per-tile data, derived once from `node`. Carries the
+    /// pre-formatted size string so a `ByteCountFormatter` call isn't paid per
+    /// layout pass, and the resolved `category` so the file-kind classification
+    /// isn't recomputed on every resize frame.
+    private struct TileModel: Identifiable {
+        let id: DiskNode.ID
         let node: DiskNode
-        let rect: CGRect
         let category: FileCategory
+        let formattedSize: String
+        let weight: Double
+
+        init(node: DiskNode, category: FileCategory) {
+            self.id = node.id
+            self.node = node
+            self.category = category
+            self.formattedSize = node.formattedSize
+            self.weight = Double(node.size)
+        }
     }
 
-    private func computeTiles(in bounds: CGRect) -> [TileEntry] {
-        // Filter out zero-byte children up front. A directory with a
-        // mixture of zero-byte and large files would otherwise spend
-        // half its strip budget on slivers that the
-        // `minRenderDimension` filter would discard anyway, leaving
-        // empty space inside the parent tile. Skipping them at the
-        // weight stage means the surviving tiles share the full area.
-        let children = node.children.filter { $0.size > 0 }
-        guard !children.isEmpty else { return [] }
+    /// A `TileModel` paired with the rectangle the layout assigned it for the
+    /// current bounds. Only `rect` changes across layout passes.
+    private struct PlacedTile: Identifiable {
+        let model: TileModel
+        let rect: CGRect
 
-        let weighted = children.map { (id: $0.id, weight: Double($0.size)) }
-        let layout = TreemapLayout.layout(items: weighted, in: bounds)
-        let nodeByID = Dictionary(uniqueKeysWithValues: children.map { ($0.id, $0) })
+        var id: DiskNode.ID { model.id }
+    }
 
-        return layout.compactMap { tile -> TileEntry? in
-            guard let child = nodeByID[tile.id] else { return nil }
+    /// The size-independent tile models for `node`'s displayable children.
+    ///
+    /// Filters out zero-byte children up front. A directory with a mixture of
+    /// zero-byte and large files would otherwise spend half its strip budget
+    /// on slivers that the `minRenderDimension` filter would discard anyway,
+    /// leaving empty space inside the parent tile. Skipping them at the weight
+    /// stage means the surviving tiles share the full area.
+    private var tileModels: [TileModel] {
+        node.children
+            .filter { $0.size > 0 }
+            .map { child in
+                TileModel(node: child, category: FileCategory.from(node: child))
+            }
+    }
+
+    /// Runs the squarified layout for the current bounds and pairs each result
+    /// rect back to its precomputed model. This is the only treemap work that
+    /// genuinely depends on the geometry, so it's the only part left inside the
+    /// `GeometryReader` closure.
+    private func placeTiles(
+        weightedItems: [(id: DiskNode.ID, weight: Double)],
+        modelsByID: [DiskNode.ID: TileModel],
+        in bounds: CGRect
+    ) -> [PlacedTile] {
+        guard !weightedItems.isEmpty else { return [] }
+
+        let layout = TreemapLayout.layout(items: weightedItems, in: bounds)
+
+        return layout.compactMap { tile -> PlacedTile? in
+            guard let model = modelsByID[tile.id] else { return nil }
             // Skip tiles that would render as a sliver. Below the
             // threshold the rectangle is just visual noise; the user can
             // drill into the parent if they need to see it.
             if tile.rect.width < Self.minRenderDimension || tile.rect.height < Self.minRenderDimension {
                 return nil
             }
-            return TileEntry(
-                node: child,
-                rect: tile.rect,
-                category: FileCategory.from(node: child)
-            )
+            return PlacedTile(model: model, rect: tile.rect)
         }
     }
 
     @ViewBuilder
-    private func tileView(for entry: TileEntry) -> some View {
+    private func tileView(for entry: PlacedTile) -> some View {
+        let model = entry.model
         let showLabel = entry.rect.width >= Self.minLabelDimension
             && entry.rect.height >= Self.minLabelDimension
 
         Rectangle()
-            .fill(entry.category.color.opacity(entry.node.isDirectory ? 0.55 : 0.7))
+            .fill(model.category.color.opacity(model.node.isDirectory ? 0.55 : 0.7))
             .overlay(
                 Rectangle()
                     .strokeBorder(Color.white.opacity(0.6), lineWidth: Self.tileStroke)
@@ -107,12 +149,12 @@ struct TreemapView: View {
                 Group {
                     if showLabel {
                         VStack(alignment: .leading, spacing: 2) {
-                            Text(entry.node.name)
+                            Text(model.node.name)
                                 .font(.caption.weight(.semibold))
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                                 .foregroundStyle(.white)
-                            Text(entry.node.formattedSize)
+                            Text(model.formattedSize)
                                 .font(.caption2.monospacedDigit())
                                 .foregroundStyle(.white.opacity(0.85))
                         }
@@ -131,11 +173,11 @@ struct TreemapView: View {
                 x: entry.rect.midX,
                 y: entry.rect.midY
             )
-            .help("\(entry.node.url.path)\n\(entry.node.formattedSize)")
+            .help("\(model.node.url.path)\n\(model.formattedSize)")
             .onTapGesture {
-                viewModel.drillDown(into: entry.node)
+                viewModel.drillDown(into: model.node)
             }
-            .accessibilityIdentifier("space-lens.tile.\(entry.node.url.lastPathComponent)")
-            .accessibilityLabel("\(entry.node.name), \(entry.node.formattedSize)")
+            .accessibilityIdentifier("space-lens.tile.\(model.node.url.lastPathComponent)")
+            .accessibilityLabel("\(model.node.name), \(model.formattedSize)")
     }
 }

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -88,6 +88,27 @@ final class FileScannerTests: XCTestCase {
         XCTAssertEqual(batchSizes, [2, 2, 1])
     }
 
+    // MARK: - Progress
+
+    func test_scan_reportsWalkedItemProgress() async throws {
+        try TestHelpers.createDummyFiles(count: 5, size: 8, in: tempRoot)
+
+        let scanner = FileScanner()
+        let recorder = TestHelpers.ProgressRecorder()
+        try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .userCache)],
+            excluding: [],
+            options: .default,
+            batchSize: FileScanner.defaultBatchSize,
+            onProgress: { recorder.record($0) }
+        ) { _ in }
+
+        let reported = recorder.snapshot
+        XCTAssertFalse(reported.isEmpty, "Expected at least the final progress tick")
+        XCTAssertEqual(reported, reported.sorted(), "Walked count must be non-decreasing")
+        XCTAssertEqual(reported.last, 5, "Final tick should report every walked item")
+    }
+
     func test_scan_stopsWhenBatchConsumerCancels() async throws {
         try TestHelpers.createDummyFiles(count: 20, size: 8, in: tempRoot)
 

--- a/VaderCleanerTests/FileScannerTests.swift
+++ b/VaderCleanerTests/FileScannerTests.swift
@@ -342,6 +342,32 @@ final class FileScannerTests: XCTestCase {
         XCTAssertEqual(files.first?.category, .largeFile)
     }
 
+    func test_scan_packagesAsFilesCountsPackageDescendantsInProgress() async throws {
+        let package = tempRoot.appendingPathComponent("Demo.app", isDirectory: true)
+        let contents = package.appendingPathComponent("Contents", isDirectory: true)
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFiles(count: 4, size: 16, in: contents)
+
+        let scanner = FileScanner()
+        let recorder = TestHelpers.ProgressRecorder()
+        try await scanner.scan(
+            roots: [ScanRoot(url: tempRoot, category: .largeFile)],
+            excluding: [],
+            options: FileScanOptions(packagesAsFiles: true),
+            batchSize: FileScanner.defaultBatchSize,
+            onProgress: { recorder.record($0) }
+        ) { _ in }
+
+        // The package's internal files are walked by PackageDirectorySizer; the
+        // final tick must include them, not just the rolled-up bundle root —
+        // otherwise a scan dominated by one big package would look stalled.
+        XCTAssertGreaterThanOrEqual(
+            recorder.snapshot.last ?? 0,
+            4,
+            "Walked count should include the files inside the package, not just the bundle root"
+        )
+    }
+
     func test_scan_packagesAsFilesDescendsWhenExclusionTargetsPackageChild() async throws {
         let package = tempRoot.appendingPathComponent("Demo.app", isDirectory: true)
         let contents = package.appendingPathComponent("Contents", isDirectory: true)

--- a/VaderCleanerTests/Helpers/TestHelpers.swift
+++ b/VaderCleanerTests/Helpers/TestHelpers.swift
@@ -86,4 +86,27 @@ enum TestHelpers {
         }
         return current
     }
+
+    // MARK: - Progress collection
+
+    /// Thread-safe collector for `@Sendable (Int) -> Void` progress callbacks.
+    /// Scanners invoke `onProgress` from whatever task awaits the scan, so the
+    /// backing array is guarded with a lock rather than assuming
+    /// single-threaded access.
+    final class ProgressRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Int] = []
+
+        func record(_ value: Int) {
+            lock.lock()
+            values.append(value)
+            lock.unlock()
+        }
+
+        var snapshot: [Int] {
+            lock.lock()
+            defer { lock.unlock() }
+            return values
+        }
+    }
 }

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -334,6 +334,24 @@ final class LargeOldFilesScannerTests: XCTestCase {
         XCTAssertEqual(files.first?.url.lastPathComponent, "kept-large.bin")
     }
 
+    // MARK: - Progress forwarding
+
+    /// The walked-count ticks emitted by the underlying `FileScanning` must
+    /// reach the caller's `onProgress` unchanged, so the Large & Old Files
+    /// view-model can show that an in-flight scan is advancing.
+    func test_scan_forwardsWalkedProgressFromUnderlyingScanner() async throws {
+        let scanner = LargeOldFilesScanner(
+            fileScanner: ProgressEmittingFakeFileScanner(progressTicks: [512, 1024, 1500]),
+            pathProvider: StubUserFilesPathProvider(roots: [tempRoot]),
+            now: { self.referenceNow }
+        )
+        let recorder = TestHelpers.ProgressRecorder()
+
+        _ = try await scanner.scan(excluding: [], onProgress: { recorder.record($0) })
+
+        XCTAssertEqual(recorder.snapshot, [512, 1024, 1500])
+    }
+
     // MARK: - Protected media stores
 
     /// TCC-protected photo-library bundles (`.photoslibrary`, `Photo Booth
@@ -528,6 +546,33 @@ private struct FakeFileScanner: FileScanning {
     ) async throws {
         for batch in emittedBatches {
             try await onBatch(batch)
+        }
+    }
+}
+
+/// Emits a fixed sequence of walked-count progress ticks and no files, so the
+/// progress-forwarding test can assert the scanner relays them verbatim.
+private struct ProgressEmittingFakeFileScanner: FileScanning {
+    let progressTicks: [Int]
+
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        options: FileScanOptions,
+        batchSize: Int,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {}
+
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        options: FileScanOptions,
+        batchSize: Int,
+        onProgress: (@Sendable (Int) -> Void)?,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
+        for tick in progressTicks {
+            onProgress?(tick)
         }
     }
 }

--- a/VaderCleanerTests/LargeOldFilesViewModelTests.swift
+++ b/VaderCleanerTests/LargeOldFilesViewModelTests.swift
@@ -267,13 +267,64 @@ final class LargeOldFilesViewModelTests: XCTestCase {
         XCTAssertTrue(cache.cachedIcon(for: first) === cache.cachedIcon(for: second))
     }
 
+    // MARK: - Scan progress count
+
+    /// The scanner's progress callback must drive `scannedItemCount` so the
+    /// scanning screen can show the walk advancing.
+    func test_scan_reportsScannedItemCountFromProgress() async {
+        let vm = LargeOldFilesViewModel(
+            scanner: { progress in
+                progress(120)
+                await Task.yield()
+                progress(450)
+                await Task.yield()
+                return []
+            },
+            deleter: { Set($0) }
+        )
+
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 450 }
+
+        XCTAssertEqual(vm.scannedItemCount, 450)
+    }
+
+    /// Each scan must restart the counter from zero rather than carry the
+    /// previous run's total into the new scan's "Scanned N items…" line.
+    func test_scan_restartsScannedItemCountEachScan() async {
+        let vm = LargeOldFilesViewModel(
+            scanner: { progress in
+                progress(999)
+                await Task.yield()
+                return []
+            },
+            deleter: { Set($0) }
+        )
+
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 999 }
+
+        let observed = await recordTransitions(of: \.scannedItemCount, on: vm) {
+            await vm.scan()
+            await waitUntil { vm.scannedItemCount == 999 }
+        }
+
+        XCTAssertTrue(
+            observed.contains(0),
+            "A new scan must reset the counter to zero before counting up again, got \(observed)"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel(
         scanner: @escaping () async throws -> [ScannedFile] = { [] },
         deleter: @escaping ([URL]) async -> Set<URL> = { Set($0) }
     ) -> LargeOldFilesViewModel {
-        LargeOldFilesViewModel(scanner: scanner, deleter: deleter)
+        // Adapt the progress-free test closures to the production scanner
+        // signature; the count tests below construct the VM directly to drive
+        // the progress callback.
+        LargeOldFilesViewModel(scanner: { _ in try await scanner() }, deleter: deleter)
     }
 
     private func makeFile(

--- a/VaderCleanerTests/MalwareViewModelTests.swift
+++ b/VaderCleanerTests/MalwareViewModelTests.swift
@@ -150,6 +150,37 @@ final class MalwareViewModelTests: XCTestCase {
         XCTAssertEqual(vm.scannedItemCount, 3, "Counter must restart each scan, not accumulate to 6")
     }
 
+    /// Cancelling mid-scan must reset the live count and return to idle, and a
+    /// failure thrown *after* cancel (e.g. clamscan SIGTERMed by the cancel)
+    /// must not flip the phase to `.failed` — `cancel()` advances the
+    /// generation so the late `catch` is dropped.
+    func test_cancel_resetsCountAndDropsLateFailure() async {
+        struct Boom: Error {}
+        let gate = AsyncGate()
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { progress in
+                progress("/a: OK")
+                await gate.wait()
+                throw Boom()
+            }
+        )
+
+        vm.startScan()
+        await waitUntil { if case .scanning = vm.phase { return true } else { return false } }
+
+        vm.cancel()
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.scannedItemCount, 0, "cancel() must reset the live count")
+
+        // Release the scan so it throws *after* cancel; the guarded catch must
+        // drop the failure rather than overwrite the idle state.
+        gate.fire()
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(vm.phase, .idle, "A failure thrown after cancel must not become .failed")
+    }
+
     func test_scan_withThreats_movesToResults() async {
         let vm = makeViewModel(
             checkInstalled: { true },
@@ -458,5 +489,35 @@ final class MalwareViewModelTests: XCTestCase {
             notify: notify,
             shouldNotify: shouldNotify
         )
+    }
+}
+
+/// One-shot async gate: a scan closure `await`s `wait()` until the test calls
+/// `fire()`, letting a test control exactly when an injected scan resolves.
+private final class AsyncGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var fired = false
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if fired {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+            }
+        }
+    }
+
+    func fire() {
+        lock.lock()
+        fired = true
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume()
     }
 }

--- a/VaderCleanerTests/MalwareViewModelTests.swift
+++ b/VaderCleanerTests/MalwareViewModelTests.swift
@@ -108,6 +108,48 @@ final class MalwareViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.lastScanDate)
     }
 
+    /// Each clamscan stdout line must bump `scannedItemCount` so the scanning
+    /// screen can show "Scanned N files…" advancing.
+    func test_scan_reportsScannedItemCountFromProgressLines() async {
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { progress in
+                progress("/a: OK")
+                progress("/b: OK")
+                progress("/c: OK")
+                return []
+            }
+        )
+
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 3 }
+
+        XCTAssertEqual(vm.scannedItemCount, 3)
+    }
+
+    /// Each scan must restart the counter from zero rather than accumulate
+    /// across runs.
+    func test_scan_restartsScannedItemCountEachScan() async {
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { progress in
+                progress("/a: OK")
+                progress("/b: OK")
+                progress("/c: OK")
+                return []
+            }
+        )
+
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 3 }
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 3 }
+
+        XCTAssertEqual(vm.scannedItemCount, 3, "Counter must restart each scan, not accumulate to 6")
+    }
+
     func test_scan_withThreats_movesToResults() async {
         let vm = makeViewModel(
             checkInstalled: { true },

--- a/VaderCleanerTests/PrivacyViewModelTests.swift
+++ b/VaderCleanerTests/PrivacyViewModelTests.swift
@@ -64,6 +64,20 @@ final class PrivacyViewModelTests: XCTestCase {
                       "Recent items toggle must default to checked")
     }
 
+    /// Each `(browser, category)` location sized must bump `scannedItemCount`
+    /// so the scanning screen can show "Scanned N items…" advancing. `preview()`
+    /// awaits its work, so the final tally is deterministic on return.
+    func test_preview_reportsScannedItemCount() async {
+        let vm = makeViewModel(
+            detected: [.safari, .chrome],
+            sizer: { _, _ in 100 }
+        )
+
+        await vm.preview()
+
+        XCTAssertEqual(vm.scannedItemCount, 2 * PrivacyCategory.allCases.count)
+    }
+
     /// Per-category sizes must be exposed for the view to render
     /// "20 MB"-style labels next to each checkbox without recomputing
     /// from scratch on every redraw.

--- a/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
+++ b/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
@@ -671,11 +671,11 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
     // *ViewModelTests use so a test only overrides the closure it exercises.
 
     private func makeSmartScan(
-        junkScanner: @escaping SmartScanViewModel.JunkScanner = { ScanResult(items: []) },
+        junkScanner: @escaping () async throws -> ScanResult = { ScanResult(items: []) },
         malwareInstalled: @escaping SmartScanViewModel.MalwareInstalled = { true },
         malwareScanner: @escaping SmartScanViewModel.MalwareScanner = { [] },
         loginItemsLoader: @escaping SmartScanViewModel.LoginItemsLoader = { [] },
-        largeOldFilesScanner: @escaping SmartScanViewModel.ClutterScanner = { [] },
+        largeOldFilesScanner: @escaping () async -> [ScannedFile] = { [] },
         updatesChecker: @escaping SmartScanViewModel.UpdatesChecker = { [] },
         junkCleaner: @escaping SmartScanViewModel.JunkCleaner = { _ in 0 },
         threatRemover: @escaping SmartScanViewModel.ThreatRemover = { _ in [] },
@@ -684,11 +684,11 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
         largeFileDeleter: @escaping SmartScanViewModel.LargeFileDeleter = { _ in [] }
     ) -> SmartScanViewModel {
         SmartScanViewModel(
-            junkScanner: junkScanner,
+            junkScanner: { _ in try await junkScanner() },
             malwareInstalled: malwareInstalled,
             malwareScanner: malwareScanner,
             loginItemsLoader: loginItemsLoader,
-            largeOldFilesScanner: largeOldFilesScanner,
+            largeOldFilesScanner: { _ in await largeOldFilesScanner() },
             updatesChecker: updatesChecker,
             junkCleaner: junkCleaner,
             threatRemover: threatRemover,
@@ -699,17 +699,17 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
     }
 
     private func makeSystemJunk(
-        scanner: @escaping SystemJunkViewModel.Scanner = { ScanResult(items: []) },
+        scanner: @escaping () async throws -> ScanResult = { ScanResult(items: []) },
         deleter: @escaping SystemJunkViewModel.Deleter = { _ in 0 }
     ) -> SystemJunkViewModel {
-        SystemJunkViewModel(scanner: scanner, deleter: deleter)
+        SystemJunkViewModel(scanner: { _ in try await scanner() }, deleter: deleter)
     }
 
     private func makeLargeOldFiles(
         scanner: @escaping () async throws -> [ScannedFile] = { [] },
         deleter: @escaping ([URL]) async -> Set<URL> = { Set($0) }
     ) -> LargeOldFilesViewModel {
-        LargeOldFilesViewModel(scanner: scanner, deleter: deleter)
+        LargeOldFilesViewModel(scanner: { _ in try await scanner() }, deleter: deleter)
     }
 
     private func makeMalware(

--- a/VaderCleanerTests/SmartScanViewModelTests.swift
+++ b/VaderCleanerTests/SmartScanViewModelTests.swift
@@ -984,14 +984,55 @@ final class SmartScanViewModelTests: XCTestCase {
         XCTAssertTrue(vm.willExecute(.myClutter))
     }
 
+    // MARK: - Scan progress count
+
+    /// The combined "Scanned N items…" tally must sum the walked counts of the
+    /// two concurrent file-walk sub-scans (System Junk + My Clutter).
+    func test_scan_reportsCombinedScannedItemCountAcrossFileWalkSubScans() async {
+        let vm = SmartScanViewModel(
+            junkScanner: { progress in
+                progress(100)
+                await Task.yield()
+                progress(300)
+                await Task.yield()
+                return ScanResult(items: [])
+            },
+            malwareInstalled: { false },
+            malwareScanner: { [] },
+            loginItemsLoader: { [] },
+            largeOldFilesScanner: { progress in
+                progress(50)
+                await Task.yield()
+                progress(200)
+                await Task.yield()
+                return []
+            },
+            updatesChecker: { [] },
+            junkCleaner: { _ in 0 },
+            threatRemover: { _ in [] },
+            maintenanceRunner: { "" },
+            updateOpener: { _ in },
+            largeFileDeleter: { _ in [] }
+        )
+
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 500 }
+
+        XCTAssertEqual(
+            vm.scannedItemCount,
+            500,
+            "Smart Scan count must sum the junk (300) and clutter (200) walk totals"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel(
-        junkScanner: @escaping SmartScanViewModel.JunkScanner = { ScanResult(items: []) },
+        junkScanner: @escaping () async throws -> ScanResult = { ScanResult(items: []) },
         malwareInstalled: @escaping SmartScanViewModel.MalwareInstalled = { true },
         malwareScanner: @escaping SmartScanViewModel.MalwareScanner = { [] },
         loginItemsLoader: @escaping SmartScanViewModel.LoginItemsLoader = { [] },
-        largeOldFilesScanner: @escaping SmartScanViewModel.ClutterScanner = { [] },
+        largeOldFilesScanner: @escaping () async -> [ScannedFile] = { [] },
         updatesChecker: @escaping SmartScanViewModel.UpdatesChecker = { [] },
         junkCleaner: @escaping SmartScanViewModel.JunkCleaner = { _ in 0 },
         threatRemover: @escaping SmartScanViewModel.ThreatRemover = { _ in [] },
@@ -999,12 +1040,15 @@ final class SmartScanViewModelTests: XCTestCase {
         updateOpener: @escaping SmartScanViewModel.UpdateOpener = { _ in },
         largeFileDeleter: @escaping SmartScanViewModel.LargeFileDeleter = { _ in [] }
     ) -> SmartScanViewModel {
+        // Adapt the progress-free test closures to the production sub-scanner
+        // signatures; the count test below constructs the VM directly to drive
+        // the progress callbacks.
         SmartScanViewModel(
-            junkScanner: junkScanner,
+            junkScanner: { _ in try await junkScanner() },
             malwareInstalled: malwareInstalled,
             malwareScanner: malwareScanner,
             loginItemsLoader: loginItemsLoader,
-            largeOldFilesScanner: largeOldFilesScanner,
+            largeOldFilesScanner: { _ in await largeOldFilesScanner() },
             updatesChecker: updatesChecker,
             junkCleaner: junkCleaner,
             threatRemover: threatRemover,

--- a/VaderCleanerTests/SystemJunkScannerTests.swift
+++ b/VaderCleanerTests/SystemJunkScannerTests.swift
@@ -217,6 +217,25 @@ final class SystemJunkScannerTests: XCTestCase {
         )
     }
 
+    // MARK: - Progress forwarding
+
+    /// Walked-count ticks from the underlying `FileScanning` must reach the
+    /// caller's `onProgress` unchanged so the System Junk view-model can show
+    /// an in-flight scan advancing.
+    func test_scan_forwardsWalkedProgressFromUnderlyingScanner() async throws {
+        let scanner = SystemJunkScanner(
+            fileScanner: ProgressEmittingFakeFileScanner(progressTicks: [512, 1024, 2000]),
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: tempRoot, category: .userCache)
+            ])
+        )
+        let recorder = TestHelpers.ProgressRecorder()
+
+        _ = try await scanner.scan(excluding: [], onProgress: { recorder.record($0) })
+
+        XCTAssertEqual(recorder.snapshot, [512, 1024, 2000])
+    }
+
     // MARK: - Helpers
 
     /// Creates a uniquely named subdirectory under `tempRoot` so each scan
@@ -237,4 +256,31 @@ private struct StubSystemPathProvider: SystemPathProviding {
     private let stubbedRoots: [ScanRoot]
     init(roots: [ScanRoot]) { self.stubbedRoots = roots }
     func roots() -> [ScanRoot] { stubbedRoots }
+}
+
+/// Emits a fixed sequence of walked-count progress ticks and no files, so the
+/// progress-forwarding test can assert the scanner relays them verbatim.
+private struct ProgressEmittingFakeFileScanner: FileScanning {
+    let progressTicks: [Int]
+
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        options: FileScanOptions,
+        batchSize: Int,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {}
+
+    func scan(
+        roots: [ScanRoot],
+        excluding: [URL],
+        options: FileScanOptions,
+        batchSize: Int,
+        onProgress: (@Sendable (Int) -> Void)?,
+        onBatch: ([ScannedFile]) async throws -> Void
+    ) async throws {
+        for tick in progressTicks {
+            onProgress?(tick)
+        }
+    }
 }

--- a/VaderCleanerTests/SystemJunkViewModelTests.swift
+++ b/VaderCleanerTests/SystemJunkViewModelTests.swift
@@ -269,13 +269,64 @@ final class SystemJunkViewModelTests: XCTestCase {
         XCTAssertTrue(vm.checkedCategories.isEmpty)
     }
 
+    // MARK: - Scan progress count
+
+    /// The scanner's progress callback must drive `scannedItemCount` so the
+    /// scanning screen can show the walk advancing.
+    func test_scan_reportsScannedItemCountFromProgress() async {
+        let vm = SystemJunkViewModel(
+            scanner: { progress in
+                progress(64)
+                await Task.yield()
+                progress(900)
+                await Task.yield()
+                return ScanResult(items: [])
+            },
+            deleter: { _ in 0 }
+        )
+
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 900 }
+
+        XCTAssertEqual(vm.scannedItemCount, 900)
+    }
+
+    /// Each scan must restart the counter from zero rather than carry the
+    /// previous run's total forward.
+    func test_scan_restartsScannedItemCountEachScan() async {
+        let vm = SystemJunkViewModel(
+            scanner: { progress in
+                progress(900)
+                await Task.yield()
+                return ScanResult(items: [])
+            },
+            deleter: { _ in 0 }
+        )
+
+        await vm.scan()
+        await waitUntil { vm.scannedItemCount == 900 }
+
+        let observed = await recordTransitions(of: \.scannedItemCount, on: vm) {
+            await vm.scan()
+            await waitUntil { vm.scannedItemCount == 900 }
+        }
+
+        XCTAssertTrue(
+            observed.contains(0),
+            "A new scan must reset the counter to zero before counting up again, got \(observed)"
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel(
         scanner: @escaping () async throws -> ScanResult = { ScanResult(items: []) },
         deleter: @escaping ([ScannedFile]) async throws -> Int64 = { _ in 0 }
     ) -> SystemJunkViewModel {
-        SystemJunkViewModel(scanner: scanner, deleter: deleter)
+        // Adapt the progress-free test closures to the production scanner
+        // signature; the count test constructs the VM directly to drive the
+        // progress callback.
+        SystemJunkViewModel(scanner: { _ in try await scanner() }, deleter: deleter)
     }
 
     private func makeResult(_ groups: (ScanCategory, [ScannedFile])...) -> ScanResult {


### PR DESCRIPTION
## Why

While a scan ran, every section except Space Lens showed only an indeterminate spinner with a static label — a long scan looked hung, prompting "is it stuck?". This surfaces a continuously-changing signal during **every** scan so it's obvious work is happening.

The PR also carries two small SwiftUI performance-audit fixes that came out of this session.

## What changed

### Live scan progress (main change)

Honest feedback per scan — a real number where one exists, never a fabricated one:

| Section | Feedback | Source |
|---|---|---|
| Space Lens | `NN%` climbing | existing `scanProgress` fraction |
| Large & Old Files | "Scanned N items…" | `FileScanner` walked-count |
| System Junk | "Scanned N items…" | `FileScanner` walked-count |
| Smart Scan | "Scanned N items…" under the stage label | sum of its junk + clutter sub-scans |
| Privacy | "Scanned N items…" | `(browser × category)` locations sized |
| Malware | "Scanned N files…" under the streamed path | clamscan output lines |

**Honest-signal principle:** counts reflect files *walked*, not files *matched*. Large & Old Files matches sparsely (>50 MB / 6-months-old), so a matched count would sit at 0 while walking GBs and look stuck. An estimated percentage for the open-ended walks was rejected for the same reason — it can stall near 100%.

**Mechanism:** a defaulted `onProgress` overload on the `FileScanning` protocol, bridged in an extension so existing test fakes satisfy it for free. It fires the cumulative walked count on the existing 512-item cancellation cadence — no new per-file cost. Feature scanners forward it; view-models expose a `scannedItemCount`, reset per scan and fed through a generation-guarded main-actor hop. The heavy result views stay phase-gated, so the frequent count updates only re-render the small progress view (no render storm). Shared copy/number formatting lives in the new `ScanProgressFormatting`; counts use `monospacedDigit` + `numericText` so they tick without layout jitter.

### SwiftUI performance fixes (first commit)

- **TreemapView**: hoist the size-independent work (child filter, weighted items, id lookup, `FileCategory` classification, per-tile `ByteCountFormatter` calls) out of the `GeometryReader` closure — only the squarified layout, which depends on bounds, now recomputes per resize frame.
- **FloatingScanButton**: replace the `repeatForever` shadow whose blur *radius* animated (re-rasterizing the gaussian blur every frame) with a fixed-radius blurred glow layer whose opacity pulses, compositing a cached blur on the GPU.

## Reviewer notes

- The two perf fixes are behavior-/identity-/accessibility-preserving and are isolated in the first commit if you want to review them separately.
- `ScanProgressFormatting.swift` is picked up via the XcodeGen `VaderCleaner/` source glob; the project was regenerated with `xcodegen generate` so the pbxproj is canonical.
- Privacy's count ticks in `(browser × category)` jumps, so it can sit briefly static while one large category's sizer walks — accepted tradeoff over a fake percentage.

## Testing

- **Unit:** full suite green — **805 tests, 0 failures**. New coverage for the `FileScanner` walked-count tick, scanner forwarding, and each view-model's count (update + reset).
- **UI:** `SpaceLensUITests`, `SystemJunkUITests`, `SmartScanUITests`, `MalwareUITests` all pass — `SystemJunk`'s scan→preview test exercises a real filesystem walk through the production `.live()` wiring (now carrying `onProgress`).
- One caveat: automated tests confirm the scanning screens render and the real scan path runs end-to-end, but don't assert the digits *visibly* incrementing — worth a quick eyeball on one scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scanning operations now report live progress counts and percentages across System Junk, My Clutter, Malware, Privacy, Large/Old Files, Smart Scan and Space Lens.
* **UI Improvements**
  * Progress lines added to scanning states with locale-aware formatting; Space Lens shows a live percent.
  * Floating scan button glow animation refined for smoother visual effect.
* **Performance / Reliability**
  * Treemap rendering improved to reduce work during layout and skip tiny tiles for smoother responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->