### PR TITLE
Performance: maintenance-task dashboard, catalog, and macOS 26 gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Podfile.lock
 
 # Code coverage artifacts
 *.profraw
+
+# Per-developer signing override (not shared)
+Signing.local.xcconfig

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Podfile.lock
 
 # Local developer tooling — per-machine config, not shared
 .claude/settings.local.json
+
+# Code coverage artifacts
+*.profraw

--- a/Scripts/sign-dev.sh
+++ b/Scripts/sign-dev.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# sign-dev.sh
+# Ad-hoc code-signs the privileged helper and the app for local (unsigned)
+# development builds, so SMAppService will register the helper and the
+# Optimization actions can reach it. No-ops when a real signing identity is
+# configured, leaving Developer ID / release signing untouched.
+
+set -e
+
+# Skip when a real signing identity is in use — release/distribution builds sign
+# with Developer ID, and re-signing ad-hoc here would clobber that. Ad-hoc
+# builds report an empty identity or the "-" sentinel.
+if [ -n "${CODE_SIGN_IDENTITY:-}" ] && [ "${CODE_SIGN_IDENTITY}" != "-" ]; then
+    echo "sign-dev: signing identity '${CODE_SIGN_IDENTITY}' in use — skipping ad-hoc signing."
+    exit 0
+fi
+
+APP="${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}"
+HELPER="${APP}/Contents/MacOS/VaderCleanerHelper"
+
+if [ ! -d "${APP}" ]; then
+    echo "sign-dev: app bundle not found at ${APP}" >&2
+    exit 1
+fi
+if [ ! -f "${HELPER}" ]; then
+    echo "sign-dev: helper executable not found at ${HELPER}" >&2
+    exit 1
+fi
+
+# Sign inside-out so sealing the app bundle doesn't trip over unsigned nested
+# code. `--deep` is deliberately avoided: it would re-sign the helper with the
+# wrong (default) identifier and break the XPC code-signing requirement.
+
+# Auxiliary dylibs Xcode emits alongside the main executable in a debug build
+# (the debug dylib and, with Previews enabled, __preview.dylib) are unsigned and
+# must be signed before the bundle seal. The ClamAV dylibs in Contents/Frameworks
+# are already signed by stage-clamav.sh.
+for dylib in "${APP}/Contents/MacOS/"*.dylib; do
+    [ -e "${dylib}" ] || continue
+    echo "sign-dev: ad-hoc signing $(basename "${dylib}")"
+    codesign --force --sign - "${dylib}"
+done
+
+# The helper is a command-line tool, whose default signing identifier is the
+# executable name — pass its bundle identifier explicitly so it matches the
+# code-signing requirement the helper enforces on the XPC connection.
+echo "sign-dev: ad-hoc signing helper (com.personal.VaderCleaner.helper)"
+codesign --force --sign - --identifier com.personal.VaderCleaner.helper "${HELPER}"
+
+echo "sign-dev: ad-hoc signing app bundle"
+codesign --force --sign - "${APP}"
+
+echo "sign-dev: done."

--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -86,4 +86,19 @@ protocol VaderCleanerHelperProtocol {
     /// Frees inactive memory by invoking the system `purge` command.
     @objc(flushInactiveMemoryWithReply:)
     func flushInactiveMemory(reply: @escaping (Error?) -> Void)
+
+    /// Flushes the DNS resolver cache (`dscacheutil -flushcache` followed by
+    /// `killall -HUP mDNSResponder`).
+    @objc(flushDNSCacheWithReply:)
+    func flushDNSCache(reply: @escaping (Error?) -> Void)
+
+    /// Erases and rebuilds the Spotlight index for the boot volume
+    /// (`mdutil -E /`).
+    @objc(reindexSpotlightWithReply:)
+    func reindexSpotlight(reply: @escaping (Error?) -> Void)
+
+    /// Thins local Time Machine snapshots on the boot volume
+    /// (`tmutil thinlocalsnapshots / <bytes> 4`).
+    @objc(thinTimeMachineSnapshotsWithReply:)
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void)
 }

--- a/Signing.local.xcconfig.example
+++ b/Signing.local.xcconfig.example
@@ -1,0 +1,12 @@
+// Signing.local.xcconfig.example
+// Copy this to Signing.local.xcconfig (gitignored) and set your own Apple
+// Development Team ID to give the privileged helper a stable signing identity
+// so SMAppService can launch it locally. Then run `xcodegen generate` (or just
+// rebuild) and Build & Run from Xcode.
+//
+// Find your Team ID with:  security find-identity -v -p codesigning
+// (it's the 10-character code in the "Apple Development: …" certificate).
+
+CODE_SIGN_IDENTITY = Apple Development
+CODE_SIGNING_REQUIRED = YES
+DEVELOPMENT_TEAM = YOUR_TEAM_ID

--- a/Signing.xcconfig
+++ b/Signing.xcconfig
@@ -1,0 +1,20 @@
+// Signing.xcconfig
+// Team-agnostic signing defaults so any checkout (and CI) can build. The app
+// builds unsigned here and Scripts/sign-dev.sh ad-hoc signs it as a post-build
+// step.
+//
+// The privileged helper (an SMAppService daemon) needs a STABLE Team identity
+// to launch — ad-hoc has no team and its cdhash churns each build, which
+// SMAppService rejects (EX_CONFIG). To run the helper-backed Optimization
+// actions locally, copy Signing.local.xcconfig.example to Signing.local.xcconfig
+// (gitignored) and set your own Apple Development Team ID. Without it the app
+// still builds and runs; only the helper-backed actions are unavailable.
+
+CODE_SIGN_STYLE = Manual
+CODE_SIGN_IDENTITY =
+CODE_SIGNING_REQUIRED = NO
+CODE_SIGNING_ALLOWED = YES
+DEVELOPMENT_TEAM =
+
+// Optional, per-developer override — not committed (see .gitignore).
+#include? "Signing.local.xcconfig"

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
 		82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotCounter.swift; sourceTree = "<group>"; };
+		869E8D8A460A998AA0E6B854 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
 		88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanOverlay.swift; sourceTree = "<group>"; };
 		897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensView.swift; sourceTree = "<group>"; };
@@ -578,6 +579,7 @@
 			children = (
 				E64E279A077DB78FF7F39BDD /* Shared */,
 				82214E451FF2D64A74A4B196 /* VaderCleaner */,
+				89BDE2EE038F8B5544BF44FE /* VaderCleaner */,
 				DD23DA844162EC496E4C0C1D /* VaderCleanerHelper */,
 				E90D4526947C1F261F963425 /* VaderCleanerTests */,
 				6A2D96C9C63AD506553F0BE0 /* VaderCleanerUITests */,
@@ -744,6 +746,15 @@
 				1316773A7836F762A217D5E2 /* Resources */,
 			);
 			path = VaderCleaner;
+			sourceTree = "<group>";
+		};
+		89BDE2EE038F8B5544BF44FE /* VaderCleaner */ = {
+			isa = PBXGroup;
+			children = (
+				869E8D8A460A998AA0E6B854 /* Signing.xcconfig */,
+			);
+			name = VaderCleaner;
+			path = .;
 			sourceTree = "<group>";
 		};
 		D1CA1C4B91CA064A86FEE9DA /* Models */ = {
@@ -969,19 +980,19 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					0A2954465B4713F8951601A1 = {
-						DevelopmentTeam = XGQ94CMBTN;
+						DevelopmentTeam = "";
 						ProvisioningStyle = Manual;
 					};
 					8309E530B1256636F6042A29 = {
-						DevelopmentTeam = XGQ94CMBTN;
+						DevelopmentTeam = "";
 						ProvisioningStyle = Manual;
 					};
 					AECD709401424A144DA3AD4A = {
-						DevelopmentTeam = XGQ94CMBTN;
+						DevelopmentTeam = "";
 						ProvisioningStyle = Manual;
 					};
 					F6D57048ED0E43FEADC2CFAF = {
-						DevelopmentTeam = XGQ94CMBTN;
+						DevelopmentTeam = "";
 						ProvisioningStyle = Manual;
 						TestTargetID = AECD709401424A144DA3AD4A;
 					};
@@ -1447,6 +1458,7 @@
 		};
 		6FC5B4C07B6F4D2470E81C20 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 869E8D8A460A998AA0E6B854 /* Signing.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1478,13 +1490,8 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_ALLOWED = YES;
-				CODE_SIGNING_REQUIRED = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = XGQ94CMBTN;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1516,6 +1523,7 @@
 		};
 		7AC507F3249F5A68448657EF /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 869E8D8A460A998AA0E6B854 /* Signing.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1547,13 +1555,8 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_ALLOWED = YES;
-				CODE_SIGNING_REQUIRED = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = XGQ94CMBTN;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -7,12 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00EA71EF4E372CADB9F1BDCD /* MaintenanceRunLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */; };
 		024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */; };
 		03546E424E99155428A6D25F /* HelperConnectionErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E776BF468380DFF621C6063C /* HelperConnectionErrorTests.swift */; };
 		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
 		04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
 		09756E0B2E09D8BF521C1141 /* MalwareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7315AD5A081B0855C316F00F /* MalwareView.swift */; };
+		0CB34F6C9EDA3A4723026B5C /* SunburstLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6387590A274A5888D9BF28D /* SunburstLayoutTests.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
@@ -29,15 +31,13 @@
 		161EB790ECA69115DBAC1B6F /* malwareRemoval.usdz in Resources */ = {isa = PBXBuildFile; fileRef = D1D5689879C5C19243A7AF1E /* malwareRemoval.usdz */; };
 		17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */; };
 		1947460A68C713844C308694 /* TreemapLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */; };
-		65FED5757882F56378BE1E5D /* SpaceLensViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49AF7388796118B18C97F45 /* SpaceLensViewMode.swift */; };
-		2B5D08DE02EC0F4548A037AF /* SunburstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FF58BEFFFB4D547C5749B9 /* SunburstView.swift */; };
-		68A1828E35374F73EA5D598D /* SpaceLensHoverCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1E33C927182B28BDBE65DF /* SpaceLensHoverCard.swift */; };
-		83089B096416267341C2EA8C /* SunburstLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D260D83F735F56606617A8 /* SunburstLayout.swift */; };
 		196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
 		1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */; };
 		1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */; };
 		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
+		1F7B67D271BC88E4A13A1AE8 /* MaintenanceTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */; };
+		1F88CDFF1571AB8A8DCB3F7D /* MailReindexerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933E3B42C683C14A7398939F /* MailReindexerTests.swift */; };
 		20A0A0A414E0D919060C99D2 /* MalwareThreatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */; };
 		218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46943B264F72B3753075A8C /* UpdateInfoTests.swift */; };
 		2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */; };
@@ -61,6 +61,7 @@
 		2DD748D16E344D435A5C3E24 /* HelperRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */; };
 		2DF208D271EE337E2E36CC06 /* largeOldFiles.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 1683C13B4837D58AD519341C /* largeOldFiles.usdz */; };
 		2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CA7922445475111927C0B /* AppInfo.swift */; };
+		3312F51624418F8A57FFA6C6 /* SpaceLensViewModeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707C4D6B14FF468458441A6 /* SpaceLensViewModeStoreTests.swift */; };
 		3328707476CC1411FA1270D0 /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D92F45290B56030CBFA83D3 /* Browser.swift */; };
 		3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6697CA6EEE719B2E2D46CE /* AppState.swift */; };
 		3551B102B5ADE80553AA1A4F /* SmartScanMalwareReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD71B02544D13F9E3A36014 /* SmartScanMalwareReview.swift */; };
@@ -80,18 +81,21 @@
 		3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */; };
 		406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */; };
 		4156DAE09EB7579F22FA6959 /* MalwareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */; };
+		431465517AFBE2AE7342608D /* SpaceLensViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3631D872F6AA2F98BA133922 /* SpaceLensViewMode.swift */; };
 		4453CD1C9BEA6DFD3C62E054 /* FloatingRunOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */; };
 		4536F93FC837F56C61CDD236 /* spaceLens.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 785EECE3C6B84ECB7D0A3384 /* spaceLens.usdz */; };
 		45825BEE32AC83FC8B685E28 /* ScanProgressFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A3AE9EED81844B80CF3A1A /* ScanProgressFormatting.swift */; };
 		45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */; };
 		472FECDAABC513309987AA5E /* SmartScanJunkReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67824DA18085247812F6E08 /* SmartScanJunkReview.swift */; };
 		483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */; };
+		486889584CC330C197D3641C /* SunburstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E22C1BDB2BEFB0F5CF93927 /* SunburstView.swift */; };
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
 		4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */; };
 		4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */; };
+		501740B00BAF4BDC50747510 /* MaintenanceTaskRunnersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F08CF19441CB25F982CDCD2 /* MaintenanceTaskRunnersTests.swift */; };
 		50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */; };
 		52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */; };
 		5325F2401AF35C69086E2056 /* NavigationRailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */; };
@@ -103,6 +107,7 @@
 		5C240506F97A777E37CA25B2 /* PrivacyViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */; };
 		5DF68FC234F70DA478496658 /* SystemStatsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */; };
 		5DFC3E9A2E5B6A578312E485 /* HelperConnectionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F973B5B33642739FB9D7D004 /* HelperConnectionError.swift */; };
+		5EB593DAA9232D5B705166E7 /* LocalSnapshotCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */; };
 		5F2AB607564A60D0DCBFABEC /* PermissionOnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */; };
 		5FCAAC81ED67F40178636235 /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
 		5FE19122629FE05486A04159 /* smartScan.usdz in Resources */ = {isa = PBXBuildFile; fileRef = BBE51C5A592BB78EAB7E3A5D /* smartScan.usdz */; };
@@ -117,6 +122,7 @@
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
 		6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */; };
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
+		6E0D8F255BA67DF884857717 /* PerformanceRecommendationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31CF01651B0768E98E36F3E /* PerformanceRecommendationEngine.swift */; };
 		6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */; };
 		6EF22E5516F91C461FBBB850 /* SmartScanApplicationsReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215EFDDDC81E5E7C6DBD72AB /* SmartScanApplicationsReview.swift */; };
 		6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */; };
@@ -149,10 +155,13 @@
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8AB1E73B111F38CE182AD9D3 /* ObservationRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462B37702C713BE1630DC992 /* ObservationRecording.swift */; };
 		8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */; };
+		8D1F98F5CF62C8E5539D0ADF /* OptimizationDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0558BA919F5FF29A56051C /* OptimizationDashboardSubviews.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
 		91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */; };
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
 		9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */; };
+		948B522FF71E5F5417EC78E6 /* SunburstLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D42C1D0E2A41D26EF168F1 /* SunburstLayout.swift */; };
+		97F42752FD75E7F3E6CAF219 /* SpaceLensHoverCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */; };
 		99B965EE0BB2762D13896FF6 /* EmptyStateFullDiskAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */; };
 		99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC50A90E584320709971BCB /* ScanCategoryTests.swift */; };
 		9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */; };
@@ -165,6 +174,7 @@
 		A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */; };
 		A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
+		A91615BDF2CBB95FF6444C46 /* MaintenanceRunLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */; };
 		A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */; };
 		ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */; };
 		AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC67B639248BC5EA1F5473 /* ScanCategory.swift */; };
@@ -188,8 +198,6 @@
 		BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133467A06193C406B027D97C /* NavigationSectionTests.swift */; };
 		BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC391B523110720320AD89 /* SystemPathProviding.swift */; };
 		BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */; };
-		F55EB106F505A83D0683544C /* SpaceLensViewModeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA4FCCD6881922F9CCBA421 /* SpaceLensViewModeStoreTests.swift */; };
-		F9AC9391D8126F241AF625F1 /* SunburstLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1081ECF8AC14D5DFE7974FD /* SunburstLayoutTests.swift */; };
 		BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */; };
 		BEFCD2F309C985449A2901F5 /* SmartScanMyClutterReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F498579A77E1DAED6AC00AF /* SmartScanMyClutterReview.swift */; };
 		C2542EE3974C2F9232EE74D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5E978BB01AD677AEDE122B1C /* Assets.xcassets */; };
@@ -200,13 +208,16 @@
 		C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */; };
 		C3F9A86A896DAD3A63EB8F9F /* ExclusionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6085B6A39985DFF334821551 /* ExclusionsStore.swift */; };
 		C75E96295ED70F91F6B2A0F1 /* SectionTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */; };
+		C848FD080F1DED2282ADC12E /* LocalSnapshotCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */; };
 		C9DB75A7B6E045D306393638 /* PrivacyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */; };
 		CF68F2891382E3F3D4CA5474 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */; };
 		D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */; };
 		D04A64F83480761DF5F12344 /* OptimizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669493D60C3958979B97FA04 /* OptimizationViewModelTests.swift */; };
+		D25319BADD929D75CA704136 /* MailReindexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2017911CF02D2B89E8BF865 /* MailReindexer.swift */; };
 		D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */; };
 		D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */; };
 		DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */; };
+		DC01035B8409197605E03C76 /* PerformanceRecommendationEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD3CFDAD89263D0CAE10471 /* PerformanceRecommendationEngineTests.swift */; };
 		DC099BEFD567C81EAA36519E /* ClamAVScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */; };
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
 		DD929B8195C7904CB4AC2E62 /* OptimizationViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */; };
@@ -221,6 +232,7 @@
 		E7B7C87B22F9328A45CC6A4B /* AppStoreUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */; };
 		E8FC89247E29889B193EC7B3 /* optimization.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 6363E1DC5E00AABB550C3541 /* optimization.usdz */; };
 		EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */; };
+		EB8DA1022F80D620B92D6BAC /* MaintenanceTaskRunners.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13455C35AFED113F2D85DE /* MaintenanceTaskRunners.swift */; };
 		EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */; };
 		EC99895496A545FE0F9A9222 /* FullDiskAccessPromptCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */; };
 		EE62512542BF54B5D6ADFA9D /* FloatingScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */; };
@@ -237,6 +249,7 @@
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
 		FE156E2CD69BA8F894E9078D /* FloatingScanButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A35775D85A4E890A04EE26 /* FloatingScanButtonTests.swift */; };
 		FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */; };
+		FF8163DBE33C05789BE5F41C /* MaintenanceTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D83104C36AA0A0E85DB7698 /* MaintenanceTask.swift */; };
 		FF87A6FAB563AF43345061BB /* PreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */; };
 		FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */; };
 /* End PBXBuildFile section */
