### PR TITLE
feat(uninstaller): remove root-owned App Store apps via privileged helper

### DIFF
--- a/Shared/HelperDeletionPolicy.swift
+++ b/Shared/HelperDeletionPolicy.swift
@@ -47,6 +47,13 @@ struct HelperDeletionPolicy {
             URL(fileURLWithPath: "/Library/Application Support", isDirectory: true),
             URL(fileURLWithPath: "/Library/Frameworks", isDirectory: true)
         ],
+        // Top-level `.app` bundles the App Uninstaller removes when
+        // NSWorkspace can't (root-owned / App Store apps). Scoped to
+        // `/Applications` only — user-domain apps under `~/Applications` are
+        // user-writable and never need privileged removal.
+        allowedApplicationBundleRoots: [
+            URL(fileURLWithPath: "/Applications", isDirectory: true)
+        ],
         volumesRoot: URL(fileURLWithPath: "/Volumes", isDirectory: true)
     )
 
@@ -54,6 +61,7 @@ struct HelperDeletionPolicy {
     private let allowedLaunchPlistRoots: [URL]
     private let allowedUserLaunchAgentsRoot: URL?
     private let allowedLanguageResourceRoots: [URL]
+    private let allowedApplicationBundleRoots: [URL]
     private let volumesRoot: URL
 
     init(
@@ -61,12 +69,14 @@ struct HelperDeletionPolicy {
         allowedLaunchPlistRoots: [URL] = [],
         allowedUserLaunchAgentsRoot: URL? = nil,
         allowedLanguageResourceRoots: [URL],
+        allowedApplicationBundleRoots: [URL] = [],
         volumesRoot: URL
     ) {
         self.allowedDescendantRoots = allowedDescendantRoots.map(Self.canonicalRoot)
         self.allowedLaunchPlistRoots = allowedLaunchPlistRoots.map(Self.canonicalRoot)
         self.allowedUserLaunchAgentsRoot = allowedUserLaunchAgentsRoot.map(Self.canonicalRoot)
         self.allowedLanguageResourceRoots = allowedLanguageResourceRoots.map(Self.canonicalRoot)
+        self.allowedApplicationBundleRoots = allowedApplicationBundleRoots.map(Self.canonicalRoot)
         self.volumesRoot = Self.canonicalRoot(volumesRoot)
     }
 
@@ -160,7 +170,34 @@ struct HelperDeletionPolicy {
         if isAllowedLanguageResource(url) {
             return true
         }
+        if isAllowedApplicationBundle(url) {
+            return true
+        }
         return false
+    }
+
+    /// A top-level `.app` bundle under one of `allowedApplicationBundleRoots`.
+    /// Permits `/Applications/Example.app` and apps nested in plain subfolders
+    /// (`/Applications/Utilities/Example.app`), but refuses anything inside
+    /// another package (`/Applications/Outer.app/Contents/.../Inner.app`) so
+    /// the uninstall path can only remove a whole installed app, never carve
+    /// out a piece of one.
+    private func isAllowedApplicationBundle(_ url: URL) -> Bool {
+        guard let root = allowedApplicationBundleRoots.first(where: { Self.isDescendant(url, of: $0) }) else {
+            return false
+        }
+        guard Self.pathExtension(of: url.lastPathComponent).caseInsensitiveCompare("app") == .orderedSame else {
+            return false
+        }
+        let relative = Self.relativeComponents(of: url, under: root)
+        let intermediates = relative.dropLast()
+        return !intermediates.contains(where: { component in
+            let ext = Self.pathExtension(of: component)
+            return ext.caseInsensitiveCompare("app") == .orderedSame
+                || ext.caseInsensitiveCompare("framework") == .orderedSame
+                || ext.caseInsensitiveCompare("bundle") == .orderedSame
+                || ext.caseInsensitiveCompare("appex") == .orderedSame
+        })
     }
 
     private func isAllowedVolumeTrashDescendant(_ url: URL) -> Bool {

--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -22,6 +22,9 @@ struct AppUninstallerView: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .id(phaseTransitionID)
+            .transition(.opacity)
+            .animation(.smooth(duration: 0.35), value: phaseTransitionID)
             .navigationTitle(NavigationSection.appUninstaller.title)
             .task {
                 if viewModel.phase == .idle {
@@ -33,15 +36,39 @@ struct AppUninstallerView: View {
                     localized: "Cancel",
                     comment: "Cancel button on the App Uninstaller confirmation alert."
                 ), role: .cancel) { }
-                Button(String(
-                    localized: "Move to Trash",
-                    comment: "Confirm-uninstall button on the App Uninstaller confirmation alert."
-                ), role: .destructive) {
+                Button(uninstallConfirmActionLabel, role: .destructive) {
                     Task { await viewModel.uninstall() }
                 }
             } message: {
                 Text(uninstallConfirmationMessage)
             }
+    }
+
+    /// Best-effort *prediction* that the selected app will be permanently
+    /// removed rather than moved to the Trash, used to phrase the
+    /// confirmation alert. A bundle the current user can't write (root-owned
+    /// App Store or pkg-installed apps) can't be moved to the Trash, so the
+    /// uninstaller removes it permanently through the privileged helper. The
+    /// completion screen does not rely on this guess — it reflects the actual
+    /// recycle outcome.
+    private var selectedAppIsPermanentRemoval: Bool {
+        guard let app = viewModel.selectedApp else { return false }
+        return !FileManager.default.isWritableFile(atPath: app.bundleURL.path)
+    }
+
+    /// Stable per-phase token so moving between flow phases crossfades
+    /// instead of hard-cutting. Distinct phases map to distinct strings;
+    /// associated values are intentionally ignored — only the phase identity
+    /// drives the transition.
+    private var phaseTransitionID: String {
+        switch viewModel.phase {
+        case .idle:         return "idle"
+        case .loading:      return "loading"
+        case .ready:        return "ready"
+        case .uninstalling: return "uninstalling"
+        case .complete:     return "complete"
+        case .failed:       return "failed"
+        }
     }
 
     @ViewBuilder
@@ -61,12 +88,15 @@ struct AppUninstallerView: View {
                                             comment: "Progress label while the App Uninstaller is moving items to Trash."
                                         ),
                                          identifier: "appUninstaller.uninstalling")
-        case .complete(let bytes):
+        case .complete(let bytes, let permanentRemoval):
             AppUninstallerCompleteState(bytesFreed: bytes,
+                                        isPermanentRemoval: permanentRemoval,
                                         onContinue: viewModel.dismissResult)
-        case .failed(let stage, let message):
+        case .failed(let stage, let message, let helperConnectionIssue):
             AppUninstallerFailedState(stage: stage,
                                      message: message,
+                                     canReinstallHelper: helperConnectionIssue,
+                                     onReinstallHelper: { Task { await viewModel.reinstallHelper() } },
                                      onTryAgain: { Task { await viewModel.loadApps() } })
         }
     }
