### PR TITLE
Move rescan from toolbar into section content

### DIFF
--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -15,18 +15,6 @@ struct AppUpdaterView: View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle(NavigationSection.appUpdater.title)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button(action: { Task { await viewModel.checkForUpdates() } }) {
-                        Label(String(
-                            localized: "Check for Updates",
-                            comment: "Toolbar button on the App Updater that re-checks for updates."
-                        ), systemImage: "arrow.clockwise")
-                    }
-                    .disabled(viewModel.phase == .checking)
-                    .accessibilityIdentifier("appUpdater.check")
-                }
-            }
             .task {
                 if viewModel.phase == .idle {
                     await viewModel.checkForUpdates()
@@ -41,14 +29,17 @@ struct AppUpdaterView: View {
             AppUpdaterProgressState()
         case .ready:
             if viewModel.availableUpdates.isEmpty {
-                AppUpdaterUpToDateState()
+                AppUpdaterUpToDateState(
+                    onCheckAgain: { Task { await viewModel.checkForUpdates() } }
+                )
             } else {
                 AppUpdaterListState(
                     updates: viewModel.availableUpdates,
                     onUpdate: { info in
                         Task { await viewModel.update(info) }
                     },
-                    onUpdateAll: { Task { await viewModel.updateAll() } }
+                    onUpdateAll: { Task { await viewModel.updateAll() } },
+                    onCheckAgain: { Task { await viewModel.checkForUpdates() } }
                 )
             }
         case .failed(let message):
@@ -80,6 +71,8 @@ private struct AppUpdaterProgressState: View {
 }
 
 private struct AppUpdaterUpToDateState: View {
+    let onCheckAgain: () -> Void
+
     var body: some View {
         VStack(spacing: 12) {
             Image(systemName: "checkmark.seal.fill")
@@ -98,6 +91,12 @@ private struct AppUpdaterUpToDateState: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 460)
+            Button(String(
+                localized: "Check for Updates",
+                comment: "Button on the App Updater that re-checks for updates."
+            ), action: onCheckAgain)
+                .controlSize(.large)
+                .accessibilityIdentifier("appUpdater.check")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("appUpdater.upToDate")
@@ -108,6 +107,7 @@ private struct AppUpdaterListState: View {
     let updates: [UpdateInfo]
     let onUpdate: (UpdateInfo) -> Void
     let onUpdateAll: () -> Void
+    let onCheckAgain: () -> Void
 
     /// Above this many pending updates, "Update All" asks for
     /// confirmation first — each entry opens an App Store page or a
@@ -132,6 +132,11 @@ private struct AppUpdaterListState: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
+                Button(String(
+                    localized: "Check for Updates",
+                    comment: "Footer button on the App Updater that re-checks for updates."
+                ), action: onCheckAgain)
+                    .accessibilityIdentifier("appUpdater.check")
                 Button(String(
                     localized: "Update All",
                     comment: "Footer button on the App Updater that opens every available update."

--- a/VaderCleaner/ExtensionsManagerView.swift
+++ b/VaderCleaner/ExtensionsManagerView.swift
@@ -19,20 +19,6 @@ struct ExtensionsManagerView: View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle(NavigationSection.extensions.title)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        Task { await viewModel.refresh() }
-                    } label: {
-                        Label(String(
-                            localized: "Refresh",
-                            comment: "Toolbar button that re-runs Extensions Manager discovery."
-                        ), systemImage: "arrow.clockwise")
-                    }
-                    .disabled(viewModel.phase == .loading || viewModel.phase == .removing)
-                    .accessibilityIdentifier("extensions.refresh")
-                }
-            }
             .task {
                 if viewModel.phase == .idle {
                     await viewModel.refresh()
@@ -86,11 +72,14 @@ struct ExtensionsManagerView: View {
             )
         case .ready:
             if viewModel.groupedByType.isEmpty {
-                ExtensionsManagerEmptyState()
+                ExtensionsManagerEmptyState(
+                    onRefresh: { Task { await viewModel.refresh() } }
+                )
             } else {
                 ExtensionsManagerList(
                     groups: viewModel.groupedByType,
-                    onRemove: { pendingRemoval = $0 }
+                    onRemove: { pendingRemoval = $0 },
+                    onRefresh: { Task { await viewModel.refresh() } }
                 )
             }
         case .failed(let stage, let message):

--- a/VaderCleaner/ExtensionsManagerViewSubviews.swift
+++ b/VaderCleaner/ExtensionsManagerViewSubviews.swift
@@ -30,6 +30,8 @@ struct ExtensionsManagerProgressState: View {
 }
 
 struct ExtensionsManagerEmptyState: View {
+    let onRefresh: () -> Void
+
     var body: some View {
         VStack(spacing: 12) {
             Image(systemName: "puzzlepiece.extension")
@@ -48,6 +50,12 @@ struct ExtensionsManagerEmptyState: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 420)
+            Button(String(
+                localized: "Refresh",
+                comment: "Button that re-runs Extensions Manager discovery."
+            ), action: onRefresh)
+                .controlSize(.large)
+                .accessibilityIdentifier("extensions.refresh")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("extensions.empty")
@@ -57,23 +65,36 @@ struct ExtensionsManagerEmptyState: View {
 struct ExtensionsManagerList: View {
     let groups: [(ExtensionType, [ExtensionItem])]
     let onRemove: (ExtensionItem) -> Void
+    let onRefresh: () -> Void
 
     var body: some View {
-        List {
-            ForEach(groups, id: \.0) { pair in
-                Section {
-                    ForEach(pair.1) { item in
-                        ExtensionsManagerRow(item: item) { onRemove(item) }
-                            .accessibilityIdentifier("extensions.row.\(pair.0.rawValue).\(item.path.lastPathComponent)")
+        VStack(spacing: 0) {
+            List {
+                ForEach(groups, id: \.0) { pair in
+                    Section {
+                        ForEach(pair.1) { item in
+                            ExtensionsManagerRow(item: item) { onRemove(item) }
+                                .accessibilityIdentifier("extensions.row.\(pair.0.rawValue).\(item.path.lastPathComponent)")
+                        }
+                    } header: {
+                        Text(LocalizedStringKey(pair.0.displayName))
+                            .font(.callout.weight(.semibold))
                     }
-                } header: {
-                    Text(LocalizedStringKey(pair.0.displayName))
-                        .font(.callout.weight(.semibold))
                 }
             }
+            .listStyle(.inset)
+            .scrollContentBackground(.hidden)
+            Divider()
+            HStack {
+                Spacer()
+                Button(String(
+                    localized: "Refresh",
+                    comment: "Footer button that re-runs Extensions Manager discovery."
+                ), action: onRefresh)
+                    .accessibilityIdentifier("extensions.refresh")
+            }
+            .padding(16)
         }
-        .listStyle(.inset)
-        .scrollContentBackground(.hidden)
     }
 }
 

--- a/VaderCleaner/OptimizationView.swift
+++ b/VaderCleaner/OptimizationView.swift
@@ -19,20 +19,6 @@ struct OptimizationView: View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle(NavigationSection.optimization.title)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        Task { await viewModel.refresh() }
-                    } label: {
-                        Label(String(
-                            localized: "Refresh",
-                            comment: "Toolbar button that reloads Optimization data."
-                        ), systemImage: "arrow.clockwise")
-                    }
-                    .disabled(viewModel.phase == .loading || viewModel.phase == .working)
-                    .accessibilityIdentifier("optimization.refresh")
-                }
-            }
             .task {
                 if viewModel.phase == .idle {
                     await viewModel.refresh()
@@ -103,46 +89,60 @@ struct OptimizationView: View {
     }
 
     private var sections: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                OptimizationLoginItemsSection(
-                    items: viewModel.loginItems,
-                    onToggle: { item, enabled in
-                        Task { await viewModel.setLoginItem(item, enabled: enabled) }
-                    }
-                )
-                OptimizationLaunchAgentsSection(
-                    title: String(
-                        localized: "Launch Agents (User)",
-                        comment: "Section header for user launch agents."
-                    ),
-                    identifier: "optimization.userAgents",
-                    agents: viewModel.userAgents,
-                    onDisable: { agent in Task { await viewModel.disable(agent) } },
-                    onRemove: { pendingRemoval = $0 }
-                )
-                OptimizationLaunchAgentsSection(
-                    title: String(
-                        localized: "Launch Agents & Daemons (System)",
-                        comment: "Section header for system launch agents and daemons."
-                    ),
-                    identifier: "optimization.systemAgents",
-                    agents: viewModel.systemAgents,
-                    onDisable: { agent in Task { await viewModel.disable(agent) } },
-                    onRemove: { pendingRemoval = $0 }
-                )
-                OptimizationRAMSection(
-                    memory: viewModel.memory,
-                    result: viewModel.ramResult,
-                    onFlush: { Task { await viewModel.flushRAM() } }
-                )
-                OptimizationMaintenanceSection(
-                    output: viewModel.maintenanceOutput,
-                    onRun: { Task { await viewModel.runMaintenanceScripts() } }
-                )
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    OptimizationLoginItemsSection(
+                        items: viewModel.loginItems,
+                        onToggle: { item, enabled in
+                            Task { await viewModel.setLoginItem(item, enabled: enabled) }
+                        }
+                    )
+                    OptimizationLaunchAgentsSection(
+                        title: String(
+                            localized: "Launch Agents (User)",
+                            comment: "Section header for user launch agents."
+                        ),
+                        identifier: "optimization.userAgents",
+                        agents: viewModel.userAgents,
+                        onDisable: { agent in Task { await viewModel.disable(agent) } },
+                        onRemove: { pendingRemoval = $0 }
+                    )
+                    OptimizationLaunchAgentsSection(
+                        title: String(
+                            localized: "Launch Agents & Daemons (System)",
+                            comment: "Section header for system launch agents and daemons."
+                        ),
+                        identifier: "optimization.systemAgents",
+                        agents: viewModel.systemAgents,
+                        onDisable: { agent in Task { await viewModel.disable(agent) } },
+                        onRemove: { pendingRemoval = $0 }
+                    )
+                    OptimizationRAMSection(
+                        memory: viewModel.memory,
+                        result: viewModel.ramResult,
+                        onFlush: { Task { await viewModel.flushRAM() } }
+                    )
+                    OptimizationMaintenanceSection(
+                        output: viewModel.maintenanceOutput,
+                        onRun: { Task { await viewModel.runMaintenanceScripts() } }
+                    )
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding(24)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            Divider()
+            HStack {
+                Spacer()
+                Button(String(
+                    localized: "Refresh",
+                    comment: "Footer button that reloads Optimization data."
+                )) {
+                    Task { await viewModel.refresh() }
+                }
+                .accessibilityIdentifier("optimization.refresh")
+            }
+            .padding(16)
         }
     }
 

--- a/VaderCleanerUITests/OptimizationUITests.swift
+++ b/VaderCleanerUITests/OptimizationUITests.swift
@@ -1,5 +1,5 @@
 // OptimizationUITests.swift
-// End-to-end UI test for Optimization — navigates to the section, taps the floating Scan on the unified intro, and asserts the view renders (toolbar + a ready-state section) so the sidebar → view-model → view wiring is exercised against the real app process.
+// End-to-end UI test for Optimization — navigates to the section, taps the floating Scan on the unified intro, and asserts the view renders (a ready-state section + its in-content Refresh control) so the sidebar → view-model → view wiring is exercised against the real app process.
 
 import XCTest
 
@@ -24,7 +24,7 @@ final class OptimizationUITests: XCTestCase {
         app = nil
     }
 
-    func test_navigateToOptimization_scan_revealsToolbarAndContent() throws {
+    func test_navigateToOptimization_scan_revealsRefreshAndContent() throws {
         dismissOnboardingIfNeeded()
 
         let sidebarRow = app.buttons["sidebar.optimization"].firstMatch
@@ -47,18 +47,20 @@ final class OptimizationUITests: XCTestCase {
                       "Expected the floating Scan button on the Optimization intro")
         floatingScan.click()
 
-        // The refresh toolbar button is present whenever the view renders,
-        // independent of phase — strongest "view did not crash" signal.
-        let refresh = app.buttons["optimization.refresh"]
-        XCTAssertTrue(refresh.waitForExistence(timeout: 10),
-                      "Expected Optimization toolbar to render")
-
         // Loading runs automatically on first appearance; landing on the
         // ready state surfaces the RAM usage label. Generous timeout because
-        // discovery shells out to `launchctl list`.
+        // discovery shells out to `launchctl list`. Assert ready first: the
+        // Refresh control now lives in the ready-state footer, so it cannot
+        // appear before the section renders.
         let ramUsage = app.staticTexts["optimization.ramUsage"]
         XCTAssertTrue(ramUsage.waitForExistence(timeout: 30),
                       "Expected Optimization to reach its ready state")
+
+        // The in-content Refresh button renders alongside the ready state —
+        // strongest "view did not crash" signal once the section is shown.
+        let refresh = app.buttons["optimization.refresh"]
+        XCTAssertTrue(refresh.waitForExistence(timeout: 5),
+                      "Expected Optimization Refresh control to render")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## What

Removes the rescan button from the window toolbar (next to the traffic lights) on **App Updater**, **Extensions**, and **Optimization**, and relocates it *inside* each section's content.

## Why

The toolbar placement put rescan up next to the traffic lights, away from the content it acts on. This moves it into the section body using the footer idiom the app already uses on System Junk and Space Lens — scrollable content → `Divider` → a footer row with the action on the trailing edge — so the three sections match the rest of the app.

## Details

- **App Updater** — dropped the toolbar; added "Check for Updates" to the existing list footer next to "Update All", and to the up-to-date empty state.
- **Extensions** — dropped the toolbar; wrapped the grouped list in a `VStack` with a `Divider` + footer "Refresh", and added "Refresh" to the empty state.
- **Optimization** — dropped the toolbar; added a `Divider` + footer "Refresh" below the scrolling sections.

The toolbar button previously rendered in every phase, so rescan is kept reachable in the empty / up-to-date states too — not just the populated list. Failed states keep their existing "Try Again" actions.

## Notes for reviewers

- Accessibility identifiers (`appUpdater.check`, `extensions.refresh`, `optimization.refresh`) are preserved on `.bordered`/text buttons, deliberately avoiding the `Label`-in-`.plain` button XCUITest pitfall so existing test wiring keeps working.
- `optimization.refresh` now renders only in the ready state, so `OptimizationUITests` was reordered to assert the ready state *before* the Refresh control (the 10s wait could otherwise fire before `launchctl` discovery finished), and the now-false "toolbar" wording in its comments, assertion, method name, and file header was corrected.
- Verified with `xcodebuild build-for-testing` (app + test targets compile). The UI test itself was not executed — the XCUITest runner can't bootstrap from a headless terminal in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved "Check for Updates" action from toolbar to in-content buttons, appearing in both up-to-date and update-available states
  * Moved "Refresh" action from toolbar to in-content footer buttons in extensions and optimization views
  * Updated button visibility and placement across multiple management screens

* **Tests**
  * Updated UI tests to verify button placement in updated view layouts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jayvicsanantonio/VaderCleaner/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->