@@ -302,6 +315,7 @@
 		0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyCategory.swift; sourceTree = "<group>"; };
 		0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitor.swift; sourceTree = "<group>"; };
 		0D4E92A146A223EA836C156D /* ScanResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResultTests.swift; sourceTree = "<group>"; };
+		0D83104C36AA0A0E85DB7698 /* MaintenanceTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTask.swift; sourceTree = "<group>"; };
 		0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensUITests.swift; sourceTree = "<group>"; };
 		0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModel.swift; sourceTree = "<group>"; };
 		1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewSubviews.swift; sourceTree = "<group>"; };
@@ -338,6 +352,7 @@
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
+		3631D872F6AA2F98BA133922 /* SpaceLensViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewMode.swift; sourceTree = "<group>"; };
 		3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscHostView.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
 		374A11FF89347AF05A14498B /* ScannableSectionContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannableSectionContent.swift; sourceTree = "<group>"; };
@@ -353,6 +368,7 @@
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
 		42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewSubviews.swift; sourceTree = "<group>"; };
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
+		44D42C1D0E2A41D26EF168F1 /* SunburstLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstLayout.swift; sourceTree = "<group>"; };
 		450554B15FB43AFECE584589 /* SmartScanOptimizationReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanOptimizationReview.swift; sourceTree = "<group>"; };
 		462B37702C713BE1630DC992 /* ObservationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationRecording.swift; sourceTree = "<group>"; };
 		46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpersTests.swift; sourceTree = "<group>"; };
@@ -360,10 +376,6 @@
 		48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscWindowController.swift; sourceTree = "<group>"; };
 		49D62624319B764770F02292 /* AppUninstallerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModel.swift; sourceTree = "<group>"; };
 		4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayout.swift; sourceTree = "<group>"; };
-		D49AF7388796118B18C97F45 /* SpaceLensViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewMode.swift; sourceTree = "<group>"; };
-		E9FF58BEFFFB4D547C5749B9 /* SunburstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstView.swift; sourceTree = "<group>"; };
-		1B1E33C927182B28BDBE65DF /* SpaceLensHoverCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensHoverCard.swift; sourceTree = "<group>"; };
-		C8D260D83F735F56606617A8 /* SunburstLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstLayout.swift; sourceTree = "<group>"; };
 		4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScanner.swift; sourceTree = "<group>"; };
 		4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkUITests.swift; sourceTree = "<group>"; };
 		4D92F45290B56030CBFA83D3 /* Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
@@ -408,15 +420,17 @@
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
 		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
+		7707C4D6B14FF468458441A6 /* SpaceLensViewModeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewModeStoreTests.swift; sourceTree = "<group>"; };
 		785EECE3C6B84ECB7D0A3384 /* spaceLens.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = spaceLens.usdz; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
+		7E22C1BDB2BEFB0F5CF93927 /* SunburstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstView.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
+		7F08CF19441CB25F982CDCD2 /* MaintenanceTaskRunnersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTaskRunnersTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
 		80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapLayoutTests.swift; sourceTree = "<group>"; };
-		3EA4FCCD6881922F9CCBA421 /* SpaceLensViewModeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewModeStoreTests.swift; sourceTree = "<group>"; };
-		E1081ECF8AC14D5DFE7974FD /* SunburstLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstLayoutTests.swift; sourceTree = "<group>"; };
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
+		82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotCounter.swift; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
 		88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanOverlay.swift; sourceTree = "<group>"; };
 		897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensView.swift; sourceTree = "<group>"; };
@@ -433,6 +447,7 @@
 		90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModel.swift; sourceTree = "<group>"; };
 		91C01D5C9DD349049220AFB2 /* VaderCleanerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VaderCleanerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResult.swift; sourceTree = "<group>"; };
+		933E3B42C683C14A7398939F /* MailReindexerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailReindexerTests.swift; sourceTree = "<group>"; };
 		93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesView.swift; sourceTree = "<group>"; };
 		9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearer.swift; sourceTree = "<group>"; };
 		9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionThemeTests.swift; sourceTree = "<group>"; };
@@ -451,6 +466,7 @@
 		A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemoverTests.swift; sourceTree = "<group>"; };
 		A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviderTests.swift; sourceTree = "<group>"; };
 		A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkView.swift; sourceTree = "<group>"; };
+		AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTaskTests.swift; sourceTree = "<group>"; };
 		ABD71B02544D13F9E3A36014 /* SmartScanMalwareReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanMalwareReview.swift; sourceTree = "<group>"; };
 		AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinating.swift; sourceTree = "<group>"; };
 		AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorView.swift; sourceTree = "<group>"; };
@@ -461,6 +477,7 @@
 		B39407E2EA6D045893F1BA4B /* DiskNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskNode.swift; sourceTree = "<group>"; };
 		B3CD8C98E8253953444DD99F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		B46943B264F72B3753075A8C /* UpdateInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfoTests.swift; sourceTree = "<group>"; };
+		B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensHoverCard.swift; sourceTree = "<group>"; };
 		B79E0766E335360E04FC6A53 /* AppDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscovery.swift; sourceTree = "<group>"; };
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
 		BBE51C5A592BB78EAB7E3A5D /* smartScan.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = smartScan.usdz; sourceTree = "<group>"; };
@@ -471,20 +488,24 @@
 		BF767348D39506E36221A89D /* MalwareThreatRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemover.swift; sourceTree = "<group>"; };
 		BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewModelTests.swift; sourceTree = "<group>"; };
 		C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewSubviews.swift; sourceTree = "<group>"; };
+		C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotCounterTests.swift; sourceTree = "<group>"; };
 		C2A35775D85A4E890A04EE26 /* FloatingScanButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButtonTests.swift; sourceTree = "<group>"; };
 		C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScannerTests.swift; sourceTree = "<group>"; };
 		C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
 		C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinderTests.swift; sourceTree = "<group>"; };
 		C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScanner.swift; sourceTree = "<group>"; };
 		C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C6387590A274A5888D9BF28D /* SunburstLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstLayoutTests.swift; sourceTree = "<group>"; };
 		C751F5671E4A4657944A7DFC /* PrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyView.swift; sourceTree = "<group>"; };
 		C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStoreTests.swift; sourceTree = "<group>"; };
 		C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewSubviews.swift; sourceTree = "<group>"; };
 		CAC2037BDF5D632418393BD9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		CC13455C35AFED113F2D85DE /* MaintenanceTaskRunners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTaskRunners.swift; sourceTree = "<group>"; };
 		CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVOutputParserTests.swift; sourceTree = "<group>"; };
 		CEAF96E747AD4C1378B4043D /* VersionComparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparator.swift; sourceTree = "<group>"; };
 		CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateChecker.swift; sourceTree = "<group>"; };
 		CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModelTests.swift; sourceTree = "<group>"; };
+		CFD3CFDAD89263D0CAE10471 /* PerformanceRecommendationEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceRecommendationEngineTests.swift; sourceTree = "<group>"; };
 		D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingRunOverlay.swift; sourceTree = "<group>"; };
 		D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVOutputParser.swift; sourceTree = "<group>"; };
 		D1CC391B523110720320AD89 /* SystemPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPathProviding.swift; sourceTree = "<group>"; };
@@ -495,14 +516,17 @@
 		D2A9C2E47C91B66B79030BE7 /* MalwareViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModelTests.swift; sourceTree = "<group>"; };
 		D2C2B92863509818189F46CD /* MenuBarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContent.swift; sourceTree = "<group>"; };
 		D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRailView.swift; sourceTree = "<group>"; };
+		DB0558BA919F5FF29A56051C /* OptimizationDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationDashboardSubviews.swift; sourceTree = "<group>"; };
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
 		DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewSubviews.swift; sourceTree = "<group>"; };
+		DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceRunLogTests.swift; sourceTree = "<group>"; };
 		DEB9C7A07E62C19FD94824B5 /* SmartScanViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanViewSubviews.swift; sourceTree = "<group>"; };
 		DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItemTests.swift; sourceTree = "<group>"; };
 		DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitorTests.swift; sourceTree = "<group>"; };
 		E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalPolishUITests.swift; sourceTree = "<group>"; };
 		E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStore.swift; sourceTree = "<group>"; };
 		E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModel.swift; sourceTree = "<group>"; };
+		E2017911CF02D2B89E8BF865 /* MailReindexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailReindexer.swift; sourceTree = "<group>"; };
 		E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModel.swift; sourceTree = "<group>"; };
 		E67824DA18085247812F6E08 /* SmartScanJunkReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanJunkReview.swift; sourceTree = "<group>"; };
 		E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVDetectorTests.swift; sourceTree = "<group>"; };
@@ -517,11 +541,13 @@
 		F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunnerTests.swift; sourceTree = "<group>"; };
 		F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManagerTests.swift; sourceTree = "<group>"; };
 		F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleterTests.swift; sourceTree = "<group>"; };
+		F31CF01651B0768E98E36F3E /* PerformanceRecommendationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceRecommendationEngine.swift; sourceTree = "<group>"; };
 		F421495C84A41EDEF253EBD6 /* FileCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategory.swift; sourceTree = "<group>"; };
 		F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderTheme.swift; sourceTree = "<group>"; };
 		F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanAccessPopoverTests.swift; sourceTree = "<group>"; };
 		F973B5B33642739FB9D7D004 /* HelperConnectionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionError.swift; sourceTree = "<group>"; };
 		FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VaderCleaner.entitlements; sourceTree = "<group>"; };
+		FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceRunLog.swift; sourceTree = "<group>"; };
 		FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManagerTests.swift; sourceTree = "<group>"; };
 		FE6697CA6EEE719B2E2D46CE /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorViewModel.swift; sourceTree = "<group>"; };
@@ -630,9 +656,14 @@
 				E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */,
 				1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */,
 				B17B889E32D6334AED35F2BE /* LaunchAgent.swift */,
+				82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */,
 				27F1DC062C52C51730548216 /* LoginItem.swift */,
 				5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */,
+				E2017911CF02D2B89E8BF865 /* MailReindexer.swift */,
+				FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */,
 				AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */,
+				0D83104C36AA0A0E85DB7698 /* MaintenanceTask.swift */,
+				CC13455C35AFED113F2D85DE /* MaintenanceTaskRunners.swift */,
 				882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */,
 				E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */,
 				5741874005D8A34BB7D82287 /* MalwareThreat.swift */,
@@ -646,9 +677,11 @@
 				2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */,
 				B3CD8C98E8253953444DD99F /* NotificationManager.swift */,
 				0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */,
+				DB0558BA919F5FF29A56051C /* OptimizationDashboardSubviews.swift */,
 				59C47AD889D249E865B928C8 /* OptimizationView.swift */,
 				6DDE71332468CC343A9C6091 /* OptimizationViewModel.swift */,
 				C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */,
+				F31CF01651B0768E98E36F3E /* PerformanceRecommendationEngine.swift */,
 				6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */,
 				2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */,
 				E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */,
@@ -684,8 +717,12 @@
 				3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */,
 				D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */,
 				DEB9C7A07E62C19FD94824B5 /* SmartScanViewSubviews.swift */,
+				B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */,
 				897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */,
+				3631D872F6AA2F98BA133922 /* SpaceLensViewMode.swift */,
 				CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */,
+				44D42C1D0E2A41D26EF168F1 /* SunburstLayout.swift */,
+				7E22C1BDB2BEFB0F5CF93927 /* SunburstView.swift */,
 				16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */,
 				9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */,
 				A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */,
@@ -694,10 +731,6 @@
 				02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */,
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
 				4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */,
-				D49AF7388796118B18C97F45 /* SpaceLensViewMode.swift */,
-				E9FF58BEFFFB4D547C5749B9 /* SunburstView.swift */,
-				1B1E33C927182B28BDBE65DF /* SpaceLensHoverCard.swift */,
-				C8D260D83F735F56606617A8 /* SunburstLayout.swift */,
 				50BDB24525760C96625DD266 /* TreemapView.swift */,
 				2617BC26104D5196DEDB3589 /* UpdateInfo.swift */,
 				9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */,
@@ -794,9 +827,14 @@
 				603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */,
 				BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */,
 				FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */,
+				C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */,
 				1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */,
 				5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */,
+				933E3B42C683C14A7398939F /* MailReindexerTests.swift */,
+				DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */,
 				F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */,
+				7F08CF19441CB25F982CDCD2 /* MaintenanceTaskRunnersTests.swift */,
+				AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */,
 				6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */,
 				A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */,
 				EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */,
@@ -807,6 +845,7 @@
 				DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */,
 				462B37702C713BE1630DC992 /* ObservationRecording.swift */,
 				669493D60C3958979B97FA04 /* OptimizationViewModelTests.swift */,
+				CFD3CFDAD89263D0CAE10471 /* PerformanceRecommendationEngineTests.swift */,
 				7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */,
 				6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */,
 				8FDCA830E855A79696389B2A /* PrivacyCategoryTests.swift */,
@@ -825,15 +864,15 @@
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
+				7707C4D6B14FF468458441A6 /* SpaceLensViewModeStoreTests.swift */,
 				22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */,
+				C6387590A274A5888D9BF28D /* SunburstLayoutTests.swift */,
 				F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */,
 				2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */,
 				DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */,
 				6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */,
 				46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */,
 				80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */,
-				3EA4FCCD6881922F9CCBA421 /* SpaceLensViewModeStoreTests.swift */,
-				E1081ECF8AC14D5DFE7974FD /* SunburstLayoutTests.swift */,
 				B46943B264F72B3753075A8C /* UpdateInfoTests.swift */,
 				1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */,
 				E149BD1FE4E65D6589292B84 /* Helpers */,
@@ -888,6 +927,7 @@
 				789DD6BBD4FECA89B890AEF3 /* Resources */,
 				0C5C5E5270D52EFEBF1EE933 /* CopyFiles */,
 				D37833ADC32F18DB4C339B74 /* Embed Dependencies */,
+				F4E4466B06149CF339F8CD03 /* Ad-hoc sign for local development */,
 			);
 			buildRules = (
 			);
@@ -929,19 +969,19 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					0A2954465B4713F8951601A1 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = XGQ94CMBTN;
 						ProvisioningStyle = Manual;
 					};
 					8309E530B1256636F6042A29 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = XGQ94CMBTN;
 						ProvisioningStyle = Manual;
 					};
 					AECD709401424A144DA3AD4A = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = XGQ94CMBTN;
 						ProvisioningStyle = Manual;
 					};
 					F6D57048ED0E43FEADC2CFAF = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = XGQ94CMBTN;
 						ProvisioningStyle = Manual;
 						TestTargetID = AECD709401424A144DA3AD4A;
 					};
@@ -1013,6 +1053,25 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Scripts/stage-clamav.sh\"\n";
 		};
+		F4E4466B06149CF339F8CD03 /* Ad-hoc sign for local development */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Ad-hoc sign for local development";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Scripts/sign-dev.sh\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1058,9 +1117,14 @@
 				50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */,
 				2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */,
 				04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */,
+				C848FD080F1DED2282ADC12E /* LocalSnapshotCounterTests.swift in Sources */,
 				8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */,
 				406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */,
+				1F88CDFF1571AB8A8DCB3F7D /* MailReindexerTests.swift in Sources */,
+				00EA71EF4E372CADB9F1BDCD /* MaintenanceRunLogTests.swift in Sources */,
 				1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */,
+				501740B00BAF4BDC50747510 /* MaintenanceTaskRunnersTests.swift in Sources */,
+				1F7B67D271BC88E4A13A1AE8 /* MaintenanceTaskTests.swift in Sources */,
 				E39551732C1E81A0418FF7EE /* MalwareOnboardingViewModelTests.swift in Sources */,
 				70D8E3251176A02F51CB78FD /* MalwareThreatRemoverTests.swift in Sources */,
 				20A0A0A414E0D919060C99D2 /* MalwareThreatTests.swift in Sources */,
@@ -1071,6 +1135,7 @@
 				2BB370554CD9C84ED37C81A0 /* NotificationThresholdMonitorTests.swift in Sources */,
 				8AB1E73B111F38CE182AD9D3 /* ObservationRecording.swift in Sources */,
 				D04A64F83480761DF5F12344 /* OptimizationViewModelTests.swift in Sources */,
+				DC01035B8409197605E03C76 /* PerformanceRecommendationEngineTests.swift in Sources */,
 				5F2AB607564A60D0DCBFABEC /* PermissionOnboardingViewModelTests.swift in Sources */,
 				1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */,
 				2A9EFA38DAE2163D06793B46 /* PrivacyCategoryTests.swift in Sources */,
@@ -1089,7 +1154,9 @@
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				2D8DAC3191BC1733AE762C03 /* SectionThemeTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
+				3312F51624418F8A57FFA6C6 /* SpaceLensViewModeStoreTests.swift in Sources */,
 				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,
+				0CB34F6C9EDA3A4723026B5C /* SunburstLayoutTests.swift in Sources */,
 				6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */,
 				13606F2F7161EAECBE67338C /* SystemJunkScannerTests.swift in Sources */,
 				0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */,
@@ -1097,8 +1164,6 @@
 				C26E98922A61A57DB9369C60 /* TestHelpers.swift in Sources */,
 				109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */,
 				BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */,
-				F55EB106F505A83D0683544C /* SpaceLensViewModeStoreTests.swift in Sources */,
-				F9AC9391D8126F241AF625F1 /* SunburstLayoutTests.swift in Sources */,
 				218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */,
 				3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */,
 			);
@@ -1186,9 +1251,14 @@
 				91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */,
 				483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */,
 				12253CA18E39F944F433E1AF /* LaunchAgent.swift in Sources */,
+				5EB593DAA9232D5B705166E7 /* LocalSnapshotCounter.swift in Sources */,
 				2CF8285ADDBEB285A1DB56AC /* LoginItem.swift in Sources */,
 				EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */,
+				D25319BADD929D75CA704136 /* MailReindexer.swift in Sources */,
+				A91615BDF2CBB95FF6444C46 /* MaintenanceRunLog.swift in Sources */,
 				A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */,
+				FF8163DBE33C05789BE5F41C /* MaintenanceTask.swift in Sources */,
+				EB8DA1022F80D620B92D6BAC /* MaintenanceTaskRunners.swift in Sources */,
 				E5548C91729D71FDA8D8ADC8 /* MalwareOnboardingView.swift in Sources */,
 				5B5767BC82C24D92B50032FE /* MalwareOnboardingViewModel.swift in Sources */,
 				B9E44C0566F7DFAFAF8A6071 /* MalwareThreat.swift in Sources */,
@@ -1202,9 +1272,11 @@
 				F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */,
 				65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */,
 				B60909E266277B691B876E63 /* NotificationThresholdMonitor.swift in Sources */,
+				8D1F98F5CF62C8E5539D0ADF /* OptimizationDashboardSubviews.swift in Sources */,
 				2AADBFF21DB782577861CB44 /* OptimizationView.swift in Sources */,
 				3685B2DC3948B9ACFD86FF71 /* OptimizationViewModel.swift in Sources */,
 				DD929B8195C7904CB4AC2E62 /* OptimizationViewSubviews.swift in Sources */,
+				6E0D8F255BA67DF884857717 /* PerformanceRecommendationEngine.swift in Sources */,
 				832F1B34810FF292EAF9A810 /* PermissionOnboardingView.swift in Sources */,
 				834DC89A0BA1ED2A0B5B33CB /* PermissionOnboardingViewModel.swift in Sources */,
 				FF87A6FAB563AF43345061BB /* PreferencesStore.swift in Sources */,
@@ -1240,8 +1312,12 @@
 				FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */,
 				9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */,
 				E357AD8EDB1FA65E6D5EB59E /* SmartScanViewSubviews.swift in Sources */,
+				97F42752FD75E7F3E6CAF219 /* SpaceLensHoverCard.swift in Sources */,
 				024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */,
+				431465517AFBE2AE7342608D /* SpaceLensViewMode.swift in Sources */,
 				B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */,
+				948B522FF71E5F5417EC78E6 /* SunburstLayout.swift in Sources */,
+				486889584CC330C197D3641C /* SunburstView.swift in Sources */,
 				1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */,
 				DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */,
 				B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */,
@@ -1250,10 +1326,6 @@
 				9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */,
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
 				1947460A68C713844C308694 /* TreemapLayout.swift in Sources */,
-				65FED5757882F56378BE1E5D /* SpaceLensViewMode.swift in Sources */,
-				2B5D08DE02EC0F4548A037AF /* SunburstView.swift in Sources */,
-				68A1828E35374F73EA5D598D /* SpaceLensHoverCard.swift in Sources */,
-				83089B096416267341C2EA8C /* SunburstLayout.swift in Sources */,
 				35F306676A3412253929EF55 /* TreemapView.swift in Sources */,
 				7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */,
 				6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */,
@@ -1308,6 +1380,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -1358,6 +1432,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -1402,11 +1478,13 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGNING_ALLOWED = YES;
+				CODE_SIGNING_REQUIRED = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = XGQ94CMBTN;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1469,11 +1547,13 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGNING_ALLOWED = YES;
+				CODE_SIGNING_REQUIRED = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = XGQ94CMBTN;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/VaderCleaner/LocalSnapshotCounter.swift
+++ b/VaderCleaner/LocalSnapshotCounter.swift
@@ -1,0 +1,46 @@
+// LocalSnapshotCounter.swift
+// Counts local Time Machine snapshots on the boot volume by parsing `tmutil listlocalsnapshots /`. Listing snapshots is unprivileged, so this runs in-app without the helper.
+
+import Foundation
+
+/// Counts the boot volume's local Time Machine snapshots. The raw command
+/// output is injected so unit tests parse canned output without running
+/// `tmutil` or depending on the host's snapshot state.
+struct LocalSnapshotCounter {
+
+    typealias ListSnapshots = () -> String
+
+    private let listSnapshots: ListSnapshots
+
+    init(listSnapshots: @escaping ListSnapshots = LocalSnapshotCounter.defaultListSnapshots) {
+        self.listSnapshots = listSnapshots
+    }
+
+    /// The number of local snapshots. `tmutil` prints one
+    /// `com.apple.TimeMachine.<date>.local` line per snapshot under a header.
+    func count() -> Int {
+        listSnapshots()
+            .split(whereSeparator: \.isNewline)
+            .filter { $0.contains("com.apple.TimeMachine") }
+            .count
+    }
+
+    /// Runs `/usr/bin/tmutil listlocalsnapshots /` and returns its stdout, or an
+    /// empty string if the command can't be run.
+    static func defaultListSnapshots() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tmutil")
+        process.arguments = ["listlocalsnapshots", "/"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return ""
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/VaderCleaner/LocalSnapshotCounter.swift
+++ b/VaderCleaner/LocalSnapshotCounter.swift
@@ -36,11 +36,14 @@ struct LocalSnapshotCounter {
         process.standardError = FileHandle.nullDevice
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return ""
         }
+        // Drain the pipe before waiting: if `tmutil`'s output exceeded the pipe
+        // buffer, waiting first would deadlock (the process blocks writing while
+        // we block waiting).
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
         return String(data: data, encoding: .utf8) ?? ""
     }
 }

--- a/VaderCleaner/MailReindexer.swift
+++ b/VaderCleaner/MailReindexer.swift
@@ -1,0 +1,137 @@
+// MailReindexer.swift
+// Rebuilds the Mail "Envelope Index" SQLite databases (VACUUM; REINDEX) to speed up Mail search. Runs at user level — no privileged helper — and distinguishes "no Full Disk Access" from "no Mail data" so the UI can guide the user.
+
+import Foundation
+import os.log
+
+/// Speeds up Mail by compacting and reindexing its envelope-index databases.
+/// The index locator and the per-database vacuum are injected so unit tests
+/// exercise the flow without touching real Mail data or running `sqlite3`.
+struct MailReindexer {
+
+    /// Locates the envelope-index databases. Throwing so it can signal the
+    /// difference between "no access" (Full Disk Access missing) and "no mail".
+    typealias LocateIndexes = () throws -> [URL]
+    typealias VacuumIndex = (URL) throws -> Void
+
+    private let locateIndexes: LocateIndexes
+    private let vacuumIndex: VacuumIndex
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "MailReindexer")
+
+    init(
+        locateIndexes: @escaping LocateIndexes = MailReindexer.defaultLocateIndexes,
+        vacuumIndex: @escaping VacuumIndex = MailReindexer.defaultVacuumIndex
+    ) {
+        self.locateIndexes = locateIndexes
+        self.vacuumIndex = vacuumIndex
+    }
+
+    /// Vacuums and reindexes every located envelope index. Throws
+    /// `.fullDiskAccessRequired` when `~/Library/Mail` can't be read (the common
+    /// case — the app isn't in Full Disk Access), `.noMailData` when Mail simply
+    /// has no databases, and rethrows the first vacuum failure (e.g. Mail is
+    /// open and holding a lock).
+    func run() async throws -> String {
+        let indexes = try locateIndexes()
+        guard !indexes.isEmpty else {
+            throw MailReindexerError.noMailData
+        }
+        for index in indexes {
+            try vacuumIndex(index)
+        }
+        let format = String(
+            localized: "Reindexed %d Mail database(s). Quit and reopen Mail to see the change.",
+            comment: "Result line after the Mail envelope indexes are rebuilt; %d is the count."
+        )
+        return String.localizedStringWithFormat(format, indexes.count)
+    }
+
+    // MARK: - Production collaborators
+
+    /// Finds the envelope-index databases under `~/Library/Mail`. Mail stores
+    /// them per account-format version at `V<n>/MailData/Envelope Index`, so this
+    /// looks only at that shallow, known location rather than walking the whole
+    /// (potentially huge) Mail tree. Reading `~/Library/Mail` is gated by Full
+    /// Disk Access: a permission failure there means the app hasn't been
+    /// granted access, which is reported distinctly from "no mail".
+    static func defaultLocateIndexes() throws -> [URL] {
+        let mailRoot = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Mail", isDirectory: true)
+
+        let versionDirs: [URL]
+        do {
+            versionDirs = try FileManager.default.contentsOfDirectory(
+                at: mailRoot,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        } catch CocoaError.fileReadNoPermission {
+            throw MailReindexerError.fullDiskAccessRequired
+        } catch let error as NSError where error.domain == NSPOSIXErrorDomain
+            && error.code == Int(EPERM) {
+            throw MailReindexerError.fullDiskAccessRequired
+        } catch {
+            // No Mail folder (never set up) or some other read error — treat as
+            // "nothing to reindex" rather than a permission problem.
+            return []
+        }
+
+        // Mail's index lives at V<n>/MailData/Envelope Index on current macOS;
+        // the bare V<n>/Envelope Index covers older layouts.
+        var found: [URL] = []
+        for dir in versionDirs where dir.lastPathComponent.hasPrefix("V") {
+            for relative in ["MailData/Envelope Index", "Envelope Index"] {
+                let candidate = dir.appendingPathComponent(relative)
+                if FileManager.default.fileExists(atPath: candidate.path) {
+                    found.append(candidate)
+                }
+            }
+        }
+        return found
+    }
+
+    /// Runs `/usr/bin/sqlite3 <index> "VACUUM; REINDEX;"`. Throws on a non-zero
+    /// exit (a locked database while Mail is open is the common case).
+    static func defaultVacuumIndex(_ index: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        process.arguments = [index.path, "VACUUM; REINDEX;"]
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw MailReindexerError.vacuumFailed(
+                path: index.path,
+                status: process.terminationStatus
+            )
+        }
+    }
+}
+
+/// Failures surfaced by `MailReindexer`, with user-facing messages.
+enum MailReindexerError: LocalizedError {
+    case fullDiskAccessRequired
+    case noMailData
+    case vacuumFailed(path: String, status: Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .fullDiskAccessRequired:
+            return String(
+                localized: "Speeding up Mail needs Full Disk Access. Grant it in System Settings → Privacy & Security → Full Disk Access, then try again.",
+                comment: "Error when MailReindexer can't read ~/Library/Mail because the app lacks Full Disk Access."
+            )
+        case .noMailData:
+            return String(
+                localized: "No Mail databases were found to reindex.",
+                comment: "Error when MailReindexer finds no envelope-index databases even though it could read the Mail folder."
+            )
+        case .vacuumFailed:
+            return String(
+                localized: "Couldn't reindex Mail. Quit Mail and try again.",
+                comment: "Error when the Mail envelope-index vacuum fails, usually because Mail is open."
+            )
+        }
+    }
+}