@@ -116,24 +146,53 @@ struct AppUninstallerView: View {
     }
 
     private var uninstallConfirmationTitle: String {
-        String(
+        if selectedAppIsPermanentRemoval {
+            return String(
+                localized: "Permanently remove this app?",
+                comment: "Alert title confirming removal of an App Store app that can't be moved to the Trash."
+            )
+        }
+        return String(
             localized: "Move app and its data to Trash?",
             comment: "Alert title asking the user to confirm uninstalling an app."
         )
     }
 
+    private var uninstallConfirmActionLabel: String {
+        if selectedAppIsPermanentRemoval {
+            return String(
+                localized: "Remove",
+                comment: "Confirm-uninstall button when the app will be permanently removed."
+            )
+        }
+        return String(
+            localized: "Move to Trash",
+            comment: "Confirm-uninstall button on the App Uninstaller confirmation alert."
+        )
+    }
+
     private var uninstallConfirmationMessage: String {
-        if let app = viewModel.selectedApp {
+        guard let app = viewModel.selectedApp else {
+            return String(
+                localized: "The selected app and its associated files will be moved to the Trash.",
+                comment: "Fallback alert message confirming an app uninstall when the app name is unavailable."
+            )
+        }
+        if selectedAppIsPermanentRemoval {
+            // App Store apps are installed root-owned; the app itself can't be
+            // sent to the Trash, so it is permanently removed. Its user-domain
+            // data still goes to the Trash and stays restorable.
             let format = String(
-                localized: "%@ and its associated files will be moved to the Trash. You can restore them from the Trash until you empty it.",
-                comment: "Alert message confirming an app uninstall."
+                localized: "%@ was installed from the App Store and will be permanently removed — it can't be moved to the Trash. Its associated files will be moved to the Trash.",
+                comment: "Alert message confirming permanent removal of an App Store app."
             )
             return String.localizedStringWithFormat(format, app.name)
         }
-        return String(
-            localized: "The selected app and its associated files will be moved to the Trash.",
-            comment: "Fallback alert message confirming an app uninstall when the app name is unavailable."
+        let format = String(
+            localized: "%@ and its associated files will be moved to the Trash. You can restore them from the Trash until you empty it.",
+            comment: "Alert message confirming an app uninstall."
         )
+        return String.localizedStringWithFormat(format, app.name)
     }
 }
 
@@ -141,7 +200,7 @@ struct AppUninstallerView: View {
     AppUninstallerView(viewModel: AppUninstallerViewModel(
         discover: { _ in [] },
         findFiles: { _ in [] },
-        recycle: { _, _ in 0 }
+        recycle: { _, _ in AppUninstallerViewModel.RecycleOutcome(bytesFreed: 0, bundlePermanentlyRemoved: false) }
     ))
     .frame(width: 900, height: 600)
     .environment(ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!))

--- a/VaderCleaner/AppUninstallerViewModel.swift
+++ b/VaderCleaner/AppUninstallerViewModel.swift
@@ -29,8 +29,23 @@ final class AppUninstallerViewModel {
         case loading
         case ready
         case uninstalling
-        case complete(bytesFreed: Int64)
-        case failed(stage: FailureStage, message: String)
+        /// `permanentRemoval` is true when the app bundle was permanently
+        /// removed (root-owned / App Store app the user couldn't Trash)
+        /// rather than moved to the Trash, so the completion screen can stay
+        /// truthful about whether the app can be restored.
+        case complete(bytesFreed: Int64, permanentRemoval: Bool)
+        /// `helperConnectionIssue` is true when the failure was the privileged
+        /// helper being unreachable, so the failure screen can offer a
+        /// "Reinstall Helper" recovery instead of a plain retry.
+        case failed(stage: FailureStage, message: String, helperConnectionIssue: Bool)
+    }
+
+    /// Result of a recycle: how many bytes were actually freed, and whether
+    /// the bundle had to be permanently removed via the privileged helper
+    /// (because the user couldn't move a root-owned bundle to the Trash).
+    struct RecycleOutcome: Equatable, Sendable {
+        let bytesFreed: Int64
+        let bundlePermanentlyRemoved: Bool
     }
 
     typealias Discover     = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
@@ -39,8 +54,12 @@ final class AppUninstallerViewModel {
     /// Recycler contract: takes the `.app` bundle URL and the associated
     /// file URLs separately so the production implementation can verify
     /// the bundle itself was moved (and not just the user-writable
-    /// residue). Returns the byte-count actually freed.
-    typealias Recycle      = @Sendable (_ bundleURL: URL, _ associatedURLs: [URL]) async throws -> Int64
+    /// residue). Reports the bytes actually freed and whether the bundle
+    /// was permanently removed rather than Trashed.
+    typealias Recycle      = @Sendable (_ bundleURL: URL, _ associatedURLs: [URL]) async throws -> RecycleOutcome
+    /// Forces a clean re-registration of the privileged helper and points the
+    /// user at the approval UI. Injected so tests don't touch `SMAppService`.
+    typealias ReinstallHelper = @Sendable () async -> Void
 
     private(set) var phase: Phase = .idle
     private(set) var apps: [AppInfo] = []
@@ -57,6 +76,7 @@ final class AppUninstallerViewModel {
     @ObservationIgnored private let findFiles: FindFiles
     @ObservationIgnored private let measureSize: MeasureSize
     @ObservationIgnored private let recycle: Recycle
+    @ObservationIgnored private let reinstallHelperService: ReinstallHelper
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "AppUninstallerViewModel")
 
@@ -78,12 +98,14 @@ final class AppUninstallerViewModel {
         discover: @escaping Discover,
         findFiles: @escaping FindFiles,
         measureSize: @escaping MeasureSize = { _ in 0 },
-        recycle: @escaping Recycle
+        recycle: @escaping Recycle,
+        reinstallHelper: @escaping ReinstallHelper = {}
     ) {
         self.discover = discover
         self.findFiles = findFiles
         self.measureSize = measureSize
         self.recycle = recycle
+        self.reinstallHelperService = reinstallHelper
     }
 
     // MARK: - Public surface
@@ -160,7 +182,9 @@ final class AppUninstallerViewModel {
             self.apps = []
             self.selectedAppID = nil
             self.associatedFiles = []
-            self.phase = .failed(stage: .loading, message: error.localizedDescription)
+            self.phase = .failed(stage: .loading,
+                                 message: error.localizedDescription,
+                                 helperConnectionIssue: false)
         }
     }
 
@@ -262,12 +286,12 @@ final class AppUninstallerViewModel {
         let associatedURLs = associatedFiles.map { $0.url }
         phase = .uninstalling
         do {
-            let bytesFreed = try await recycle(app.bundleURL, associatedURLs)
+            let outcome = try await recycle(app.bundleURL, associatedURLs)
             // Drop the app from the cached list and reset selection so the
             // user sees the result without a stale row pointing at a now-
-            // Trashed bundle. `bytesFreed` is the recycler's authoritative
-            // sum of what it actually moved to Trash — we do NOT fall back
-            // to a planned/optimistic total, since that would claim
+            // removed bundle. `outcome.bytesFreed` is the recycler's
+            // authoritative sum of what it actually removed — we do NOT fall
+            // back to a planned/optimistic total, since that would claim
             // "X MB freed" when the recycler reports 0.
             apps.removeAll(where: { $0.id == app.id })
             selectedAppID = nil
@@ -275,12 +299,31 @@ final class AppUninstallerViewModel {
             selectedAppBundleSize = nil
             associatedFilesCache.removeValue(forKey: app.id)
             bundleSizeCache.removeValue(forKey: app.id)
-            phase = .complete(bytesFreed: bytesFreed)
+            phase = .complete(bytesFreed: outcome.bytesFreed,
+                              permanentRemoval: outcome.bundlePermanentlyRemoved)
         } catch {
             // Privacy: errors may include user-specific paths.
             log.error("App uninstall failed: \(String(describing: error), privacy: .private)")
-            phase = .failed(stage: .uninstalling, message: error.localizedDescription)
+            // Route through the shared mapper so an unreachable privileged
+            // helper surfaces the friendly "Helper is not responding" copy
+            // instead of the cryptic "Couldn't communicate with a helper
+            // application." NSXPC string. Non-connection errors (a real
+            // permission denial) still pass through their own description.
+            // Flag connection failures so the failure screen can offer to
+            // reinstall the helper rather than only retry.
+            phase = .failed(stage: .uninstalling,
+                            message: HelperConnectionError.userFacingMessage(for: error),
+                            helperConnectionIssue: HelperConnectionError.isConnectionFailure(error))
         }
+    }
+
+    /// Re-registers the privileged helper (and opens the approval UI) after a
+    /// helper-connection failure, then reloads the app list so the user can
+    /// retry the uninstall. Invoked by the "Reinstall Helper" action on the
+    /// failure screen.
+    func reinstallHelper() async {
+        await reinstallHelperService()
+        await loadApps()
     }
 
     /// Returns the VM to `.ready` after a complete / failed phase so the
@@ -335,55 +378,139 @@ extension AppUninstallerViewModel {
                     bundleURL: bundleURL,
                     associatedURLs: associatedURLs
                 )
+            },
+            // recycleViaWorkspace already returns a RecycleOutcome.
+            reinstallHelper: {
+                await HelperRegistration.reregister()
+                await HelperRegistration.openLoginItemsSettings()
             }
         )
     }
 
