### PR TITLE
fix(optimization): Login Items toggle approval + Background Items label declutter

### DIFF
--- a/VaderCleaner/LoginItem.swift
+++ b/VaderCleaner/LoginItem.swift
@@ -9,6 +9,19 @@ struct LoginItem: Identifiable, Equatable {
     let id: String
     let name: String
     let isEnabled: Bool
+    /// `true` when launchd holds the registration but it is not yet active —
+    /// the user must finish enabling it in System Settings → Login Items.
+    /// SMAppService reports this as `.requiresApproval`; it is treated as
+    /// enabled so a fresh `register()` doesn't read as "off", while the view
+    /// shows a "finish in System Settings" hint.
+    let requiresApproval: Bool
+
+    init(id: String, name: String, isEnabled: Bool, requiresApproval: Bool = false) {
+        self.id = id
+        self.name = name
+        self.isEnabled = isEnabled
+        self.requiresApproval = requiresApproval
+    }
 }
 
 /// Surfaces and toggles login items through `SMAppService`.
@@ -45,11 +58,17 @@ struct LoginItemsManager {
     /// The host app's login item, reflecting the live `SMAppService` status so
     /// a change made in System Settings → Login Items is picked up on refresh.
     func items() -> [LoginItem] {
-        [
+        let status = statusProvider()
+        return [
             LoginItem(
                 id: identifier,
                 name: displayName,
-                isEnabled: statusProvider() == .enabled
+                // `.requiresApproval` means launchd holds the registration but
+                // it is not active yet; treat it as enabled so a fresh
+                // `register()` — which lands in `.requiresApproval` pending the
+                // user's approval — doesn't snap the toggle back to off.
+                isEnabled: status == .enabled || status == .requiresApproval,
+                requiresApproval: status == .requiresApproval
             )
         ]
     }

--- a/VaderCleaner/OptimizationDashboardSubviews.swift
+++ b/VaderCleaner/OptimizationDashboardSubviews.swift
@@ -196,6 +196,7 @@ struct OptimizationTaskCatalogView: View {
     let systemAgents: [LaunchAgent]
     let onRunSelected: ([MaintenanceTask]) -> Void
     let onToggleLoginItem: (LoginItem, Bool) -> Void
+    let onApproveLoginItem: () -> Void
     let onSetAgentEnabled: (LaunchAgent, Bool) -> Void
     let onRemoveAgent: (LaunchAgent) -> Void
     let onBack: () -> Void
@@ -292,7 +293,11 @@ struct OptimizationTaskCatalogView: View {
             maintenanceTasksPane
         case .loginItems:
             paneScroll {
-                OptimizationLoginItemsSection(items: loginItems, onToggle: onToggleLoginItem)
+                OptimizationLoginItemsSection(
+                    items: loginItems,
+                    onToggle: onToggleLoginItem,
+                    onApprove: onApproveLoginItem
+                )
             }
         case .backgroundItems:
             paneScroll {

--- a/VaderCleaner/OptimizationDashboardSubviews.swift
+++ b/VaderCleaner/OptimizationDashboardSubviews.swift
@@ -316,6 +316,10 @@ struct OptimizationTaskCatalogView: View {
                         localized: "Launch Agents & Daemons (System)",
                         comment: "Section header for system launch agents and daemons."
                     ),
+                    subtitle: String(
+                        localized: "Managed by macOS · change these in System Settings or the app that installed them",
+                        comment: "Note under the system launch-agents header explaining the whole group is read-only here."
+                    ),
                     identifier: "optimization.systemAgents",
                     agents: systemAgents,
                     onSetEnabled: onSetAgentEnabled,

--- a/VaderCleaner/OptimizationView.swift
+++ b/VaderCleaner/OptimizationView.swift
@@ -142,6 +142,7 @@ struct OptimizationView: View {
                 onToggleLoginItem: { item, enabled in
                     Task { await viewModel.setLoginItem(item, enabled: enabled) }
                 },
+                onApproveLoginItem: { viewModel.openLoginItemsSettings() },
                 onSetAgentEnabled: { agent, enabled in
                     Task {
                         if enabled {

--- a/VaderCleaner/OptimizationViewModel.swift
+++ b/VaderCleaner/OptimizationViewModel.swift
@@ -4,6 +4,7 @@
 import Combine
 import Foundation
 import Observation
+import ServiceManagement
 import os.log
 
 /// Drives the Optimization feature view. Collaborators are injected as
@@ -29,6 +30,9 @@ final class OptimizationViewModel {
     typealias LoadAgents = () async -> [LaunchAgent]
     typealias ReadMemory = @MainActor () -> MemoryStats
     typealias SetLoginItemEnabled = (Bool, LoginItem) async throws -> Void
+    /// Opens System Settings to the Login Items pane, so a row pending the
+    /// user's approval can deep-link there instead of asking them to navigate.
+    typealias OpenLoginItemsSettings = @MainActor () -> Void
     typealias DisableAgent = (LaunchAgent) async throws -> Void
     typealias EnableAgent = (LaunchAgent) async throws -> Void
     typealias RemoveAgent = (LaunchAgent) async throws -> Void
@@ -95,6 +99,7 @@ final class OptimizationViewModel {
     @ObservationIgnored private let loadSystemAgents: LoadAgents
     @ObservationIgnored private let readMemory: ReadMemory
     @ObservationIgnored private let setLoginItemEnabled: SetLoginItemEnabled
+    @ObservationIgnored private let openLoginItemsSettingsAction: OpenLoginItemsSettings
     @ObservationIgnored private let disableAgent: DisableAgent
     @ObservationIgnored private let enableAgent: EnableAgent
     @ObservationIgnored private let removeAgent: RemoveAgent
@@ -126,6 +131,7 @@ final class OptimizationViewModel {
         loadSystemAgents: @escaping LoadAgents,
         readMemory: @escaping ReadMemory,
         setLoginItemEnabled: @escaping SetLoginItemEnabled,
+        openLoginItemsSettings: @escaping OpenLoginItemsSettings = {},
         disableAgent: @escaping DisableAgent,
         enableAgent: @escaping EnableAgent,
         removeAgent: @escaping RemoveAgent,
@@ -145,6 +151,7 @@ final class OptimizationViewModel {
         self.loadSystemAgents = loadSystemAgents
         self.readMemory = readMemory
         self.setLoginItemEnabled = setLoginItemEnabled
+        self.openLoginItemsSettingsAction = openLoginItemsSettings
         self.disableAgent = disableAgent
         self.enableAgent = enableAgent
         self.removeAgent = removeAgent
@@ -389,6 +396,14 @@ final class OptimizationViewModel {
         }
     }
 
+    /// Opens System Settings to the Login Items pane. Used by a row that is
+    /// registered but pending the user's approval — macOS grants that approval
+    /// only in System Settings, so this is the closest we can get to an in-app
+    /// approval: a one-click deep link instead of manual navigation.
+    func openLoginItemsSettings() {
+        openLoginItemsSettingsAction()
+    }
+
     /// Reloads only the login-items row after the launch-at-login
     /// preference was changed elsewhere (the Preferences toggle). Unlike
     /// `refresh()` this does not touch `phase` — it is a background
@@ -531,10 +546,16 @@ extension OptimizationViewModel {
             // preference, and reports failures (issue #65). The reload
             // after this closure returns then reflects the new state, and
             // the Preferences toggle — bound to the same published value —
-            // updates in lockstep.
+            // updates in lockstep. The throwing variant rethrows a failed
+            // registration so `setLoginItem` can surface it inline instead of
+            // the global "Launch at Login" alert.
             setLoginItemEnabled: { enabled, _ in
-                preferences.launchAtLogin = enabled
+                try preferences.setLaunchAtLogin(enabled)
             },
+            // A login item macOS holds in `.requiresApproval` can only be
+            // approved by the user in System Settings; deep-link straight to
+            // the Login Items pane so that's one click, not a manual hunt.
+            openLoginItemsSettings: { SMAppService.openSystemSettingsLoginItems() },
             disableAgent: { agent in
                 try await Task.detached(priority: .userInitiated) {
                     try agentManager.disable(agent)

--- a/VaderCleaner/OptimizationViewSubviews.swift
+++ b/VaderCleaner/OptimizationViewSubviews.swift
@@ -98,6 +98,7 @@ private struct OptimizationEmptyRow: View {
 struct OptimizationLoginItemsSection: View {
     let items: [LoginItem]
     let onToggle: (LoginItem, Bool) -> Void
+    let onApprove: () -> Void
 
     var body: some View {
         OptimizationSection(title: String(
@@ -117,6 +118,32 @@ struct OptimizationLoginItemsSection: View {
                             Text(item.id)
                                 .font(.caption.monospaced())
                                 .foregroundStyle(.secondary)
+                            // launchd holds the registration but it isn't active
+                            // until the user approves it in System Settings —
+                            // macOS grants that approval nowhere else. The
+                            // caption explains the state and the link deep-links
+                            // to the Login Items pane so it's one click. The
+                            // wording reads correctly whether this is a brand-new
+                            // registration awaiting first approval or one the
+                            // user switched off there.
+                            if item.requiresApproval {
+                                HStack(spacing: 6) {
+                                    Text(String(
+                                        localized: "Pending — not active until approved",
+                                        comment: "Hint shown when the app is registered for launch at login but the user must still approve it in System Settings."
+                                    ))
+                                    .foregroundStyle(.orange)
+                                    Button(action: onApprove) {
+                                        Text(String(
+                                            localized: "Approve in Settings →",
+                                            comment: "Link that opens System Settings to the Login Items pane so the user can approve the pending registration."
+                                        ))
+                                    }
+                                    .buttonStyle(.link)
+                                    .accessibilityIdentifier("optimization.loginItem.\(item.id).approve")
+                                }
+                                .font(.caption2)
+                            }
                         }
                         Spacer()
                         Toggle("", isOn: Binding(

--- a/VaderCleaner/OptimizationViewSubviews.swift
+++ b/VaderCleaner/OptimizationViewSubviews.swift
@@ -71,12 +71,23 @@ struct OptimizationFailedState: View {
 
 private struct OptimizationSection<Content: View>: View {
     let title: String
+    /// Optional one-line note under the title. Used to state a fact shared by
+    /// every row once — e.g. "Managed by macOS" for the system-agents group —
+    /// instead of repeating it down the column.
+    var subtitle: String? = nil
     @ViewBuilder let content: Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(title)
-                .font(.title3.weight(.semibold))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.title3.weight(.semibold))
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
             content
         }
     }
@@ -166,13 +177,16 @@ struct OptimizationLoginItemsSection: View {
 
 struct OptimizationLaunchAgentsSection: View {
     let title: String
+    /// Optional note shown once under the header — e.g. the system group is
+    /// entirely "Managed by macOS", so the rows no longer repeat that label.
+    var subtitle: String? = nil
     let identifier: String
     let agents: [LaunchAgent]
     let onSetEnabled: (LaunchAgent, Bool) -> Void
     let onRemove: (LaunchAgent) -> Void
 
     var body: some View {
-        OptimizationSection(title: title) {
+        OptimizationSection(title: title, subtitle: subtitle) {
             if agents.isEmpty {
                 OptimizationEmptyRow(message: String(
                     localized: "Nothing found here.",
@@ -223,6 +237,16 @@ struct OptimizationLaunchAgentRow: View {
                         .background(Color.secondary.opacity(0.18))
                         .clipShape(Capsule())
                     }
+                    // A stub plist with no runnable job can never load, so it
+                    // carries no toggle — only Remove. The status sits as a
+                    // compact badge by the name (rather than a repeated
+                    // right-column label); tapping it explains the term, since
+                    // hover tooltips don't fire reliably in this window.
+                    if agent.isOrphaned && agent.domain == .user {
+                        OptimizationOrphanedBadge(
+                            accessibilityIdentifier: "\(identifier).orphaned.\(agent.path.lastPathComponent)"
+                        )
+                    }
                 }
                 Text(agent.programPath ?? agent.path.path)
                     .font(.caption.monospaced())
@@ -233,56 +257,17 @@ struct OptimizationLaunchAgentRow: View {
             Spacer()
             // System daemons live in launchd's privileged domain: `launchctl
             // unload` from the user session can't touch them and deleting one
-            // can break macOS or the app that installed it. Rather than offer
-            // dead controls, surface a read-only "Managed by macOS" indicator.
-            if agent.domain == .system {
-                // System daemons live in launchd's privileged domain and can't
-                // be changed here. The info button explains why on click, since
-                // hover tooltips don't fire reliably in this window.
-                HStack(spacing: 4) {
-                    OptimizationInfoButton(
-                        message: String(
-                            localized: "This item is controlled by macOS or the app that installed it, so it can't be turned off or removed here. To change it, use System Settings or that app's own settings.",
-                            comment: "Popover explaining why a system launch daemon can't be disabled or removed."
-                        ),
-                        accessibilityIdentifier: "\(identifier).managed.info.\(agent.path.lastPathComponent)"
-                    )
-                    Text(String(
-                        localized: "Managed by macOS",
-                        comment: "Read-only indicator shown for system launch agents and daemons that can't be changed in the app."
-                    ))
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .accessibilityIdentifier("\(identifier).managed.\(agent.path.lastPathComponent)")
-            } else {
-                if agent.isOrphaned {
-                    // A stub plist with no runnable job can never be loaded, so a
-                    // toggle would only ever bounce back to off. Mark it as a
-                    // leftover file the user can remove instead, with an info
-                    // button explaining the "Orphaned" term on click.
-                    HStack(spacing: 4) {
-                        OptimizationInfoButton(
-                            message: String(
-                                localized: "“Orphaned” means this is an empty leftover file with no app or program to start, so there's nothing to turn on. It's safe to remove, though the app that left it behind may add it back later.",
-                                comment: "Popover explaining what an orphaned launch agent is and why it shows no toggle."
-                            ),
-                            accessibilityIdentifier: "\(identifier).orphaned.info.\(agent.path.lastPathComponent)"
-                        )
-                        Text(String(
-                            localized: "Orphaned",
-                            comment: "Indicator for a launch-agent plist that defines no runnable job and can only be removed."
-                        ))
-                    }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("\(identifier).orphaned.\(agent.path.lastPathComponent)")
-                } else {
+            // can break macOS or the app that installed it. They carry no
+            // per-row control — the section's "Managed by macOS" note states
+            // that once for the whole group. User agents get the controls.
+            if agent.domain != .system {
+                if !agent.isOrphaned {
                     // The toggle is the agent's loaded state: on loads it via
                     // `launchctl load -w`, off unloads it via `unload -w`. Unlike
                     // a one-way "Disable" button it never greys into a dead
                     // control — a not-loaded agent simply shows the switch in its
-                    // off position, which the user can flip back on.
+                    // off position, which the user can flip back on. Orphaned
+                    // plists can never load, so they show only Remove.
                     Toggle("", isOn: Binding(
                         get: { agent.isEnabled },
                         set: { onSetEnabled($0) }
@@ -315,11 +300,12 @@ struct OptimizationLaunchAgentRow: View {
     }
 }
 
-/// A small "ⓘ" button that reveals an explanatory message in a popover on
-/// click. Used in place of hover tooltips, which don't fire reliably in this
-/// app's window; a click-triggered popover always works and is testable.
-struct OptimizationInfoButton: View {
-    let message: String
+/// A compact "Orphaned" badge placed next to a launch agent's name. It reads as
+/// a status pill but is tappable: clicking reveals what "orphaned" means in a
+/// popover, since hover tooltips don't fire reliably in this window. Built from
+/// an `HStack(Image, Text)` rather than a `Label` so the button still surfaces
+/// to UI tests.
+struct OptimizationOrphanedBadge: View {
     let accessibilityIdentifier: String
 
     @State private var isPresented = false
@@ -328,19 +314,33 @@ struct OptimizationInfoButton: View {
         Button {
             isPresented = true
         } label: {
-            Image(systemName: "info.circle")
-                .imageScale(.medium)
+            HStack(spacing: 3) {
+                Image(systemName: "info.circle")
+                    .imageScale(.small)
+                Text(String(
+                    localized: "Orphaned",
+                    comment: "Badge for a launch-agent plist that defines no runnable job and can only be removed."
+                ))
+            }
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Color.secondary.opacity(0.18))
+            .clipShape(Capsule())
         }
-        .buttonStyle(.borderless)
+        .buttonStyle(.plain)
         .accessibilityIdentifier(accessibilityIdentifier)
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-            Text(message)
-                .font(.callout)
-                .foregroundStyle(.primary)
-                .multilineTextAlignment(.leading)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(14)
-                .frame(width: 300)
+            Text(String(
+                localized: "“Orphaned” means this is an empty leftover file with no app or program to start, so there's nothing to turn on. It's safe to remove, though the app that left it behind may add it back later.",
+                comment: "Popover explaining what an orphaned launch agent is and why it shows no toggle."
+            ))
+            .font(.callout)
+            .foregroundStyle(.primary)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(14)
+            .frame(width: 300)
         }
     }
 }

--- a/VaderCleaner/PreferencesStore.swift
+++ b/VaderCleaner/PreferencesStore.swift
@@ -97,6 +97,13 @@ final class PreferencesStore {
     var launchAtLogin: Bool {
         didSet {
             defaults.set(launchAtLogin, forKey: Key.launchAtLogin)
+            // The property setter is the Preferences-toggle entry point, which
+            // has no inline failure UI, so apply the change and route any
+            // failure to the global alert reporter. `setLaunchAtLogin(_:)`
+            // applies the side effect itself before updating the tracked value,
+            // so it sets `isApplyingLaunchAtLogin` to skip this path and avoid a
+            // duplicate SMAppService write (issue #65).
+            guard !isApplyingLaunchAtLogin else { return }
             applyLaunchAtLogin()
         }
     }
@@ -110,6 +117,9 @@ final class PreferencesStore {
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let launchAtLoginHandler: LaunchAtLoginHandler?
     @ObservationIgnored private let launchAtLoginErrorReporter: LaunchAtLoginErrorReporter?
+    /// Set while `setLaunchAtLogin(_:)` updates the tracked value, so the
+    /// property's `didSet` skips re-applying a side effect it has already run.
+    @ObservationIgnored private var isApplyingLaunchAtLogin = false
 
     init(
         defaults: UserDefaults = .standard,
@@ -156,6 +166,25 @@ final class PreferencesStore {
     }
 
     // MARK: - Side effects
+
+    /// Throwing entry point for surfaces that present their own inline failure
+    /// (the Optimization view's Login Items row). Applies the launch-at-login
+    /// change through the same handler the property setter uses — keeping
+    /// `SMAppService` access in one place (issue #65) — but rethrows any failure
+    /// to the caller instead of routing it to the global alert reporter, so the
+    /// error can be shown inline without double-reporting. On success it updates
+    /// and persists the tracked value, keeping the Preferences toggle in lockstep.
+    func setLaunchAtLogin(_ enabled: Bool) throws {
+        // Apply first so a failure propagates before the model changes. The
+        // tracked-value update below would otherwise re-apply via `didSet`, so
+        // guard it to keep the handler running exactly once per change.
+        if let handler = launchAtLoginHandler {
+            try handler(enabled)
+        }
+        isApplyingLaunchAtLogin = true
+        launchAtLogin = enabled
+        isApplyingLaunchAtLogin = false
+    }
 
     /// Pushes the current `launchAtLogin` value through the injected handler
     /// (in production, `LoginItemManager.setEnabled`). Errors are forwarded to

--- a/VaderCleanerTests/LoginItemsManagerTests.swift
+++ b/VaderCleanerTests/LoginItemsManagerTests.swift
@@ -21,6 +21,7 @@ final class LoginItemsManagerTests: XCTestCase {
         XCTAssertEqual(items.first?.id, "com.personal.VaderCleaner")
         XCTAssertEqual(items.first?.name, "VaderCleaner")
         XCTAssertTrue(items.first?.isEnabled == true)
+        XCTAssertFalse(items.first?.requiresApproval == true)
     }
 
     func test_items_reflectsDisabledStatusFromProvider() {
@@ -32,6 +33,25 @@ final class LoginItemsManagerTests: XCTestCase {
         )
 
         XCTAssertFalse(manager.items().first?.isEnabled == true)
+    }
+
+    func test_items_requiresApproval_readsAsEnabledAndFlagsApproval() {
+        let manager = LoginItemsManager(
+            displayName: "VaderCleaner",
+            identifier: "com.personal.VaderCleaner",
+            statusProvider: { .requiresApproval },
+            setEnabledHandler: { _ in }
+        )
+
+        let item = manager.items().first
+
+        // `.requiresApproval` means launchd holds the registration but it is
+        // not active until the user approves it in System Settings. The row
+        // treats it as enabled — so a fresh `register()`, which lands in
+        // `.requiresApproval`, doesn't snap the toggle back to off — and flags
+        // it so the view can show a "finish in System Settings" hint.
+        XCTAssertTrue(item?.isEnabled == true)
+        XCTAssertTrue(item?.requiresApproval == true)
     }
 
     func test_setEnabled_forwardsRequestedStateToHandler() throws {

--- a/VaderCleanerTests/OptimizationViewModelTests.swift
+++ b/VaderCleanerTests/OptimizationViewModelTests.swift
@@ -333,6 +333,15 @@ final class OptimizationViewModelTests: XCTestCase {
         }
     }
 
+    func test_openLoginItemsSettings_invokesInjectedOpener() {
+        var opened = 0
+        let vm = makeViewModel(openLoginItemsSettings: { opened += 1 })
+
+        vm.openLoginItemsSettings()
+
+        XCTAssertEqual(opened, 1)
+    }
+
     // MARK: - Launch-at-login cross-update (issue #65)
 
     /// An external change to the launch-at-login preference (the
@@ -408,7 +417,7 @@ final class OptimizationViewModelTests: XCTestCase {
             loadLoginItems: {
                 [LoginItem(id: "host", name: "VaderCleaner", isEnabled: loginEnabled)]
             },
-            setLoginItemEnabled: { enabled, _ in prefs.launchAtLogin = enabled },
+            setLoginItemEnabled: { enabled, _ in try prefs.setLaunchAtLogin(enabled) },
             launchAtLoginChanges: OptimizationViewModel.launchAtLoginChangePublisher(for: prefs)
         )
         await vm.refresh()
@@ -559,6 +568,7 @@ final class OptimizationViewModelTests: XCTestCase {
         loadSystemAgents: @escaping OptimizationViewModel.LoadAgents = { [] },
         readMemory: @escaping OptimizationViewModel.ReadMemory = { .empty },
         setLoginItemEnabled: @escaping OptimizationViewModel.SetLoginItemEnabled = { _, _ in },
+        openLoginItemsSettings: @escaping OptimizationViewModel.OpenLoginItemsSettings = {},
         disableAgent: @escaping OptimizationViewModel.DisableAgent = { _ in },
         enableAgent: @escaping OptimizationViewModel.EnableAgent = { _ in },
         removeAgent: @escaping OptimizationViewModel.RemoveAgent = { _ in },
@@ -584,6 +594,7 @@ final class OptimizationViewModelTests: XCTestCase {
             loadSystemAgents: loadSystemAgents,
             readMemory: readMemory,
             setLoginItemEnabled: setLoginItemEnabled,
+            openLoginItemsSettings: openLoginItemsSettings,
             disableAgent: disableAgent,
             enableAgent: enableAgent,
             removeAgent: removeAgent,

--- a/VaderCleanerTests/PreferencesStoreTests.swift
+++ b/VaderCleanerTests/PreferencesStoreTests.swift
@@ -138,6 +138,49 @@ final class PreferencesStoreTests: XCTestCase {
         XCTAssertEqual(received, [false])
     }
 
+    // MARK: - Inline launch-at-login entry point
+
+    func test_setLaunchAtLogin_appliesHandlerOnceAndPersists() throws {
+        var received: [Bool] = []
+        let sut = PreferencesStore(
+            defaults: defaults,
+            launchAtLoginHandler: { received.append($0) }
+        )
+        // Drop the init reconcile so the assertion counts only this call.
+        received.removeAll()
+
+        try sut.setLaunchAtLogin(false)
+
+        // Exactly one SMAppService write per change — the issue #65 single-path
+        // invariant — even though the tracked value is updated and persisted too.
+        XCTAssertEqual(received, [false])
+        XCTAssertFalse(sut.launchAtLogin)
+
+        let reader = PreferencesStore(defaults: defaults)
+        XCTAssertFalse(reader.launchAtLogin)
+    }
+
+    func test_setLaunchAtLogin_rethrowsHandlerErrorWithoutReporting() {
+        struct StubError: Error, Equatable {}
+        var reported: [StubError] = []
+        let sut = PreferencesStore(
+            defaults: defaults,
+            launchAtLoginHandler: { _ in throw StubError() },
+            launchAtLoginErrorReporter: { error in
+                if let stub = error as? StubError { reported.append(stub) }
+            }
+        )
+        // Drop the init reconcile's throw before exercising the entry point.
+        reported.removeAll()
+
+        // Unlike the property setter — which routes failures to the global
+        // alert reporter — this entry point rethrows so a caller with its own
+        // inline failure UI (the Optimization row) can surface the error
+        // without double-reporting it.
+        XCTAssertThrowsError(try sut.setLaunchAtLogin(!sut.launchAtLogin))
+        XCTAssertTrue(reported.isEmpty)
+    }
+
     func test_init_skipsReconcile_whenHandlerNil() {
         // Pins the nil-handler contract that all the other PreferencesStore
         // tests depend on: constructing the store with no handler must not


### PR DESCRIPTION
## Overview

Two related fixes for the Optimization → Performance Manager surface, in distinct commits.

### 1. Login Items toggle wouldn't stick, and registration errors were hidden

The host app's Login Items row computed its on/off state as `SMAppService.Status == .enabled` and nothing else. A fresh `register()` lands in `.requiresApproval` (registered, pending the user's approval in System Settings), so the row reloaded as *off* and the toggle snapped back. Separately, a failed `register()` was swallowed by `PreferencesStore`'s alert reporter and never reached the Optimization view's own inline failure surface.

- Treat `.requiresApproval` as enabled and flag it on `LoginItem`, so a pending registration keeps the toggle on instead of bouncing back.
- Show a *"Pending — not active until approved"* caption with an **"Approve in Settings →"** link that deep-links to the Login Items pane via `SMAppService.openSystemSettingsLoginItems()` — the one-click path, since macOS grants that approval only in System Settings (there is no API to approve on the user's behalf).
- Add `PreferencesStore.setLaunchAtLogin(_:)`, a throwing entry point that applies the change through the same handler (single SMAppService path, issue #65) but **rethrows** instead of routing to the global alert, so the Optimization toggle reports a failed registration inline without double-reporting. A re-entrancy guard keeps the handler running exactly once per change.

### 2. Background Items status labels were visually repetitive

Every row of the system launch-agents group repeated a *"Managed by macOS"* label, and every orphaned user agent a right-column *"Orphaned"* label — noisy down the column.

- State *"Managed by macOS"* **once** as a note under the System section header; system rows are now just name + path.
- Move *"Orphaned"* to a compact pill next to the agent name (matching the existing "Not loaded" badge), tappable to reveal the explanation in a popover.
- Add an optional subtitle to `OptimizationSection`; remove `OptimizationInfoButton`, now unused after both labels stopped using it.

## Testing

- All **885** unit tests pass; build is clean.
- New coverage: `.requiresApproval` reads as enabled + flagged (`LoginItemsManagerTests`); `setLaunchAtLogin` applies once / rethrows without reporting (`PreferencesStoreTests`); the deep-link opener is wired (`OptimizationViewModelTests`). The issue-#65 integration test was rewired to drive the real `setLaunchAtLogin` path.

## Reviewer notes

- **Hard macOS constraint:** the Settings round-trip for `.requiresApproval` cannot be eliminated — Apple removed silent login-item registration; approval happens only in System Settings. The deep-link is the closest we can get (one click, not zero).
- **Worth verifying on a real launch:** which login-item case you actually hit. `log stream --predicate 'subsystem == "com.personal.VaderCleaner" AND category == "LoginItemManager"' --info` — `status=requiresApproval` means the approve link is your path; an *error* from `register()` means a dev-build/signing/`/Applications` issue, where the link won't appear (now surfaced inline instead of silently reverting).
- **UI not auto-verified:** both rounds touch SwiftUI that can't render in this environment (UI tests can't bootstrap here). The Approve link, the pending caption, the section note, and the Orphaned pill need a visual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Login items requiring approval now display an "Approve in Settings →" link for quick access to System Settings.
  * Orphaned launch agents now display a dedicated badge indicator.

* **Improvements**
  * System-managed launch agents now include a note clarifying they're controlled by macOS.
  * Enhanced error handling for launch-at-login state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->