--- a/VaderCleaner/MailReindexer.swift
+++ b/VaderCleaner/MailReindexer.swift
@@ -70,7 +70,9 @@ struct MailReindexer {
         } catch CocoaError.fileReadNoPermission {
             throw MailReindexerError.fullDiskAccessRequired
         } catch let error as NSError where error.domain == NSPOSIXErrorDomain
-            && error.code == Int(EPERM) {
+            && (error.code == Int(EPERM) || error.code == Int(EACCES)) {
+            // TCC/sandbox denials surface as EPERM or EACCES depending on the
+            // API and macOS version — treat both as "needs Full Disk Access".
             throw MailReindexerError.fullDiskAccessRequired
         } catch {
             // No Mail folder (never set up) or some other read error — treat as
@@ -81,7 +83,9 @@ struct MailReindexer {
         // Mail's index lives at V<n>/MailData/Envelope Index on current macOS;
         // the bare V<n>/Envelope Index covers older layouts.
         var found: [URL] = []
-        for dir in versionDirs where dir.lastPathComponent.hasPrefix("V") {
+        // Match version dirs like "V10" — "V" followed by digits — so unrelated
+        // folders (e.g. a hypothetical "Vendor") aren't treated as Mail data.
+        for dir in versionDirs where isMailVersionDirectory(dir.lastPathComponent) {
             for relative in ["MailData/Envelope Index", "Envelope Index"] {
                 let candidate = dir.appendingPathComponent(relative)
                 if FileManager.default.fileExists(atPath: candidate.path) {
@@ -90,6 +94,13 @@ struct MailReindexer {
             }
         }
         return found
+    }
+
+    /// A Mail account-format version directory is "V" followed by one or more
+    /// digits (V2…V10…). The digit check avoids matching unrelated folders.
+    private static func isMailVersionDirectory(_ name: String) -> Bool {
+        let suffix = name.dropFirst()
+        return name.hasPrefix("V") && !suffix.isEmpty && suffix.allSatisfy(\.isNumber)
     }
 
     /// Runs `/usr/bin/sqlite3 <index> "VACUUM; REINDEX;"`. Throws on a non-zero

--- a/VaderCleaner/MaintenanceRunLog.swift
+++ b/VaderCleaner/MaintenanceRunLog.swift
@@ -1,0 +1,51 @@
+// MaintenanceRunLog.swift
+// Persists the last time each maintenance task was run (UserDefaults-backed) so the recommendation engine can flag tasks that are due to run again.
+
+import Foundation
+
+/// Records and reads per-task last-run timestamps. Backed by `UserDefaults`
+/// (a single dictionary entry keyed by task id) so the data survives relaunch;
+/// the suite is injected so tests use an isolated suite instead of `.standard`.
+struct MaintenanceRunLog {
+
+    /// Tasks not run within this window count as stale (due to run again).
+    static let staleWindow: TimeInterval = 7 * 24 * 60 * 60
+
+    private let defaults: UserDefaults
+    private let key = "performance.maintenanceLastRun"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// The last time the given task id was run, or `nil` if it never has.
+    func lastRun(for id: String) -> Date? {
+        guard let interval = storedIntervals()[id] else { return nil }
+        return Date(timeIntervalSinceReferenceDate: interval)
+    }
+
+    /// Stamps the given task id as having run at `date` (defaults to now).
+    func record(_ id: String, at date: Date = Date()) {
+        var intervals = storedIntervals()
+        intervals[id] = date.timeIntervalSinceReferenceDate
+        defaults.set(intervals, forKey: key)
+    }
+
+    /// The given ids that are due to run again — never run, or last run longer
+    /// ago than `staleWindow`.
+    func staleTaskIDs(among ids: [String], now: Date = Date()) -> [String] {
+        ids.filter { id in
+            guard let last = lastRun(for: id) else { return true }
+            return now.timeIntervalSince(last) > Self.staleWindow
+        }
+    }
+
+    /// How many of the given ids are due to run again.
+    func staleTaskCount(among ids: [String], now: Date = Date()) -> Int {
+        staleTaskIDs(among: ids, now: now).count
+    }
+
+    private func storedIntervals() -> [String: TimeInterval] {
+        defaults.dictionary(forKey: key) as? [String: TimeInterval] ?? [:]
+    }
+}

--- a/VaderCleaner/MaintenanceTask.swift
+++ b/VaderCleaner/MaintenanceTask.swift
@@ -1,0 +1,104 @@
+// MaintenanceTask.swift
+// Catalog of the performance maintenance tasks the Optimization section can run, with display metadata for the "View All Tasks" list and the recommendation cards.
+
+import Foundation
+
+/// One entry in the maintenance-task catalog. Pure display + classification
+/// metadata; the actual work is performed by the matching runner wired into
+/// `OptimizationViewModel`. Availability that depends on live system state
+/// (e.g. whether local snapshots exist) is decided by the recommendation
+/// engine, not baked in here — the catalog list itself is fixed.
+struct MaintenanceTask: Identifiable, Hashable {
+
+    /// The fixed set of tasks. `requiresHelper` distinguishes privileged tasks
+    /// (run through `VaderCleanerHelper`) from the user-level Mail reindex.
+    enum Kind: String, CaseIterable {
+        case freeUpRAM
+        case runMaintenanceScripts
+        case flushDNS
+        case reindexSpotlight
+        case thinTimeMachineSnapshots
+        case speedUpMail
+    }
+
+    let kind: Kind
+    let title: String
+    let summary: String
+    let icon: String
+    let requiresHelper: Bool
+
+    var id: String { kind.rawValue }
+
+    /// The tasks the "Maintenance Tasks Recommended" card counts and runs — the
+    /// recurring upkeep cocktail. Free up RAM (its own hero card) and Thin Time
+    /// Machine Snapshots (its own card) are surfaced separately, so they are
+    /// excluded here to keep the maintenance card's count and action aligned.
+    static let maintenanceCocktailKinds: [Kind] = [
+        .runMaintenanceScripts, .flushDNS, .reindexSpotlight, .speedUpMail
+    ]
+
+    /// The catalog in display order — Free up RAM and Maintenance Scripts first
+    /// (the long-standing actions), then the newer system tasks.
+    static let catalog: [MaintenanceTask] = [
+        MaintenanceTask(
+            kind: .freeUpRAM,
+            title: String(localized: "Free Up RAM", comment: "Maintenance task title."),
+            summary: String(
+                localized: "Reclaim inactive memory so active apps have more room to work.",
+                comment: "Maintenance task summary for freeing RAM."
+            ),
+            icon: "memorychip",
+            requiresHelper: true
+        ),
+        MaintenanceTask(
+            kind: .runMaintenanceScripts,
+            title: String(localized: "Run Maintenance Scripts", comment: "Maintenance task title."),
+            summary: String(
+                localized: "Run the system periodic daily, weekly, and monthly scripts.",
+                comment: "Maintenance task summary for periodic scripts."
+            ),
+            icon: "wrench.and.screwdriver",
+            requiresHelper: true
+        ),
+        MaintenanceTask(
+            kind: .flushDNS,
+            title: String(localized: "Flush DNS Cache", comment: "Maintenance task title."),
+            summary: String(
+                localized: "Clear cached DNS records to fix stale lookups and connection slowdowns.",
+                comment: "Maintenance task summary for flushing DNS."
+            ),
+            icon: "network",
+            requiresHelper: true
+        ),
+        MaintenanceTask(
+            kind: .reindexSpotlight,
+            title: String(localized: "Reindex Spotlight", comment: "Maintenance task title."),
+            summary: String(
+                localized: "Rebuild the Spotlight index to restore search speed and accuracy.",
+                comment: "Maintenance task summary for reindexing Spotlight."
+            ),
+            icon: "magnifyingglass",
+            requiresHelper: true
+        ),
+        MaintenanceTask(
+            kind: .thinTimeMachineSnapshots,
+            title: String(localized: "Thin Time Machine Snapshots", comment: "Maintenance task title."),
+            summary: String(
+                localized: "Reclaim disk space from local snapshots without affecting your backups.",
+                comment: "Maintenance task summary for thinning Time Machine snapshots."
+            ),
+            icon: "clock.arrow.circlepath",
+            requiresHelper: true
+        ),
+        MaintenanceTask(
+            kind: .speedUpMail,
+            title: String(localized: "Speed Up Mail", comment: "Maintenance task title."),
+            summary: String(
+                localized: "Rebuild the Mail database to improve search and message handling.",
+                comment: "Maintenance task summary for speeding up Mail."
+            ),
+            icon: "envelope",
+            requiresHelper: false
+        )
+    ]
+}

--- a/VaderCleaner/MaintenanceTaskRunners.swift
+++ b/VaderCleaner/MaintenanceTaskRunners.swift
@@ -1,0 +1,138 @@
+// MaintenanceTaskRunners.swift
+// Privileged maintenance-task runners — bridges the DNS-flush, Spotlight-reindex, and Time Machine snapshot-thinning XPC calls to async/throwing and returns a human-readable result line for each.
+
+import Foundation
+import os.log
+
+/// Shared bridge from a reply-block helper selector to async/throwing. Mirrors
+/// `MaintenanceScriptRunner`'s structure but is parameterised by the selector
+/// to invoke and the success message to return, so the three privileged
+/// maintenance tasks share one connection/continuation path instead of three
+/// copies. Collaborators are injected as a `helperProvider` closure so unit
+/// tests exercise success / failure / dropped-reply without a live helper.
+struct PrivilegedTaskRunner {
+
+    typealias HelperProvider = (@escaping (Error) -> Void) -> VaderCleanerHelperProtocol?
+    typealias Invoke = (VaderCleanerHelperProtocol, @escaping (Error?) -> Void) -> Void
+
+    private let helperProvider: HelperProvider
+    private let invoke: Invoke
+    private let successMessage: String
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "PrivilegedTaskRunner")
+
+    init(
+        helperProvider: @escaping HelperProvider,
+        invoke: @escaping Invoke,
+        successMessage: String
+    ) {
+        self.helperProvider = helperProvider
+        self.invoke = invoke
+        self.successMessage = successMessage
+    }
+
+    /// Invokes the configured selector. Installs both the per-call XPC error
+    /// handler and the reply block so a dropped connection can't freeze the UI.
+    /// Returns the success line on success; throws on any failure (including an
+    /// unreachable helper).
+    func run() async throws -> String {
+        let error: Error? = await withCheckedContinuation { continuation in
+            let resumer = TaskResumer(continuation: continuation)
+            let helper = helperProvider { connectionError in
+                resumer.resume(with: connectionError)
+            }
+            guard let helper else {
+                resumer.resume(with: HelperConnectionError.unavailable)
+                return
+            }
+            invoke(helper) { replyError in
+                resumer.resume(with: replyError)
+            }
+        }
+        if let error {
+            log.error("Maintenance task failed: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+        return successMessage
+    }
+}
+
+/// Once-only continuation resume — the XPC reply block and the connection-level
+/// error handler may both fire and `CheckedContinuation` traps on a second
+/// resume, so the first wins and later attempts are dropped.
+private final class TaskResumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: error)
+    }
+}
+
+// MARK: - DNS cache
+
+/// Flushes the DNS resolver cache through the privileged helper.
+struct DNSCacheFlusher {
+    private let runner: PrivilegedTaskRunner
+
+    init(helperProvider: @escaping PrivilegedTaskRunner.HelperProvider = SystemJunkDeleter.defaultHelperProvider) {
+        runner = PrivilegedTaskRunner(
+            helperProvider: helperProvider,
+            invoke: { helper, done in helper.flushDNSCache(reply: done) },
+            successMessage: String(
+                localized: "Flushed the DNS resolver cache.",
+                comment: "Result line shown after the DNS cache is flushed."
+            )
+        )
+    }
+
+    func run() async throws -> String { try await runner.run() }
+}
+
+// MARK: - Spotlight
+
+/// Erases and rebuilds the Spotlight index for the boot volume.
+struct SpotlightReindexer {
+    private let runner: PrivilegedTaskRunner
+
+    init(helperProvider: @escaping PrivilegedTaskRunner.HelperProvider = SystemJunkDeleter.defaultHelperProvider) {
+        runner = PrivilegedTaskRunner(
+            helperProvider: helperProvider,
+            invoke: { helper, done in helper.reindexSpotlight(reply: done) },
+            successMessage: String(
+                localized: "Started rebuilding the Spotlight index. Search may be slower until indexing finishes.",
+                comment: "Result line shown after a Spotlight reindex is started."
+            )
+        )
+    }
+
+    func run() async throws -> String { try await runner.run() }
+}
+
+// MARK: - Time Machine
+
+/// Thins local Time Machine snapshots on the boot volume.
+struct TimeMachineSnapshotThinner {
+    private let runner: PrivilegedTaskRunner
+
+    init(helperProvider: @escaping PrivilegedTaskRunner.HelperProvider = SystemJunkDeleter.defaultHelperProvider) {
+        runner = PrivilegedTaskRunner(
+            helperProvider: helperProvider,
+            invoke: { helper, done in helper.thinTimeMachineSnapshots(reply: done) },
+            successMessage: String(
+                localized: "Thinned local Time Machine snapshots.",
+                comment: "Result line shown after local Time Machine snapshots are thinned."
+            )
+        )
+    }
+
+    func run() async throws -> String { try await runner.run() }
+}

--- a/VaderCleaner/OptimizationDashboardSubviews.swift
+++ b/VaderCleaner/OptimizationDashboardSubviews.swift
@@ -1,0 +1,537 @@
+// OptimizationDashboardSubviews.swift
+// Curated-recommendations dashboard and the "View All Tasks" catalog for the Optimization screen — glass recommendation cards, the maintenance-task list, and the folded-in background-items (login items / launch agents) sections.
+
+import SwiftUI
+
+// MARK: - Dashboard
+
+/// The Optimization landing surface: a header tagline, a "View All Tasks"
+/// affordance, and the curated recommendation cards (a tall hero card on the
+/// left, the rest in an adaptive grid), mirroring the Performance dashboard.
+struct OptimizationDashboardView: View {
+    let recommendations: [PerformanceRecommendation]
+    /// Recommendation kinds whose action has completed — their tiles show a check.
+    let completedKinds: Set<PerformanceRecommendation.Kind>
+    let onAction: (PerformanceRecommendation) -> Void
+    let onViewAllTasks: () -> Void
+
+    private var hero: PerformanceRecommendation? {
+        recommendations.first { $0.isHero }
+    }
+
+    private var standardCards: [PerformanceRecommendation] {
+        recommendations.filter { !$0.isHero }
+    }
+
+    var body: some View {
+        VStack(spacing: 28) {
+            header
+            if recommendations.isEmpty {
+                emptyState
+            } else {
+                cardLayout
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        .accessibilityIdentifier("optimization.dashboard")
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Text(String(
+                localized: "Apply curated recommendations\nor run performance tasks manually.",
+                comment: "Optimization dashboard tagline."
+            ))
+            .font(.title2.weight(.semibold))
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+
+            Button(action: onViewAllTasks) {
+                Text(String(
+                    localized: "View All Tasks",
+                    comment: "Button that opens the full maintenance-task catalog."
+                ))
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("optimization.viewAllTasks")
+        }
+    }
+
+    private var cardLayout: some View {
+        HStack(alignment: .top, spacing: 16) {
+            if let hero {
+                PerformanceRecommendationCard(
+                    recommendation: hero,
+                    isCompleted: completedKinds.contains(hero.kind)
+                ) { onAction(hero) }
+                    .frame(maxWidth: 320)
+            }
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 260), spacing: 16)],
+                alignment: .leading,
+                spacing: 16
+            ) {
+                ForEach(standardCards) { recommendation in
+                    PerformanceRecommendationCard(
+                        recommendation: recommendation,
+                        isCompleted: completedKinds.contains(recommendation.kind)
+                    ) {
+                        onAction(recommendation)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+            Text(String(
+                localized: "Your Mac is in good shape",
+                comment: "Optimization dashboard empty-state title."
+            ))
+            .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "No performance recommendations right now. You can still run any task manually.",
+                comment: "Optimization dashboard empty-state detail."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 24)
+        .accessibilityIdentifier("optimization.dashboard.empty")
+    }
+}
+
+/// A single curated recommendation card. Uses the same glass surface and corner
+/// radius as the Smart Scan / Health dashboards so the app's card surfaces stay
+/// consistent. The hero card is rendered taller. When its action has completed,
+/// a green check replaces the icon and the button reads "Done".
+struct PerformanceRecommendationCard: View {
+    let recommendation: PerformanceRecommendation
+    var isCompleted: Bool = false
+    let onAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Text(recommendation.title)
+                    .font(.headline)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                Image(systemName: isCompleted ? "checkmark.circle.fill" : recommendation.icon)
+                    .font(.title2)
+                    .foregroundStyle(isCompleted ? AnyShapeStyle(.green) : AnyShapeStyle(.tint))
+                    .contentTransition(.symbolEffect(.replace))
+                    .accessibilityIdentifier(
+                        isCompleted ? "optimization.recommendation.\(recommendation.kind.rawValue).done" : ""
+                    )
+            }
+            Text(recommendation.detail)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 8)
+            HStack {
+                Spacer()
+                Button(action: onAction) {
+                    if isCompleted {
+                        Label(
+                            String(localized: "Done", comment: "Recommendation card button after its action completed."),
+                            systemImage: "checkmark"
+                        )
+                    } else {
+                        Text(recommendation.actionLabel)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(isCompleted ? .green : nil)
+                .accessibilityIdentifier("optimization.recommendation.\(recommendation.kind.rawValue)")
+            }
+        }
+        .padding(18)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: recommendation.isHero ? 260 : 150,
+            alignment: .leading
+        )
+        // 12 matches the Smart Scan / Health cards so every dashboard card
+        // surface shares one corner radius.
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .animation(.smooth(duration: 0.25), value: isCompleted)
+    }
+}
+
+// MARK: - Task catalog
+
+/// The "View All Tasks" surface, modelled on a Performance Manager: a back
+/// affordance, a left sub-navigation (Maintenance Tasks / Login Items /
+/// Background Items), and a detail pane. The Maintenance Tasks pane is a
+/// multi-select checklist with a "Run" bar that runs every selected task at
+/// once; the other two panes host the existing management sections.
+struct OptimizationTaskCatalogView: View {
+
+    /// The three catalog panes the sub-navigation switches between.
+    enum Pane: Hashable {
+        case maintenanceTasks
+        case loginItems
+        case backgroundItems
+    }
+
+    /// Which pane is shown. Bound to the owning view so the selection survives
+    /// the "Working…" remount and so a dashboard card can open a specific pane.
+    @Binding var pane: Pane
+    let tasks: [MaintenanceTask]
+    let results: [String: String]
+    let loginItems: [LoginItem]
+    let userAgents: [LaunchAgent]
+    let systemAgents: [LaunchAgent]
+    let onRunSelected: ([MaintenanceTask]) -> Void
+    let onToggleLoginItem: (LoginItem, Bool) -> Void
+    let onDisableAgent: (LaunchAgent) -> Void
+    let onRemoveAgent: (LaunchAgent) -> Void
+    let onBack: () -> Void
+
+    @State private var selectedTaskIDs: Set<String> = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            HStack(spacing: 0) {
+                subNavigation
+                    .frame(width: 220)
+                    .padding(16)
+                Divider()
+                detailPane
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("optimization.catalog")
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack {
+            Button(action: onBack) {
+                // HStack(Image, Text) rather than Label so the control surfaces
+                // reliably in XCUITest.
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text(String(
+                        localized: "Back",
+                        comment: "Back button returning from the task catalog to the dashboard."
+                    ))
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("optimization.backToDashboard")
+            Spacer()
+            Text(String(
+                localized: "Performance Manager",
+                comment: "Title of the View All Tasks catalog."
+            ))
+            .font(.headline)
+            Spacer()
+            // Balances the leading Back button so the title stays centred.
+            Color.clear.frame(width: 44, height: 1)
+        }
+        .padding(16)
+    }
+
+    // MARK: Sub-navigation
+
+    private var subNavigation: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            navItem(.maintenanceTasks,
+                    String(localized: "Maintenance Tasks", comment: "Catalog sub-nav item."),
+                    "optimization.catalog.nav.maintenanceTasks")
+            navItem(.loginItems,
+                    String(localized: "Login Items", comment: "Catalog sub-nav item."),
+                    "optimization.catalog.nav.loginItems")
+            navItem(.backgroundItems,
+                    String(localized: "Background Items", comment: "Catalog sub-nav item."),
+                    "optimization.catalog.nav.backgroundItems")
+            Spacer()
+        }
+    }
+
+    private func navItem(_ target: Pane, _ title: String, _ identifier: String) -> some View {
+        Button {
+            pane = target
+        } label: {
+            Text(title)
+                .font(.body.weight(pane == target ? .semibold : .regular))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    pane == target ? Color.primary.opacity(0.10) : .clear,
+                    in: .rect(cornerRadius: 8)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+
+    // MARK: Detail pane
+
+    @ViewBuilder
+    private var detailPane: some View {
+        switch pane {
+        case .maintenanceTasks:
+            maintenanceTasksPane
+        case .loginItems:
+            paneScroll {
+                OptimizationLoginItemsSection(items: loginItems, onToggle: onToggleLoginItem)
+            }
+        case .backgroundItems:
+            paneScroll {
+                OptimizationLaunchAgentsSection(
+                    title: String(
+                        localized: "Launch Agents (User)",
+                        comment: "Section header for user launch agents."
+                    ),
+                    identifier: "optimization.userAgents",
+                    agents: userAgents,
+                    onDisable: onDisableAgent,
+                    onRemove: onRemoveAgent
+                )
+                OptimizationLaunchAgentsSection(
+                    title: String(
+                        localized: "Launch Agents & Daemons (System)",
+                        comment: "Section header for system launch agents and daemons."
+                    ),
+                    identifier: "optimization.systemAgents",
+                    agents: systemAgents,
+                    onDisable: onDisableAgent,
+                    onRemove: onRemoveAgent
+                )
+            }
+        }
+    }
+
+    private func paneScroll<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                content()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(24)
+        }
+    }
+
+    private var maintenanceTasksPane: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(String(localized: "Maintenance Tasks", comment: "Maintenance tasks pane heading."))
+                        .font(.title3.weight(.semibold))
+                    Text(String(
+                        localized: "Essential Mac care, run in one place. Select the tasks you want and run them together.",
+                        comment: "Maintenance tasks pane description."
+                    ))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                    VStack(spacing: 10) {
+                        ForEach(tasks) { task in
+                            OptimizationTaskRow(
+                                task: task,
+                                tint: OptimizationTaskPalette.tint(for: task.kind),
+                                isSelected: selectedTaskIDs.contains(task.id),
+                                result: results[task.id],
+                                onToggle: { toggle(task) }
+                            )
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(24)
+            }
+            Divider()
+            runBar
+        }
+    }
+
+    private var runBar: some View {
+        ZStack {
+            Text(selectionSummary)
+                .font(.callout.weight(.medium))
+                .frame(maxWidth: .infinity, alignment: .center)
+            HStack {
+                Spacer()
+                Button(String(localized: "Run", comment: "Runs the selected maintenance tasks.")) {
+                    onRunSelected(tasks.filter { selectedTaskIDs.contains($0.id) })
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(selectedTaskIDs.isEmpty)
+                .accessibilityIdentifier("optimization.runSelected")
+            }
+        }
+        .padding(16)
+    }
+
+    private var selectionSummary: String {
+        let format = String(
+            localized: "%d Tasks Selected",
+            comment: "Footer count of selected maintenance tasks; %d is the count."
+        )
+        return String.localizedStringWithFormat(format, selectedTaskIDs.count)
+    }
+
+    private func toggle(_ task: MaintenanceTask) {
+        if selectedTaskIDs.contains(task.id) {
+            selectedTaskIDs.remove(task.id)
+        } else {
+            selectedTaskIDs.insert(task.id)
+        }
+    }
+}
+
+/// One selectable maintenance task — a checkbox, a colourful icon badge, the
+/// task name, an info button explaining what it does, and (after running) the
+/// most recent result line.
+struct OptimizationTaskRow: View {
+    let task: MaintenanceTask
+    let tint: Color
+    let isSelected: Bool
+    let result: String?
+    let onToggle: () -> Void
+
+    @State private var showInfo = false
+
+    private var isCompleted: Bool { result != nil }
+
+    /// Always-present secondary line: the task summary normally, the result once
+    /// it has run. Kept to one line so the row height never changes.
+    private var subtitle: String { result ?? task.summary }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+                .accessibilityIdentifier("optimization.task.checkbox.\(task.kind.rawValue)")
+
+            TaskIconBadge(symbol: task.icon, tint: tint)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(task.title)
+                        .font(.body.weight(.medium))
+                    // Clear success indicator once the task has run.
+                    if isCompleted {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(.green)
+                            .transition(.scale.combined(with: .opacity))
+                            .accessibilityIdentifier("optimization.task.done.\(task.kind.rawValue)")
+                    }
+                }
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(isCompleted ? AnyShapeStyle(Color.green) : AnyShapeStyle(.secondary))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    // The full result/summary is available on hover; the row
+                    // stays one line so its height is stable.
+                    .help(subtitle)
+            }
+
+            Spacer()
+
+            Button {
+                showInfo = true
+            } label: {
+                Image(systemName: "info.circle")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityIdentifier("optimization.task.info.\(task.kind.rawValue)")
+            .popover(isPresented: $showInfo, arrowEdge: .bottom) {
+                TaskInfoPopover(task: task, tint: tint)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onToggle() }
+        .padding(12)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .accessibilityIdentifier("optimization.task.\(task.kind.rawValue)")
+        .animation(.smooth(duration: 0.25), value: isCompleted)
+    }
+}
+
+/// A colourful rounded-square icon badge — the SF Symbol on a per-task tinted
+/// gradient, giving each task a distinct, app-like glyph.
+struct TaskIconBadge: View {
+    let symbol: String
+    let tint: Color
+
+    var body: some View {
+        Image(systemName: symbol)
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: 38, height: 38)
+            .background(
+                LinearGradient(
+                    colors: [tint.opacity(0.95), tint.opacity(0.65)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                ),
+                in: .rect(cornerRadius: 10)
+            )
+    }
+}
+
+/// The popover shown by a task row's info button — what the task does, in the
+/// task's own words.
+struct TaskInfoPopover: View {
+    let task: MaintenanceTask
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                TaskIconBadge(symbol: task.icon, tint: tint)
+                Text(task.title).font(.headline)
+            }
+            Text(task.summary)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .frame(width: 300)
+    }
+}
+
+/// Per-task accent colours for the icon badges. Kept in the view layer so the
+/// `MaintenanceTask` model stays free of UI types.
+enum OptimizationTaskPalette {
+    static func tint(for kind: MaintenanceTask.Kind) -> Color {
+        switch kind {
+        case .freeUpRAM:
+            return Color(red: 0.95, green: 0.45, blue: 0.20)
+        case .runMaintenanceScripts:
+            return Color(red: 0.55, green: 0.45, blue: 0.95)
+        case .flushDNS:
+            return Color(red: 0.96, green: 0.62, blue: 0.24)
+        case .reindexSpotlight:
+            return Color(red: 0.95, green: 0.76, blue: 0.20)
+        case .thinTimeMachineSnapshots:
+            return Color(red: 0.96, green: 0.55, blue: 0.30)
+        case .speedUpMail:
+            return Color(red: 0.36, green: 0.62, blue: 0.96)
+        }
+    }
+}

