### PR TITLE
Add sunburst view mode to Space Lens with hover details

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		161EB790ECA69115DBAC1B6F /* malwareRemoval.usdz in Resources */ = {isa = PBXBuildFile; fileRef = D1D5689879C5C19243A7AF1E /* malwareRemoval.usdz */; };
 		17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */; };
 		1947460A68C713844C308694 /* TreemapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */; };
+		65FED5757882F56378BE1E5D /* SpaceLensViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49AF7388796118B18C97F45 /* SpaceLensViewMode.swift */; };
+		2B5D08DE02EC0F4548A037AF /* SunburstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FF58BEFFFB4D547C5749B9 /* SunburstView.swift */; };
+		68A1828E35374F73EA5D598D /* SpaceLensHoverCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1E33C927182B28BDBE65DF /* SpaceLensHoverCard.swift */; };
+		83089B096416267341C2EA8C /* SunburstLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D260D83F735F56606617A8 /* SunburstLayout.swift */; };
 		196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
 		1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */; };
@@ -184,6 +188,8 @@
 		BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133467A06193C406B027D97C /* NavigationSectionTests.swift */; };
 		BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC391B523110720320AD89 /* SystemPathProviding.swift */; };
 		BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */; };
+		F55EB106F505A83D0683544C /* SpaceLensViewModeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA4FCCD6881922F9CCBA421 /* SpaceLensViewModeStoreTests.swift */; };
+		F9AC9391D8126F241AF625F1 /* SunburstLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1081ECF8AC14D5DFE7974FD /* SunburstLayoutTests.swift */; };
 		BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */; };
 		BEFCD2F309C985449A2901F5 /* SmartScanMyClutterReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F498579A77E1DAED6AC00AF /* SmartScanMyClutterReview.swift */; };
 		C2542EE3974C2F9232EE74D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5E978BB01AD677AEDE122B1C /* Assets.xcassets */; };
@@ -354,6 +360,10 @@
 		48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscWindowController.swift; sourceTree = "<group>"; };
 		49D62624319B764770F02292 /* AppUninstallerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModel.swift; sourceTree = "<group>"; };
 		4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayout.swift; sourceTree = "<group>"; };
+		D49AF7388796118B18C97F45 /* SpaceLensViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewMode.swift; sourceTree = "<group>"; };
+		E9FF58BEFFFB4D547C5749B9 /* SunburstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstView.swift; sourceTree = "<group>"; };
+		1B1E33C927182B28BDBE65DF /* SpaceLensHoverCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensHoverCard.swift; sourceTree = "<group>"; };
+		C8D260D83F735F56606617A8 /* SunburstLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstLayout.swift; sourceTree = "<group>"; };
 		4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScanner.swift; sourceTree = "<group>"; };
 		4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkUITests.swift; sourceTree = "<group>"; };
 		4D92F45290B56030CBFA83D3 /* Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
@@ -403,6 +413,8 @@
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
 		80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayoutTests.swift; sourceTree = "<group>"; };
+		3EA4FCCD6881922F9CCBA421 /* SpaceLensViewModeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewModeStoreTests.swift; sourceTree = "<group>"; };
+		E1081ECF8AC14D5DFE7974FD /* SunburstLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstLayoutTests.swift; sourceTree = "<group>"; };
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
@@ -682,6 +694,10 @@
 				02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */,
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
 				4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */,
+				D49AF7388796118B18C97F45 /* SpaceLensViewMode.swift */,
+				E9FF58BEFFFB4D547C5749B9 /* SunburstView.swift */,
+				1B1E33C927182B28BDBE65DF /* SpaceLensHoverCard.swift */,
+				C8D260D83F735F56606617A8 /* SunburstLayout.swift */,
 				50BDB24525760C96625DD266 /* TreemapView.swift */,
 				2617BC26104D5196DEDB3589 /* UpdateInfo.swift */,
 				9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */,
@@ -816,6 +832,8 @@
 				6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */,
 				46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */,
 				80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */,
+				3EA4FCCD6881922F9CCBA421 /* SpaceLensViewModeStoreTests.swift */,
+				E1081ECF8AC14D5DFE7974FD /* SunburstLayoutTests.swift */,
 				B46943B264F72B3753075A8C /* UpdateInfoTests.swift */,
 				1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */,
 				E149BD1FE4E65D6589292B84 /* Helpers */,
@@ -1079,6 +1097,8 @@
 				C26E98922A61A57DB9369C60 /* TestHelpers.swift in Sources */,
 				109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */,
 				BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */,
+				F55EB106F505A83D0683544C /* SpaceLensViewModeStoreTests.swift in Sources */,
+				F9AC9391D8126F241AF625F1 /* SunburstLayoutTests.swift in Sources */,
 				218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */,
 				3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */,
 			);
@@ -1230,6 +1250,10 @@
 				9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */,
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
 				1947460A68C713844C308694 /* TreemapLayout.swift in Sources */,
+				65FED5757882F56378BE1E5D /* SpaceLensViewMode.swift in Sources */,
+				2B5D08DE02EC0F4548A037AF /* SunburstView.swift in Sources */,
+				68A1828E35374F73EA5D598D /* SpaceLensHoverCard.swift in Sources */,
+				83089B096416267341C2EA8C /* SunburstLayout.swift in Sources */,
 				35F306676A3412253929EF55 /* TreemapView.swift in Sources */,
 				7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */,
 				6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     private let systemJunkViewModel: SystemJunkViewModel
     private let largeOldFilesViewModel: LargeOldFilesViewModel
     private let spaceLensViewModel: DiskScannerViewModel
+    private let spaceLensViewMode: SpaceLensViewModeStore
     private let privacyViewModel: PrivacyViewModel
     private let appUninstallerViewModel: AppUninstallerViewModel
     private let appUpdaterViewModel: AppUpdaterViewModel