-    /// Bridges `NSWorkspace.recycle(_:completionHandler:)` (callback-based,
-    /// returns a `[URL: URL]` map of original → Trash URLs) to an async
-    /// throwing call that reports total bytes successfully Trashed.
-    ///
-    /// `NSWorkspace.recycle` does NOT throw on partial failure — it returns
-    /// the items it managed to Trash and reports an error only when the
-    /// entire batch failed. The `.app` bundle is the must-succeed item:
-    /// if user-writable residue gets Trashed but the root-owned bundle
-    /// itself is denied, the app is still installed and showing
-    /// "Complete" would mislead the user (and leave a stale row in the
-    /// list). We therefore throw whenever the bundle URL is missing from
-    /// `newURLs`, even if some associated files succeeded. Associated-
-    /// file partial failures are tolerated — they're best-effort
-    /// cleanup, and "we Trashed the app and most of its data" is a
-    /// useful outcome.
+    /// Production recycle: move to Trash via `NSWorkspace`, then escalate
+    /// anything the user couldn't move (a root-owned / App Store bundle) to
+    /// the privileged helper. Wires the real side-effecting primitives into
+    /// `recycleWithEscalation`.
     private static func recycleViaWorkspace(
         bundleURL: URL,
         associatedURLs: [URL]
-    ) async throws -> Int64 {
+    ) async throws -> RecycleOutcome {
+        try await recycleWithEscalation(
+            bundleURL: bundleURL,
+            associatedURLs: associatedURLs,
+            recycle: { urls in await workspaceRecycle(urls) },
+            escalate: { paths in await escalateToHelper(paths) },
+            sizeFor: { sizes(for: $0) },
+            exists: { FileManager.default.fileExists(atPath: $0) }
+        )
+    }
+
+    /// Pure orchestration of the recycle → privileged-escalation → byte-credit
+    /// flow, with every side-effecting primitive injected so it can be unit
+    /// tested without `NSWorkspace` or a live XPC helper.
+    ///
+    /// Steps:
+    ///   1. Snapshot sizes *before* anything moves — a Trashed or deleted path
+    ///      no longer stats, so we couldn't credit it afterwards.
+    ///   2. Move everything via `recycle` (`NSWorkspace` → the user's Trash).
+    ///      User-owned residue lands here and stays restorable.
+    ///   3. Anything still on disk afterwards is a path the user lacked
+    ///      permission to move — typically the root-owned `.app` bundle of an
+    ///      App Store app. Escalate those to the privileged helper, which
+    ///      removes them *permanently* (it cannot move to the user's Trash).
+    ///   4. Credit bytes for every original item that no longer exists,
+    ///      whether it was Trashed or permanently removed.
+    ///   5. The `.app` bundle is the must-succeed item. If it survives both
+    ///      passes the app is still installed, so throw rather than report a
+    ///      false "Complete" and leave a stale row in the list. Associated-
+    ///      file partial failures are tolerated — best-effort cleanup.
+    static func recycleWithEscalation(
+        bundleURL: URL,
+        associatedURLs: [URL],
+        recycle: (_ urls: [URL]) async -> (moved: Set<String>, error: Error?),
+        escalate: (_ paths: [String]) async -> Error?,
+        sizeFor: (_ urls: [URL]) -> [String: Int64],
+        exists: (_ path: String) -> Bool
+    ) async throws -> RecycleOutcome {
         let allURLs = [bundleURL] + associatedURLs
-        // Capture sizes before recycle — once the path is in Trash, the
-        // original URL doesn't stat anymore. We need this to credit
-        // bytes-freed for the items the workspace successfully moved.
-        let sizesByPath = sizes(for: allURLs)
-        return try await withCheckedThrowingContinuation { continuation in
-            NSWorkspace.shared.recycle(allURLs) { newURLs, error in
-                let bundleMoved = newURLs.keys.contains(where: { $0.path == bundleURL.path })
-                if !bundleMoved {
-                    let resolvedError = error ?? NSError(
-                        domain: "com.personal.VaderCleaner.AppUninstaller",
-                        code: -1,
-                        userInfo: [
-                            NSLocalizedDescriptionKey: "The application bundle could not be moved to the Trash."
-                        ]
-                    )
-                    continuation.resume(throwing: resolvedError)
-                    return
-                }
-                var bytesFreed: Int64 = 0
-                for original in newURLs.keys {
-                    bytesFreed += sizesByPath[original.path] ?? 0
-                }
-                continuation.resume(returning: bytesFreed)
+        let sizesByPath = sizeFor(allURLs)
+
+        let (moved, recycleError) = await recycle(allURLs)
+
+        // Escalate only the *bundle* to the privileged helper for permanent
+        // removal — never the associated files. The confirmation promised the
+        // associated files would be moved to the Trash (restorable), so any
+        // the user couldn't Trash are left in place best-effort rather than
+        // permanently deleted behind the user's back.
+        var escalateError: Error?
+        if !moved.contains(bundleURL.path), exists(bundleURL.path) {
+            escalateError = await escalate([bundleURL.path])
+        }
+
+        if exists(bundleURL.path) {
+            throw escalateError ?? recycleError ?? bundleNotMovedError()
+        }
+
+        let bytesFreed = allURLs.reduce(Int64(0)) { sum, url in
+            exists(url.path) ? sum : sum + (sizesByPath[url.path] ?? 0)
+        }
+        // The bundle was permanently removed (not Trashed) when NSWorkspace
+        // didn't move it but it is now gone — i.e. the privileged helper
+        // deleted it. This is the authoritative signal the completion screen
+        // uses, rather than a pre-flight guess at App Store status.
+        let bundlePermanentlyRemoved = !moved.contains(bundleURL.path)
+            && !exists(bundleURL.path)
+        return RecycleOutcome(
+            bytesFreed: bytesFreed,
+            bundlePermanentlyRemoved: bundlePermanentlyRemoved
+        )
+    }
+
+    /// Bridges `NSWorkspace.recycle(_:completionHandler:)` (callback-based,
+    /// returns a `[URL: URL]` map of original → Trash URLs) to an async call
+    /// that reports the set of original paths successfully Trashed plus any
+    /// batch-level error. `NSWorkspace.recycle` does NOT throw on partial
+    /// failure — it Trashes what it can and reports an error only when the
+    /// whole batch fails.
+    private static func workspaceRecycle(
+        _ urls: [URL]
+    ) async -> (moved: Set<String>, error: Error?) {
+        await withCheckedContinuation { continuation in
+            NSWorkspace.shared.recycle(urls) { newURLs, error in
+                let moved = Set(newURLs.keys.map { $0.path })
+                continuation.resume(returning: (moved, error))
             }
         }
+    }
+
+    /// Sends `paths` to the privileged helper for permanent removal. Mirrors
+    /// `SystemJunkDeleter`'s dual-resume guard: `NSXPCConnection` may fire the
+    /// connection-level error handler *instead of* the reply block, so we arm
+    /// both and let whichever lands first resolve the call.
+    private static func escalateToHelper(_ paths: [String]) async -> Error? {
+        await withCheckedContinuation { continuation in
+            let resumer = HelperReplyResumer(continuation: continuation)
+            let helper = HelperConnectionManager.shared.helper { error in
+                resumer.resume(with: error)
+            }
+            guard let helper else {
+                resumer.resume(with: HelperConnectionError.unavailable)
+                return
+            }
+            helper.deleteFiles(paths) { replyError in
+                resumer.resume(with: replyError)
+            }
+        }
+    }
+
+    private static func bundleNotMovedError() -> NSError {
+        NSError(
+            domain: "com.personal.VaderCleaner.AppUninstaller",
+            code: -1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "The application bundle could not be moved to the Trash."
+            ]
+        )
     }
 
     /// Pre-recycle size snapshot keyed by absolute path. Directories sum
@@ -425,5 +552,29 @@ extension AppUninstallerViewModel {
             result[url.path] = total
         }
         return result
+    }
+}
+
+// MARK: - Once-only continuation resume
+
+/// Wraps a `CheckedContinuation` so exactly one of the paths that may complete
+/// a helper XPC call (reply block, connection error handler, "helper
+/// unavailable" early return) actually resumes it — `CheckedContinuation`
+/// traps on a second resume. Mirrors the `Resumer` used by `SystemJunkDeleter`
+/// for the same dual-callback race.
+private final class HelperReplyResumer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Error?, Never>?
+
+    init(continuation: CheckedContinuation<Error?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(with error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: error)
     }
 }