--- a/VaderCleaner/OptimizationDashboardSubviews.swift
+++ b/VaderCleaner/OptimizationDashboardSubviews.swift
@@ -186,6 +186,9 @@ struct OptimizationTaskCatalogView: View {
     /// Which pane is shown. Bound to the owning view so the selection survives
     /// the "Working…" remount and so a dashboard card can open a specific pane.
     @Binding var pane: Pane
+    /// Selected task ids, bound to the owning view so the selection persists
+    /// across the progress screen and a completed run.
+    @Binding var selectedTaskIDs: Set<String>
     let tasks: [MaintenanceTask]
     let results: [String: String]
     let loginItems: [LoginItem]
@@ -196,8 +199,6 @@ struct OptimizationTaskCatalogView: View {
     let onDisableAgent: (LaunchAgent) -> Void
     let onRemoveAgent: (LaunchAgent) -> Void
     let onBack: () -> Void
-
-    @State private var selectedTaskIDs: Set<String> = []
 
     var body: some View {
         VStack(spacing: 0) {

--- a/VaderCleaner/OptimizationView.swift
+++ b/VaderCleaner/OptimizationView.swift
@@ -18,6 +18,9 @@ struct OptimizationView: View {
     /// survives the brief "Working…" remount and so a recommendation card can
     /// open the catalog on the matching pane — e.g. Review → Background Items.
     @State private var catalogPane: OptimizationTaskCatalogView.Pane = .maintenanceTasks
+    /// Selected task ids for the catalog's multi-select Run. Owned here so the
+    /// selection persists across the progress screen and a completed run.
+    @State private var selectedTaskIDs: Set<String> = []
 
     init(viewModel: OptimizationViewModel) {
         self.viewModel = viewModel
@@ -64,6 +67,18 @@ struct OptimizationView: View {
 
     @ViewBuilder
     private var content: some View {
+        // A multi-task batch flips each task's phase between .working and .ready;
+        // keep the progress screen up for the whole batch so the view doesn't
+        // flicker between progress and the catalog.
+        if viewModel.isRunningBatch {
+            OptimizationProgressState(label: workingLabel, identifier: "optimization.working")
+        } else {
+            phaseContent
+        }
+    }
+
+    @ViewBuilder
+    private var phaseContent: some View {
         switch viewModel.phase {
         case .idle:
             // Unreachable: ContentView shows the unified SectionIntroView
@@ -117,6 +132,7 @@ struct OptimizationView: View {
             // ScrollView / Refresh footer.
             OptimizationTaskCatalogView(
                 pane: $catalogPane,
+                selectedTaskIDs: $selectedTaskIDs,
                 tasks: viewModel.tasks,
                 results: viewModel.taskResults,
                 loginItems: viewModel.loginItems,

--- a/VaderCleaner/OptimizationView.swift
+++ b/VaderCleaner/OptimizationView.swift
@@ -9,7 +9,15 @@ import SwiftUI
 struct OptimizationView: View {
 
     private var viewModel: OptimizationViewModel
+    @Environment(\.openURL) private var openURL
     @State private var pendingRemoval: LaunchAgent?
+    /// Toggles the ready surface between the recommendation dashboard and the
+    /// full "View All Tasks" catalog.
+    @State private var showAllTasks = false
+    /// Which catalog pane to show. Owned here (not inside the catalog) so it
+    /// survives the brief "Working…" remount and so a recommendation card can
+    /// open the catalog on the matching pane — e.g. Review → Background Items.
+    @State private var catalogPane: OptimizationTaskCatalogView.Pane = .maintenanceTasks
 
     init(viewModel: OptimizationViewModel) {
         self.viewModel = viewModel
@@ -73,76 +81,100 @@ struct OptimizationView: View {
             )
         case .working:
             OptimizationProgressState(
-                label: String(
-                    localized: "Working…",
-                    comment: "Progress label while an Optimization action runs."
-                ),
+                label: workingLabel,
                 identifier: "optimization.working"
             )
         case .ready:
-            sections
+            readyContent
         case .failed(let message):
-            OptimizationFailedState(message: message) {
-                viewModel.dismissResult()
+            OptimizationFailedState(
+                message: message,
+                onDismiss: { viewModel.dismissResult() },
+                onOpenFullDiskAccess: viewModel.failureNeedsFullDiskAccess
+                    ? { openURL(PermissionOnboardingViewModel.systemSettingsURL) }
+                    : nil
+            )
+        }
+    }
+
+    /// Names the running action on the progress screen, falling back to a
+    /// generic label for loads that don't set a title.
+    private var workingLabel: String {
+        if let title = viewModel.workingTitle {
+            return "\(title)…"
+        }
+        return String(
+            localized: "Working…",
+            comment: "Progress label while an Optimization action runs."
+        )
+    }
+
+    @ViewBuilder
+    private var readyContent: some View {
+        if showAllTasks {
+            // The catalog owns its full-height layout (sub-nav + scrolling pane
+            // + pinned Run bar), so it is not wrapped in the dashboard's
+            // ScrollView / Refresh footer.
+            OptimizationTaskCatalogView(
+                pane: $catalogPane,
+                tasks: viewModel.tasks,
+                results: viewModel.taskResults,
+                loginItems: viewModel.loginItems,
+                userAgents: viewModel.userAgents,
+                systemAgents: viewModel.systemAgents,
+                onRunSelected: { tasks in Task { await viewModel.run(tasks) } },
+                onToggleLoginItem: { item, enabled in
+                    Task { await viewModel.setLoginItem(item, enabled: enabled) }
+                },
+                onDisableAgent: { agent in Task { await viewModel.disable(agent) } },
+                onRemoveAgent: { pendingRemoval = $0 },
+                onBack: { showAllTasks = false }
+            )
+        } else {
+            VStack(spacing: 0) {
+                ScrollView {
+                    OptimizationDashboardView(
+                        recommendations: viewModel.recommendations,
+                        completedKinds: viewModel.completedRecommendations,
+                        onAction: handleRecommendation,
+                        onViewAllTasks: {
+                            catalogPane = .maintenanceTasks
+                            showAllTasks = true
+                        }
+                    )
+                    .padding(24)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Divider()
+                HStack {
+                    Spacer()
+                    Button(String(
+                        localized: "Refresh",
+                        comment: "Footer button that reloads Optimization data."
+                    )) {
+                        Task { await viewModel.refresh() }
+                    }
+                    .accessibilityIdentifier("optimization.refresh")
+                }
+                .padding(16)
             }
         }
     }
 
-    private var sections: some View {
-        VStack(spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
-                    OptimizationLoginItemsSection(
-                        items: viewModel.loginItems,
-                        onToggle: { item, enabled in
-                            Task { await viewModel.setLoginItem(item, enabled: enabled) }
-                        }
-                    )
-                    OptimizationLaunchAgentsSection(
-                        title: String(
-                            localized: "Launch Agents (User)",
-                            comment: "Section header for user launch agents."
-                        ),
-                        identifier: "optimization.userAgents",
-                        agents: viewModel.userAgents,
-                        onDisable: { agent in Task { await viewModel.disable(agent) } },
-                        onRemove: { pendingRemoval = $0 }
-                    )
-                    OptimizationLaunchAgentsSection(
-                        title: String(
-                            localized: "Launch Agents & Daemons (System)",
-                            comment: "Section header for system launch agents and daemons."
-                        ),
-                        identifier: "optimization.systemAgents",
-                        agents: viewModel.systemAgents,
-                        onDisable: { agent in Task { await viewModel.disable(agent) } },
-                        onRemove: { pendingRemoval = $0 }
-                    )
-                    OptimizationRAMSection(
-                        memory: viewModel.memory,
-                        result: viewModel.ramResult,
-                        onFlush: { Task { await viewModel.flushRAM() } }
-                    )
-                    OptimizationMaintenanceSection(
-                        output: viewModel.maintenanceOutput,
-                        onRun: { Task { await viewModel.runMaintenanceScripts() } }
-                    )
-                }
-                .padding(24)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            Divider()
-            HStack {
-                Spacer()
-                Button(String(
-                    localized: "Refresh",
-                    comment: "Footer button that reloads Optimization data."
-                )) {
-                    Task { await viewModel.refresh() }
-                }
-                .accessibilityIdentifier("optimization.refresh")
-            }
-            .padding(16)
+    /// Routes a recommendation card's primary action: the RAM, maintenance, and
+    /// snapshot cards run their task directly; the background-items card opens
+    /// the catalog where those items are managed.
+    private func handleRecommendation(_ recommendation: PerformanceRecommendation) {
+        switch recommendation.kind {
+        case .backgroundItems:
+            // Open the catalog directly on the Background Items pane, where
+            // login items and launch agents are managed.
+            catalogPane = .backgroundItems
+            showAllTasks = true
+        case .freeUpRAM, .maintenanceTasks, .thinSnapshots:
+            // Runnable tiles route through the view model, which marks the tile
+            // complete on success so it shows a green check.
+            Task { await viewModel.runRecommendation(recommendation) }
         }
     }
 

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -33,6 +33,9 @@ final class OptimizationViewModel {
     typealias RemoveAgent = (LaunchAgent) async throws -> Void
     typealias FlushRAM = () async throws -> Void
     typealias RunMaintenance = () async throws -> String
+    /// A maintenance task that performs its work and returns a result line.
+    typealias RunTask = () async throws -> String
+    typealias ReadSnapshotCount = () async -> Int
 
     private(set) var phase: Phase = .idle
     private(set) var loginItems: [LoginItem] = []
@@ -41,6 +44,44 @@ final class OptimizationViewModel {
     private(set) var memory: MemoryStats = .empty
     private(set) var ramResult: String?
     private(set) var maintenanceOutput: String?
+
+    /// Count of local Time Machine snapshots, refreshed alongside the rest of
+    /// the section state and fed into the recommendation engine.
+    private(set) var localSnapshotCount: Int = 0
+    /// Curated dashboard cards derived from the current system state.
+    private(set) var recommendations: [PerformanceRecommendation] = []
+    /// Most recent result line per task id, surfaced in the task catalog.
+    private(set) var taskResults: [String: String] = [:]
+
+    /// Human-readable title of the action currently running, so the progress
+    /// screen can name it ("Free Up RAM…") instead of a bare spinner.
+    private(set) var workingTitle: String?
+    /// Recommendation kinds whose action completed successfully, so the matching
+    /// dashboard tile can show a green check. Cleared on the next refresh, or
+    /// when that tile's action is run again.
+    private(set) var completedRecommendations: Set<PerformanceRecommendation.Kind> = []
+
+    /// Set when the current failure is specifically a missing Full Disk Access
+    /// (Speed Up Mail), so the failure screen can offer an "Open Settings"
+    /// recovery instead of a dead end.
+    private(set) var failureNeedsFullDiskAccess = false
+
+    /// The maintenance-task catalog shown in "View All Tasks", with tasks that
+    /// can't run on this system filtered out — Run Maintenance Scripts relies on
+    /// `/usr/sbin/periodic`, which Apple removed in macOS 26.
+    var tasks: [MaintenanceTask] {
+        MaintenanceTask.catalog.filter { task in
+            task.kind != .runMaintenanceScripts || maintenanceScriptsAvailable
+        }
+    }
+
+    /// Cocktail task ids that are actually available, for the recommendation
+    /// count and the "Run Tasks" action.
+    private var availableCocktailIDs: [String] {
+        tasks
+            .filter { MaintenanceTask.maintenanceCocktailKinds.contains($0.kind) }
+            .map(\.id)
+    }
 
     @ObservationIgnored private let loadLoginItems: LoadLoginItems
     @ObservationIgnored private let loadUserAgents: LoadAgents
@@ -51,6 +92,15 @@ final class OptimizationViewModel {
     @ObservationIgnored private let removeAgent: RemoveAgent
     @ObservationIgnored private let flushRAMAction: FlushRAM
     @ObservationIgnored private let runMaintenance: RunMaintenance
+    @ObservationIgnored private let flushDNSAction: RunTask
+    @ObservationIgnored private let reindexSpotlightAction: RunTask
+    @ObservationIgnored private let thinSnapshotsAction: RunTask
+    @ObservationIgnored private let speedUpMailAction: RunTask
+    @ObservationIgnored private let readSnapshotCount: ReadSnapshotCount
+    @ObservationIgnored private let runLog: MaintenanceRunLog
+    /// Whether `/usr/sbin/periodic` exists — false on macOS 26+, where Apple
+    /// removed it, so Run Maintenance Scripts is hidden and never run.
+    @ObservationIgnored private let maintenanceScriptsAvailable: Bool
 
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "OptimizationViewModel")
@@ -72,6 +122,13 @@ final class OptimizationViewModel {
         removeAgent: @escaping RemoveAgent,
         flushRAM: @escaping FlushRAM,
         runMaintenance: @escaping RunMaintenance,
+        flushDNS: @escaping RunTask = { "" },
+        reindexSpotlight: @escaping RunTask = { "" },
+        thinSnapshots: @escaping RunTask = { "" },
+        speedUpMail: @escaping RunTask = { "" },
+        readSnapshotCount: @escaping ReadSnapshotCount = { 0 },
+        runLog: MaintenanceRunLog = MaintenanceRunLog(),
+        maintenanceScriptsAvailable: Bool = true,
         launchAtLoginChanges: AnyPublisher<Void, Never>? = nil
     ) {
         self.loadLoginItems = loadLoginItems
@@ -83,6 +140,13 @@ final class OptimizationViewModel {
         self.removeAgent = removeAgent
         self.flushRAMAction = flushRAM
         self.runMaintenance = runMaintenance
+        self.flushDNSAction = flushDNS
+        self.reindexSpotlightAction = reindexSpotlight
+        self.thinSnapshotsAction = thinSnapshots
+        self.speedUpMailAction = speedUpMail
+        self.readSnapshotCount = readSnapshotCount
+        self.runLog = runLog
+        self.maintenanceScriptsAvailable = maintenanceScriptsAvailable
 
         // The host app's launch-at-login state has a second entry point:
         // the Preferences "Launch at Login" toggle, which mutates
@@ -117,7 +181,9 @@ final class OptimizationViewModel {
         async let login = loadLoginItems()
         async let user = loadUserAgents()
         async let system = loadSystemAgents()
-        let (loadedLogin, loadedUser, loadedSystem) = await (login, user, system)
+        async let snapshots = readSnapshotCount()
+        let (loadedLogin, loadedUser, loadedSystem, loadedSnapshots) =
+            await (login, user, system, snapshots)
         let mem = readMemory()
 
         guard loadGeneration == generation else { return }
@@ -125,7 +191,133 @@ final class OptimizationViewModel {
         userAgents = loadedUser
         systemAgents = loadedSystem
         memory = mem
+        localSnapshotCount = loadedSnapshots
+        completedRecommendations.removeAll()
+        rebuildRecommendations()
         phase = .ready
+    }
+
+    // MARK: - Recommendations
+
+    /// Runs the action behind a dashboard recommendation tile and, on success,
+    /// marks that tile complete so the view can show a green check on it. The
+    /// background-items tile only navigates (handled by the view), so it never
+    /// reaches here.
+    func runRecommendation(_ recommendation: PerformanceRecommendation) async {
+        completedRecommendations.remove(recommendation.kind)
+        switch recommendation.kind {
+        case .freeUpRAM:
+            if let task = MaintenanceTask.catalog.first(where: { $0.kind == .freeUpRAM }) {
+                await run(task)
+            }
+        case .maintenanceTasks:
+            await runDueMaintenance()
+        case .thinSnapshots:
+            if let task = MaintenanceTask.catalog.first(where: { $0.kind == .thinTimeMachineSnapshots }) {
+                await run(task)
+            }
+        case .backgroundItems:
+            return
+        }
+        if phase == .ready {
+            completedRecommendations.insert(recommendation.kind)
+        }
+    }
+
+    // MARK: - Maintenance tasks
+
+    /// Runs a catalog task. Free up RAM and the maintenance scripts route
+    /// through their existing methods (which keep their own result lines and
+    /// memory re-read); the newer system tasks run through the shared `perform`
+    /// path. On success the task is stamped in the run log and the
+    /// recommendation cards are rebuilt.
+    func run(_ task: MaintenanceTask) async {
+        // Name the running action for the progress screen, and clear any prior
+        // FDA-recovery flag so it only reflects this run's outcome.
+        workingTitle = task.title
+        failureNeedsFullDiskAccess = false
+        switch task.kind {
+        case .freeUpRAM:
+            await flushRAM()
+            finishTask(task.kind, result: ramResult)
+        case .runMaintenanceScripts:
+            await runMaintenanceScripts()
+            finishTask(task.kind, result: maintenanceOutput)
+        case .flushDNS:
+            await perform(task.kind, action: flushDNSAction)
+        case .reindexSpotlight:
+            await perform(task.kind, action: reindexSpotlightAction)
+        case .thinTimeMachineSnapshots:
+            await perform(task.kind, action: thinSnapshotsAction)
+        case .speedUpMail:
+            await perform(task.kind, action: speedUpMailAction)
+        }
+        workingTitle = nil
+    }
+
+    /// Shared run path for the system maintenance tasks: drive `.working`, run
+    /// the action, capture its result line, stamp the run log, and rebuild
+    /// recommendations. Surfaces `.failed` on any error.
+    private func perform(_ kind: MaintenanceTask.Kind, action: RunTask) async {
+        phase = .working
+        do {
+            let result = try await action()
+            taskResults[kind.rawValue] = result
+            runLog.record(kind.rawValue)
+            localSnapshotCount = await readSnapshotCount()
+            rebuildRecommendations()
+            phase = .ready
+        } catch {
+            log.error("Maintenance task \(kind.rawValue, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            if case MailReindexerError.fullDiskAccessRequired = error {
+                failureNeedsFullDiskAccess = true
+            }
+            phase = .failed(message: HelperConnectionError.userFacingMessage(for: error))
+        }
+    }
+
+    /// Post-success bookkeeping for the tasks that route through their existing
+    /// methods. Skips when the underlying method left a non-ready phase (e.g. a
+    /// flush failure already surfaced `.failed`).
+    private func finishTask(_ kind: MaintenanceTask.Kind, result: String?) {
+        guard phase == .ready else { return }
+        if let result {
+            taskResults[kind.rawValue] = result
+        }
+        runLog.record(kind.rawValue)
+        rebuildRecommendations()
+    }
+
+    /// Runs the given tasks in order — the action behind the catalog's
+    /// multi-select "Run" bar. Stops at the first failure, which surfaces
+    /// `.failed` so the user sees what went wrong.
+    func run(_ tasks: [MaintenanceTask]) async {
+        for task in tasks {
+            await run(task)
+            if case .failed = phase { return }
+        }
+    }
+
+    /// Runs every due maintenance-cocktail task (the action behind the
+    /// "Maintenance Tasks Recommended" card), so the card's count and its "Run
+    /// Tasks" action cover the same set.
+    func runDueMaintenance() async {
+        let dueIDs = runLog.staleTaskIDs(among: availableCocktailIDs)
+        let dueTasks = tasks.filter { dueIDs.contains($0.id) }
+        await run(dueTasks)
+    }
+
+    /// Recomputes the curated recommendation cards from current section state.
+    /// The maintenance count is scoped to the cocktail tasks so it matches what
+    /// `runDueMaintenance()` actually runs.
+    private func rebuildRecommendations() {
+        let snapshot = PerformanceSnapshot(
+            memory: memory,
+            localSnapshotCount: localSnapshotCount,
+            backgroundItemCount: loginItems.count + userAgents.count + systemAgents.count,
+            staleTaskCount: runLog.staleTaskCount(among: availableCocktailIDs)
+        )
+        recommendations = PerformanceRecommendationEngine.recommendations(for: snapshot)
     }
 
     // MARK: - RAM
@@ -218,7 +410,16 @@ final class OptimizationViewModel {
 
     /// Removes an agent's plist. On success the row is dropped; on failure
     /// the lists are left intact so the user can retry.
+    ///
+    /// System daemons are protected: they live in launchd's privileged domain
+    /// and removing one can break macOS or the app that installed it, so the
+    /// request is refused here regardless of how it was triggered. The UI also
+    /// hides the control for system agents — this guard is the backstop.
     func remove(_ agent: LaunchAgent) async {
+        guard agent.domain != .system else {
+            log.error("Refused to remove protected system daemon: \(agent.label, privacy: .public)")
+            return
+        }
         phase = .working
         do {
             try await removeAgent(agent)
@@ -263,6 +464,11 @@ extension OptimizationViewModel {
         let agentManager = LaunchAgentManager()
         let ram = RAMManager()
         let maintenance = MaintenanceScriptRunner()
+        let dnsFlusher = DNSCacheFlusher()
+        let spotlight = SpotlightReindexer()
+        let snapshotThinner = TimeMachineSnapshotThinner()
+        let mail = MailReindexer()
+        let snapshotCounter = LocalSnapshotCounter()
 
         return OptimizationViewModel(
             loadLoginItems: { loginManager.items() },
@@ -303,6 +509,20 @@ extension OptimizationViewModel {
             removeAgent: { try await agentManager.remove($0) },
             flushRAM: { try await ram.flush() },
             runMaintenance: { try await maintenance.run() },
+            flushDNS: { try await dnsFlusher.run() },
+            reindexSpotlight: { try await spotlight.run() },
+            thinSnapshots: { try await snapshotThinner.run() },
+            speedUpMail: { try await mail.run() },
+            // Listing snapshots shells out to `tmutil`; keep it off the main
+            // actor so the dashboard refresh never blocks on the process.
+            readSnapshotCount: {
+                await Task.detached(priority: .userInitiated) {
+                    snapshotCounter.count()
+                }.value
+            },
+            // `periodic` was removed in macOS 26; when it's absent, Run
+            // Maintenance Scripts is hidden and excluded from "Run Tasks".
+            maintenanceScriptsAvailable: FileManager.default.fileExists(atPath: "/usr/sbin/periodic"),
             // Reflect a Preferences-side toggle in this view's row. See
             // the `init` comment for why ordering matters here. The bridge
             // converts `PreferencesStore`'s Observation-tracked property

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -56,6 +56,12 @@ final class OptimizationViewModel {
     /// Human-readable title of the action currently running, so the progress
     /// screen can name it ("Free Up RAM…") instead of a bare spinner.
     private(set) var workingTitle: String?
+
+    /// True while a multi-task batch ("Run Tasks" / catalog multi-select) is in
+    /// flight. The view holds the progress screen for the whole batch so it
+    /// doesn't flicker between progress and the catalog as each task's phase
+    /// flips `.working`→`.ready`.
+    private(set) var isRunningBatch = false
     /// Recommendation kinds whose action completed successfully, so the matching
     /// dashboard tile can show a green check. Cleared on the next refresh, or
     /// when that tile's action is run again.
@@ -292,6 +298,10 @@ final class OptimizationViewModel {
     /// multi-select "Run" bar. Stops at the first failure, which surfaces
     /// `.failed` so the user sees what went wrong.
     func run(_ tasks: [MaintenanceTask]) async {
+        // Hold the progress screen for the whole batch so the UI doesn't flicker
+        // as each task's phase flips between .working and .ready.
+        isRunningBatch = true
+        defer { isRunningBatch = false }
         for task in tasks {
             await run(task)
             if case .failed = phase { return }

--- a/VaderCleaner/OptimizationViewSubviews.swift
+++ b/VaderCleaner/OptimizationViewSubviews.swift
@@ -25,6 +25,9 @@ struct OptimizationProgressState: View {
 struct OptimizationFailedState: View {
     let message: String
     let onDismiss: () -> Void
+    /// When set, the failure is recoverable by granting Full Disk Access — the
+    /// screen offers a button that jumps straight to that Settings pane.
+    var onOpenFullDiskAccess: (() -> Void)? = nil
 
     var body: some View {
         VStack(spacing: 16) {
@@ -42,12 +45,21 @@ struct OptimizationFailedState: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 460)
                 .accessibilityIdentifier("optimization.errorMessage")
+            if let onOpenFullDiskAccess {
+                Button(String(
+                    localized: "Open Full Disk Access Settings",
+                    comment: "Recovery button that opens the Full Disk Access settings pane."
+                ), action: onOpenFullDiskAccess)
+                    .controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("optimization.failureOpenFullDiskAccess")
+            }
             Button(String(
                 localized: "Back to Optimization",
                 comment: "Return button on the Optimization failure screen."
             ), action: onDismiss)
                 .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
+                .keyboardShortcut(onOpenFullDiskAccess == nil ? .defaultAction : nil)
                 .accessibilityIdentifier("optimization.failurePrimary")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -201,13 +213,12 @@ struct OptimizationLaunchAgentRow: View {
             .buttonStyle(.bordered)
             // System daemons live in launchd's privileged domain; `launchctl
             // unload` from the user session can't touch them, so the control
-            // is offered only for user agents. Removal still works for system
-            // agents (it routes through the privileged helper).
+            // is offered only for user agents.
             .disabled(!agent.isEnabled || agent.domain == .system)
             .help(agent.domain == .system
                   ? String(
-                        localized: "System agents can't be unloaded from here. Use Remove to delete the plist.",
-                        comment: "Tooltip explaining why Disable is unavailable for system launch agents."
+                        localized: "System daemons are managed by macOS or the app that installed them and can't be changed here.",
+                        comment: "Tooltip explaining why a system launch daemon can't be disabled or removed."
                     )
                   : "")
             .accessibilityIdentifier("\(identifier).disable.\(agent.path.lastPathComponent)")
@@ -219,87 +230,17 @@ struct OptimizationLaunchAgentRow: View {
                 ))
             }
             .buttonStyle(.bordered)
+            // System daemons are protected from removal — deleting one can break
+            // macOS or the app that installed it. Only user agents can be removed.
+            .disabled(agent.domain == .system)
+            .help(agent.domain == .system
+                  ? String(
+                        localized: "Protected: system daemons can't be removed here. Disable it in System Settings or its app instead.",
+                        comment: "Tooltip explaining why a system launch daemon can't be removed."
+                    )
+                  : "")
             .accessibilityIdentifier("\(identifier).remove.\(agent.path.lastPathComponent)")
         }
         .padding(.vertical, 4)
-    }
-}
-
-// MARK: - RAM
-
-struct OptimizationRAMSection: View {
-    let memory: MemoryStats
-    let result: String?
-    let onFlush: () -> Void
-
-    var body: some View {
-        OptimizationSection(title: String(
-            localized: "RAM",
-            comment: "Optimization section header for memory."
-        )) {
-            HStack {
-                Text(SystemStatsFormatters.memoryUsageString(memory))
-                    .font(.body.monospacedDigit())
-                    .accessibilityIdentifier("optimization.ramUsage")
-                Spacer()
-                Button(action: onFlush) {
-                    Text(String(
-                        localized: "Free Up RAM",
-                        comment: "Button that flushes inactive memory."
-                    ))
-                }
-                .buttonStyle(.borderedProminent)
-                .accessibilityIdentifier("optimization.freeRAM")
-            }
-            if let result {
-                Text(result)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("optimization.ramResult")
-            }
-        }
-    }
-}
-
-// MARK: - Maintenance
-
-struct OptimizationMaintenanceSection: View {
-    let output: String?
-    let onRun: () -> Void
-
-    var body: some View {
-        OptimizationSection(title: String(
-            localized: "Maintenance Scripts",
-            comment: "Optimization section header for maintenance scripts."
-        )) {
-            HStack {
-                Text(String(
-                    localized: "Runs the system periodic daily, weekly, and monthly scripts.",
-                    comment: "Explanatory text for the maintenance scripts action."
-                ))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                Spacer()
-                Button(action: onRun) {
-                    Text(String(
-                        localized: "Run Maintenance Scripts",
-                        comment: "Button that runs the system maintenance scripts."
-                    ))
-                }
-                .buttonStyle(.borderedProminent)
-                .accessibilityIdentifier("optimization.runMaintenance")
-            }
-            if let output {
-                Text(output)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-                    .padding(10)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.secondary.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .accessibilityIdentifier("optimization.maintenanceOutput")
-            }
-        }
     }
 }

--- a/VaderCleaner/PerformanceRecommendationEngine.swift
+++ b/VaderCleaner/PerformanceRecommendationEngine.swift
@@ -1,0 +1,119 @@
+// PerformanceRecommendationEngine.swift
+// Turns a snapshot of system state into the curated recommendation cards shown on the Optimization dashboard (Free up RAM, maintenance tasks due, background items, local snapshots).
+
+import Foundation
+
+/// A curated recommendation card surfaced on the Optimization dashboard.
+struct PerformanceRecommendation: Identifiable, Hashable {
+
+    /// Each kind maps to one card and one primary action.
+    enum Kind: String {
+        case freeUpRAM
+        case maintenanceTasks
+        case backgroundItems
+        case thinSnapshots
+    }
+
+    let kind: Kind
+    let title: String
+    let detail: String
+    let icon: String
+    let actionLabel: String
+    /// The single large card on the dashboard (rendered tall on the left,
+    /// matching the screenshot). At most one recommendation is the hero.
+    let isHero: Bool
+
+    var id: String { kind.rawValue }
+}
+
+/// The system state the engine reasons over. Gathered by `OptimizationViewModel`
+/// from the shared stats service, the launch-item/agent lists, the local
+/// snapshot count, and the maintenance run log.
+struct PerformanceSnapshot {
+    var memory: MemoryStats
+    var localSnapshotCount: Int
+    var backgroundItemCount: Int
+    var staleTaskCount: Int
+}
+
+/// Decides which recommendation cards to surface for a given `PerformanceSnapshot`.
+/// Pure and deterministic so it is exhaustively unit-testable; the order of the
+/// returned cards is the dashboard layout order.
+enum PerformanceRecommendationEngine {
+
+    static func recommendations(for snapshot: PerformanceSnapshot) -> [PerformanceRecommendation] {
+        var recommendations: [PerformanceRecommendation] = []
+
+        // RAM is the persistent hero card — always offered, mirroring the
+        // Performance dashboard where "Free Up Your RAM" is always present.
+        recommendations.append(PerformanceRecommendation(
+            kind: .freeUpRAM,
+            title: String(
+                localized: "Free Up Your RAM",
+                comment: "Recommendation card title for freeing memory."
+            ),
+            detail: String(
+                localized: "Make room for more activities in your Mac's memory. Retrieve as much free RAM as possible.",
+                comment: "Recommendation card detail for freeing memory."
+            ),
+            icon: "memorychip",
+            actionLabel: String(localized: "Free Up", comment: "Action button on the free-RAM card."),
+            isHero: true
+        ))
+
+        if snapshot.staleTaskCount > 0 {
+            let titleFormat = String(
+                localized: "%d Maintenance Tasks Recommended",
+                comment: "Recommendation card title; %d is the number of due tasks."
+            )
+            recommendations.append(PerformanceRecommendation(
+                kind: .maintenanceTasks,
+                title: String.localizedStringWithFormat(titleFormat, snapshot.staleTaskCount),
+                detail: String(
+                    localized: "Your maintenance cocktail is ready. Run these tasks to keep your Mac in shape.",
+                    comment: "Recommendation card detail for due maintenance tasks."
+                ),
+                icon: "wrench.and.screwdriver",
+                actionLabel: String(localized: "Run Tasks", comment: "Action button on the maintenance-tasks card."),
+                isHero: false
+            ))
+        }
+
+        if snapshot.backgroundItemCount > 0 {
+            let titleFormat = String(
+                localized: "%d Background Items Found",
+                comment: "Recommendation card title; %d is the number of background items."
+            )
+            recommendations.append(PerformanceRecommendation(
+                kind: .backgroundItems,
+                title: String.localizedStringWithFormat(titleFormat, snapshot.backgroundItemCount),
+                detail: String(
+                    localized: "Review login items and launch agents that start automatically with your Mac.",
+                    comment: "Recommendation card detail for background items."
+                ),
+                icon: "gearshape",
+                actionLabel: String(localized: "Review", comment: "Action button on the background-items card."),
+                isHero: false
+            ))
+        }
+
+        if snapshot.localSnapshotCount > 0 {
+            recommendations.append(PerformanceRecommendation(
+                kind: .thinSnapshots,
+                title: String(
+                    localized: "Thin Time Machine Snapshots",
+                    comment: "Recommendation card title for thinning snapshots."
+                ),
+                detail: String(
+                    localized: "Reduce local snapshot storage without affecting your backups.",
+                    comment: "Recommendation card detail for thinning snapshots."
+                ),
+                icon: "clock.arrow.circlepath",
+                actionLabel: String(localized: "Run", comment: "Action button on the thin-snapshots card."),
+                isHero: false
+            ))
+        }
+
+        return recommendations
+    }
+}

--- a/VaderCleaner/SmartScanOptimizationReview.swift
+++ b/VaderCleaner/SmartScanOptimizationReview.swift
@@ -10,8 +10,24 @@ import SwiftUI
 /// standalone screen to manage login items / launch agents / RAM in detail.
 struct SmartScanOptimizationReview: View {
     let result: SmartScanResult
+    /// Whether the maintenance scripts can run — false on macOS 26+, where
+    /// `periodic` was removed. Drives the explainer wording.
+    var maintenanceScriptsAvailable: Bool = true
     let onBack: () -> Void
     let onOpenOptimization: () -> Void
+
+    private var explainer: String {
+        if maintenanceScriptsAvailable {
+            return String(
+                localized: "Run will execute the system maintenance scripts (periodic daily, weekly, monthly).",
+                comment: "Explainer at the top of the Smart Scan Performance Review screen."
+            )
+        }
+        return String(
+            localized: "System maintenance scripts aren't available on this version of macOS. The login items below are shown for review.",
+            comment: "Explainer shown when periodic maintenance scripts are unavailable (macOS 26+)."
+        )
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,10 +40,7 @@ struct SmartScanOptimizationReview: View {
             )
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    Text(String(
-                        localized: "Run will execute the system maintenance scripts (periodic daily, weekly, monthly).",
-                        comment: "Explainer at the top of the Smart Scan Performance Review screen."
-                    ))
+                    Text(explainer)
                         .font(.callout)
                         .foregroundStyle(.secondary)
 

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -126,6 +126,7 @@ struct SmartScanView: View {
             case .optimization:
                 SmartScanOptimizationReview(
                     result: result,
+                    maintenanceScriptsAvailable: viewModel.maintenanceScriptsSupported,
                     onBack: { self.review = nil },
                     onOpenOptimization: onOpenOptimization
                 )

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -232,6 +232,10 @@ final class SmartScanViewModel {
     @ObservationIgnored private let maintenanceRunner: MaintenanceRunner
     @ObservationIgnored private let updateOpener: UpdateOpener
     @ObservationIgnored private let largeFileDeleter: LargeFileDeleter
+    /// Whether `/usr/sbin/periodic` exists — false on macOS 26+, where Apple
+    /// removed it. When false the Optimization tile's maintenance-scripts action
+    /// has nothing to run, so it is not auto-selected and Run skips it.
+    @ObservationIgnored private let maintenanceScriptsAvailable: Bool
 
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "SmartScanViewModel")
@@ -247,7 +251,8 @@ final class SmartScanViewModel {
         threatRemover: @escaping ThreatRemover,
         maintenanceRunner: @escaping MaintenanceRunner,
         updateOpener: @escaping UpdateOpener,
-        largeFileDeleter: @escaping LargeFileDeleter
+        largeFileDeleter: @escaping LargeFileDeleter,
+        maintenanceScriptsAvailable: Bool = true
     ) {
         self.junkScanner = junkScanner
         self.malwareInstalled = malwareInstalled
@@ -260,6 +265,7 @@ final class SmartScanViewModel {
         self.maintenanceRunner = maintenanceRunner
         self.updateOpener = updateOpener
         self.largeFileDeleter = largeFileDeleter
+        self.maintenanceScriptsAvailable = maintenanceScriptsAvailable
     }
 
     // MARK: - Scan
@@ -347,7 +353,10 @@ final class SmartScanViewModel {
                 availableUpdates: foundUpdates,
                 clamAVAvailable: clamAVAvailable
             )
-            tileSelection = Self.defaultTileSelection(for: result)
+            tileSelection = Self.defaultTileSelection(
+                for: result,
+                maintenanceScriptsAvailable: maintenanceScriptsAvailable
+            )
             junkCategorySelection = Set(result.junkResult.itemsByCategory.keys)
             threatSelection = Set(foundThreats.map(\.filePath))
             updateSelection = Set(foundUpdates.map(\.bundleID))
@@ -428,7 +437,10 @@ final class SmartScanViewModel {
             }
         }
 
-        if tileSelection.contains(.optimization) {
+        // `maintenanceScriptsAvailable` guards the run even if the tile is
+        // somehow selected — periodic was removed in macOS 26, so running it
+        // would only surface "The file 'periodic' doesn't exist."
+        if tileSelection.contains(.optimization), maintenanceScriptsAvailable {
             do {
                 maintenanceOutput = try await maintenanceRunner()
             } catch {
@@ -561,9 +573,9 @@ final class SmartScanViewModel {
 
     /// Whether the given module would actually produce work if Run were
     /// pressed right now. The tile must be selected, *and* its sub-selection
-    /// must filter down to at least one item. Optimization is the exception
-    /// — its action is to run the system maintenance scripts, which is
-    /// always available, so being selected is sufficient.
+    /// must filter down to at least one item. Optimization's only Run work is
+    /// the system maintenance scripts, so it produces work iff those scripts are
+    /// available on this macOS (`periodic` was removed in macOS 26).
     ///
     /// Read by both the dashboard's per-tile caption decisions and the
     /// floating Run disc's visibility gate, so the two surfaces share one
@@ -585,7 +597,7 @@ final class SmartScanViewModel {
                 threatSelection.contains($0.filePath)
             }
         case .optimization:
-            return true
+            return maintenanceScriptsAvailable
         case .applications:
             return result.availableUpdates.contains {
                 updateSelection.contains($0.bundleID)
@@ -602,14 +614,22 @@ final class SmartScanViewModel {
         SmartScanModule.allCases.contains { willExecute($0) }
     }
 
+    /// Whether the system maintenance scripts can run on this macOS — false on
+    /// macOS 26+, where Apple removed `periodic`. Exposed so the Performance
+    /// Review can phrase its explainer accurately.
+    var maintenanceScriptsSupported: Bool { maintenanceScriptsAvailable }
+
     /// Default tile-selection seed for a freshly-landed `.results` payload.
     /// A module starts checked iff it has actionable work for Run. Optimization
-    /// is *always* on because its action — running the system maintenance
-    /// scripts — is available on every macOS install (there is nothing to
-    /// "find" the way junk or threats are found). The user can still
-    /// deselect it on the dashboard.
-    private static func defaultTileSelection(for result: SmartScanResult) -> Set<SmartScanModule> {
-        var selection: Set<SmartScanModule> = [.optimization]
+    /// starts on only when the system maintenance scripts are available — its
+    /// Run action has nothing to do otherwise (`periodic` was removed in macOS
+    /// 26). The user can still deselect it on the dashboard.
+    private static func defaultTileSelection(
+        for result: SmartScanResult,
+        maintenanceScriptsAvailable: Bool
+    ) -> Set<SmartScanModule> {
+        var selection: Set<SmartScanModule> = []
+        if maintenanceScriptsAvailable { selection.insert(.optimization) }
         if result.totalJunkBytes > 0 { selection.insert(.systemJunk) }
         if !result.threats.isEmpty { selection.insert(.malware) }
         if !result.availableUpdates.isEmpty { selection.insert(.applications) }
@@ -728,7 +748,11 @@ extension SmartScanViewModel {
             // dashboard if Run is re-run.
             largeFileDeleter: { urls in
                 await Self.removeClutterFiles(at: urls, log: log)
-            }
+            },
+            // `periodic` was removed in macOS 26; when it's absent the
+            // Performance tile's maintenance action is skipped rather than
+            // erroring with "The file 'periodic' doesn't exist."
+            maintenanceScriptsAvailable: FileManager.default.fileExists(atPath: "/usr/sbin/periodic")
         )
     }
 

--- a/VaderCleanerHelper/main.swift
+++ b/VaderCleanerHelper/main.swift
@@ -87,6 +87,11 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
 
     /// Runs each command in order and replies with the first failure, or `nil`
     /// once all succeed. A non-zero exit or launch error short-circuits the rest.
+    ///
+    /// `runProcess` is synchronous — it calls `waitUntilExit()` and then invokes
+    /// its reply *before returning* — so this loop runs the commands strictly
+    /// sequentially and `commandError` is always populated by the time it is
+    /// checked. (No recursion/continuation needed; the reply block is not async.)
     private func runProcesses(
         commands: [(executable: String, arguments: [String])],
         reply: @escaping (Error?) -> Void

--- a/VaderCleanerHelper/main.swift
+++ b/VaderCleanerHelper/main.swift
@@ -56,7 +56,53 @@ final class HelperService: NSObject, NSXPCListenerDelegate, VaderCleanerHelperPr
         runProcess(executable: "/usr/sbin/purge", arguments: [], reply: reply)
     }
 
+    func flushDNSCache(reply: @escaping (Error?) -> Void) {
+        // Flushing the resolver cache is two steps: clear the directory-service
+        // cache, then signal mDNSResponder to drop its own. Run them in sequence
+        // and surface the first failure.
+        runProcesses(
+            commands: [
+                (executable: "/usr/bin/dscacheutil", arguments: ["-flushcache"]),
+                (executable: "/usr/bin/killall", arguments: ["-HUP", "mDNSResponder"])
+            ],
+            reply: reply
+        )
+    }
+
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) {
+        runProcess(executable: "/usr/bin/mdutil", arguments: ["-E", "/"], reply: reply)
+    }
+
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) {
+        // Ask Time Machine to reclaim up to 20 GiB of local snapshot space at
+        // the highest urgency (4). macOS removes only as much as it safely can.
+        runProcess(
+            executable: "/usr/bin/tmutil",
+            arguments: ["thinlocalsnapshots", "/", "21474836480", "4"],
+            reply: reply
+        )
+    }
+
     // MARK: - Private
+
+    /// Runs each command in order and replies with the first failure, or `nil`
+    /// once all succeed. A non-zero exit or launch error short-circuits the rest.
+    private func runProcesses(
+        commands: [(executable: String, arguments: [String])],
+        reply: @escaping (Error?) -> Void
+    ) {
+        for command in commands {
+            var commandError: Error?
+            runProcess(executable: command.executable, arguments: command.arguments) { error in
+                commandError = error
+            }
+            if let commandError {
+                reply(commandError)
+                return
+            }
+        }
+        reply(nil)
+    }
 
     private func runProcess(
         executable: String,

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -66,7 +66,10 @@ final class HelperProtocolTests: XCTestCase {
             "runMaintenanceScriptsWithReply:",
             "removeLoginItemAtPath:reply:",
             "removeLaunchAgentAtPath:reply:",
-            "flushInactiveMemoryWithReply:"
+            "flushInactiveMemoryWithReply:",
+            "flushDNSCacheWithReply:",
+            "reindexSpotlightWithReply:",
+            "thinTimeMachineSnapshotsWithReply:"
         ]
 
         for selectorName in expectedSelectors {

--- a/VaderCleanerTests/LaunchAgentManagerTests.swift
+++ b/VaderCleanerTests/LaunchAgentManagerTests.swift
@@ -194,4 +194,7 @@ private final class FakeRemovalHelper: NSObject, VaderCleanerHelperProtocol {
         reply(nil)
     }
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushDNSCache(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) { reply(nil) }
 }

--- a/VaderCleanerTests/LocalSnapshotCounterTests.swift
+++ b/VaderCleanerTests/LocalSnapshotCounterTests.swift
@@ -1,0 +1,34 @@
+// LocalSnapshotCounterTests.swift
+// Verifies LocalSnapshotCounter parses `tmutil listlocalsnapshots /` output into a count of local snapshots.
+
+import XCTest
+@testable import VaderCleaner
+
+final class LocalSnapshotCounterTests: XCTestCase {
+
+    func test_count_returnsZeroForNoSnapshots() {
+        let counter = LocalSnapshotCounter(listSnapshots: {
+            "Snapshots for disk /:\n"
+        })
+        XCTAssertEqual(counter.count(), 0)
+    }
+
+    func test_count_countsSnapshotLines() {
+        let counter = LocalSnapshotCounter(listSnapshots: {
+            """
+            Snapshots for disk /:
+            com.apple.TimeMachine.2026-05-29-120000.local
+            com.apple.TimeMachine.2026-05-30-120000.local
+            com.apple.TimeMachine.2026-05-30-180000.local
+            """
+        })
+        XCTAssertEqual(counter.count(), 3)
+    }
+
+    func test_count_ignoresNonSnapshotNoise() {
+        let counter = LocalSnapshotCounter(listSnapshots: {
+            "garbage\ncom.apple.TimeMachine.2026-05-30-120000.local\n"
+        })
+        XCTAssertEqual(counter.count(), 1)
+    }
+}

--- a/VaderCleanerTests/MailReindexerTests.swift
+++ b/VaderCleanerTests/MailReindexerTests.swift
@@ -1,0 +1,68 @@
+// MailReindexerTests.swift
+// Verifies MailReindexer locates Mail envelope-index databases, vacuums/reindexes each, and reports clear errors when Mail data is absent or the database is locked.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MailReindexerTests: XCTestCase {
+
+    func test_run_vacuumsEveryLocatedIndexAndReturnsResult() async throws {
+        let indexes = [
+            URL(fileURLWithPath: "/tmp/mail/V1/Envelope Index"),
+            URL(fileURLWithPath: "/tmp/mail/V2/Envelope Index")
+        ]
+        var vacuumed: [URL] = []
+        let runner = MailReindexer(
+            locateIndexes: { indexes },
+            vacuumIndex: { vacuumed.append($0) }
+        )
+
+        let output = try await runner.run()
+
+        XCTAssertEqual(vacuumed, indexes)
+        XCTAssertFalse(output.isEmpty)
+    }
+
+    func test_run_throwsNoMailDataWhenFolderReadableButEmpty() async {
+        let runner = MailReindexer(locateIndexes: { [] }, vacuumIndex: { _ in })
+        do {
+            _ = try await runner.run()
+            XCTFail("Expected run() to throw when no Mail data is present")
+        } catch MailReindexerError.noMailData {
+            // Expected — readable but nothing to reindex.
+        } catch {
+            XCTFail("Expected .noMailData, got \(error)")
+        }
+    }
+
+    func test_run_surfacesFullDiskAccessRequiredFromLocator() async {
+        // The locator signals a permission failure (app not in Full Disk
+        // Access); run() must propagate it rather than report "no mail".
+        let runner = MailReindexer(
+            locateIndexes: { throw MailReindexerError.fullDiskAccessRequired },
+            vacuumIndex: { _ in }
+        )
+        do {
+            _ = try await runner.run()
+            XCTFail("Expected run() to throw .fullDiskAccessRequired")
+        } catch MailReindexerError.fullDiskAccessRequired {
+            // Expected.
+        } catch {
+            XCTFail("Expected .fullDiskAccessRequired, got \(error)")
+        }
+    }
+
+    func test_run_throwsWhenVacuumFails() async {
+        struct Locked: Error {}
+        let runner = MailReindexer(
+            locateIndexes: { [URL(fileURLWithPath: "/tmp/mail/Envelope Index")] },
+            vacuumIndex: { _ in throw Locked() }
+        )
+        do {
+            _ = try await runner.run()
+            XCTFail("Expected run() to throw when the vacuum fails")
+        } catch {
+            // Expected.
+        }
+    }
+}

--- a/VaderCleanerTests/MaintenanceRunLogTests.swift
+++ b/VaderCleanerTests/MaintenanceRunLogTests.swift
@@ -1,0 +1,61 @@
+// MaintenanceRunLogTests.swift
+// Verifies MaintenanceRunLog persists and reads per-task last-run timestamps and reports which tasks are stale.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MaintenanceRunLogTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "MaintenanceRunLogTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func test_lastRun_isNilBeforeAnyRun() {
+        let log = MaintenanceRunLog(defaults: defaults)
+        XCTAssertNil(log.lastRun(for: "flushDNS"))
+    }
+
+    func test_record_thenLastRun_roundTrips() {
+        let log = MaintenanceRunLog(defaults: defaults)
+        let when = Date(timeIntervalSinceReferenceDate: 1000)
+
+        log.record("flushDNS", at: when)
+
+        XCTAssertEqual(log.lastRun(for: "flushDNS"), when)
+    }
+
+    func test_record_persistsAcrossInstances() {
+        let when = Date(timeIntervalSinceReferenceDate: 2000)
+        MaintenanceRunLog(defaults: defaults).record("reindexSpotlight", at: when)
+
+        let reloaded = MaintenanceRunLog(defaults: defaults)
+
+        XCTAssertEqual(reloaded.lastRun(for: "reindexSpotlight"), when)
+    }
+
+    func test_staleTaskCount_countsNeverRunAndOlderThanWindow() {
+        let log = MaintenanceRunLog(defaults: defaults)
+        let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        // Ran 1 day ago — fresh.
+        log.record("a", at: now.addingTimeInterval(-86_400))
+        // Ran 10 days ago — stale.
+        log.record("b", at: now.addingTimeInterval(-10 * 86_400))
+
+        // "a" fresh, "b" stale, "c" never run → 2 stale.
+        let stale = log.staleTaskCount(among: ["a", "b", "c"], now: now)
+
+        XCTAssertEqual(stale, 2)
+    }
+}

--- a/VaderCleanerTests/MaintenanceScriptRunnerTests.swift
+++ b/VaderCleanerTests/MaintenanceScriptRunnerTests.swift
@@ -64,6 +64,9 @@ private final class DroppingMaintenanceHelper: NSObject, VaderCleanerHelperProto
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
+    func flushDNSCache(reply: @escaping (Error?) -> Void) {}
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) {}
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) {}
 }
 
 private final class SpyMaintenanceHelper: NSObject, VaderCleanerHelperProtocol {
@@ -80,4 +83,7 @@ private final class SpyMaintenanceHelper: NSObject, VaderCleanerHelperProtocol {
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushDNSCache(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) { reply(nil) }
 }

--- a/VaderCleanerTests/MaintenanceTaskRunnersTests.swift
+++ b/VaderCleanerTests/MaintenanceTaskRunnersTests.swift
@@ -1,0 +1,134 @@
+// MaintenanceTaskRunnersTests.swift
+// Verifies the privileged maintenance-task runners (DNS flush, Spotlight reindex, Time Machine thinning) each invoke their selector and bridge success/failure/dropped-reply correctly.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MaintenanceTaskRunnersTests: XCTestCase {
+
+    // MARK: - DNS cache
+
+    func test_dnsFlusher_invokesSelectorAndReturnsResult() async throws {
+        let helper = RecordingHelper(replyError: nil)
+        let runner = DNSCacheFlusher(helperProvider: { _ in helper })
+
+        let output = try await runner.run()
+
+        XCTAssertTrue(helper.calledSelectors.contains("flushDNSCache"))
+        XCTAssertFalse(output.isEmpty)
+    }
+
+    func test_dnsFlusher_throwsWhenHelperRepliesError() async {
+        let helper = RecordingHelper(replyError: Boom())
+        let runner = DNSCacheFlusher(helperProvider: { _ in helper })
+        await XCTAssertThrowsErrorAsync(try await runner.run())
+    }
+
+    func test_dnsFlusher_throwsWhenHelperUnavailable() async {
+        let runner = DNSCacheFlusher(helperProvider: { _ in nil })
+        await XCTAssertThrowsErrorAsync(try await runner.run())
+    }
+
+    /// The reply block is dropped (mirrors a dropped NSXPCConnection); the
+    /// connection-level error handler must still resolve the await so the
+    /// shared once-only continuation guarantee holds.
+    func test_dnsFlusher_resolvesViaConnectionErrorHandlerWhenReplyDropped() async {
+        let runner = DNSCacheFlusher(helperProvider: { errorHandler in
+            DispatchQueue.global().async { errorHandler(Boom()) }
+            return DroppingHelper()
+        })
+        await XCTAssertThrowsErrorAsync(try await runner.run())
+    }
+
+    // MARK: - Spotlight
+
+    func test_spotlightReindexer_invokesSelectorAndReturnsResult() async throws {
+        let helper = RecordingHelper(replyError: nil)
+        let runner = SpotlightReindexer(helperProvider: { _ in helper })
+
+        let output = try await runner.run()
+
+        XCTAssertTrue(helper.calledSelectors.contains("reindexSpotlight"))
+        XCTAssertFalse(output.isEmpty)
+    }
+
+    func test_spotlightReindexer_throwsWhenHelperRepliesError() async {
+        let helper = RecordingHelper(replyError: Boom())
+        let runner = SpotlightReindexer(helperProvider: { _ in helper })
+        await XCTAssertThrowsErrorAsync(try await runner.run())
+    }
+
+    // MARK: - Time Machine
+
+    func test_tmThinner_invokesSelectorAndReturnsResult() async throws {
+        let helper = RecordingHelper(replyError: nil)
+        let runner = TimeMachineSnapshotThinner(helperProvider: { _ in helper })
+
+        let output = try await runner.run()
+
+        XCTAssertTrue(helper.calledSelectors.contains("thinTimeMachineSnapshots"))
+        XCTAssertFalse(output.isEmpty)
+    }
+
+    func test_tmThinner_throwsWhenHelperRepliesError() async {
+        let helper = RecordingHelper(replyError: Boom())
+        let runner = TimeMachineSnapshotThinner(helperProvider: { _ in helper })
+        await XCTAssertThrowsErrorAsync(try await runner.run())
+    }
+}
+
+private struct Boom: Error {}
+
+/// Async XCTAssertThrowsError — XCTest's built-in version is synchronous.
+private func XCTAssertThrowsErrorAsync(
+    _ expression: @autoclosure () async throws -> some Any,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected an error to be thrown", file: file, line: line)
+    } catch {
+        // Expected.
+    }
+}
+
+/// Records which protocol selectors were invoked and replies with a configured
+/// error. Replies success for the calls the runners under test don't make.
+private final class RecordingHelper: NSObject, VaderCleanerHelperProtocol {
+    private let replyError: Error?
+    private(set) var calledSelectors: [String] = []
+
+    init(replyError: Error?) { self.replyError = replyError }
+
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) { reply(nil) }
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushDNSCache(reply: @escaping (Error?) -> Void) {
+        calledSelectors.append("flushDNSCache")
+        reply(replyError)
+    }
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) {
+        calledSelectors.append("reindexSpotlight")
+        reply(replyError)
+    }
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) {
+        calledSelectors.append("thinTimeMachineSnapshots")
+        reply(replyError)
+    }
+}
+
+/// Drops every reply block — models a dead NSXPCConnection where the
+/// connection-level error handler fires instead of the per-call reply.
+private final class DroppingHelper: NSObject, VaderCleanerHelperProtocol {
+    func deleteFiles(_ paths: [String], reply: @escaping (Error?) -> Void) {}
+    func runMaintenanceScripts(reply: @escaping (Error?) -> Void) {}
+    func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
+    func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
+    func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
+    func flushDNSCache(reply: @escaping (Error?) -> Void) {}
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) {}
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) {}
+}

--- a/VaderCleanerTests/MaintenanceTaskRunnersTests.swift
+++ b/VaderCleanerTests/MaintenanceTaskRunnersTests.swift
@@ -58,6 +58,11 @@ final class MaintenanceTaskRunnersTests: XCTestCase {
         await XCTAssertThrowsErrorAsync(try await runner.run())
     }
 
+    func test_spotlightReindexer_throwsWhenHelperUnavailable() async {
+        let runner = SpotlightReindexer(helperProvider: { _ in nil })
+        await XCTAssertThrowsErrorAsync(try await runner.run())
+    }
+
     // MARK: - Time Machine
 
     func test_tmThinner_invokesSelectorAndReturnsResult() async throws {
@@ -73,6 +78,11 @@ final class MaintenanceTaskRunnersTests: XCTestCase {
     func test_tmThinner_throwsWhenHelperRepliesError() async {
         let helper = RecordingHelper(replyError: Boom())
         let runner = TimeMachineSnapshotThinner(helperProvider: { _ in helper })
+        await XCTAssertThrowsErrorAsync(try await runner.run())
+    }
+
+    func test_tmThinner_throwsWhenHelperUnavailable() async {
+        let runner = TimeMachineSnapshotThinner(helperProvider: { _ in nil })
         await XCTAssertThrowsErrorAsync(try await runner.run())
     }
 }

--- a/VaderCleanerTests/MaintenanceTaskTests.swift
+++ b/VaderCleanerTests/MaintenanceTaskTests.swift
@@ -1,0 +1,43 @@
+// MaintenanceTaskTests.swift
+// Verifies the maintenance-task catalog is complete, uniquely identified, and fully described.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MaintenanceTaskTests: XCTestCase {
+
+    func test_catalog_containsEveryTaskKindExactlyOnce() {
+        let kinds = MaintenanceTask.catalog.map(\.kind)
+        XCTAssertEqual(Set(kinds).count, kinds.count, "Catalog must not repeat a task kind")
+        XCTAssertEqual(Set(kinds), Set(MaintenanceTask.Kind.allCases))
+    }
+
+    func test_catalog_everyTaskIsFullyDescribed() {
+        for task in MaintenanceTask.catalog {
+            XCTAssertFalse(task.title.isEmpty, "\(task.kind) needs a title")
+            XCTAssertFalse(task.summary.isEmpty, "\(task.kind) needs a summary")
+            XCTAssertFalse(task.icon.isEmpty, "\(task.kind) needs an icon")
+        }
+    }
+
+    func test_catalog_idsAreUnique() {
+        let ids = MaintenanceTask.catalog.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+    }
+
+    func test_speedUpMail_isTheOnlyUserLevelTask() {
+        let userLevel = MaintenanceTask.catalog.filter { !$0.requiresHelper }.map(\.kind)
+        XCTAssertEqual(userLevel, [.speedUpMail])
+    }
+
+    func test_maintenanceCocktail_excludesTheTasksWithDedicatedCards() {
+        // Free up RAM (hero) and Thin Time Machine Snapshots (own card) are
+        // surfaced separately, so the cocktail must not double-count them.
+        XCTAssertFalse(MaintenanceTask.maintenanceCocktailKinds.contains(.freeUpRAM))
+        XCTAssertFalse(MaintenanceTask.maintenanceCocktailKinds.contains(.thinTimeMachineSnapshots))
+        XCTAssertEqual(
+            Set(MaintenanceTask.maintenanceCocktailKinds),
+            [.runMaintenanceScripts, .flushDNS, .reindexSpotlight, .speedUpMail]
+        )
+    }
+}

--- a/VaderCleanerTests/MalwareThreatRemoverTests.swift
+++ b/VaderCleanerTests/MalwareThreatRemoverTests.swift
@@ -154,6 +154,9 @@ private final class FakeHelper: NSObject, VaderCleanerHelperProtocol {
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushDNSCache(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) { reply(nil) }
 }
 
 /// Helper stand-in that drops the reply block — models the `NSXPCConnection`
@@ -164,4 +167,7 @@ private final class DroppingReplyHelper: NSObject, VaderCleanerHelperProtocol {
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
+    func flushDNSCache(reply: @escaping (Error?) -> Void) {}
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) {}
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) {}
 }

--- a/VaderCleanerTests/OptimizationViewModelTests.swift
+++ b/VaderCleanerTests/OptimizationViewModelTests.swift
@@ -95,6 +95,207 @@ final class OptimizationViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Maintenance task catalog
+
+    func test_runTask_flushDNS_invokesRunnerStampsResultAndReady() async {
+        var ran = false
+        let vm = makeViewModel(flushDNS: { ran = true; return "Flushed DNS." })
+        await vm.refresh()
+
+        await vm.run(Self.task(.flushDNS))
+
+        XCTAssertTrue(ran, "run(.flushDNS) must invoke its runner")
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.taskResults["flushDNS"], "Flushed DNS.")
+    }
+
+    func test_runTask_speedUpMail_failureTransitionsToFailed() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(speedUpMail: { throw Boom() })
+        await vm.refresh()
+
+        await vm.run(Self.task(.speedUpMail))
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+        XCTAssertFalse(vm.failureNeedsFullDiskAccess, "A generic failure is not an FDA recovery case")
+    }
+
+    func test_runTask_speedUpMail_fullDiskAccessFailureFlagsRecovery() async {
+        let vm = makeViewModel(speedUpMail: { throw MailReindexerError.fullDiskAccessRequired })
+        await vm.refresh()
+
+        await vm.run(Self.task(.speedUpMail))
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+        XCTAssertTrue(vm.failureNeedsFullDiskAccess,
+                      "A Full Disk Access failure must flag the recovery affordance")
+    }
+
+    func test_runTask_recordsLastRunSoTaskIsNoLongerStale() async {
+        let defaults = UserDefaults(suiteName: "OptVMRunLog.\(UUID().uuidString)")!
+        let log = MaintenanceRunLog(defaults: defaults)
+        let vm = makeViewModel(flushDNS: { "ok" }, runLog: log)
+        await vm.refresh()
+        XCTAssertNil(log.lastRun(for: "flushDNS"))
+
+        await vm.run(Self.task(.flushDNS))
+
+        XCTAssertNotNil(log.lastRun(for: "flushDNS"))
+        defaults.removePersistentDomain(forName: "OptVMRunLog")
+    }
+
+    func test_run_clearsWorkingTitleWhenFinished() async {
+        let vm = makeViewModel(flushDNS: { "Flushed the DNS resolver cache." })
+        await vm.refresh()
+
+        await vm.run(Self.task(.flushDNS))
+
+        XCTAssertNil(vm.workingTitle, "The progress title clears when the action finishes")
+    }
+
+    func test_runRecommendation_marksTileCompletedOnSuccess() async {
+        var freed = false
+        let vm = makeViewModel(flushRAM: { freed = true })
+        await vm.refresh()
+
+        await vm.runRecommendation(Self.recommendation(.freeUpRAM))
+
+        XCTAssertTrue(freed, "Running the Free Up RAM tile must invoke the RAM flush")
+        XCTAssertTrue(vm.completedRecommendations.contains(.freeUpRAM))
+    }
+
+    func test_runRecommendation_failureDoesNotMarkCompleted() async {
+        struct Boom: Error {}
+        let vm = makeViewModel(flushRAM: { throw Boom() })
+        await vm.refresh()
+
+        await vm.runRecommendation(Self.recommendation(.freeUpRAM))
+
+        XCTAssertFalse(vm.completedRecommendations.contains(.freeUpRAM),
+                       "A failed action must not mark the tile complete")
+    }
+
+    func test_runRecommendation_backgroundItems_isNavigationOnly() async {
+        var flushed = false
+        let vm = makeViewModel(flushRAM: { flushed = true })
+        await vm.refresh()
+
+        await vm.runRecommendation(Self.recommendation(.backgroundItems))
+
+        XCTAssertFalse(flushed, "The background-items tile only navigates; it runs nothing")
+        XCTAssertFalse(vm.completedRecommendations.contains(.backgroundItems))
+    }
+
+    func test_refresh_clearsCompletedRecommendations() async {
+        let vm = makeViewModel(flushRAM: {})
+        await vm.refresh()
+        await vm.runRecommendation(Self.recommendation(.freeUpRAM))
+        XCTAssertTrue(vm.completedRecommendations.contains(.freeUpRAM))
+
+        await vm.refresh()
+
+        XCTAssertTrue(vm.completedRecommendations.isEmpty, "A refresh clears completed-tile marks")
+    }
+
+    func test_tasks_excludeMaintenanceScriptsWhenPeriodicUnavailable() async {
+        let vm = makeViewModel(maintenanceScriptsAvailable: false)
+        await vm.refresh()
+
+        XCTAssertFalse(
+            vm.tasks.contains { $0.kind == .runMaintenanceScripts },
+            "Run Maintenance Scripts must be hidden when /usr/sbin/periodic is absent"
+        )
+        // The other tasks remain.
+        XCTAssertTrue(vm.tasks.contains { $0.kind == .flushDNS })
+    }
+
+    func test_runDueMaintenance_skipsMaintenanceScriptsWhenUnavailable() async {
+        var ranScripts = false
+        var ranDNS = false
+        let vm = makeViewModel(
+            runMaintenance: { ranScripts = true; return "scripts" },
+            flushDNS: { ranDNS = true; return "dns" },
+            maintenanceScriptsAvailable: false
+        )
+        await vm.refresh()
+
+        await vm.runDueMaintenance()
+
+        XCTAssertFalse(ranScripts, "The removed periodic task must never be invoked")
+        XCTAssertTrue(ranDNS, "The available cocktail tasks still run")
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    func test_runDueMaintenance_runsEveryDueCocktailTask() async {
+        // Fresh run log → every cocktail task is due. Each runner records that
+        // it ran; RAM and Thin TM are excluded from the cocktail.
+        var ranScripts = false, ranDNS = false, ranSpotlight = false, ranMail = false
+        let vm = makeViewModel(
+            runMaintenance: { ranScripts = true; return "scripts" },
+            flushDNS: { ranDNS = true; return "dns" },
+            reindexSpotlight: { ranSpotlight = true; return "spotlight" },
+            speedUpMail: { ranMail = true; return "mail" }
+        )
+        await vm.refresh()
+
+        await vm.runDueMaintenance()
+
+        XCTAssertTrue(ranScripts && ranDNS && ranSpotlight && ranMail,
+                      "runDueMaintenance() must run every due cocktail task")
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
+    func test_runTasks_runsEverySelectedTaskInOrder() async {
+        var ranDNS = false, ranSpotlight = false
+        let vm = makeViewModel(
+            flushDNS: { ranDNS = true; return "dns" },
+            reindexSpotlight: { ranSpotlight = true; return "spotlight" }
+        )
+        await vm.refresh()
+
+        await vm.run([Self.task(.flushDNS), Self.task(.reindexSpotlight)])
+
+        XCTAssertTrue(ranDNS && ranSpotlight, "Both selected tasks must run")
+        XCTAssertEqual(vm.phase, .ready)
+        XCTAssertEqual(vm.taskResults["flushDNS"], "dns")
+        XCTAssertEqual(vm.taskResults["reindexSpotlight"], "spotlight")
+    }
+
+    func test_runTasks_stopsAtFirstFailure() async {
+        struct Boom: Error {}
+        var ranSpotlight = false
+        let vm = makeViewModel(
+            flushDNS: { throw Boom() },
+            reindexSpotlight: { ranSpotlight = true; return "spotlight" }
+        )
+        await vm.refresh()
+
+        await vm.run([Self.task(.flushDNS), Self.task(.reindexSpotlight)])
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+        XCTAssertFalse(ranSpotlight, "A failure must halt the remaining tasks")
+    }
+
+    func test_refresh_buildsRecommendationsFromSystemState() async {
+        let vm = makeViewModel(
+            loadLoginItems: { [Self.loginItem(name: "A")] },
+            readMemory: { MemoryStats(usedBytes: 15, totalBytes: 16) }, // high pressure
+            readSnapshotCount: { 3 }
+        )
+
+        await vm.refresh()
+
+        XCTAssertTrue(vm.recommendations.contains { $0.kind == .freeUpRAM })
+        XCTAssertTrue(vm.recommendations.contains { $0.kind == .backgroundItems })
+        XCTAssertTrue(vm.recommendations.contains { $0.kind == .thinSnapshots })
+    }
+
     // MARK: - Login items
 
     func test_setLoginItem_forwardsRequestedStateToCollaborator() async {
@@ -277,6 +478,23 @@ final class OptimizationViewModelTests: XCTestCase {
         XCTAssertEqual(vm.userAgents.map(\.label), ["com.user.doomed"])
     }
 
+    func test_removeAgent_systemDaemonIsProtectedAndNotRemoved() async {
+        var removeCalled = false
+        let systemDaemon = Self.agent(label: "com.apple.somethingImportant", domain: .system)
+        let vm = makeViewModel(
+            loadSystemAgents: { [systemDaemon] },
+            removeAgent: { _ in removeCalled = true }
+        )
+        await vm.refresh()
+
+        await vm.remove(systemDaemon)
+
+        XCTAssertFalse(removeCalled, "System daemons must never be removed")
+        XCTAssertEqual(vm.systemAgents.map(\.label), ["com.apple.somethingImportant"],
+                       "The protected system daemon must remain in the list")
+        XCTAssertEqual(vm.phase, .ready)
+    }
+
     func test_dismissResult_returnsToReady() async {
         struct Boom: Error {}
         let vm = makeViewModel(flushRAM: { throw Boom() })
@@ -300,9 +518,21 @@ final class OptimizationViewModelTests: XCTestCase {
         removeAgent: @escaping OptimizationViewModel.RemoveAgent = { _ in },
         flushRAM: @escaping OptimizationViewModel.FlushRAM = {},
         runMaintenance: @escaping OptimizationViewModel.RunMaintenance = { "" },
+        flushDNS: @escaping OptimizationViewModel.RunTask = { "" },
+        reindexSpotlight: @escaping OptimizationViewModel.RunTask = { "" },
+        thinSnapshots: @escaping OptimizationViewModel.RunTask = { "" },
+        speedUpMail: @escaping OptimizationViewModel.RunTask = { "" },
+        readSnapshotCount: @escaping OptimizationViewModel.ReadSnapshotCount = { 0 },
+        runLog: MaintenanceRunLog? = nil,
+        maintenanceScriptsAvailable: Bool = true,
         launchAtLoginChanges: AnyPublisher<Void, Never>? = nil
     ) -> OptimizationViewModel {
-        OptimizationViewModel(
+        // Default to an isolated, empty UserDefaults suite so the run log never
+        // touches `.standard` or leaks state between tests.
+        let isolatedLog = runLog ?? MaintenanceRunLog(
+            defaults: UserDefaults(suiteName: "OptimizationViewModelTests.\(UUID().uuidString)")!
+        )
+        return OptimizationViewModel(
             loadLoginItems: loadLoginItems,
             loadUserAgents: loadUserAgents,
             loadSystemAgents: loadSystemAgents,
@@ -312,7 +542,24 @@ final class OptimizationViewModelTests: XCTestCase {
             removeAgent: removeAgent,
             flushRAM: flushRAM,
             runMaintenance: runMaintenance,
+            flushDNS: flushDNS,
+            reindexSpotlight: reindexSpotlight,
+            thinSnapshots: thinSnapshots,
+            speedUpMail: speedUpMail,
+            readSnapshotCount: readSnapshotCount,
+            runLog: isolatedLog,
+            maintenanceScriptsAvailable: maintenanceScriptsAvailable,
             launchAtLoginChanges: launchAtLoginChanges
+        )
+    }
+
+    private static func task(_ kind: MaintenanceTask.Kind) -> MaintenanceTask {
+        MaintenanceTask.catalog.first { $0.kind == kind }!
+    }
+
+    private static func recommendation(_ kind: PerformanceRecommendation.Kind) -> PerformanceRecommendation {
+        PerformanceRecommendation(
+            kind: kind, title: "", detail: "", icon: "", actionLabel: "", isHero: kind == .freeUpRAM
         )
     }
 

--- a/VaderCleanerTests/OptimizationViewModelTests.swift
+++ b/VaderCleanerTests/OptimizationViewModelTests.swift
@@ -136,7 +136,9 @@ final class OptimizationViewModelTests: XCTestCase {
     }
 
     func test_runTask_recordsLastRunSoTaskIsNoLongerStale() async {
-        let defaults = UserDefaults(suiteName: "OptVMRunLog.\(UUID().uuidString)")!
+        let suiteName = "OptVMRunLog.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let log = MaintenanceRunLog(defaults: defaults)
         let vm = makeViewModel(flushDNS: { "ok" }, runLog: log)
         await vm.refresh()
@@ -145,7 +147,6 @@ final class OptimizationViewModelTests: XCTestCase {
         await vm.run(Self.task(.flushDNS))
 
         XCTAssertNotNil(log.lastRun(for: "flushDNS"))
-        defaults.removePersistentDomain(forName: "OptVMRunLog")
     }
 
     func test_run_clearsWorkingTitleWhenFinished() async {

--- a/VaderCleanerTests/PerformanceRecommendationEngineTests.swift
+++ b/VaderCleanerTests/PerformanceRecommendationEngineTests.swift
@@ -1,0 +1,93 @@
+// PerformanceRecommendationEngineTests.swift
+// Verifies the recommendation engine surfaces the right curated cards (RAM, maintenance, background items, snapshots) for a given system snapshot, in display order.
+
+import XCTest
+@testable import VaderCleaner
+
+final class PerformanceRecommendationEngineTests: XCTestCase {
+
+    func test_healthySystem_offersOnlyThePersistentRAMHero() {
+        let snapshot = PerformanceSnapshot(
+            memory: MemoryStats(usedBytes: 4_000_000_000, totalBytes: 16_000_000_000), // 25%
+            localSnapshotCount: 0,
+            backgroundItemCount: 0,
+            staleTaskCount: 0
+        )
+
+        let recs = PerformanceRecommendationEngine.recommendations(for: snapshot)
+
+        // RAM is a persistent hero; nothing else surfaces on a healthy system.
+        XCTAssertEqual(recs.map(\.kind), [.freeUpRAM])
+        XCTAssertTrue(recs.first?.isHero ?? false)
+    }
+
+    func test_freeUpRAM_isAlwaysTheHeroCard() {
+        let snapshot = PerformanceSnapshot(
+            memory: .empty,
+            localSnapshotCount: 0,
+            backgroundItemCount: 0,
+            staleTaskCount: 0
+        )
+
+        let recs = PerformanceRecommendationEngine.recommendations(for: snapshot)
+
+        XCTAssertEqual(recs.first?.kind, .freeUpRAM)
+        XCTAssertTrue(recs.first?.isHero ?? false)
+    }
+
+    func test_staleTasks_recommendsMaintenanceWithCount() {
+        let snapshot = PerformanceSnapshot(
+            memory: .empty,
+            localSnapshotCount: 0,
+            backgroundItemCount: 0,
+            staleTaskCount: 3
+        )
+
+        let recs = PerformanceRecommendationEngine.recommendations(for: snapshot)
+        let maintenance = recs.first { $0.kind == .maintenanceTasks }
+
+        XCTAssertNotNil(maintenance)
+        XCTAssertTrue(maintenance?.title.contains("3") ?? false)
+    }
+
+    func test_backgroundItems_recommendsWithCount() {
+        let snapshot = PerformanceSnapshot(
+            memory: .empty,
+            localSnapshotCount: 0,
+            backgroundItemCount: 12,
+            staleTaskCount: 0
+        )
+
+        let recs = PerformanceRecommendationEngine.recommendations(for: snapshot)
+        let background = recs.first { $0.kind == .backgroundItems }
+
+        XCTAssertNotNil(background)
+        XCTAssertTrue(background?.title.contains("12") ?? false)
+    }
+
+    func test_localSnapshots_recommendsThinning() {
+        let snapshot = PerformanceSnapshot(
+            memory: .empty,
+            localSnapshotCount: 5,
+            backgroundItemCount: 0,
+            staleTaskCount: 0
+        )
+
+        let recs = PerformanceRecommendationEngine.recommendations(for: snapshot)
+
+        XCTAssertTrue(recs.contains { $0.kind == .thinSnapshots })
+    }
+
+    func test_recommendationOrder_isRamThenMaintenanceThenBackgroundThenSnapshots() {
+        let snapshot = PerformanceSnapshot(
+            memory: MemoryStats(usedBytes: 15_000_000_000, totalBytes: 16_000_000_000),
+            localSnapshotCount: 5,
+            backgroundItemCount: 12,
+            staleTaskCount: 3
+        )
+
+        let kinds = PerformanceRecommendationEngine.recommendations(for: snapshot).map(\.kind)
+
+        XCTAssertEqual(kinds, [.freeUpRAM, .maintenanceTasks, .backgroundItems, .thinSnapshots])
+    }
+}

--- a/VaderCleanerTests/RAMManagerTests.swift
+++ b/VaderCleanerTests/RAMManagerTests.swift
@@ -70,6 +70,9 @@ private final class SpyFlushHelper: NSObject, VaderCleanerHelperProtocol {
         flushCalled = true
         reply(replyError)
     }
+    func flushDNSCache(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) { reply(nil) }
 }
 
 private final class DroppingFlushHelper: NSObject, VaderCleanerHelperProtocol {
@@ -78,4 +81,7 @@ private final class DroppingFlushHelper: NSObject, VaderCleanerHelperProtocol {
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
+    func flushDNSCache(reply: @escaping (Error?) -> Void) {}
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) {}
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) {}
 }

--- a/VaderCleanerTests/SmartScanViewModelTests.swift
+++ b/VaderCleanerTests/SmartScanViewModelTests.swift
@@ -984,6 +984,40 @@ final class SmartScanViewModelTests: XCTestCase {
         XCTAssertTrue(vm.willExecute(.myClutter))
     }
 
+    // MARK: - Maintenance-scripts availability (periodic removed in macOS 26)
+
+    func test_optimization_isActionableAndSelectedWhenMaintenanceAvailable() async {
+        let vm = makeViewModel(maintenanceScriptsAvailable: true)
+        await vm.scan()
+        XCTAssertTrue(vm.isModuleSelected(.optimization), "Optimization seeds on when maintenance is available")
+        XCTAssertTrue(vm.willExecute(.optimization))
+    }
+
+    func test_optimization_isNotActionableOrSelectedWhenMaintenanceUnavailable() async {
+        let vm = makeViewModel(maintenanceScriptsAvailable: false)
+        await vm.scan()
+        XCTAssertFalse(vm.isModuleSelected(.optimization),
+                       "Optimization must not auto-select when periodic is gone")
+        XCTAssertFalse(vm.willExecute(.optimization),
+                       "Optimization has no Run work when maintenance scripts are unavailable")
+    }
+
+    func test_run_skipsMaintenanceWhenUnavailableEvenIfTileSelected() async {
+        var ran = false
+        let vm = makeViewModel(
+            maintenanceRunner: { ran = true; return "ran" },
+            maintenanceScriptsAvailable: false
+        )
+        await vm.scan()
+        // Force the tile on to prove the run-time guard, not just the seed.
+        vm.toggleModule(.optimization)
+        XCTAssertTrue(vm.isModuleSelected(.optimization))
+
+        await vm.run()
+
+        XCTAssertFalse(ran, "The removed periodic maintenance must never be invoked")
+    }
+
     // MARK: - Scan progress count
 
     /// The combined "Scanned N items…" tally must sum the walked counts of the
@@ -1038,7 +1072,8 @@ final class SmartScanViewModelTests: XCTestCase {
         threatRemover: @escaping SmartScanViewModel.ThreatRemover = { _ in [] },
         maintenanceRunner: @escaping SmartScanViewModel.MaintenanceRunner = { "" },
         updateOpener: @escaping SmartScanViewModel.UpdateOpener = { _ in },
-        largeFileDeleter: @escaping SmartScanViewModel.LargeFileDeleter = { _ in [] }
+        largeFileDeleter: @escaping SmartScanViewModel.LargeFileDeleter = { _ in [] },
+        maintenanceScriptsAvailable: Bool = true
     ) -> SmartScanViewModel {
         // Adapt the progress-free test closures to the production sub-scanner
         // signatures; the count test below constructs the VM directly to drive
@@ -1054,7 +1089,8 @@ final class SmartScanViewModelTests: XCTestCase {
             threatRemover: threatRemover,
             maintenanceRunner: maintenanceRunner,
             updateOpener: updateOpener,
-            largeFileDeleter: largeFileDeleter
+            largeFileDeleter: largeFileDeleter,
+            maintenanceScriptsAvailable: maintenanceScriptsAvailable
         )
     }
 

--- a/VaderCleanerTests/SystemJunkDeleterTests.swift
+++ b/VaderCleanerTests/SystemJunkDeleterTests.swift
@@ -229,6 +229,9 @@ private final class FakeHelper: NSObject, VaderCleanerHelperProtocol {
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) { reply(nil) }
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func flushDNSCache(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) { reply(nil) }
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) { reply(nil) }
 }
 
 /// Helper stand-in that intentionally drops the reply block on the floor —
@@ -243,4 +246,7 @@ private final class DroppingReplyHelper: NSObject, VaderCleanerHelperProtocol {
     func removeLoginItem(path: String, reply: @escaping (Error?) -> Void) {}
     func removeLaunchAgent(path: String, reply: @escaping (Error?) -> Void) {}
     func flushInactiveMemory(reply: @escaping (Error?) -> Void) {}
+    func flushDNSCache(reply: @escaping (Error?) -> Void) {}
+    func reindexSpotlight(reply: @escaping (Error?) -> Void) {}
+    func thinTimeMachineSnapshots(reply: @escaping (Error?) -> Void) {}
 }

--- a/VaderCleanerUITests/OptimizationUITests.swift
+++ b/VaderCleanerUITests/OptimizationUITests.swift
@@ -24,7 +24,7 @@ final class OptimizationUITests: XCTestCase {
         app = nil
     }
 
-    func test_navigateToOptimization_scan_revealsRefreshAndContent() throws {
+    func test_navigateToOptimization_scan_revealsDashboardAndCatalog() throws {
         dismissOnboardingIfNeeded()
 
         let sidebarRow = app.buttons["sidebar.optimization"].firstMatch
@@ -47,20 +47,28 @@ final class OptimizationUITests: XCTestCase {
                       "Expected the floating Scan button on the Optimization intro")
         floatingScan.click()
 
-        // Loading runs automatically on first appearance; landing on the
-        // ready state surfaces the RAM usage label. Generous timeout because
-        // discovery shells out to `launchctl list`. Assert ready first: the
-        // Refresh control now lives in the ready-state footer, so it cannot
-        // appear before the section renders.
-        let ramUsage = app.staticTexts["optimization.ramUsage"]
-        XCTAssertTrue(ramUsage.waitForExistence(timeout: 30),
-                      "Expected Optimization to reach its ready state")
+        // Landing on the ready state surfaces the recommendation dashboard.
+        // Generous timeout because discovery shells out to `launchctl list`.
+        // "View All Tasks" is always present on the dashboard (even when there
+        // are no recommendations), so it is the stable "section rendered" signal.
+        let viewAllTasks = app.buttons["optimization.viewAllTasks"]
+        XCTAssertTrue(viewAllTasks.waitForExistence(timeout: 30),
+                      "Expected the Optimization dashboard to reach its ready state")
 
-        // The in-content Refresh button renders alongside the ready state —
-        // strongest "view did not crash" signal once the section is shown.
+        // The in-content Refresh button renders alongside the ready state.
         let refresh = app.buttons["optimization.refresh"]
         XCTAssertTrue(refresh.waitForExistence(timeout: 5),
                       "Expected Optimization Refresh control to render")
+
+        // Opening "View All Tasks" reveals the catalog with the maintenance
+        // tasks — proves the dashboard → catalog swap wiring works.
+        viewAllTasks.click()
+        let catalog = app.descendants(matching: .any)["optimization.catalog"]
+        XCTAssertTrue(catalog.waitForExistence(timeout: 5),
+                      "Expected the task catalog after tapping View All Tasks")
+        let flushDNSRow = app.descendants(matching: .any)["optimization.task.flushDNS"]
+        XCTAssertTrue(flushDNSRow.waitForExistence(timeout: 5),
+                      "Expected the Flush DNS task row in the catalog")
     }
 
     // MARK: - Helpers

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -1,0 +1,321 @@
+# Optimization — User Guide
+
+The **Optimization** section keeps your Mac running smoothly by handling routine
+upkeep that macOS doesn't always do on its own. Think of it as a tune‑up for your
+computer: a handful of safe, well‑understood maintenance jobs you can run with a
+single click.
+
+This guide explains, in plain language, what the section shows you, what each task
+actually does, and the trade‑offs of running it — so you can decide what's worth
+doing and when.
+
+---
+
+## Table of contents
+
+- [How the section is laid out](#how-the-section-is-laid-out)
+- [The recommendation cards](#the-recommendation-cards)
+- [The tasks, explained](#the-tasks-explained)
+  - [Free Up RAM](#free-up-ram)
+  - [Run Maintenance Scripts](#run-maintenance-scripts)
+  - [Flush DNS Cache](#flush-dns-cache)
+  - [Reindex Spotlight](#reindex-spotlight)
+  - [Thin Time Machine Snapshots](#thin-time-machine-snapshots)
+  - [Speed Up Mail](#speed-up-mail)
+- [Background Items](#background-items)
+- [Frequently asked questions](#frequently-asked-questions)
+- [Quick reference table](#quick-reference-table)
+
+---
+
+## How the section is laid out
+
+When you open **Optimization**, you'll see two views:
+
+1. **The dashboard** (the first thing you see). This is a set of *recommendation
+   cards*. The app looks at the current state of your Mac and surfaces the things
+   most worth doing right now — for example, freeing up memory, or thinning old
+   backup snapshots that are taking up space. Each card has a button to act on it.
+
+2. **View All Tasks** (a button on the dashboard). This opens the full *catalog*,
+   organized like a control panel with a list on the left:
+   - **Maintenance Tasks** — every task with a checkbox and a colorful icon. Tick
+     the ones you want, and the bar at the bottom shows how many you've selected
+     and a **Run** button that runs them all together. Each row also has an **info
+     (ⓘ)** button that explains, in a sentence, what the task does.
+   - **Login Items** — apps set to launch when you log in.
+   - **Background Items** — helper programs that start automatically with your Mac.
+
+   Use the catalog when you want to choose tasks yourself rather than follow a
+   recommendation.
+
+You can move back and forth freely. Nothing runs until you click a button.
+
+> **A note on permissions.** Most of these tasks change system‑level settings, so
+> macOS requires administrator rights. VaderCleaner performs them through a small,
+> signed background helper that has permission to do this safely. You may be asked
+> to approve the helper the first time. The one exception is **Speed Up Mail**,
+> which works at the user level and needs the Mail app to be closed.
+
+---
+
+## The recommendation cards
+
+The dashboard chooses what to show based on your Mac's current condition:
+
+| Card | When it appears | What its button does |
+| --- | --- | --- |
+| **Free Up Your RAM** | Always — it's the main, permanent card | Frees inactive memory |
+| **N Maintenance Tasks Recommended** | When routine tasks haven't run in a while (over a week) | Runs all the due upkeep tasks in one go |
+| **N Background Items Found** | When apps/helpers start automatically with your Mac | Opens the list so you can review them |
+| **Thin Time Machine Snapshots** | When local backup snapshots are using disk space | Reclaims that space |
+
+The number on a card (like "3 Maintenance Tasks Recommended") matches exactly what
+its button will do — if it says three tasks, clicking **Run Tasks** runs those
+three.
+
+If your Mac is in good shape, the dashboard may only show the RAM card. That's
+normal — it means there's nothing else worth doing right now. You can still open
+**View All Tasks** to run anything manually.
+
+---
+
+## The tasks, explained
+
+Each task below includes a plain‑English description, when it helps, and the
+pros and cons so you know what you're trading off.
+
+---
+
+### Free Up RAM
+
+**What it is.** RAM (memory) is your Mac's short‑term workspace — where apps keep
+the things they're actively using. Over time, closed apps can leave behind
+"inactive" memory that isn't doing anything useful. This task asks macOS to
+release that inactive memory back to the pool.
+
+**When it helps.** If your Mac feels sluggish after a long session with many apps
+open and closed, or you're about to start something memory‑hungry (video editing,
+a virtual machine, lots of browser tabs).
+
+**Pros**
+- Quick and safe; nothing is deleted.
+- Can give active apps a bit more breathing room.
+
+**Cons**
+- macOS already manages memory well on its own. The benefit is often small and
+  temporary — memory fills back up as you keep working.
+- Right after running it, your Mac may briefly feel *slower* as apps reload things
+  they need from disk.
+
+**Bottom line.** Harmless and occasionally helpful, but not something you need to
+do regularly. macOS usually handles this for you.
+
+---
+
+### Run Maintenance Scripts
+
+**What it is.** macOS ships with built‑in housekeeping routines (called the
+*daily*, *weekly*, and *monthly* periodic scripts). They tidy up temporary files,
+rotate and compress old log files, and refresh some system databases. They're
+scheduled to run automatically — but only if your Mac is awake at the right time.
+Many Macs are asleep overnight, so these can fall behind. This task runs them on
+demand.
+
+**When it helps.** If your Mac is frequently asleep or shut down overnight, the
+scripts may rarely run on their own. Running them manually catches up the backlog.
+
+**Pros**
+- Keeps logs from piling up and clears out stale temporary files.
+- Standard, Apple‑provided maintenance — very safe.
+
+**Cons**
+- The effect is mostly invisible; you won't see a dramatic speed‑up.
+- Can take a little while and use some CPU while it runs.
+
+**Availability.** Apple removed the `periodic` mechanism in **macOS 26**, so this
+task only appears on macOS versions that still include it (Ventura and earlier).
+On macOS 26+ it won't show, because the system handles this maintenance itself.
+
+**Bottom line.** Good occasional housekeeping, especially if your Mac doesn't stay
+awake overnight. Low risk.
+
+---
+
+### Flush DNS Cache
+
+**What it is.** When you visit a website, your Mac remembers ("caches") the address
+lookup so it doesn't have to ask again every time. Occasionally that cached
+information goes stale — for example, after a website moves, or your network
+changes. This task clears the cache so your Mac fetches fresh address information.
+
+**When it helps.** A site won't load, loads the wrong/old version, or you've just
+changed network settings (new router, VPN, switched DNS providers) and pages behave
+oddly.
+
+**Pros**
+- Often fixes "this site works on my phone but not my Mac" type problems.
+- Instant and safe.
+
+**Cons**
+- The next few lookups are a touch slower while the cache rebuilds (you won't
+  really notice).
+- Does nothing if your problem isn't DNS‑related.
+
+**Bottom line.** A great first thing to try for stubborn website or connection
+issues. No downside worth worrying about.
+
+---
+
+### Reindex Spotlight
+
+**What it is.** Spotlight is your Mac's built‑in search (the magnifying glass).
+It keeps an *index* — a catalog of your files — so searches are instant. If search
+starts missing files or returning wrong results, the index may be corrupted. This
+task erases and rebuilds it from scratch.
+
+**When it helps.** Spotlight search is incomplete, slow, or returns stale results.
+
+**Pros**
+- Restores accurate, fast search once rebuilding finishes.
+- Fixes a class of problems nothing else can.
+
+**Cons**
+- **Rebuilding takes time** — anywhere from minutes to a couple of hours depending
+  on how much data you have.
+- **While it rebuilds, search will be slow or incomplete**, and your Mac may run
+  warmer and use more CPU. Best to start it when you don't urgently need search.
+
+**Bottom line.** Powerful fix, but disruptive while it works. Only run it when
+search is actually misbehaving, and ideally when you can leave the Mac to finish.
+
+---
+
+### Thin Time Machine Snapshots
+
+**What it is.** Time Machine (Apple's backup system) keeps temporary *local
+snapshots* on your Mac's own disk between backups to your external/network drive.
+These are handy, but they can quietly eat up disk space. This task asks macOS to
+trim them down.
+
+**When it helps.** You're low on disk space and Time Machine is enabled. "Purgeable"
+space that you can't seem to free up is often these snapshots.
+
+**Pros**
+- Can reclaim a meaningful amount of disk space.
+- **Your real backups are not affected** — only the temporary local copies are
+  thinned, and macOS only removes what it safely can.
+
+**Cons**
+- If you delete a file and then thin snapshots, the short‑term "undo" that local
+  snapshots provide may no longer be available (your proper Time Machine backups
+  still are).
+- Does nothing if you don't use Time Machine.
+
+**Does this affect my backups or encryption?** No.
+- **Your backups are safe.** This only thins the *local* snapshots stored on your
+  Mac's internal disk. The full backup history on your external or network Time
+  Machine drive is never touched — and macOS only removes what it can safely
+  remove. Under the hood, this simply asks macOS to reclaim space
+  (`tmutil thinlocalsnapshots`); it does not delete specific backups by hand.
+- **Encryption is unchanged.** If FileVault is on, your disk and the snapshots on
+  it stay fully encrypted — thinning doesn't decrypt anything. If your Time Machine
+  backup drive is encrypted, that's a separate disk this task doesn't touch, so its
+  encryption is unaffected too.
+
+**Bottom line.** A safe way to recover disk space if you use Time Machine. Your
+backups stay intact and nothing is decrypted — the only cost is losing some very
+recent local "undo" points until macOS makes new snapshots.
+
+---
+
+### Speed Up Mail
+
+**What it is.** The Mail app keeps a database (an "envelope index") of all your
+messages so it can search and sort quickly. Over time this database can become
+bloated or fragmented, making Mail feel slow. This task compacts and rebuilds it.
+
+**When it helps.** Mail is slow to search, sluggish when switching mailboxes, or
+generally feels heavy.
+
+**Pros**
+- Can noticeably improve Mail's responsiveness and search.
+- Doesn't touch your actual emails — only the behind‑the‑scenes index.
+
+**Cons**
+- **Mail must be closed** while this runs, or it will fail (the database is locked
+  while Mail is open). The app will tell you if that's the case.
+- Requires that the app can read your Mail data, which may need **Full Disk Access**
+  granted to VaderCleaner in System Settings → Privacy & Security.
+- The first time you reopen Mail afterward, it may take a moment to settle.
+
+**Bottom line.** Worth it if Mail feels slow. Just quit Mail first.
+
+---
+
+## Background Items
+
+In **View All Tasks**, below the maintenance tasks, you'll find **Background Items**.
+These are programs that start automatically when you log in or boot your Mac:
+
+- **Login Items** — apps set to launch at login.
+- **Launch Agents & Daemons** — smaller helper programs (often installed alongside
+  other apps) that run quietly in the background.
+
+Too many of these can slow down startup and use resources all day. Here you can:
+
+- **Disable** an item so it stops launching automatically (you can re‑enable it).
+- **Remove** a *user* item entirely (this deletes its startup configuration and
+  can't be undone from here).
+
+**System daemons are protected.** Items in the "Launch Agents & Daemons (System)"
+group belong to macOS itself or to the app that installed them. Removing one can
+break your system or that app, so VaderCleaner does not let you remove them here —
+the **Remove** button is unavailable for them. If you really need to change a
+system daemon, do it through **System Settings** or the app that installed it.
+
+**A word of caution.** Some background items are needed by apps you rely on (for
+example, cloud‑storage syncing or keyboard/mouse utilities). Disabling is reversible
+and the safer choice; removing is permanent. If you're not sure what something is,
+leave it alone or just disable it and see whether anything you use stops working.
+
+---
+
+## Frequently asked questions
+
+**Will any of these delete my files?**
+No. None of these tasks touch your documents, photos, or emails. They clear caches,
+run housekeeping, trim *temporary* backup snapshots, and rebuild *indexes* — not
+your actual data.
+
+**Do I need to run these regularly?**
+Not really. Most are "run it when you notice a specific problem" tools rather than
+chores. The dashboard will nudge you when something is genuinely worth doing.
+
+**Why does it ask for a password or approval?**
+Several tasks change system‑level settings, which macOS protects. VaderCleaner uses
+a small signed helper to do this safely; approving it is a one‑time step.
+
+**Can I undo a task?**
+There's nothing to undo for most of them — they don't remove anything you'd want
+back. Reindex Spotlight and Speed Up Mail simply rebuild their indexes. Removing a
+Background Item is the only action that's permanent.
+
+**Is it safe to just click everything?**
+Mostly yes, but two tasks are disruptive *while they run*: **Reindex Spotlight**
+(search is degraded until it finishes) and **Speed Up Mail** (Mail must be closed).
+Run those when it's convenient.
+
+---
+
+## Quick reference table
+
+| Task | What it does | Best for | Main downside | Risk |
+| --- | --- | --- | --- | --- |
+| **Free Up RAM** | Releases inactive memory | A sluggish Mac after heavy use | Effect is small and temporary | Very low |
+| **Run Maintenance Scripts** | Runs Apple's daily/weekly/monthly housekeeping | Macs that sleep overnight | Mostly invisible benefit | Very low |
+| **Flush DNS Cache** | Clears stale website address lookups | Sites that won't load right | Brief, unnoticeable slowdown after | Very low |
+| **Reindex Spotlight** | Rebuilds the search index | Broken or incomplete search | Slow/degraded search while rebuilding | Low (disruptive) |
+| **Thin Time Machine Snapshots** | Trims local backup snapshots | Recovering disk space | Loses short‑term local "undo" | Low (backups safe) |
+| **Speed Up Mail** | Rebuilds the Mail database | A slow Mail app | Mail must be closed; needs Full Disk Access | Low |
+| **Background Items** | Manage auto‑starting programs | Faster startup, fewer resources | Removing is permanent | Medium (be careful) |

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -133,9 +133,9 @@ scripts may rarely run on their own. Running them manually catches up the backlo
 - The effect is mostly invisible; you won't see a dramatic speed‑up.
 - Can take a little while and use some CPU while it runs.
 
-**Availability.** Apple removed the `periodic` mechanism in **macOS 26**, so this
-task only appears on macOS versions that still include it (Ventura and earlier).
-On macOS 26+ it won't show, because the system handles this maintenance itself.
+**Availability.** This task only appears on Macs that still include the system
+`periodic` tool. Apple has removed it from recent macOS, where the system handles
+this upkeep itself — on those Macs the task simply won't show.
 
 **Bottom line.** Good occasional housekeeping, especially if your Mac doesn't stay
 awake overnight. Low risk.

--- a/project.yml
+++ b/project.yml
@@ -15,16 +15,13 @@ settings:
     SWIFT_VERSION: "5.9"
     MACOSX_DEPLOYMENT_TARGET: "26.0"
     ENABLE_HARDENED_RUNTIME: NO
-    # Sign with the Apple Development certificate so the privileged helper has a
-    # stable Team identity that launchd will spawn (ad-hoc signing has no team
-    # and its cdhash churns every build, which SMAppService rejects with
-    # EX_CONFIG). The app's entitlements need no provisioned capabilities, so
-    # manual signing with the dev cert works without a provisioning profile.
-    CODE_SIGN_STYLE: Manual
-    CODE_SIGN_IDENTITY: "Apple Development"
-    CODE_SIGNING_REQUIRED: YES
-    CODE_SIGNING_ALLOWED: YES
-    DEVELOPMENT_TEAM: XGQ94CMBTN
+
+# Signing lives in Signing.xcconfig (team-agnostic defaults) with an optional,
+# gitignored Signing.local.xcconfig override, so no personal Team ID is
+# committed and any checkout / CI can still build. See Signing.xcconfig.
+configFiles:
+  Debug: Signing.xcconfig
+  Release: Signing.xcconfig
 
 targets:
   VaderCleaner:

--- a/project.yml
+++ b/project.yml
@@ -15,9 +15,16 @@ settings:
     SWIFT_VERSION: "5.9"
     MACOSX_DEPLOYMENT_TARGET: "26.0"
     ENABLE_HARDENED_RUNTIME: NO
+    # Sign with the Apple Development certificate so the privileged helper has a
+    # stable Team identity that launchd will spawn (ad-hoc signing has no team
+    # and its cdhash churns every build, which SMAppService rejects with
+    # EX_CONFIG). The app's entitlements need no provisioned capabilities, so
+    # manual signing with the dev cert works without a provisioning profile.
     CODE_SIGN_STYLE: Manual
-    CODE_SIGNING_REQUIRED: NO
-    DEVELOPMENT_TEAM: ""
+    CODE_SIGN_IDENTITY: "Apple Development"
+    CODE_SIGNING_REQUIRED: YES
+    CODE_SIGNING_ALLOWED: YES
+    DEVELOPMENT_TEAM: XGQ94CMBTN
 
 targets:
   VaderCleaner:
@@ -52,6 +59,17 @@ targets:
         outputFiles:
           - "$(BUILT_PRODUCTS_DIR)/$(CONTENTS_FOLDER_PATH)/Resources/clamav/bin/clamscan"
           - "$(BUILT_PRODUCTS_DIR)/$(CONTENTS_FOLDER_PATH)/Resources/clamav/bin/freshclam"
+    postBuildScripts:
+      # Ad-hoc signs the embedded helper and the app so SMAppService can register
+      # the privileged helper on local, unsigned development builds (the
+      # Optimization actions need it). Runs last — after the helper is embedded
+      # and ClamAV is staged — and no-ops when a real Developer ID identity is
+      # configured, so release signing is untouched. alwaysOutOfDate so it
+      # re-signs on every build.
+      - name: Ad-hoc sign for local development
+        script: "\"${SRCROOT}/Scripts/sign-dev.sh\"\n"
+        shell: /bin/sh
+        basedOnDependencyAnalysis: false
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.personal.VaderCleaner
@@ -87,6 +105,13 @@ targets:
         PRODUCT_NAME: VaderCleanerHelper
         PRODUCT_BUNDLE_IDENTIFIER: com.personal.VaderCleaner.helper
         SKIP_INSTALL: YES
+        # Embed an Info.plist in the tool's Mach-O so codesign uses its bundle id
+        # (com.personal.VaderCleaner.helper) as the signing identifier. Without
+        # this a command-line tool signs under its executable name
+        # (VaderCleanerHelper), which fails the app's XPC code-signing
+        # requirement and the connection is rejected.
+        GENERATE_INFOPLIST_FILE: YES
+        CREATE_INFOPLIST_SECTION_IN_BINARY: YES
 
   VaderCleanerTests:
     type: bundle.unit-test


### PR DESCRIPTION
## What & why

Rebuilds the **Optimization (Performance)** section into a curated‑recommendation dashboard plus a **View All Tasks** catalog, and adds the feasible CleanMyMac‑style maintenance tasks. Also fixes several macOS 26 / permission realities the old design didn't account for.

## Highlights

**Maintenance tasks**
- New privileged XPC ops in the helper: **Flush DNS Cache**, **Reindex Spotlight**, **Thin Time Machine Snapshots** (selectors added to `HelperProtocolTests` TDD‑first; all protocol spies stubbed).
- New runners: `DNSCacheFlusher` / `SpotlightReindexer` / `TimeMachineSnapshotThinner` share one `PrivilegedTaskRunner`; `MailReindexer` is user‑level (`sqlite3 VACUUM; REINDEX`). Plus `LocalSnapshotCounter` and `MaintenanceRunLog`.
- `MaintenanceTask` catalog + `PerformanceRecommendationEngine` (RAM is a persistent hero; maintenance / background‑items / snapshot cards are state‑driven).

**UI**
- Glass recommendation cards with colored icon badges; **View All Tasks** catalog with a sub‑nav (Maintenance Tasks / Login Items / Background Items), checkbox multi‑select + a bottom **Run** bar, per‑task info popovers, **fixed‑height rows**, and green success checks on tiles and rows.
- Progress screen now names the running task.

**Correctness / safety**
- **System launch daemons are protected from removal** (Disable‑only).
- **macOS 26**: `/usr/sbin/periodic` was removed, so **Run Maintenance Scripts** is gated on its existence in both Optimization and Smart Scan (hidden / excluded from Run Tasks) instead of erroring.
- **Speed Up Mail** distinguishes *no Full Disk Access* from *no Mail data*, and the failure screen offers an **Open Full Disk Access Settings** recovery button.

**Dev signing (important for the privileged helper)**
- `project.yml` signs with the **Apple Development** team identity; the helper target embeds an Info.plist so it signs under its bundle id — both required for `SMAppService` to actually spawn the daemon (ad‑hoc isn't enough on macOS 26).
- `Scripts/sign-dev.sh` is an ad‑hoc fallback that **no‑ops when a real identity is present**.

**Docs**
- `docs/Optimization.md` — a non‑technical guide to every task with pros/cons, safety notes, and an FAQ.

## Testing
- New unit/integration tests cover the runners, recommendation engine, run log, snapshot counter, catalog/task model, and view‑model transitions (including the FDA and macOS‑26 gating paths). Full `VaderCleanerTests` suite passes (`xcodebuild test … CODE_SIGNING_ALLOWED=NO`).
- UI test (`OptimizationUITests`) updated for the new dashboard/catalog; compiles but is run manually (the XCUITest runner can't bootstrap from CI/terminal in this setup).

## Reviewer notes
- The privileged helper requires a signed build to register via `SMAppService`; run from Xcode (team signing is in `project.yml`) and approve it once in **System Settings → Login Items & Extensions**.
- A couple of follow‑ups were intentionally left out of scope: making a multi‑task "Run Tasks" batch resilient to a single task's failure (currently aborts on first failure), and a richer "Requires Full Disk Access" inline state for Speed Up Mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Performance optimization dashboard with intelligent maintenance recommendations
  * New maintenance operations: DNS cache flushing, Spotlight reindexing, Time Machine snapshot thinning, and Mail optimization
  * Interactive task catalog for managing and running maintenance tasks in batch
  * Automatic tracking of local Time Machine snapshots

* **Improvements**
  * System daemons are now protected from accidental removal
  * Enhanced Full Disk Access permission handling
  * Compatibility with macOS 26+ systems

* **Documentation**
  * Comprehensive guide for the Optimization section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->