@@ -49,6 +50,7 @@ struct ContentView: View {
         systemJunkViewModel: SystemJunkViewModel,
         largeOldFilesViewModel: LargeOldFilesViewModel,
         spaceLensViewModel: DiskScannerViewModel,
+        spaceLensViewMode: SpaceLensViewModeStore,
         privacyViewModel: PrivacyViewModel,
         appUninstallerViewModel: AppUninstallerViewModel,
         appUpdaterViewModel: AppUpdaterViewModel,
@@ -60,6 +62,7 @@ struct ContentView: View {
         self.systemJunkViewModel = systemJunkViewModel
         self.largeOldFilesViewModel = largeOldFilesViewModel
         self.spaceLensViewModel = spaceLensViewModel
+        self.spaceLensViewMode = spaceLensViewMode
         self.privacyViewModel = privacyViewModel
         self.appUninstallerViewModel = appUninstallerViewModel
         self.appUpdaterViewModel = appUpdaterViewModel
@@ -263,7 +266,7 @@ struct ContentView: View {
             }
         case .spaceLens:
             ScannableSectionContent(coordinator: spaceLensViewModel, section: section) {
-                SpaceLensView(viewModel: spaceLensViewModel)
+                SpaceLensView(viewModel: spaceLensViewModel, viewMode: spaceLensViewMode)
             }
         case .privacy:
             ScannableSectionContent(coordinator: privacyViewModel, section: section) {
@@ -342,6 +345,7 @@ private extension AnyTransition {
         systemJunkViewModel: SystemJunkViewModel.live(exclusions: exclusions),
         largeOldFilesViewModel: LargeOldFilesViewModel.live(exclusions: exclusions),
         spaceLensViewModel: DiskScannerViewModel.live(exclusions: exclusions),
+        spaceLensViewMode: SpaceLensViewModeStore(defaults: UserDefaults(suiteName: "preview")!),
         privacyViewModel: PrivacyViewModel.live(),
         appUninstallerViewModel: AppUninstallerViewModel.live(exclusions: exclusions),
         appUpdaterViewModel: AppUpdaterViewModel.live(),

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -72,17 +72,49 @@ final class DiskScannerViewModel {
 
     // MARK: - Navigation
 
-    /// Drill into a directory child. Pushes onto `navigationPath` so the
-    /// treemap re-renders the child's contents and the breadcrumb grows
-    /// by one entry.
+    /// Drill into a directory the user clicked. Pushes onto `navigationPath`
+    /// so the visualization re-renders the target's contents and the
+    /// breadcrumb grows.
+    ///
+    /// **Records the full ancestor chain.** The treemap's tiles are always
+    /// direct children of the current node, but the sunburst surfaces several
+    /// rings of descendants at once — tapping a deeper ring hands us a node
+    /// that is *not* a direct child. Appending only that node would skip the
+    /// folders in between, so the breadcrumb would read `root > descendant`
+    /// and `navigateUp` would jump back too far. Instead we append every node
+    /// from the current node down to the target. For a direct child this is a
+    /// single-element chain, so the treemap path is unchanged.
     ///
     /// **No-op for non-directories** — files have no children, so a
     /// drill-down would land the view on an empty rectangle. Centralising
     /// the guard here means the view layer doesn't have to check before
-    /// every tile click.
+    /// every click.
     func drillDown(into node: DiskNode) {
         guard node.isDirectory else { return }
-        navigationPath.append(node)
+        guard let current = currentNode,
+              let chain = Self.ancestryChain(from: current, to: node),
+              !chain.isEmpty else {
+            // `node` is the current node itself (empty chain) or not within its
+            // subtree (nil) — nothing new to navigate into.
+            return
+        }
+        navigationPath.append(contentsOf: chain)
+    }
+
+    /// The chain of nodes from `ancestor`'s matching child down to `target`
+    /// (inclusive), or `nil` when `target` isn't in `ancestor`'s subtree.
+    /// Returns an empty array when `target` *is* `ancestor`. Identity-based
+    /// (`===`) because two scans produce distinct nodes for the same path
+    /// (see the `DiskNode` doc comment).
+    private static func ancestryChain(from ancestor: DiskNode, to target: DiskNode) -> [DiskNode]? {
+        if ancestor === target { return [] }
+        for child in ancestor.children {
+            if child === target { return [child] }
+            if let deeper = ancestryChain(from: child, to: target) {
+                return [child] + deeper
+            }
+        }
+        return nil
     }
 
     /// Pop the breadcrumb stack by one entry. No-op when already at root,

--- a/VaderCleaner/SpaceLensHoverCard.swift
+++ b/VaderCleaner/SpaceLensHoverCard.swift
@@ -1,0 +1,91 @@
+// SpaceLensHoverCard.swift
+// Floating details card the Space Lens treemap and sunburst overlay while the pointer hovers a tile/segment — shows the item's name, size, share of the current folder, and path.
+
+import SwiftUI
+import CoreGraphics
+
+/// Small material card surfaced on hover by both Space Lens visualizations.
+/// Reports the hovered item's name, formatted size, its share of the folder
+/// currently shown, and its path, so the user gets at-a-glance detail without
+/// drilling in. Stateless and view-agnostic — the treemap and sunburst each
+/// track which node is hovered and feed the values in.
+struct SpaceLensHoverCard: View {
+
+    let name: String
+    let formattedSize: String
+    /// Share of the currently-displayed folder, in `[0, 1]`.
+    let fraction: Double
+    let path: String
+
+    /// Fixed width the visualizations frame the card to, so the anchor-clamping
+    /// math has a known size to keep the card on-canvas.
+    static let preferredWidth: CGFloat = 260
+    /// Half the card's assumed height, used only to clamp its center within the
+    /// canvas. A slight overestimate is harmless — it just keeps a tall card
+    /// from being clipped at the bottom edge.
+    private static let halfHeight: CGFloat = 48
+
+    /// Clamp the card's center so a card of `preferredWidth` stays fully inside
+    /// `bounds`. Anchored to the hovered item, an arc near the edge would
+    /// otherwise push the card off-canvas.
+    static func clampedCenter(anchor: CGPoint, in bounds: CGSize) -> CGPoint {
+        let halfWidth = preferredWidth / 2
+        let minX = halfWidth
+        let maxX = max(halfWidth, bounds.width - halfWidth)
+        let minY = halfHeight
+        let maxY = max(halfHeight, bounds.height - halfHeight)
+        return CGPoint(
+            x: min(max(anchor.x, minX), maxX),
+            y: min(max(anchor.y, minY), maxY)
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(name)
+                .font(.callout.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            HStack(spacing: 8) {
+                Text(formattedSize)
+                    .monospacedDigit()
+                Text(Self.percent(fraction))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .font(.caption)
+            Text(path)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.head)
+        }
+        .padding(10)
+        .frame(maxWidth: 320, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("space-lens.hoverInfo")
+    }
+
+    /// "12.3%". One fraction digit (unlike the whole-percent scan readout) so a
+    /// small file or folder still shows a non-zero share on hover.
+    private static func percent(_ ratio: Double) -> String {
+        let clamped = max(0.0, min(1.0, ratio))
+        return clamped.formatted(.percent.precision(.fractionLength(1)))
+    }
+}
+
+#Preview {
+    SpaceLensHoverCard(
+        name: "Xcode.app",
+        formattedSize: "12.3 GB",
+        fraction: 0.214,
+        path: "/Applications/Xcode.app"
+    )
+    .padding()
+    .frame(width: 360, height: 160)
+}

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -21,9 +21,11 @@ import SwiftUI
 struct SpaceLensView: View {
 
     private var viewModel: DiskScannerViewModel
+    private var viewMode: SpaceLensViewModeStore
 
-    init(viewModel: DiskScannerViewModel) {
+    init(viewModel: DiskScannerViewModel, viewMode: SpaceLensViewModeStore) {
         self.viewModel = viewModel
+        self.viewMode = viewMode
     }
 
     var body: some View {
@@ -117,12 +119,54 @@ struct SpaceLensView: View {
 
     private func readyState(current: DiskNode) -> some View {
         VStack(spacing: 0) {
-            breadcrumb(current: current)
+            topBar(current: current)
             Divider()
             treemapOrEmpty(current: current)
             Divider()
             footer(current: current)
         }
+    }
+
+    /// The control row above the visualization: the breadcrumb on the leading
+    /// edge (taking the flexible width) and the treemap/sunburst toggle pinned
+    /// trailing. Lives above the `Divider` so it stays in reach in both the
+    /// populated and empty states.
+    private func topBar(current: DiskNode) -> some View {
+        HStack(spacing: 8) {
+            breadcrumb(current: current)
+            viewModeToggle
+                .padding(.trailing, 12)
+        }
+    }
+
+    /// Treemap / sunburst switch. Two distinct bordered buttons (rather than a
+    /// segmented `Picker`) so each carries a stable accessibility identifier
+    /// the UI test can tap directly; the active mode is tinted with the accent
+    /// color and marked selected for VoiceOver.
+    private var viewModeToggle: some View {
+        HStack(spacing: 4) {
+            ForEach(SpaceLensViewMode.allCases, id: \.self) { mode in
+                modeButton(mode)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("space-lens.viewMode")
+    }
+
+    private func modeButton(_ mode: SpaceLensViewMode) -> some View {
+        let isSelected = viewMode.mode == mode
+        return Button {
+            viewMode.mode = mode
+        } label: {
+            Image(systemName: mode.symbolName)
+                .frame(width: 18, height: 18)
+        }
+        .buttonStyle(.bordered)
+        .tint(isSelected ? Color.accentColor : Color.secondary)
+        .help(mode.displayName)
+        .accessibilityIdentifier("space-lens.viewMode.\(mode.rawValue)")
+        .accessibilityLabel(mode.displayName)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     }
 
     /// Empty placeholder shown when the current node has no displayable
@@ -132,13 +176,25 @@ struct SpaceLensView: View {
     private func treemapOrEmpty(current: DiskNode) -> some View {
         Group {
             if hasDisplayableChildren(current) {
-                TreemapView(viewModel: viewModel, node: current)
+                switch viewMode.mode {
+                case .treemap:
+                    TreemapView(viewModel: viewModel, node: current)
+                case .sunburst:
+                    SunburstView(viewModel: viewModel, node: current)
+                }
             } else {
                 emptyTreemapPlaceholder
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Inset the visualization so it reads a touch smaller than the pane,
+        // with breathing room around the treemap edges and the sunburst's
+        // outer ring rather than running flush to the dividers.
+        .padding(Self.visualizationInset)
     }
+
+    /// Padding around the treemap / sunburst inside the detail pane.
+    private static let visualizationInset: CGFloat = 32
 
     private var emptyTreemapPlaceholder: some View {
         VStack(spacing: 12) {
@@ -296,7 +352,8 @@ struct SpaceLensView: View {
                 isDirectory: true,
                 children: []
             )
-        })
+        }),
+        viewMode: SpaceLensViewModeStore(defaults: UserDefaults(suiteName: "preview")!)
     )
     .frame(width: 800, height: 520)
 }

--- a/VaderCleaner/SpaceLensViewMode.swift
+++ b/VaderCleaner/SpaceLensViewMode.swift
@@ -1,0 +1,66 @@
+// SpaceLensViewMode.swift
+// The two Space Lens visualizations (treemap / sunburst) and a small observable store that persists the user's pick through an injected UserDefaults.
+
+import Foundation
+import Observation
+
+/// Which visualization Space Lens renders. The sunburst is the default — its
+/// concentric rings read disk-usage hierarchy more naturally than nested
+/// rectangles; the treemap remains available for users who prefer it.
+enum SpaceLensViewMode: String, CaseIterable {
+    case treemap
+    case sunburst
+
+    /// Toolbar label / accessibility text for the toggle control.
+    var displayName: String {
+        switch self {
+        case .treemap:  return String(localized: "Treemap")
+        case .sunburst: return String(localized: "Sunburst")
+        }
+    }
+
+    /// SF Symbol shown on the toggle button for this mode.
+    var symbolName: String {
+        switch self {
+        case .treemap:  return "square.grid.2x2"
+        case .sunburst: return "chart.pie"
+        }
+    }
+}
+
+/// Single source of truth for the Space Lens view-mode preference, backed by
+/// `UserDefaults` so the choice survives relaunch.
+///
+/// Mirrors `PreferencesStore`'s shape: the `UserDefaults` instance is injected
+/// so tests can supply an isolated suite instead of touching `.standard`, and
+/// production uses the default `.standard` argument. The tracked `mode` is
+/// assigned exactly once in `init` (so the `didSet` observer does not fire and
+/// rewrite the default on every launch) and persisted on each subsequent
+/// change.
+@MainActor
+@Observable
+final class SpaceLensViewModeStore {
+
+    /// Namespaced key so the persisted value can be located by name and never
+    /// collides with anything else `.standard` holds.
+    private static let key = "spaceLens.viewMode"
+
+    /// The sunburst is the default for fresh installs and any unreadable
+    /// persisted value — concentric rings convey hierarchy more naturally.
+    static let defaultMode: SpaceLensViewMode = .sunburst
+
+    var mode: SpaceLensViewMode {
+        didSet { defaults.set(mode.rawValue, forKey: Self.key) }
+    }
+
+    @ObservationIgnored private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        // Single assignment in init skips the `didSet` observer (Swift omits
+        // property observers for the first assignment before delegation), so a
+        // fresh launch doesn't rewrite the default back to UserDefaults.
+        let stored = defaults.string(forKey: Self.key)
+        self.mode = stored.flatMap(SpaceLensViewMode.init(rawValue:)) ?? Self.defaultMode
+    }
+}

--- a/VaderCleaner/SunburstLayout.swift
+++ b/VaderCleaner/SunburstLayout.swift
@@ -1,0 +1,203 @@
+// SunburstLayout.swift
+// Pure radial-sunburst layout — turns a weighted node hierarchy into flat annular-sector segments (id, depth, start/end angle), dividing each ring's angular span in proportion to size.
+
+import Foundation
+import CoreGraphics
+
+/// Pure value type. Given a node hierarchy, produces a flat list of
+/// `(id, depth, startAngle, endAngle)` segments describing a radial sunburst:
+/// the root is the hollow center, its children fill the first ring, their
+/// children the second, and so on out to `maxDepth`.
+///
+/// **Angles-only.** A sunburst segment is an annular sector, but the *angles*
+/// depend solely on size ratios — `childArc = child.weight / Σ(siblings) ×
+/// parentArc`, anchored at the parent's start and accumulated clockwise. None
+/// of that touches pixels. The mapping from `depth` to inner/outer radius is a
+/// render-time concern of `SunburstView`, so this layout emits no geometry.
+/// That keeps it trivially testable (assert angles, no coordinate math) and
+/// means a window resize only rescales radii, never re-walks the tree.
+///
+/// **Generic over the node type** via closures (`id` / `weight` / `children`)
+/// rather than tied to `DiskNode`, mirroring `TreemapLayout`: unit tests drive
+/// it with lightweight `Int`-keyed fixtures and future callers can reuse it
+/// without importing the disk-scanner types.
+///
+/// **No state** — every call is independent. Segments key back to the input
+/// ids so the view can pair each arc with its source node via a dictionary
+/// lookup.
+struct SunburstLayout {
+
+    /// One placed arc. `depth` is 1 for the root's immediate children, 2 for
+    /// grandchildren, and so on; the root itself is never emitted (it is the
+    /// center hole). Angles are in radians, strictly increasing from the
+    /// layout's `startAngle`.
+    struct Segment<ID: Hashable>: Equatable, Identifiable {
+        let id: ID
+        let depth: Int
+        let startAngle: Double
+        let endAngle: Double
+    }
+
+    /// Smallest arc, in radians, still worth emitting (~1.5°). A child thinner
+    /// than this — and its whole subtree — is pruned: the wedge would be too
+    /// narrow to see or click, and recursing into it only multiplies the
+    /// noise. Mirrors the treemap's `minRenderDimension` sliver skip.
+    static let minSegmentAngle: Double = 1.5 * .pi / 180
+
+    /// Layout entry point.
+    ///
+    /// - Parameters:
+    ///   - root: the node whose subtree fills the rings. Its own arc is not
+    ///     emitted; its children populate depth 1.
+    ///   - maxDepth: deepest ring to emit. Nodes below this are dropped so the
+    ///     outer rings stay legible (the reference UI's ~7 rings get too thin).
+    ///   - startAngle: angle (radians) where the first ring begins. Defaults to
+    ///     `-π/2` so the sweep starts at 12 o'clock.
+    ///   - sweep: total angular span to fill (radians). Defaults to a full
+    ///     circle; carved-out partial sunbursts can pass less.
+    ///   - id / weight / children: accessors into the caller's node type.
+    ///
+    /// **Edge cases:** empty children → empty output; negative / NaN /
+    /// non-finite / zero weights clamp to 0 and emit nothing; a parent whose
+    /// surviving siblings all clamp to 0 contributes no segments.
+    static func segments<Node, ID: Hashable>(
+        root: Node,
+        maxDepth: Int,
+        startAngle: Double = -.pi / 2,
+        sweep: Double = 2 * .pi,
+        id: (Node) -> ID,
+        weight: (Node) -> Double,
+        children: (Node) -> [Node]
+    ) -> [Segment<ID>] {
+        guard maxDepth >= 1, sweep > 0 else { return [] }
+        var output: [Segment<ID>] = []
+        place(
+            parentChildren: children(root),
+            depth: 1,
+            spanStart: startAngle,
+            spanWidth: sweep,
+            maxDepth: maxDepth,
+            id: id,
+            weight: weight,
+            children: children,
+            output: &output
+        )
+        return output
+    }
+
+    /// Inverse of the layout: given a point in the view's coordinate space,
+    /// return the id of the segment drawn under it (or `nil` for the center
+    /// hole, the gaps left by pruned slivers, or anywhere past the outer ring).
+    ///
+    /// This is what the hover and tap code uses so the reported item matches
+    /// the pointer exactly, instead of relying on overlapping `Shape` hit
+    /// regions. It must agree with how `SunburstView` maps `depth` to radius:
+    /// `innerR = innerHole + (depth-1)·ringThickness`, `outerR = innerHole +
+    /// depth·ringThickness`. The angle convention matches the renderer too —
+    /// `atan2` in SwiftUI's y-down space increases clockwise from 3 o'clock, so
+    /// with the default `startAngle` of `-π/2` the sweep starts at 12 o'clock,
+    /// exactly as `addArc(clockwise: false)` draws it.
+    static func segment<ID: Hashable>(
+        at point: CGPoint,
+        center: CGPoint,
+        innerHole: CGFloat,
+        ringThickness: CGFloat,
+        startAngle: Double = -.pi / 2,
+        segments: [Segment<ID>]
+    ) -> ID? {
+        guard ringThickness > 0 else { return nil }
+
+        let dx = Double(point.x - center.x)
+        let dy = Double(point.y - center.y)
+        let radius = (dx * dx + dy * dy).squareRoot()
+        guard radius >= Double(innerHole) else { return nil }
+
+        // Normalize the pointer angle into `[startAngle, startAngle + 2π)` so it
+        // can be compared against the segments' (also-increasing) angle ranges.
+        let twoPi = 2 * Double.pi
+        var angle = atan2(dy, dx)
+        while angle < startAngle { angle += twoPi }
+        while angle >= startAngle + twoPi { angle -= twoPi }
+
+        let hole = Double(innerHole)
+        let thickness = Double(ringThickness)
+        for segment in segments {
+            let inner = hole + Double(segment.depth - 1) * thickness
+            let outer = hole + Double(segment.depth) * thickness
+            if radius >= inner, radius <= outer,
+               angle >= segment.startAngle, angle < segment.endAngle {
+                return segment.id
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Internals
+
+    /// Place one ring's worth of children inside `[spanStart, spanStart +
+    /// spanWidth]`, then recurse into each surviving child's own sub-arc.
+    ///
+    /// Proportions are taken against the *cleaned* sibling total so the
+    /// children exactly tile the parent's span (no rounding gap). A child whose
+    /// resulting arc is below `minSegmentAngle` is skipped — both its segment
+    /// and its subtree — which leaves a small gap where the sliver would have
+    /// been rather than redistributing, keeping every surviving sibling at its
+    /// true proportional position.
+    private static func place<Node, ID: Hashable>(
+        parentChildren: [Node],
+        depth: Int,
+        spanStart: Double,
+        spanWidth: Double,
+        maxDepth: Int,
+        id: (Node) -> ID,
+        weight: (Node) -> Double,
+        children: (Node) -> [Node],
+        output: inout [Segment<ID>]
+    ) {
+        guard depth <= maxDepth else { return }
+
+        // Clamp non-finite / negative weights to 0, then order largest-first so
+        // the dominant folders lead the ring clockwise (matches the treemap's
+        // largest-first emphasis and the reference visualization).
+        let cleaned = parentChildren
+            .map { (node: $0, weight: cleanWeight(weight($0))) }
+            .filter { $0.weight > 0 }
+            .sorted { $0.weight > $1.weight }
+
+        let total = cleaned.reduce(0.0) { $0 + $1.weight }
+        guard total > 0 else { return }
+
+        var cursor = spanStart
+        for entry in cleaned {
+            let arc = entry.weight / total * spanWidth
+            let segStart = cursor
+            let segEnd = cursor + arc
+            cursor = segEnd
+
+            // Prune slivers and everything beneath them.
+            guard arc >= minSegmentAngle else { continue }
+
+            output.append(
+                Segment(id: id(entry.node), depth: depth, startAngle: segStart, endAngle: segEnd)
+            )
+            place(
+                parentChildren: children(entry.node),
+                depth: depth + 1,
+                spanStart: segStart,
+                spanWidth: arc,
+                maxDepth: maxDepth,
+                id: id,
+                weight: weight,
+                children: children,
+                output: &output
+            )
+        }
+    }
+
+    /// Treat negative, NaN, and ±infinity weights as zero. Sunburst weights
+    /// model on-disk byte counts; a corrupt record should drop out quietly
+    /// rather than skew the angles or crash the recursion.
+    private static func cleanWeight(_ w: Double) -> Double {
+        (w.isFinite && w > 0) ? w : 0
+    }
+}

--- a/VaderCleaner/SunburstLayout.swift
+++ b/VaderCleaner/SunburstLayout.swift
@@ -167,6 +167,14 @@ struct SunburstLayout {
         let total = cleaned.reduce(0.0) { $0 + $1.weight }
         guard total > 0 else { return }
 
+        // Sliver pruning exists to drop a tiny child next to larger siblings —
+        // not to blank out a whole ring. When *no* child clears the threshold
+        // (a folder with hundreds of similarly-sized items), pruning them all
+        // would render an empty ring for a non-empty folder. In that case keep
+        // every child so the ring fills; they're drawn as leaves because
+        // recursing into a sliver only repeats the situation one ring out.
+        let anyClears = cleaned.contains { ($0.weight / total) * spanWidth >= minSegmentAngle }
+
         var cursor = spanStart
         for entry in cleaned {
             let arc = entry.weight / total * spanWidth
@@ -174,12 +182,15 @@ struct SunburstLayout {
             let segEnd = cursor + arc
             cursor = segEnd
 
-            // Prune slivers and everything beneath them.
-            guard arc >= minSegmentAngle else { continue }
+            // Prune individual slivers only when a non-sliver sibling exists.
+            if anyClears && arc < minSegmentAngle { continue }
 
             output.append(
                 Segment(id: id(entry.node), depth: depth, startAngle: segStart, endAngle: segEnd)
             )
+            // Only descend into segments wide enough to carry a readable inner
+            // ring; forced-visible slivers (the `!anyClears` case) stay leaves.
+            guard arc >= minSegmentAngle else { continue }
             place(
                 parentChildren: children(entry.node),
                 depth: depth + 1,

--- a/VaderCleaner/SunburstView.swift
+++ b/VaderCleaner/SunburstView.swift
@@ -56,7 +56,8 @@ struct SunburstView: View {
             weight: { Double($0.size) },
             children: { $0.children }
         )
-        let nodesByID = nodeLookup()
+        let renderedIDs = Set(segments.map(\.id))
+        let nodesByID = nodeLookup(rendered: renderedIDs)
 
         GeometryReader { geometry in
             let center = CGPoint(x: geometry.size.width / 2, y: geometry.size.height / 2)
@@ -217,24 +218,21 @@ struct SunburstView: View {
         return min(1.0, max(0.4, faded))
     }
 
-    /// Map the rendered descendants back to their nodes so a laid-out segment
-    /// can recover its `DiskNode` for color, tooltip, and drill-down.
+    /// Map the rendered segments back to their nodes so a laid-out segment can
+    /// recover its `DiskNode` for color, tooltip, and drill-down.
     ///
-    /// Pruned to exactly the set `SunburstLayout` draws. A node is drawn iff its
-    /// sweep ≥ `minSegmentAngle`, and because each ring's span telescopes —
-    /// sibling sizes sum to the parent's size, so a node's sweep reduces to
-    /// `node.size / root.size · 2π` — that becomes a single size threshold
-    /// against the current root: `node.size ≥ root.size · minSegmentAngle / 2π`.
-    /// A child below the threshold has only smaller descendants, so the walk
-    /// stops there. Without this, a directory with thousands of tiny files
-    /// would walk and allocate an entry for every one on each hover transition,
-    /// even though none of them render.
-    private func nodeLookup() -> [DiskNode.ID: DiskNode] {
+    /// Driven by the `rendered` id set (`SunburstLayout`'s own output), so it
+    /// stays consistent with the layout's pruning no matter how that pruning
+    /// evolves, and only ever allocates entries for nodes that actually draw.
+    /// The walk descends only into rendered nodes — the layout never renders a
+    /// child whose parent it pruned — so a directory's thousands of unrendered
+    /// tiny files are skipped rather than walked and stored on every hover
+    /// transition.
+    private func nodeLookup(rendered: Set<DiskNode.ID>) -> [DiskNode.ID: DiskNode] {
         var map: [DiskNode.ID: DiskNode] = [:]
-        let threshold = Double(node.size) * (SunburstLayout.minSegmentAngle / (2 * .pi))
         func walk(_ children: [DiskNode], depth: Int) {
             guard depth <= Self.maxDepth else { return }
-            for child in children where child.size > 0 && Double(child.size) >= threshold {
+            for child in children where rendered.contains(child.id) {
                 map[child.id] = child
                 walk(child.children, depth: depth + 1)
             }

--- a/VaderCleaner/SunburstView.swift
+++ b/VaderCleaner/SunburstView.swift
@@ -217,16 +217,24 @@ struct SunburstView: View {
         return min(1.0, max(0.4, faded))
     }
 
-    /// Map every descendant within `maxDepth` back to its node so a laid-out
-    /// segment can recover its `DiskNode` for color, tooltip, and drill-down.
-    /// Built once per `node` (not per resize). Depth-bounded to match the
-    /// layout, so a huge subtree doesn't build a dictionary of nodes that are
-    /// never drawn.
+    /// Map the rendered descendants back to their nodes so a laid-out segment
+    /// can recover its `DiskNode` for color, tooltip, and drill-down.
+    ///
+    /// Pruned to exactly the set `SunburstLayout` draws. A node is drawn iff its
+    /// sweep ≥ `minSegmentAngle`, and because each ring's span telescopes —
+    /// sibling sizes sum to the parent's size, so a node's sweep reduces to
+    /// `node.size / root.size · 2π` — that becomes a single size threshold
+    /// against the current root: `node.size ≥ root.size · minSegmentAngle / 2π`.
+    /// A child below the threshold has only smaller descendants, so the walk
+    /// stops there. Without this, a directory with thousands of tiny files
+    /// would walk and allocate an entry for every one on each hover transition,
+    /// even though none of them render.
     private func nodeLookup() -> [DiskNode.ID: DiskNode] {
         var map: [DiskNode.ID: DiskNode] = [:]
+        let threshold = Double(node.size) * (SunburstLayout.minSegmentAngle / (2 * .pi))
         func walk(_ children: [DiskNode], depth: Int) {
             guard depth <= Self.maxDepth else { return }
-            for child in children {
+            for child in children where child.size > 0 && Double(child.size) >= threshold {
                 map[child.id] = child
                 walk(child.children, depth: depth + 1)
             }

--- a/VaderCleaner/SunburstView.swift
+++ b/VaderCleaner/SunburstView.swift
@@ -1,0 +1,268 @@
+// SunburstView.swift
+// SwiftUI radial-sunburst rendering for Space Lens — lays out a parent DiskNode's subtree with SunburstLayout, draws each segment as an annular sector colored by FileCategory, and routes clicks back to DiskScannerViewModel for drill-down.
+
+import SwiftUI
+
+/// Renders the subtree of a single `DiskNode` as a radial sunburst — the
+/// alternative to `TreemapView`. The view owns no tree; it binds to whatever
+/// `node` the parent hands it (typically `viewModel.currentNode`), so
+/// breadcrumb navigation just changes which node is passed in.
+///
+/// **Rings** — `node`'s children fill the innermost ring, their children the
+/// next ring out, and so on to `maxDepth`. The hollow center shows the current
+/// node's total size.
+///
+/// **Click → drill** — tapping a directory segment calls
+/// `viewModel.drillDown(into:)`, identical to the treemap. Files are inert at
+/// this stage.
+///
+/// **Hit testing** — each segment sets `.contentShape` to its own annular
+/// sector so hover and taps fire on the arc, not its (rectangular) bounding
+/// box; taps in the gaps fall through to whatever sits beneath in the `ZStack`.
+struct SunburstView: View {
+
+    var viewModel: DiskScannerViewModel
+    let node: DiskNode
+
+    /// Identity of the segment currently under the pointer, or `nil` when the
+    /// pointer is off every arc. Drives the hover highlight and the floating
+    /// details card.
+    @State private var hoveredID: DiskNode.ID?
+
+    /// Deepest ring to draw. Past this the arcs grow too thin to read or click;
+    /// the user drills in to see deeper. Matches the layout's depth cap.
+    private static let maxDepth = 5
+    /// Inset from the shorter edge so the outermost ring doesn't touch the
+    /// view bounds.
+    private static let edgePadding: CGFloat = 12
+    /// Fraction of the available radius reserved for the hollow center that
+    /// carries the total-size label.
+    private static let innerHoleRatio: CGFloat = 0.34
+    /// Hairline between adjacent segments so neighbouring arcs stay distinct
+    /// within the single crimson hue family (the treemap leans on the same
+    /// idea with 1pt white tile borders).
+    private static let segmentStroke: CGFloat = 0.75
+
+    var body: some View {
+        // Everything that depends only on `node` is derived once here, off the
+        // resize path — `GeometryReader`'s closure below re-runs every layout
+        // pass, but `body` does not. The angular layout and the id→node lookup
+        // survive a resize unchanged; only the depth→radius mapping, which
+        // genuinely needs the bounds, runs per pass.
+        let segments = SunburstLayout.segments(
+            root: node,
+            maxDepth: Self.maxDepth,
+            id: { $0.id },
+            weight: { Double($0.size) },
+            children: { $0.children }
+        )
+        let nodesByID = nodeLookup()
+
+        GeometryReader { geometry in
+            let center = CGPoint(x: geometry.size.width / 2, y: geometry.size.height / 2)
+            let maxRadius = min(geometry.size.width, geometry.size.height) / 2 - Self.edgePadding
+            let hole = max(0, maxRadius) * Self.innerHoleRatio
+            let ringThickness = max(0, (maxRadius - hole)) / CGFloat(Self.maxDepth)
+
+            ZStack {
+                ForEach(segments) { segment in
+                    if let diskNode = nodesByID[segment.id] {
+                        segmentView(
+                            segment: segment,
+                            diskNode: diskNode,
+                            center: center,
+                            hole: hole,
+                            ringThickness: ringThickness
+                        )
+                    }
+                }
+                centerLabel
+                    .position(center)
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+            // A rectangular content shape so the pointer is tracked across the
+            // whole canvas — including the gaps between arcs and the center
+            // hole — so the card clears when the pointer leaves an arc. The
+            // arcs themselves still own their taps (they sit in front), so this
+            // doesn't steal drill-down clicks.
+            .contentShape(Rectangle())
+            .onContinuousHover(coordinateSpace: .local) { phase in
+                switch phase {
+                case .active(let location):
+                    let id = SunburstLayout.segment(
+                        at: location,
+                        center: center,
+                        innerHole: hole,
+                        ringThickness: ringThickness,
+                        segments: segments
+                    )
+                    if hoveredID != id { hoveredID = id }
+                case .ended:
+                    if hoveredID != nil { hoveredID = nil }
+                }
+            }
+            .overlay {
+                hoverCard(
+                    nodesByID: nodesByID,
+                    segments: segments,
+                    center: center,
+                    hole: hole,
+                    ringThickness: ringThickness,
+                    bounds: geometry.size
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("space-lens.sunburst")
+    }
+
+    /// Details card for the hovered segment, positioned next to the segment it
+    /// describes (not the cursor — anchoring to the item keeps re-renders to
+    /// hover *transitions*, so the squarified/angular layout isn't recomputed
+    /// on every pointer move). Clamped to stay fully on-canvas. Renders nothing
+    /// when no segment is hovered.
+    @ViewBuilder
+    private func hoverCard(
+        nodesByID: [DiskNode.ID: DiskNode],
+        segments: [SunburstLayout.Segment<DiskNode.ID>],
+        center: CGPoint,
+        hole: CGFloat,
+        ringThickness: CGFloat,
+        bounds: CGSize
+    ) -> some View {
+        if let hoveredID,
+           let diskNode = nodesByID[hoveredID],
+           let segment = segments.first(where: { $0.id == hoveredID }) {
+            let midAngle = (segment.startAngle + segment.endAngle) / 2
+            let midRadius = hole + (CGFloat(segment.depth) - 0.5) * ringThickness
+            let anchor = CGPoint(
+                x: center.x + CGFloat(cos(midAngle)) * midRadius,
+                y: center.y + CGFloat(sin(midAngle)) * midRadius
+            )
+            SpaceLensHoverCard(
+                name: diskNode.name,
+                formattedSize: diskNode.formattedSize,
+                fraction: node.size > 0 ? Double(diskNode.size) / Double(node.size) : 0,
+                path: diskNode.url.path
+            )
+            .frame(width: SpaceLensHoverCard.preferredWidth)
+            .fixedSize(horizontal: false, vertical: true)
+            .position(SpaceLensHoverCard.clampedCenter(anchor: anchor, in: bounds))
+            .allowsHitTesting(false)
+        }
+    }
+
+    // MARK: - Segment rendering
+
+    @ViewBuilder
+    private func segmentView(
+        segment: SunburstLayout.Segment<DiskNode.ID>,
+        diskNode: DiskNode,
+        center: CGPoint,
+        hole: CGFloat,
+        ringThickness: CGFloat
+    ) -> some View {
+        let innerRadius = hole + CGFloat(segment.depth - 1) * ringThickness
+        let outerRadius = hole + CGFloat(segment.depth) * ringThickness
+        let sector = AnnularSector(
+            center: center,
+            innerRadius: innerRadius,
+            outerRadius: outerRadius,
+            startAngle: .radians(segment.startAngle),
+            endAngle: .radians(segment.endAngle)
+        )
+        let category = FileCategory.from(node: diskNode)
+        let isHovered = hoveredID == segment.id
+        let fillOpacity = isHovered
+            ? min(1.0, opacity(for: diskNode, depth: segment.depth) + 0.25)
+            : opacity(for: diskNode, depth: segment.depth)
+
+        sector
+            .fill(category.color.opacity(fillOpacity))
+            .overlay(
+                sector.stroke(
+                    isHovered ? Color.white.opacity(0.9) : Color.black.opacity(0.25),
+                    lineWidth: isHovered ? Self.segmentStroke + 1 : Self.segmentStroke
+                )
+            )
+            .contentShape(sector)
+            .onTapGesture { viewModel.drillDown(into: diskNode) }
+            .help("\(diskNode.url.path)\n\(diskNode.formattedSize)")
+            .accessibilityIdentifier("space-lens.arc.\(diskNode.url.lastPathComponent)")
+            .accessibilityLabel("\(diskNode.name), \(diskNode.formattedSize)")
+    }
+
+    private var centerLabel: some View {
+        VStack(spacing: 2) {
+            Text(node.name)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Text(node.formattedSize)
+                .font(.callout.weight(.semibold).monospacedDigit())
+        }
+        .foregroundStyle(.primary)
+        .padding(8)
+        .accessibilityIdentifier("space-lens.sunburst.total")
+    }
+
+    // MARK: - Helpers
+
+    /// Fade arcs as they move outward so depth reads at a glance within the
+    /// single crimson hue family, and lighten files slightly over directories
+    /// (the treemap makes the same directory/file distinction).
+    private func opacity(for node: DiskNode, depth: Int) -> Double {
+        let base = node.isDirectory ? 0.8 : 0.95
+        let faded = base - Double(depth - 1) * 0.1
+        return min(1.0, max(0.4, faded))
+    }
+
+    /// Map every descendant within `maxDepth` back to its node so a laid-out
+    /// segment can recover its `DiskNode` for color, tooltip, and drill-down.
+    /// Built once per `node` (not per resize). Depth-bounded to match the
+    /// layout, so a huge subtree doesn't build a dictionary of nodes that are
+    /// never drawn.
+    private func nodeLookup() -> [DiskNode.ID: DiskNode] {
+        var map: [DiskNode.ID: DiskNode] = [:]
+        func walk(_ children: [DiskNode], depth: Int) {
+            guard depth <= Self.maxDepth else { return }
+            for child in children {
+                map[child.id] = child
+                walk(child.children, depth: depth + 1)
+            }
+        }
+        walk(node.children, depth: 1)
+        return map
+    }
+}
+
+/// An annular sector (a slice of a ring) between two radii and two angles.
+/// Used both to draw a sunburst segment and as its `.contentShape`, so the
+/// hit area matches the visible arc exactly rather than the bounding box.
+private struct AnnularSector: Shape {
+    let center: CGPoint
+    let innerRadius: CGFloat
+    let outerRadius: CGFloat
+    let startAngle: Angle
+    let endAngle: Angle
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.addArc(
+            center: center,
+            radius: outerRadius,
+            startAngle: startAngle,
+            endAngle: endAngle,
+            clockwise: false
+        )
+        path.addArc(
+            center: center,
+            radius: innerRadius,
+            startAngle: endAngle,
+            endAngle: startAngle,
+            clockwise: true
+        )
+        path.closeSubpath()
+        return path
+    }
+}

--- a/VaderCleaner/TreemapView.swift
+++ b/VaderCleaner/TreemapView.swift
@@ -25,6 +25,11 @@ struct TreemapView: View {
     var viewModel: DiskScannerViewModel
     let node: DiskNode
 
+    /// Identity of the tile currently under the pointer, or `nil` when the
+    /// pointer is outside every tile. Drives both the per-tile hover highlight
+    /// and the floating details card.
+    @State private var hoveredID: DiskNode.ID?
+
     /// Smallest tile dimension that still renders. Anything smaller is too
     /// thin to recognize and would just clutter the canvas.
     private static let minRenderDimension: CGFloat = 4
@@ -60,9 +65,48 @@ struct TreemapView: View {
                 }
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
+            // Rectangular content shape so the pointer is tracked across the
+            // whole canvas (including the gaps left by skipped slivers); the
+            // tiles in front keep their own drill-down taps.
+            .contentShape(Rectangle())
+            .onContinuousHover(coordinateSpace: .local) { phase in
+                switch phase {
+                case .active(let location):
+                    let id = tiles.first { $0.rect.contains(location) }?.id
+                    if hoveredID != id { hoveredID = id }
+                case .ended:
+                    if hoveredID != nil { hoveredID = nil }
+                }
+            }
+            .overlay {
+                hoverCard(tiles: tiles, bounds: geometry.size)
+            }
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("space-lens.treemap")
+    }
+
+    /// Details card for the hovered tile, positioned over the tile it
+    /// describes (not the cursor — anchoring to the item keeps re-renders to
+    /// hover *transitions*, so the squarified layout isn't recomputed on every
+    /// pointer move). Clamped to stay fully on-canvas. Renders nothing when no
+    /// tile is hovered.
+    @ViewBuilder
+    private func hoverCard(tiles: [PlacedTile], bounds: CGSize) -> some View {
+        if let hoveredID, let placed = tiles.first(where: { $0.id == hoveredID }) {
+            let model = placed.model
+            let anchor = CGPoint(x: placed.rect.midX, y: placed.rect.midY)
+            SpaceLensHoverCard(
+                name: model.node.name,
+                formattedSize: model.formattedSize,
+                fraction: node.size > 0 ? Double(model.node.size) / Double(node.size) : 0,
+                path: model.node.url.path
+            )
+            .frame(width: SpaceLensHoverCard.preferredWidth)
+            .fixedSize(horizontal: false, vertical: true)
+            .position(SpaceLensHoverCard.clampedCenter(anchor: anchor, in: bounds))
+            .allowsHitTesting(false)
+        }
     }
 
     // MARK: - Tile rendering
@@ -141,12 +185,17 @@ struct TreemapView: View {
         let model = entry.model
         let showLabel = entry.rect.width >= Self.minLabelDimension
             && entry.rect.height >= Self.minLabelDimension
+        let isHovered = hoveredID == model.id
+        let baseOpacity = model.node.isDirectory ? 0.55 : 0.7
 
         Rectangle()
-            .fill(model.category.color.opacity(model.node.isDirectory ? 0.55 : 0.7))
+            .fill(model.category.color.opacity(isHovered ? min(1.0, baseOpacity + 0.25) : baseOpacity))
             .overlay(
                 Rectangle()
-                    .strokeBorder(Color.white.opacity(0.6), lineWidth: Self.tileStroke)
+                    .strokeBorder(
+                        Color.white.opacity(isHovered ? 0.95 : 0.6),
+                        lineWidth: isHovered ? Self.tileStroke + 1 : Self.tileStroke
+                    )
             )
             .overlay(
                 Group {

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -29,6 +29,7 @@ struct VaderCleanerApp: App {
     @State private var systemJunkViewModel: SystemJunkViewModel
     @State private var largeOldFilesViewModel: LargeOldFilesViewModel
     @State private var spaceLensViewModel: DiskScannerViewModel
+    @State private var spaceLensViewMode: SpaceLensViewModeStore
     @State private var privacyViewModel: PrivacyViewModel
     @State private var appUninstallerViewModel: AppUninstallerViewModel
     @State private var appUpdaterViewModel: AppUpdaterViewModel
@@ -76,6 +77,7 @@ struct VaderCleanerApp: App {
         _spaceLensViewModel = State(
             initialValue: DiskScannerViewModel.live(exclusions: exclusions)
         )
+        _spaceLensViewMode = State(initialValue: SpaceLensViewModeStore())
         _privacyViewModel = State(initialValue: PrivacyViewModel.live())
         _appUninstallerViewModel = State(
             initialValue: AppUninstallerViewModel.live(exclusions: exclusions)
@@ -190,6 +192,7 @@ struct VaderCleanerApp: App {
                 systemJunkViewModel: systemJunkViewModel,
                 largeOldFilesViewModel: largeOldFilesViewModel,
                 spaceLensViewModel: spaceLensViewModel,
+                spaceLensViewMode: spaceLensViewMode,
                 privacyViewModel: privacyViewModel,
                 appUninstallerViewModel: appUninstallerViewModel,
                 appUpdaterViewModel: appUpdaterViewModel,

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -77,7 +77,15 @@ struct VaderCleanerApp: App {
         _spaceLensViewModel = State(
             initialValue: DiskScannerViewModel.live(exclusions: exclusions)
         )
-        _spaceLensViewMode = State(initialValue: SpaceLensViewModeStore())
+        // UI tests pass an isolated UserDefaults suite name so toggling the
+        // Space Lens view mode during a test doesn't mutate the developer's
+        // real preference. Production never sets this, so it falls back to
+        // `.standard`. This is real persistence pointed at a scratch domain,
+        // not a mock.
+        let viewModeDefaults = ProcessInfo.processInfo
+            .environment["UITEST_DEFAULTS_SUITE"]
+            .flatMap { UserDefaults(suiteName: $0) } ?? .standard
+        _spaceLensViewMode = State(initialValue: SpaceLensViewModeStore(defaults: viewModeDefaults))
         _privacyViewModel = State(initialValue: PrivacyViewModel.live())
         _appUninstallerViewModel = State(
             initialValue: AppUninstallerViewModel.live(exclusions: exclusions)

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -193,6 +193,49 @@ final class DiskScannerViewModelTests: XCTestCase {
         XCTAssertTrue(vm.navigationPath.last === dirChild)
     }
 
+    /// Drilling into a deeper descendant (as the sunburst allows when the user
+    /// taps a 2nd-or-deeper ring) must record every intermediate folder, not
+    /// just the tapped node — otherwise the breadcrumb skips levels and
+    /// `navigateUp` jumps back too far.
+    func test_drillDown_pushesFullAncestorChainForDescendant() async {
+        let grandchild = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root/sub/deep"),
+            name: "deep",
+            size: 10,
+            isDirectory: true,
+            children: []
+        )
+        let child = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root/sub"),
+            name: "sub",
+            size: 10,
+            isDirectory: true,
+            children: [grandchild]
+        )
+        let root = DiskNode(
+            url: URL(fileURLWithPath: "/tmp/root"),
+            name: "root",
+            size: 10,
+            isDirectory: true,
+            children: [child]
+        )
+        let vm = DiskScannerViewModel(scanner: { _, _ in root })
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
+
+        // Tapping the grandchild directly, as a deep sunburst ring would.
+        vm.drillDown(into: grandchild)
+
+        XCTAssertEqual(vm.navigationPath.count, 2)
+        XCTAssertTrue(vm.navigationPath.first === child,
+                      "The intermediate folder must be recorded, not skipped")
+        XCTAssertTrue(vm.navigationPath.last === grandchild)
+        XCTAssertTrue(vm.currentNode === grandchild)
+
+        vm.navigateUp()
+        XCTAssertTrue(vm.currentNode === child,
+                      "Up must step back exactly one real level, to the intermediate folder")
+    }
+
     /// Files cannot be drilled into — the treemap renders `node.children`,
     /// and a file has none, so a misplaced drill-down would land the UI on
     /// an empty rectangle. The VM must reject the call instead of trusting

--- a/VaderCleanerTests/SpaceLensViewModeStoreTests.swift
+++ b/VaderCleanerTests/SpaceLensViewModeStoreTests.swift
@@ -1,0 +1,51 @@
+// SpaceLensViewModeStoreTests.swift
+// Tests that SpaceLensViewModeStore defaults to the treemap and persists the user's pick through an injected UserDefaults.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class SpaceLensViewModeStoreTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        // Isolated suite per test so reads/writes never touch the host's real
+        // .standard defaults and tests can't observe each other's state.
+        suiteName = "VaderCleanerTests.SpaceLensViewMode.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    /// A fresh install with no stored value falls back to the sunburst — the
+    /// default Space Lens view.
+    func test_defaultsToSunburst() {
+        let sut = SpaceLensViewModeStore(defaults: defaults)
+        XCTAssertEqual(sut.mode, .sunburst)
+    }
+
+    /// The chosen mode survives across store instances (i.e. an app relaunch).
+    func test_persistsModeAcrossInstances() {
+        let writer = SpaceLensViewModeStore(defaults: defaults)
+        writer.mode = .treemap
+
+        let reader = SpaceLensViewModeStore(defaults: defaults)
+        XCTAssertEqual(reader.mode, .treemap)
+    }
+
+    /// An unrecognized persisted string (e.g. a value from a future build)
+    /// falls back to the default rather than crashing.
+    func test_unknownStoredValueFallsBackToDefault() {
+        defaults.set("hexagons", forKey: "spaceLens.viewMode")
+        let sut = SpaceLensViewModeStore(defaults: defaults)
+        XCTAssertEqual(sut.mode, .sunburst)
+    }
+}

--- a/VaderCleanerTests/SunburstLayoutTests.swift
+++ b/VaderCleanerTests/SunburstLayoutTests.swift
@@ -161,41 +161,24 @@ final class SunburstLayoutTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
-    /// The set of rendered segments equals a single global size threshold
-    /// against the root: a node is drawn iff `node.size ≥ root.size ·
-    /// minSegmentAngle / 2π`. This holds because each ring's span telescopes
-    /// (sibling sizes sum to the parent's size), and `SunburstView.nodeLookup`
-    /// relies on it to prune its traversal to exactly the drawn set. The
-    /// fixture keeps children summing to their parent, as a rolled-up scan does.
-    func test_segments_renderedSetMatchesGlobalSizeThreshold() {
-        let tree = Tree(0, 1000, [
-            Tree(1, 600, [Tree(11, 400), Tree(12, 200)]),
-            Tree(2, 300, [Tree(21, 298), Tree(22, 2)]),
-            Tree(3, 100)
-        ])
-        let maxDepth = 5
-        let rendered = Set(
-            SunburstLayout.segments(
-                root: tree, maxDepth: maxDepth,
-                id: { $0.id }, weight: { $0.weight }, children: { $0.children }
-            ).map(\.id)
-        )
+    /// When every child's share falls below the sliver threshold (a folder
+    /// with hundreds of similarly-sized items), the level must not prune to
+    /// nothing — it renders every child, filling the ring, so the default
+    /// sunburst never looks blank for a non-empty folder.
+    func test_segments_renderAllChildrenWhenEveryChildIsASliver() {
+        // 300 equal children → each spans 1.2°, under the 1.5° threshold.
+        let children = (1...300).map { Tree($0, 10) }
+        let result = segments(Tree(0, 3000, children)).filter { $0.depth == 1 }
 
-        let threshold = 1000.0 * (SunburstLayout.minSegmentAngle / (2 * .pi))
-        var expected = Set<Int>()
-        func walk(_ node: Tree, depth: Int) {
-            guard depth <= maxDepth else { return }
-            for child in node.children where Double(child.weight) >= threshold {
-                expected.insert(child.id)
-                walk(child, depth: depth + 1)
-            }
+        XCTAssertEqual(result.count, 300,
+                       "Every child must render rather than the ring being pruned blank")
+        // And they still tile the full circle with no gaps.
+        let sorted = result.sorted { $0.startAngle < $1.startAngle }
+        XCTAssertEqual(sorted.first?.startAngle ?? .nan, start, accuracy: eps)
+        XCTAssertEqual(sorted.last?.endAngle ?? .nan, start + sweep, accuracy: eps)
+        for i in 0..<(sorted.count - 1) {
+            XCTAssertEqual(sorted[i].endAngle, sorted[i + 1].startAngle, accuracy: eps)
         }
-        walk(tree, depth: 1)
-
-        XCTAssertEqual(rendered, expected,
-                       "Rendered segments must match the global size threshold the lookup prunes by")
-        XCTAssertFalse(rendered.contains(22),
-                       "The 0.2%-of-root node is below the 1.5° threshold and must be pruned")
     }
 
     // MARK: - Hit testing (screen space)

--- a/VaderCleanerTests/SunburstLayoutTests.swift
+++ b/VaderCleanerTests/SunburstLayoutTests.swift
@@ -161,6 +161,43 @@ final class SunburstLayoutTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    /// The set of rendered segments equals a single global size threshold
+    /// against the root: a node is drawn iff `node.size ≥ root.size ·
+    /// minSegmentAngle / 2π`. This holds because each ring's span telescopes
+    /// (sibling sizes sum to the parent's size), and `SunburstView.nodeLookup`
+    /// relies on it to prune its traversal to exactly the drawn set. The
+    /// fixture keeps children summing to their parent, as a rolled-up scan does.
+    func test_segments_renderedSetMatchesGlobalSizeThreshold() {
+        let tree = Tree(0, 1000, [
+            Tree(1, 600, [Tree(11, 400), Tree(12, 200)]),
+            Tree(2, 300, [Tree(21, 298), Tree(22, 2)]),
+            Tree(3, 100)
+        ])
+        let maxDepth = 5
+        let rendered = Set(
+            SunburstLayout.segments(
+                root: tree, maxDepth: maxDepth,
+                id: { $0.id }, weight: { $0.weight }, children: { $0.children }
+            ).map(\.id)
+        )
+
+        let threshold = 1000.0 * (SunburstLayout.minSegmentAngle / (2 * .pi))
+        var expected = Set<Int>()
+        func walk(_ node: Tree, depth: Int) {
+            guard depth <= maxDepth else { return }
+            for child in node.children where Double(child.weight) >= threshold {
+                expected.insert(child.id)
+                walk(child, depth: depth + 1)
+            }
+        }
+        walk(tree, depth: 1)
+
+        XCTAssertEqual(rendered, expected,
+                       "Rendered segments must match the global size threshold the lookup prunes by")
+        XCTAssertFalse(rendered.contains(22),
+                       "The 0.2%-of-root node is below the 1.5° threshold and must be pruned")
+    }
+
     // MARK: - Hit testing (screen space)
 
     /// `segment(at:)` must map *pixel* positions to the visually-correct

--- a/VaderCleanerTests/SunburstLayoutTests.swift
+++ b/VaderCleanerTests/SunburstLayoutTests.swift
@@ -1,0 +1,217 @@
+// SunburstLayoutTests.swift
+// Locks the radial sunburst layout's invariants: full-circle coverage for a single child, angular proportionality, sibling contiguity, depth nesting and the maxDepth cap, sub-threshold sliver pruning, and the clamped / zero-weight edge cases.
+
+import XCTest
+import CoreGraphics
+@testable import VaderCleaner
+
+/// Unit tests for `SunburstLayout`. Like `TreemapLayout`, the layout is a pure
+/// value type with no dependence on `DiskNode` — it is generic over a node
+/// type via closures — so these tests drive it with a lightweight in-memory
+/// `Tree` fixture keyed by `Int`. Angles are asserted directly; there is no
+/// pixel/coordinate math to verify because the layout is angles-only (radii
+/// are a render-time concern of `SunburstView`).
+final class SunburstLayoutTests: XCTestCase {
+
+    /// Lightweight fixture tree. Mirrors the shape `SunburstLayout` walks via
+    /// closures without dragging in `DiskNode` or `URL`s.
+    private struct Tree {
+        let id: Int
+        let weight: Double
+        let children: [Tree]
+
+        init(_ id: Int, _ weight: Double, _ children: [Tree] = []) {
+            self.id = id
+            self.weight = weight
+            self.children = children
+        }
+    }
+
+    private let start = -Double.pi / 2
+    private let sweep = 2 * Double.pi
+    private let eps = 1e-9
+
+    private func segments(_ root: Tree, maxDepth: Int = 5) -> [SunburstLayout.Segment<Int>] {
+        SunburstLayout.segments(
+            root: root,
+            maxDepth: maxDepth,
+            startAngle: start,
+            sweep: sweep,
+            id: { $0.id },
+            weight: { $0.weight },
+            children: { $0.children }
+        )
+    }
+
+    // MARK: - Coverage & proportionality
+
+    /// A root with no children produces no segments — the view renders just
+    /// the empty center hole.
+    func test_segments_emptyForNoChildren() {
+        let result = segments(Tree(0, 100))
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    /// A single child must span the entire circle at depth 1. Without this a
+    /// folder with one subfolder would render a thin wedge in an otherwise
+    /// empty ring.
+    func test_segments_singleChildFillsFullSweep() {
+        let result = segments(Tree(0, 100, [Tree(1, 100)]))
+        XCTAssertEqual(result.count, 1)
+        let only = result[0]
+        XCTAssertEqual(only.id, 1)
+        XCTAssertEqual(only.depth, 1)
+        XCTAssertEqual(only.startAngle, start, accuracy: eps)
+        XCTAssertEqual(only.endAngle, start + sweep, accuracy: eps)
+    }
+
+    /// Sibling arcs are proportional to weight. A 3:1 split yields a
+    /// three-quarter arc and a one-quarter arc.
+    func test_segments_splitsAngleProportionally() {
+        // Largest-first ordering: the weight-75 child leads.
+        let result = segments(Tree(0, 100, [Tree(1, 25), Tree(2, 75)]))
+        XCTAssertEqual(result.count, 2)
+
+        let byID = Dictionary(uniqueKeysWithValues: result.map { ($0.id, $0) })
+        let big = try! XCTUnwrap(byID[2])
+        let small = try! XCTUnwrap(byID[1])
+        XCTAssertEqual(big.endAngle - big.startAngle, sweep * 0.75, accuracy: eps)
+        XCTAssertEqual(small.endAngle - small.startAngle, sweep * 0.25, accuracy: eps)
+    }
+
+    /// Top-level siblings tile the full circle with no gaps or overlaps:
+    /// consecutive arcs meet exactly and the last reaches `start + sweep`.
+    func test_segments_topLevelSiblingsAreContiguous() {
+        let result = segments(Tree(0, 100, [Tree(1, 50), Tree(2, 30), Tree(3, 20)]))
+            .filter { $0.depth == 1 }
+            .sorted { $0.startAngle < $1.startAngle }
+        XCTAssertEqual(result.count, 3)
+
+        XCTAssertEqual(result.first?.startAngle ?? .nan, start, accuracy: eps)
+        XCTAssertEqual(result.last?.endAngle ?? .nan, start + sweep, accuracy: eps)
+        for i in 0..<(result.count - 1) {
+            XCTAssertEqual(result[i].endAngle, result[i + 1].startAngle, accuracy: eps,
+                           "Arc \(i) must end exactly where arc \(i + 1) begins")
+        }
+    }
+
+    // MARK: - Depth
+
+    /// Children nest inside their parent's angular span at the next depth, and
+    /// the grandchild fills the parent's full sub-arc.
+    func test_segments_nestsChildrenWithinParentSpan() {
+        let result = segments(Tree(0, 100, [
+            Tree(1, 50, [Tree(11, 50)]),
+            Tree(2, 50)
+        ]))
+        let byID = Dictionary(uniqueKeysWithValues: result.map { ($0.id, $0) })
+        let parent = try! XCTUnwrap(byID[1])
+        let child = try! XCTUnwrap(byID[11])
+        XCTAssertEqual(child.depth, 2)
+        // Sole child fills the parent's arc exactly.
+        XCTAssertEqual(child.startAngle, parent.startAngle, accuracy: eps)
+        XCTAssertEqual(child.endAngle, parent.endAngle, accuracy: eps)
+    }
+
+    /// `maxDepth` caps the recursion — nodes deeper than the limit are not
+    /// emitted, so the outer rings never grow thinner than the view can draw.
+    func test_segments_respectsMaxDepth() {
+        let deep = Tree(0, 100, [Tree(1, 100, [Tree(2, 100, [Tree(3, 100)])])])
+        let result = segments(deep, maxDepth: 2)
+        XCTAssertEqual(result.map(\.depth).max(), 2)
+        XCTAssertFalse(result.contains { $0.id == 3 }, "Depth-3 node must be pruned at maxDepth 2")
+    }
+
+    // MARK: - Pruning & clamping
+
+    /// A child whose arc would be thinner than `minSegmentAngle` is dropped,
+    /// along with its descendants — too thin to see or click. The surviving
+    /// sibling keeps its own proportional position.
+    func test_segments_prunesSliversAndTheirDescendants() {
+        // 1000 : 1 → the sliver's arc is ~0.006 rad, far below the threshold.
+        let result = segments(Tree(0, 1001, [
+            Tree(1, 1000),
+            Tree(2, 1, [Tree(21, 1)])
+        ]))
+        XCTAssertTrue(result.contains { $0.id == 1 }, "The large sibling must survive")
+        XCTAssertFalse(result.contains { $0.id == 2 }, "Sub-threshold sliver must be pruned")
+        XCTAssertFalse(result.contains { $0.id == 21 }, "A pruned sliver's descendants must be pruned too")
+    }
+
+    /// Negative, NaN, and infinite weights clamp to zero and produce no
+    /// segment, so a single corrupt scan record can't poison the layout. A
+    /// valid sibling still renders.
+    func test_segments_clampsNonFiniteAndNegativeWeights() {
+        let result = segments(Tree(0, 100, [
+            Tree(1, -10),
+            Tree(2, .nan),
+            Tree(3, .infinity),
+            Tree(4, 100)
+        ]))
+        XCTAssertEqual(result.count, 1)
+        let only = try! XCTUnwrap(result.first)
+        XCTAssertEqual(only.id, 4)
+        XCTAssertEqual(only.endAngle - only.startAngle, sweep, accuracy: eps)
+    }
+
+    /// All-zero sibling weights cannot divide by zero; the result is simply
+    /// empty (nothing to draw).
+    func test_segments_handlesAllZeroWeights() {
+        let result = segments(Tree(0, 0, [Tree(1, 0), Tree(2, 0)]))
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Hit testing (screen space)
+
+    /// `segment(at:)` must map *pixel* positions to the visually-correct
+    /// segment, which is the only thing that proves the `atan2` + y-down +
+    /// `-π/2`-at-12-o'clock convention agrees with what the renderer draws.
+    ///
+    /// Fixture: a 75/25 split. Largest-first, the 75% child (id 2) occupies
+    /// `[-π/2, π]` — 12 o'clock clockwise through 3 and 6 o'clock — and the
+    /// 25% child (id 1) occupies `[π, 3π/2]`, the top-left quadrant. Center is
+    /// (100, 100); the single ring spans radius 0…50.
+    func test_segmentAt_mapsCardinalPointsToVisuallyCorrectSegments() {
+        let segs = segments(Tree(0, 100, [Tree(1, 25), Tree(2, 75)]))
+        let center = CGPoint(x: 100, y: 100)
+
+        func hit(_ x: CGFloat, _ y: CGFloat) -> Int? {
+            SunburstLayout.segment(
+                at: CGPoint(x: x, y: y),
+                center: center,
+                innerHole: 0,
+                ringThickness: 50,
+                segments: segs
+            )
+        }
+
+        // 12 o'clock, 3 o'clock, 6 o'clock all land in the 75% child (id 2).
+        XCTAssertEqual(hit(100, 70), 2, "Straight up should hit the segment that starts at 12 o'clock")
+        XCTAssertEqual(hit(130, 100), 2, "Right (3 o'clock) should hit the 75% segment")
+        XCTAssertEqual(hit(100, 130), 2, "Down (6 o'clock) should hit the 75% segment")
+        // Top-left quadrant lands in the 25% child (id 1).
+        XCTAssertEqual(hit(79, 79), 1, "Top-left should hit the 25% segment")
+    }
+
+    /// Points inside the center hole and beyond the outer ring resolve to
+    /// nothing — the hole shows the total label, and past the rings is empty
+    /// canvas.
+    func test_segmentAt_returnsNilOutsideTheRings() {
+        let segs = segments(Tree(0, 100, [Tree(1, 100)]))
+        let center = CGPoint(x: 100, y: 100)
+
+        func hit(_ x: CGFloat, _ y: CGFloat) -> Int? {
+            SunburstLayout.segment(
+                at: CGPoint(x: x, y: y),
+                center: center,
+                innerHole: 20,
+                ringThickness: 50,
+                segments: segs
+            )
+        }
+
+        XCTAssertNil(hit(100, 105), "A point inside the center hole hits nothing")
+        XCTAssertNil(hit(100, 100 - 90), "A point past the outer ring hits nothing")
+        XCTAssertEqual(hit(100, 100 - 45), 1, "A point within the ring hits the only segment")
+    }
+}

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -15,6 +15,10 @@ final class SpaceLensUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        // Persist the Space Lens view mode to a throwaway UserDefaults suite so
+        // the toggle test doesn't leak the last-selected mode into the real
+        // app preference (or couple test runs through shared state).
+        app.launchEnvironment["UITEST_DEFAULTS_SUITE"] = "VaderCleanerUITests.SpaceLens.\(UUID().uuidString)"
         app.launch()
     }
 

--- a/VaderCleanerUITests/SpaceLensUITests.swift
+++ b/VaderCleanerUITests/SpaceLensUITests.swift
@@ -30,7 +30,54 @@ final class SpaceLensUITests: XCTestCase {
     /// wiring regression.
     func test_navigateToSpaceLens_scan_revealsScanningOrTreemap() throws {
         dismissOnboardingIfNeeded()
+        navigateToSpaceLensAndScan()
 
+        // After Scan we expect either the scanning indicator or — on tiny home
+        // folders / fast machines — the treemap to land before our timeout.
+        // The error banner is accepted as well: a CI runner without
+        // home-folder access should still surface a recognizable state, not
+        // hang on a blank canvas.
+        let appeared = waitForAnySpaceLensState(timeout: 30)
+        XCTAssertTrue(appeared,
+                      "Expected to land on a recognizable Space Lens state after selection")
+    }
+
+    /// Once results render, the treemap/sunburst toggle must switch the
+    /// visualization. We don't assert on specific arcs or tiles — the host's
+    /// home directory is whatever the runner happens to have — only that
+    /// tapping each toggle reveals that mode's view (or the shared empty
+    /// placeholder, on a folder with no displayable children). Both prove the
+    /// mode switch is wired through `SpaceLensViewModeStore`.
+    func test_navigateToSpaceLens_toggleSwitchesBetweenTreemapAndSunburst() throws {
+        dismissOnboardingIfNeeded()
+        navigateToSpaceLensAndScan()
+
+        // The toggle only exists in the ready state. A permission-restricted or
+        // perpetually-scanning host can't exercise this path, so skip rather
+        // than fail — the toggle's wiring is what's under test, not the host's
+        // ability to finish a home-directory scan.
+        let sunburstToggle = app.buttons["space-lens.viewMode.sunburst"]
+        guard sunburstToggle.waitForExistence(timeout: 30) else {
+            throw XCTSkip("Space Lens did not reach the ready state on this host; the view-mode toggle only appears once results render.")
+        }
+        let treemapToggle = app.buttons["space-lens.viewMode.treemap"]
+        XCTAssertTrue(treemapToggle.exists, "Both view-mode toggle buttons should be present")
+
+        sunburstToggle.click()
+        XCTAssertTrue(waitForSpaceLensState(["space-lens.sunburst", "space-lens.empty"], timeout: 5),
+                      "Tapping Sunburst should reveal the sunburst (or the empty placeholder)")
+
+        treemapToggle.click()
+        XCTAssertTrue(waitForSpaceLensState(["space-lens.treemap", "space-lens.empty"], timeout: 5),
+                      "Tapping Treemap should reveal the treemap (or the empty placeholder)")
+    }
+
+    // MARK: - Helpers
+
+    /// Drive the sidebar → Space Lens → floating Scan flow shared by the tests.
+    /// Leaves the app in whatever post-Scan state the host's home directory
+    /// produces (scanning / ready / empty / error).
+    private func navigateToSpaceLensAndScan() {
         let sidebarRow = app.buttons["sidebar.spaceLens"].firstMatch
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5),
                       "Expected Space Lens row in sidebar")
@@ -51,18 +98,7 @@ final class SpaceLensUITests: XCTestCase {
                       "Expected the floating Scan button on the Space Lens intro")
         floatingScan.click()
         proceedPastScanAccessPopoverIfNeeded()
-
-        // After Scan we expect either the scanning indicator or — on tiny home
-        // folders / fast machines — the treemap to land before our timeout.
-        // The error banner is accepted as well: a CI runner without
-        // home-folder access should still surface a recognizable state, not
-        // hang on a blank canvas.
-        let appeared = waitForAnySpaceLensState(timeout: 30)
-        XCTAssertTrue(appeared,
-                      "Expected to land on a recognizable Space Lens state after selection")
     }
-
-    // MARK: - Helpers
 
     private func dismissOnboardingIfNeeded() {
         let continueWithout = app.buttons["Continue Without Access"]
@@ -83,12 +119,20 @@ final class SpaceLensUITests: XCTestCase {
     }
 
     private func waitForAnySpaceLensState(timeout: TimeInterval) -> Bool {
-        let identifiers = [
+        waitForSpaceLensState([
             "space-lens.scanning",
             "space-lens.treemap",
+            "space-lens.sunburst",
             "space-lens.error",
             "space-lens.empty"
-        ]
+        ], timeout: timeout)
+    }
+
+    /// Wait for any of the given accessibility identifiers to appear as a
+    /// container group. Each Space Lens state (treemap, sunburst, empty, …)
+    /// marks its root with `accessibilityElement(children: .contain)`, so they
+    /// surface as groups.
+    private func waitForSpaceLensState(_ identifiers: [String], timeout: TimeInterval) -> Bool {
         let predicate = NSPredicate(format: "identifier IN %@", identifiers)
         return app.groups.matching(predicate).firstMatch.waitForExistence(timeout: timeout)
     }


### PR DESCRIPTION
## What & why

Space Lens previously rendered disk usage only as a rectangular squarified treemap. This adds a DaisyDisk-style **radial sunburst** as a second visualization, switchable via a small persisted toggle, and adds **on-hover details** to both charts so you can read an item's size/share without drilling in.

## Changes

**New visualization**
- `SunburstLayout` — pure, generic, **angles-only** layout emitting `(id, depth, startAngle, endAngle)`. Splits each ring proportionally, prunes sub-threshold slivers (and their descendants), clamps negative/NaN/∞ weights. Mirrors `TreemapLayout`'s conventions and testability (no `DiskNode` dependency).
- `SunburstView` — `GeometryReader` annular-sector arcs colored by `FileCategory` (crimson family, depth-faded), hollow center showing the folder total, click-to-drill, tooltip.

**View-mode toggle**
- `SpaceLensViewMode` + `SpaceLensViewModeStore` — enum + `@Observable` store persisting the pick via injected `UserDefaults` (mirrors `PreferencesStore`). **Sunburst is the default**; treemap stays available.
- Toggle wired into `SpaceLensView` (store threaded through `ContentView` / `VaderCleanerApp`). Both visualizations are inset a little smaller in the pane.

**Hover details**
- Shared `SpaceLensHoverCard` (name / size / % of current folder / path), anchored to the hovered item and clamped on-canvas.
- Detection uses a single container-level `onContinuousHover` feeding a pure, **screen-space-tested** `SunburstLayout.segment(at:)` hit-test (radial) and rect containment (treemap), so the reported item matches the pointer exactly. Anchoring to the item (not the cursor) keeps re-renders to hover *transitions*, avoiding per-move layout recompute.

## Tests
- `SunburstLayoutTests` — proportional split, sibling contiguity, depth/`maxDepth`, sliver pruning, weight clamping, and **screen-space hit-tests** (cardinal pixel points map to the visually-correct segment, locking the `atan2` / y-down / `-π/2`-at-12-o'clock convention).
- `SpaceLensViewModeStoreTests` — default + persistence.
- `SpaceLensUITests` — sunburst state id + view-mode toggle test.
- **821 unit tests pass**, no regressions.

## Reviewer notes
- **UI tests compile but can't execute in a headless environment** (the XCUITest runner is signal-killed before XPC connect) — please run `VaderCleanerUITests/SpaceLensUITests` locally.
- Visual checks to confirm: sunburst loads by default after a scan; both charts read a touch smaller with margin; **hover info matches the item under the pointer** in both modes; clicking an arc/tile drills into the correct folder; chosen mode survives relaunch.
- The hover card anchors to the hovered **item**, not the cursor (deliberate, for perf). If a cursor-following tooltip is preferred, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sunburst visualization added as an alternative Space Lens view.
  * View-mode toggle to switch between sunburst and treemap.
  * Hover details card showing name, size, percent, and path.
  * Persisted view-mode stored and wired to app-level state.

* **Improvements**
  * Continuous hover tracking and visual highlight for treemap and sunburst.
  * Improved previews reflecting view-mode state.

* **Tests**
  * Unit tests for sunburst layout and view-mode persistence.
  * UI tests verifying view-mode toggle and isolated test defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->