--- a/VaderCleaner/AppUninstallerViewSubviews.swift
+++ b/VaderCleaner/AppUninstallerViewSubviews.swift
@@ -384,6 +384,10 @@ struct AppUninstallerDetailFooter: View {
 
 struct AppUninstallerCompleteState: View {
     let bytesFreed: Int64
+    /// True when the app bundle was permanently removed (App Store / root-owned
+    /// app) rather than moved to the Trash, so the copy stays truthful about
+    /// whether it can be restored.
+    var isPermanentRemoval: Bool = false
     let onContinue: () -> Void
 
     var body: some View {
@@ -394,10 +398,7 @@ struct AppUninstallerCompleteState: View {
             Text(bytesFreedText)
                 .font(.title2.weight(.semibold))
                 .accessibilityIdentifier("appUninstaller.bytesFreed")
-            Text(String(
-                localized: "Items were moved to the Trash. Empty the Trash to reclaim the space.",
-                comment: "Detail shown on the App Uninstaller complete screen."
-            ))
+            Text(detailText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -415,13 +416,31 @@ struct AppUninstallerCompleteState: View {
     }
 
     private var bytesFreedText: String {
-        let format = String(
-            localized: "%@ moved to Trash",
-            comment: "Summary of disk space that will be reclaimed after emptying the Trash."
-        )
+        let format = isPermanentRemoval
+            ? String(
+                localized: "%@ removed",
+                comment: "Summary of disk space reclaimed after permanently removing an App Store app."
+            )
+            : String(
+                localized: "%@ moved to Trash",
+                comment: "Summary of disk space that will be reclaimed after emptying the Trash."
+            )
         return String.localizedStringWithFormat(
             format,
             AppUninstallerFormatting.byteFormatter.string(fromByteCount: bytesFreed)
+        )
+    }
+
+    private var detailText: String {
+        if isPermanentRemoval {
+            return String(
+                localized: "The app was permanently removed. Its associated files were moved to the Trash where possible.",
+                comment: "Detail shown on the App Uninstaller complete screen after permanently removing an App Store app."
+            )
+        }
+        return String(
+            localized: "Items were moved to the Trash. Empty the Trash to reclaim the space.",
+            comment: "Detail shown on the App Uninstaller complete screen."
         )
     }
 }
@@ -429,6 +448,10 @@ struct AppUninstallerCompleteState: View {
 struct AppUninstallerFailedState: View {
     let stage: AppUninstallerViewModel.FailureStage
     let message: String
+    /// When true the failure was the privileged helper being unreachable, so
+    /// a "Reinstall Helper" recovery is offered in addition to a plain retry.
+    var canReinstallHelper: Bool = false
+    var onReinstallHelper: () -> Void = {}
     let onTryAgain: () -> Void
 
     var body: some View {
@@ -446,13 +469,42 @@ struct AppUninstallerFailedState: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 460)
                 .accessibilityIdentifier("appUninstaller.errorMessage")
-            Button(String(
-                localized: "Try Again",
-                comment: "Retry action on the App Uninstaller failure screen."
-            ), action: onTryAgain)
-                .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
-                .accessibilityIdentifier("appUninstaller.tryAgain")
+            if canReinstallHelper {
+                // The daemon is unreachable — re-registering it (and approving
+                // it in Login Items) is the actual fix, so lead with it.
+                Text(String(
+                    localized: "Reinstalling the helper re-registers it with the system. You may need to approve VaderCleaner in Login Items, then try again.",
+                    comment: "Guidance shown when the App Uninstaller can't reach the privileged helper."
+                ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 460)
+                HStack(spacing: 12) {
+                    Button(String(
+                        localized: "Reinstall Helper",
+                        comment: "Recovery action that re-registers the privileged helper daemon."
+                    ), action: onReinstallHelper)
+                        .controlSize(.large)
+                        .keyboardShortcut(.defaultAction)
+                        .buttonStyle(.borderedProminent)
+                        .accessibilityIdentifier("appUninstaller.reinstallHelper")
+                    Button(String(
+                        localized: "Try Again",
+                        comment: "Retry action on the App Uninstaller failure screen."
+                    ), action: onTryAgain)
+                        .controlSize(.large)
+                        .accessibilityIdentifier("appUninstaller.tryAgain")
+                }
+            } else {
+                Button(String(
+                    localized: "Try Again",
+                    comment: "Retry action on the App Uninstaller failure screen."
+                ), action: onTryAgain)
+                    .controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("appUninstaller.tryAgain")
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()

--- a/VaderCleaner/HelperConnectionError.swift
+++ b/VaderCleaner/HelperConnectionError.swift
@@ -27,21 +27,25 @@ enum HelperConnectionError: LocalizedError {
     /// localized description so a locked file or permission denial still
     /// tells the user what actually went wrong.
     static func userFacingMessage(for error: Error) -> String {
+        isConnectionFailure(error) ? message : error.localizedDescription
+    }
+
+    /// True when `error` means the privileged helper couldn't be reached (this
+    /// enum, or an `NSXPCConnection` connection-class `NSCocoaError`), as
+    /// opposed to a substantive failure the helper itself reported. Callers
+    /// use this to offer a "Reinstall Helper" recovery rather than a plain
+    /// retry.
+    ///
+    /// `NSXPCConnection` reports a dropped/unavailable connection as
+    /// `NSCocoaErrorDomain` 4097 (interrupted), 4099 (invalid), or 4101
+    /// (reply invalid) — the codes whose system `localizedDescription` is the
+    /// cryptic "Couldn't communicate with a helper application."
+    static func isConnectionFailure(_ error: Error) -> Bool {
         if error is HelperConnectionError {
-            return message
+            return true
         }
-
         let nsError = error as NSError
-
-        // NSXPCConnection reports a dropped/unavailable connection as
-        // NSCocoaErrorDomain 4097 (interrupted), 4099 (invalid), or 4101
-        // (reply invalid). The system's own localizedDescription for these
-        // is the cryptic "Couldn't communicate with a helper application."
-        if nsError.domain == NSCocoaErrorDomain,
-           [4097, 4099, 4101].contains(nsError.code) {
-            return message
-        }
-
-        return error.localizedDescription
+        return nsError.domain == NSCocoaErrorDomain
+            && [4097, 4099, 4101].contains(nsError.code)
     }
 }

--- a/VaderCleaner/HelperRegistration.swift
+++ b/VaderCleaner/HelperRegistration.swift
@@ -34,4 +34,37 @@ enum HelperRegistration {
                    log: log, type: .error, String(describing: error))
         }
     }
+
+    /// Forces a clean re-registration of the daemon. A rebuilt / updated
+    /// helper changes the binary's code-signing hash, which can leave the
+    /// launchd job stale or uninstalled while `SMAppService` still reports
+    /// `.enabled` — `registerIfNeeded()` then skips and the helper stays
+    /// unreachable ("Couldn't communicate with a helper application."). This
+    /// drops the old registration and registers fresh so launchd points at
+    /// the current binary. Re-registration may return `.requiresApproval`,
+    /// so callers should send the user to Login Items to re-approve.
+    /// Returns the resulting status.
+    @discardableResult
+    static func reregister() async -> SMAppService.Status {
+        let service = SMAppService.daemon(plistName: plistName)
+        // Tolerate "not registered" — we only care that we end unregistered
+        // before registering again.
+        try? await service.unregister()
+        do {
+            try service.register()
+            os_log("Re-registered helper daemon (status=%{public}@)",
+                   log: log, type: .info, String(describing: service.status))
+        } catch {
+            os_log("Helper daemon re-registration failed: %{public}@",
+                   log: log, type: .error, String(describing: error))
+        }
+        return service.status
+    }
+
+    /// Opens System Settings → General → Login Items & Extensions so the user
+    /// can approve the daemon after a re-registration that needs approval.
+    @MainActor
+    static func openLoginItemsSettings() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
 }

--- a/VaderCleanerTests/AppUninstallerViewModelTests.swift
+++ b/VaderCleanerTests/AppUninstallerViewModelTests.swift
@@ -41,7 +41,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         let vm = makeViewModel(discover: { _ in throw BoomError() })
         await vm.loadApps()
 
-        if case .failed(let stage, _) = vm.phase {
+        if case .failed(let stage, _, _) = vm.phase {
             XCTAssertEqual(stage, .loading)
         } else {
             XCTFail("Expected .failed(.loading), got \(vm.phase)")
@@ -234,7 +234,10 @@ final class AppUninstallerViewModelTests: XCTestCase {
                 }
                 return []
             },
-            recycle: { _, _ in await recycleCalls.increment(); return 1 }
+            recycle: { _, _ in
+                await recycleCalls.increment()
+                return AppUninstallerViewModel.RecycleOutcome(bytesFreed: 1, bundlePermanentlyRemoved: false)
+            }
         )
         await vm.loadApps()
         vm.select(app.id)
@@ -284,7 +287,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
             recycle: { bundleURL, associatedURLs in
                 await receivedBundle.set(bundleURL)
                 await receivedAssociated.set(associatedURLs)
-                return 60
+                return AppUninstallerViewModel.RecycleOutcome(bytesFreed: 60, bundlePermanentlyRemoved: false)
             }
         )
         await vm.loadApps()
@@ -297,9 +300,30 @@ final class AppUninstallerViewModelTests: XCTestCase {
         let associated = await receivedAssociated.value
         XCTAssertEqual(bundle, app.bundleURL)
         XCTAssertEqual(Set(associated), Set(stubFiles.map(\.url)))
-        XCTAssertEqual(vm.phase, .complete(bytesFreed: 60))
+        XCTAssertEqual(vm.phase, .complete(bytesFreed: 60, permanentRemoval: false))
         XCTAssertFalse(vm.apps.contains(where: { $0.id == app.id }))
         XCTAssertNil(vm.selectedAppID)
+    }
+
+    /// When the recycler reports the bundle was permanently removed (a
+    /// root-owned app the privileged helper had to delete rather than Trash),
+    /// the completion phase carries that flag so the success screen stays
+    /// honest about whether the app can be restored.
+    func test_uninstall_permanentRemovalOutcome_surfacedInCompletePhase() async {
+        let app = makeApp(name: "Canva", bundleID: "com.canva.app")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            recycle: { _, _ in
+                AppUninstallerViewModel.RecycleOutcome(bytesFreed: 5000, bundlePermanentlyRemoved: true)
+            }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { vm.canUninstallSelectedApp }
+        await vm.uninstall()
+
+        XCTAssertEqual(vm.phase, .complete(bytesFreed: 5000, permanentRemoval: true))
     }
 
     /// If the recycler reports that the bundle could not be moved
@@ -321,7 +345,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         await waitFor { vm.canUninstallSelectedApp }
         await vm.uninstall()
 
-        if case .failed(let stage, _) = vm.phase {
+        if case .failed(let stage, _, _) = vm.phase {
             XCTAssertEqual(stage, .uninstalling)
         } else {
             XCTFail("Expected .failed(.uninstalling), got \(vm.phase)")
@@ -329,6 +353,72 @@ final class AppUninstallerViewModelTests: XCTestCase {
         // App row must still be present so the user can retry.
         XCTAssertTrue(vm.apps.contains(where: { $0.id == app.id }),
                       "App must stay in the list when its bundle was not Trashed")
+    }
+
+    /// An unreachable privileged helper surfaces the friendly shared copy
+    /// (not the cryptic NSXPC string) AND flags the failure as a helper
+    /// connection issue so the failure screen can offer to reinstall it.
+    func test_uninstall_helperUnavailableSurfacesFriendlyMessageAndFlagsConnectionIssue() async {
+        let app = makeApp(name: "Canva", bundleID: "com.canva.app")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            recycle: { _, _ in throw HelperConnectionError.unavailable }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { vm.canUninstallSelectedApp }
+        await vm.uninstall()
+
+        if case .failed(let stage, let message, let helperIssue) = vm.phase {
+            XCTAssertEqual(stage, .uninstalling)
+            XCTAssertEqual(message, HelperConnectionError.message)
+            XCTAssertTrue(helperIssue, "A helper connection failure must offer the reinstall recovery")
+        } else {
+            XCTFail("Expected .failed(.uninstalling), got \(vm.phase)")
+        }
+    }
+
+    /// A substantive (non-connection) recycle failure must NOT be flagged as a
+    /// helper connection issue — the reinstall recovery would be misleading.
+    func test_uninstall_nonConnectionFailureDoesNotFlagHelperIssue() async {
+        struct PermissionError: LocalizedError { var errorDescription: String? { "Permission denied" } }
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            recycle: { _, _ in throw PermissionError() }
+        )
+        await vm.loadApps()
+        vm.select(app.id)
+        await waitFor { vm.canUninstallSelectedApp }
+        await vm.uninstall()
+
+        if case .failed(_, let message, let helperIssue) = vm.phase {
+            XCTAssertEqual(message, "Permission denied", "Substantive errors keep their own description")
+            XCTAssertFalse(helperIssue)
+        } else {
+            XCTFail("Expected .failed, got \(vm.phase)")
+        }
+    }
+
+    /// `reinstallHelper()` runs the injected re-registration and then reloads
+    /// the app list so the user lands back on a usable screen to retry.
+    func test_reinstallHelper_runsReregistrationThenReloads() async {
+        let reinstallCalls = ActorBox(0)
+        let app = makeApp(name: "Canva", bundleID: "com.canva.app")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            findFiles: { _ in [] },
+            reinstallHelper: { await reinstallCalls.increment() }
+        )
+
+        await vm.reinstallHelper()
+
+        let count = await reinstallCalls.value
+        XCTAssertEqual(count, 1, "Reinstall must invoke the injected re-registration exactly once")
+        XCTAssertEqual(vm.phase, .ready, "After reinstall the VM reloads to a usable state")
+        XCTAssertTrue(vm.apps.contains(where: { $0.id == app.id }))
     }
 
     /// A throwing recycler surfaces `.failed(stage: .uninstalling, ...)`.
@@ -347,7 +437,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
         // would never reach the recycler.
         await waitFor { vm.canUninstallSelectedApp }
         await vm.uninstall()
-        if case .failed(let stage, _) = vm.phase {
+        if case .failed(let stage, _, _) = vm.phase {
             XCTAssertEqual(stage, .uninstalling)
         } else {
             XCTFail("Expected .failed(.uninstalling), got \(vm.phase)")
@@ -359,7 +449,10 @@ final class AppUninstallerViewModelTests: XCTestCase {
         let calls = ActorBox(0)
         let vm = makeViewModel(
             discover: { _ in [] },
-            recycle: { _, _ in await calls.increment(); return 0 }
+            recycle: { _, _ in
+                await calls.increment()
+                return AppUninstallerViewModel.RecycleOutcome(bytesFreed: 0, bundlePermanentlyRemoved: false)
+            }
         )
         await vm.loadApps()
         await vm.uninstall()
@@ -375,7 +468,9 @@ final class AppUninstallerViewModelTests: XCTestCase {
         let vm = makeViewModel(
             discover: { _ in [app] },
             findFiles: { _ in [] },
-            recycle: { _, _ in 0 }
+            recycle: { _, _ in
+                AppUninstallerViewModel.RecycleOutcome(bytesFreed: 0, bundlePermanentlyRemoved: false)
+            }
         )
         await vm.loadApps()
         vm.select(app.id)
@@ -385,19 +480,131 @@ final class AppUninstallerViewModelTests: XCTestCase {
         XCTAssertEqual(vm.phase, .ready)
     }
 
+    // MARK: - recycleWithEscalation
+
+    /// A fully user-owned app: NSWorkspace Trashes everything, so the
+    /// privileged helper is never engaged and every byte is credited.
+    func test_recycleWithEscalation_userOwnedApp_trashesAll_noEscalation() async throws {
+        let bundle = URL(fileURLWithPath: "/Applications/Friendly.app")
+        let assoc = [URL(fileURLWithPath: "/Users/me/Library/Caches/com.acme.friendly")]
+        let fs = FakeFilesystem(existing: [bundle.path] + assoc.map(\.path))
+        let escalateCalls = Box(0)
+
+        let outcome = try await AppUninstallerViewModel.recycleWithEscalation(
+            bundleURL: bundle,
+            associatedURLs: assoc,
+            recycle: { urls in
+                for url in urls { fs.remove(url.path) }
+                return (Set(urls.map(\.path)), nil)
+            },
+            escalate: { _ in escalateCalls.value += 1; return nil },
+            sizeFor: { _ in [bundle.path: 100, assoc[0].path: 20] },
+            exists: { fs.contains($0) }
+        )
+
+        XCTAssertEqual(outcome.bytesFreed, 120)
+        XCTAssertFalse(outcome.bundlePermanentlyRemoved, "Bundle was Trashed, not permanently removed")
+        XCTAssertEqual(escalateCalls.value, 0, "No escalation when everything was Trashed")
+    }
+
+    /// A root-owned / App Store bundle: NSWorkspace Trashes the user-domain
+    /// residue but is denied the bundle, which is then escalated to the
+    /// privileged helper for permanent removal. Bytes are credited for both.
+    func test_recycleWithEscalation_rootOwnedBundle_escalatesBundleOnly_creditsBytes() async throws {
+        let bundle = URL(fileURLWithPath: "/Applications/Canva.app")
+        let assoc = [URL(fileURLWithPath: "/Users/me/Library/Preferences/com.canva.plist")]
+        let fs = FakeFilesystem(existing: [bundle.path] + assoc.map(\.path))
+        let escalated = Box<[String]>([])
+
+        let outcome = try await AppUninstallerViewModel.recycleWithEscalation(
+            bundleURL: bundle,
+            associatedURLs: assoc,
+            recycle: { urls in
+                // The user can only Trash the user-domain associated file.
+                let moved = urls.filter { $0.path.hasPrefix("/Users/") }
+                for url in moved { fs.remove(url.path) }
+                return (Set(moved.map(\.path)), nil)
+            },
+            escalate: { paths in
+                escalated.value = paths
+                for path in paths { fs.remove(path) } // helper permanently deletes
+                return nil
+            },
+            sizeFor: { _ in [bundle.path: 5000, assoc[0].path: 8] },
+            exists: { fs.contains($0) }
+        )
+
+        XCTAssertEqual(escalated.value, [bundle.path], "Only the unmoved bundle is escalated")
+        XCTAssertEqual(outcome.bytesFreed, 5008, "Credits both the Trashed file and the helper-deleted bundle")
+        XCTAssertTrue(outcome.bundlePermanentlyRemoved, "Bundle was permanently removed by the helper")
+    }
+
+    /// When the bundle survives both NSWorkspace and the privileged helper
+    /// (helper unreachable / denied), the call throws so the UI reports
+    /// failure rather than a false "Complete".
+    func test_recycleWithEscalation_bundleSurvivesEscalation_throws() async {
+        let bundle = URL(fileURLWithPath: "/Applications/Canva.app")
+        let fs = FakeFilesystem(existing: [bundle.path])
+
+        do {
+            _ = try await AppUninstallerViewModel.recycleWithEscalation(
+                bundleURL: bundle,
+                associatedURLs: [],
+                recycle: { _ in (Set<String>(), nil) },
+                escalate: { _ in HelperConnectionError.unavailable }, // leaves the bundle in place
+                sizeFor: { _ in [bundle.path: 100] },
+                exists: { fs.contains($0) }
+            )
+            XCTFail("Expected a throw when the bundle survives both passes")
+        } catch {
+            XCTAssertTrue(error is HelperConnectionError, "Surfaces the escalation error, got \(error)")
+        }
+    }
+
+    /// A surviving associated file is tolerated best-effort and is NEVER
+    /// escalated to the privileged helper — only the bundle is. Once the
+    /// bundle is gone the uninstall succeeds, and only removed items are
+    /// credited.
+    func test_recycleWithEscalation_associatedFileNotEscalated_whenBundleTrashed() async throws {
+        let bundle = URL(fileURLWithPath: "/Applications/Canva.app")
+        let sysFile = URL(fileURLWithPath: "/Library/LaunchDaemons/com.canva.helper.plist")
+        let fs = FakeFilesystem(existing: [bundle.path, sysFile.path])
+        let escalated = Box<[String]>([])
+
+        let outcome = try await AppUninstallerViewModel.recycleWithEscalation(
+            bundleURL: bundle,
+            associatedURLs: [sysFile],
+            recycle: { _ in
+                fs.remove(bundle.path) // bundle Trashed, system file denied
+                return (Set([bundle.path]), nil)
+            },
+            escalate: { paths in escalated.value = paths; return nil },
+            sizeFor: { _ in [bundle.path: 5000, sysFile.path: 9] },
+            exists: { fs.contains($0) }
+        )
+
+        XCTAssertTrue(escalated.value.isEmpty, "Associated files must never be escalated for permanent deletion")
+        XCTAssertEqual(outcome.bytesFreed, 5000, "Only the removed bundle is credited; the surviving file is not")
+        XCTAssertFalse(outcome.bundlePermanentlyRemoved, "Bundle was Trashed by NSWorkspace, not escalated")
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel(
         discover: @escaping AppUninstallerViewModel.Discover = { _ in [] },
         findFiles: @escaping AppUninstallerViewModel.FindFiles = { _ in [] },
         measureSize: @escaping AppUninstallerViewModel.MeasureSize = { _ in 0 },
-        recycle: @escaping AppUninstallerViewModel.Recycle = { _, _ in 0 }
+        recycle: @escaping AppUninstallerViewModel.Recycle = { _, _ in
+            AppUninstallerViewModel.RecycleOutcome(bytesFreed: 0, bundlePermanentlyRemoved: false)
+        },
+        reinstallHelper: @escaping AppUninstallerViewModel.ReinstallHelper = {}
     ) -> AppUninstallerViewModel {
         AppUninstallerViewModel(
             discover: discover,
             findFiles: findFiles,
             measureSize: measureSize,
-            recycle: recycle
+            recycle: recycle,
+            reinstallHelper: reinstallHelper
         )
     }
 
@@ -451,4 +658,21 @@ private actor ActorBox<Value: Sendable> {
 
 private extension ActorBox where Value == Int {
     func increment() { value += 1 }
+}
+
+/// In-memory existence model for `recycleWithEscalation` tests. The `recycle`
+/// and `escalate` fakes mutate it so the post-pass `exists` checks observe the
+/// same state transitions a real filesystem would.
+private final class FakeFilesystem {
+    private var existing: Set<String>
+    init(existing: [String]) { self.existing = Set(existing) }
+    func contains(_ path: String) -> Bool { existing.contains(path) }
+    func remove(_ path: String) { existing.remove(path) }
+}
+
+/// Mutable reference cell for capturing call counts / arguments from the
+/// non-escaping fakes passed to `recycleWithEscalation`.
+private final class Box<T> {
+    var value: T
+    init(_ value: T) { self.value = value }
 }

--- a/VaderCleanerTests/HelperConnectionErrorTests.swift
+++ b/VaderCleanerTests/HelperConnectionErrorTests.swift
@@ -55,4 +55,27 @@ final class HelperConnectionErrorTests: XCTestCase {
             "You don't have permission."
         )
     }
+
+    /// `isConnectionFailure` recognises the helper-unavailable sentinel and the
+    /// three NSXPC connection-class codes — the signal a caller uses to offer a
+    /// "Reinstall Helper" recovery.
+    func test_isConnectionFailure_trueForHelperErrorAndXPCConnectionCodes() {
+        XCTAssertTrue(HelperConnectionError.isConnectionFailure(HelperConnectionError.unavailable))
+        for code in [4097, 4099, 4101] {
+            XCTAssertTrue(
+                HelperConnectionError.isConnectionFailure(NSError(domain: NSCocoaErrorDomain, code: code)),
+                "Expected XPC NSCocoaError \(code) to count as a connection failure"
+            )
+        }
+    }
+
+    /// A substantive error (e.g. a permission denial) is NOT a connection
+    /// failure — reinstalling the helper wouldn't help, so it must read false.
+    func test_isConnectionFailure_falseForSubstantiveError() {
+        let permission = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteNoPermissionError)
+        XCTAssertFalse(HelperConnectionError.isConnectionFailure(permission))
+        let otherDomain = NSError(domain: "com.example.other", code: 4097)
+        XCTAssertFalse(HelperConnectionError.isConnectionFailure(otherDomain),
+                       "Connection codes only count in NSCocoaErrorDomain")
+    }
 }

--- a/VaderCleanerTests/HelperDeletionPolicyTests.swift
+++ b/VaderCleanerTests/HelperDeletionPolicyTests.swift
@@ -73,6 +73,9 @@ final class HelperDeletionPolicyTests: XCTestCase {
                 libraryApplicationSupportRoot,
                 frameworksRoot
             ],
+            allowedApplicationBundleRoots: [
+                applicationsRoot
+            ],
             volumesRoot: volumesRoot
         )
     }
@@ -140,6 +143,61 @@ final class HelperDeletionPolicyTests: XCTestCase {
             .appendingPathComponent("Example.app/Contents/Resources/fr.lproj", isDirectory: true)
 
         XCTAssertEqual(try policy.validateDeletionPath(url.path).path, url.standardizedFileURL.path)
+    }
+
+    func test_validateDeletionPath_acceptsTopLevelApplicationBundle() throws {
+        let url = applicationsRoot.appendingPathComponent("Example.app", isDirectory: true)
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path).path, url.standardizedFileURL.path)
+    }
+
+    func test_validateDeletionPath_acceptsApplicationBundleInsidePlainSubfolder() throws {
+        let url = applicationsRoot
+            .appendingPathComponent("Utilities", isDirectory: true)
+            .appendingPathComponent("Example.app", isDirectory: true)
+
+        XCTAssertEqual(try policy.validateDeletionPath(url.path).path, url.standardizedFileURL.path)
+    }
+
+    func test_validateDeletionPath_rejectsAppNestedInsideAnotherBundle() {
+        let path = applicationsRoot
+            .appendingPathComponent("Outer.app/Contents/Helpers/Inner.app", isDirectory: true)
+            .path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsNonAppDirectlyUnderApplications() {
+        let path = applicationsRoot
+            .appendingPathComponent("PlainFolder", isDirectory: true)
+            .path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_validateDeletionPath_rejectsFileInsideAppBundleAsBundle() {
+        // A regular file inside the bundle is not itself a `.app`, so the
+        // bundle rule must not green-light deleting individual interior files.
+        let path = applicationsRoot
+            .appendingPathComponent("Example.app/Contents/MacOS/Example")
+            .path
+
+        XCTAssertThrowsError(try policy.validateDeletionPath(path)) { error in
+            XCTAssertEqual(error as? HelperDeletionValidationError, .disallowedPath(path))
+        }
+    }
+
+    func test_productionPolicy_acceptsTopLevelApplicationBundle() throws {
+        let path = "/Applications/Canva.app"
+
+        XCTAssertEqual(
+            try HelperDeletionPolicy.production.validateDeletionPath(path).path,
+            URL(fileURLWithPath: path).standardizedFileURL.path
+        )
     }
 
     func test_validateDeletionPath_acceptsSystemLaunchAgentAndDaemonPlists() throws {


### PR DESCRIPTION
## What & why

App Store / root-owned apps (e.g. **Canva**) couldn't be uninstalled: `NSWorkspace.recycle` runs unprivileged and can't move a `root:wheel` bundle to the Trash, so the move was denied and the user got *"You do not have permission to move some of the files to the trash."*

This routes the **bundle** removal through the existing privileged helper when `NSWorkspace` is denied, while keeping the user-facing copy honest about the trade-off (the helper can only permanently delete — it can't put a root-owned bundle in the user's Trash restorably).

## Changes

**Privileged escalation**
- `HelperDeletionPolicy`: widened to permit a **top-level `/Applications/*.app`** bundle. Tightly scoped — refuses anything nested inside another package (`Outer.app/.../Inner.app`), validated on both the requested and symlink-resolved path.
- `recycleWithEscalation` (new, injectable/unit-tested): Trash everything via `NSWorkspace` first (user residue stays restorable), then escalate **only the bundle** to the helper for permanent removal when it was denied. Associated files are *never* permanently deleted — the confirmation promised they'd be restorable. Freed bytes credited by post-pass existence check; throws only if the bundle survives both passes.

**Honest copy**
- Confirmation alert warns when an app will be **permanently removed** (predicted by bundle writability, which also catches root-owned pkg apps, not just App Store).
- Completion screen wording is driven by the **actual runtime outcome** (`RecycleOutcome.bundlePermanentlyRemoved`), never a pre-flight guess.

**Helper-unreachable hardening**
- Uninstall failures route through `HelperConnectionError.userFacingMessage` → friendly *"Helper is not responding"* instead of the cryptic NSXPC string; added `isConnectionFailure()`.
- **"Reinstall Helper"** recovery on the failure screen (shown only for connection failures): re-registers the daemon, opens Login Items for approval, then reloads.

**UX polish**
- Crossfade the App Uninstaller phase transitions (matching `SmartScanView`), fixing the janky hard-cut after clicking Uninstall.

## Reviewer notes

- **Decision (option A):** for root-owned apps the bundle is *permanently removed*, not Trashed — the privileged helper can't deliver a restorable Trash result for a root-owned bundle. The copy reflects this.
- **Deviation worth flagging:** the "Reinstall Helper" recovery is the explicit-button form only. A *silent* auto-reregister-and-retry isn't possible because `SMAppService.unregister()` always clears approval, so re-registration needs a user approval step regardless.
- **Operational:** because the deletion policy is compiled into the helper binary, the **running daemon keeps the old policy until rebuilt/re-registered** — a stale daemon silently still rejects `/Applications/*.app`. (Documented in the `helper-bundle-binary-upgrade` note.)

## Testing

Full unit suite green: **901 tests, 0 failures**. New coverage: policy allowlist (5), escalation/credit/permanence (5), connection-failure predicate + friendly message + reinstall-flow. The SMAppService/XPC boundary itself can't be exercised from CI and was verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced uninstall messaging to clearly distinguish between permanent removal and trash-based operations
  * Added helper reconnection recovery option when connection issues occur during uninstall
  * Support for safely deleting applications from standard system directories

* **Bug Fixes**
  * Improved error handling and messaging for helper connection failures
  * Enhanced visual transitions and feedback during the uninstall process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->