### PR TITLE
feat(applications): merge App Uninstaller + Updater into scannable Applications section

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
 		6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */; };
+		01CFFFFADF27CFAF76D12B1C /* AppLeftoverScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFC65352C381CB235B98DF /* AppLeftoverScannerTests.swift */; };
 		4334DC58726B62F185A4000F /* UnusedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */; };
 		2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */; };
 		80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */; };
@@ -101,6 +102,8 @@
 		E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */; };
 		46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */; };
 		78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */; };
+		4D011CE9F968899A237FA7A7 /* AppLeftoverScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FB57D743C8DF7C3C6BBA87 /* AppLeftoverScanner.swift */; };
+		447CF7856E99CCA9C3F5CF8D /* AppLeftover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4D12F02A9A3B4645982B84 /* AppLeftover.swift */; };
 		9677B436710A0E80C747C781 /* UnusedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */; };
 		7023CA5C3D691ED6403E827B /* UnusedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0159742E841F81FCA30D03 /* UnusedApp.swift */; };
 		3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */; };
@@ -381,6 +384,7 @@
 		416D1869BE7C552C78714296 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
 		4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModelTests.swift; sourceTree = "<group>"; };
+		4EDFC65352C381CB235B98DF /* AppLeftoverScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftoverScannerTests.swift; sourceTree = "<group>"; };
 		9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScannerTests.swift; sourceTree = "<group>"; };
 		B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScannerTests.swift; sourceTree = "<group>"; };
 		BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachOHeaderReaderTests.swift; sourceTree = "<group>"; };
@@ -431,6 +435,8 @@
 		3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsDashboardSubviews.swift; sourceTree = "<group>"; };
 		FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsView.swift; sourceTree = "<group>"; };
 		FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
+		C7FB57D743C8DF7C3C6BBA87 /* AppLeftoverScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftoverScanner.swift; sourceTree = "<group>"; };
+		6F4D12F02A9A3B4645982B84 /* AppLeftover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftover.swift; sourceTree = "<group>"; };
 		935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScanner.swift; sourceTree = "<group>"; };
 		8E0159742E841F81FCA30D03 /* UnusedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedApp.swift; sourceTree = "<group>"; };
 		B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScanner.swift; sourceTree = "<group>"; };
@@ -650,6 +656,8 @@
 				3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */,
 				FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */,
 				FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */,
+				C7FB57D743C8DF7C3C6BBA87 /* AppLeftoverScanner.swift */,
+				6F4D12F02A9A3B4645982B84 /* AppLeftover.swift */,
 				935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */,
 				8E0159742E841F81FCA30D03 /* UnusedApp.swift */,
 				B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */,
@@ -848,6 +856,7 @@
 				8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */,
 				42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */,
 				4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */,
+				4EDFC65352C381CB235B98DF /* AppLeftoverScannerTests.swift */,
 				9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */,
 				B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */,
 				BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */,
@@ -1143,6 +1152,7 @@
 				565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */,
 				381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */,
 				6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */,
+				01CFFFFADF27CFAF76D12B1C /* AppLeftoverScannerTests.swift in Sources */,
 				4334DC58726B62F185A4000F /* UnusedAppScannerTests.swift in Sources */,
 				2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */,
 				80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */,
@@ -1274,6 +1284,8 @@
 				E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */,
 				46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */,
 				78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */,
+				4D011CE9F968899A237FA7A7 /* AppLeftoverScanner.swift in Sources */,
+				447CF7856E99CCA9C3F5CF8D /* AppLeftover.swift in Sources */,
 				9677B436710A0E80C747C781 /* UnusedAppScanner.swift in Sources */,
 				7023CA5C3D691ED6403E827B /* UnusedApp.swift in Sources */,
 				3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
 		1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */; };
+		8116760AAB4F16FFC4961ABD /* ApplicationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8463E125473BA9EFD1E6CABF /* ApplicationsUITests.swift */; };
 		1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */; };
 		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
 		1F7B67D271BC88E4A13A1AE8 /* MaintenanceTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */; };
@@ -70,6 +71,7 @@
 		3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */; };
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
+		6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */; };
 		390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
 		3A0AAEEE22026F9D96D875B2 /* PrivacyCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */; };
@@ -92,6 +94,9 @@
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
 		4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */; };
+		E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */; };
+		46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */; };
+		78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */; };
 		4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */; };
@@ -365,6 +370,7 @@
 		3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanView.swift; sourceTree = "<group>"; };
 		416D1869BE7C552C78714296 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
+		4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModelTests.swift; sourceTree = "<group>"; };
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
 		42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewSubviews.swift; sourceTree = "<group>"; };
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
@@ -408,6 +414,9 @@
 		67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewSubviews.swift; sourceTree = "<group>"; };
 		673CA7922445475111927C0B /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModel.swift; sourceTree = "<group>"; };
+		3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsDashboardSubviews.swift; sourceTree = "<group>"; };
+		FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsView.swift; sourceTree = "<group>"; };
+		FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
 		6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroViewTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
@@ -525,6 +534,7 @@
 		DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItemTests.swift; sourceTree = "<group>"; };
 		DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitorTests.swift; sourceTree = "<group>"; };
 		E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalPolishUITests.swift; sourceTree = "<group>"; };
+		8463E125473BA9EFD1E6CABF /* ApplicationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsUITests.swift; sourceTree = "<group>"; };
 		E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStore.swift; sourceTree = "<group>"; };
 		E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModel.swift; sourceTree = "<group>"; };
 		E2017911CF02D2B89E8BF865 /* MailReindexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailReindexer.swift; sourceTree = "<group>"; };
@@ -591,6 +601,7 @@
 			isa = PBXGroup;
 			children = (
 				E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */,
+				8463E125473BA9EFD1E6CABF /* ApplicationsUITests.swift */,
 				A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */,
 				22622AEBD53221D89CB1439D /* OptimizationUITests.swift */,
 				8B18E28D449EF4D5FB1D6E0B /* SmartScanUITests.swift */,
@@ -616,6 +627,9 @@
 				8C76CE861C998A697164C552 /* AppUpdaterError.swift */,
 				06E8635D102B895AF349A13D /* AppUpdaterView.swift */,
 				68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */,
+				3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */,
+				FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */,
+				FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */,
 				5E978BB01AD677AEDE122B1C /* Assets.xcassets */,
 				57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */,
 				8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */,
@@ -807,6 +821,7 @@
 				31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */,
 				8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */,
 				42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */,
+				4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */,
 				C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */,
 				E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */,
 				A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */,
@@ -1097,6 +1112,7 @@
 				11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */,
 				565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */,
 				381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */,
+				6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */,
 				65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */,
 				F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */,
 				B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */,
@@ -1195,6 +1211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */,
+				8116760AAB4F16FFC4961ABD /* ApplicationsUITests.swift in Sources */,
 				82DB89EC1E0EAFD90FB6018D /* MalwareUITests.swift in Sources */,
 				7B4A89F26C67D0A6372E2A78 /* OptimizationUITests.swift in Sources */,
 				2D5B0C45DB5F5EA679AF4131 /* SmartScanUITests.swift in Sources */,
@@ -1220,6 +1237,9 @@
 				BB6D9635C62A1D0635E2799F /* AppUpdaterError.swift in Sources */,
 				F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */,
 				4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */,
+				E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */,
+				46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */,
+				78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */,
 				9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */,
 				EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */,
 				3328707476CC1411FA1270D0 /* Browser.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
 		6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */; };
+		3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */; };
 		390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
 		3A0AAEEE22026F9D96D875B2 /* PrivacyCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */; };
@@ -97,6 +98,8 @@
 		E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */; };
 		46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */; };
 		78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */; };
+		78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */; };
+		82D88268A46FBE614678E869 /* InstallationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D64760E042AC0762B6AC221 /* InstallationFile.swift */; };
 		4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */; };
@@ -371,6 +374,7 @@
 		416D1869BE7C552C78714296 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
 		4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModelTests.swift; sourceTree = "<group>"; };
+		29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScannerTests.swift; sourceTree = "<group>"; };
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
 		42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewSubviews.swift; sourceTree = "<group>"; };
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
@@ -417,6 +421,8 @@
 		3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsDashboardSubviews.swift; sourceTree = "<group>"; };
 		FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsView.swift; sourceTree = "<group>"; };
 		FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
+		7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScanner.swift; sourceTree = "<group>"; };
+		1D64760E042AC0762B6AC221 /* InstallationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFile.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
 		6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroViewTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
@@ -630,6 +636,8 @@
 				3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */,
 				FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */,
 				FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */,
+				7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */,
+				1D64760E042AC0762B6AC221 /* InstallationFile.swift */,
 				5E978BB01AD677AEDE122B1C /* Assets.xcassets */,
 				57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */,
 				8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */,
@@ -822,6 +830,7 @@
 				8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */,
 				42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */,
 				4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */,
+				29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */,
 				C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */,
 				E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */,
 				A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */,
@@ -1113,6 +1122,7 @@
 				565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */,
 				381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */,
 				6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */,
+				3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */,
 				65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */,
 				F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */,
 				B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */,
@@ -1240,6 +1250,8 @@
 				E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */,
 				46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */,
 				78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */,
+				78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */,
+				82D88268A46FBE614678E869 /* InstallationFile.swift in Sources */,
 				9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */,
 				EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */,
 				3328707476CC1411FA1270D0 /* Browser.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
 		6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */; };
+		4334DC58726B62F185A4000F /* UnusedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */; };
 		2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */; };
 		80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */; };
 		3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */; };
@@ -100,6 +101,8 @@
 		E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */; };
 		46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */; };
 		78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */; };
+		9677B436710A0E80C747C781 /* UnusedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */; };
+		7023CA5C3D691ED6403E827B /* UnusedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0159742E841F81FCA30D03 /* UnusedApp.swift */; };
 		3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */; };
 		ACDE4A29C6C4E5967C7A9BDA /* UnsupportedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */; };
 		78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */; };
@@ -378,6 +381,7 @@
 		416D1869BE7C552C78714296 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
 		4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModelTests.swift; sourceTree = "<group>"; };
+		9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScannerTests.swift; sourceTree = "<group>"; };
 		B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScannerTests.swift; sourceTree = "<group>"; };
 		BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachOHeaderReaderTests.swift; sourceTree = "<group>"; };
 		29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScannerTests.swift; sourceTree = "<group>"; };
@@ -427,6 +431,8 @@
 		3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsDashboardSubviews.swift; sourceTree = "<group>"; };
 		FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsView.swift; sourceTree = "<group>"; };
 		FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
+		935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScanner.swift; sourceTree = "<group>"; };
+		8E0159742E841F81FCA30D03 /* UnusedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedApp.swift; sourceTree = "<group>"; };
 		B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScanner.swift; sourceTree = "<group>"; };
 		1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedApp.swift; sourceTree = "<group>"; };
 		7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScanner.swift; sourceTree = "<group>"; };
@@ -644,6 +650,8 @@
 				3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */,
 				FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */,
 				FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */,
+				935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */,
+				8E0159742E841F81FCA30D03 /* UnusedApp.swift */,
 				B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */,
 				1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */,
 				7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */,
@@ -840,6 +848,7 @@
 				8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */,
 				42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */,
 				4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */,
+				9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */,
 				B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */,
 				BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */,
 				29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */,
@@ -1134,6 +1143,7 @@
 				565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */,
 				381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */,
 				6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */,
+				4334DC58726B62F185A4000F /* UnusedAppScannerTests.swift in Sources */,
 				2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */,
 				80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */,
 				3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */,
@@ -1264,6 +1274,8 @@
 				E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */,
 				46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */,
 				78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */,
+				9677B436710A0E80C747C781 /* UnusedAppScanner.swift in Sources */,
+				7023CA5C3D691ED6403E827B /* UnusedApp.swift in Sources */,
 				3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */,
 				ACDE4A29C6C4E5967C7A9BDA /* UnsupportedApp.swift in Sources */,
 				78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
 		6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */; };
+		2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */; };
+		80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */; };
 		3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */; };
 		390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
@@ -98,6 +100,8 @@
 		E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */; };
 		46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */; };
 		78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */; };
+		3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */; };
+		ACDE4A29C6C4E5967C7A9BDA /* UnsupportedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */; };
 		78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */; };
 		82D88268A46FBE614678E869 /* InstallationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D64760E042AC0762B6AC221 /* InstallationFile.swift */; };
 		4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */; };
@@ -374,6 +378,8 @@
 		416D1869BE7C552C78714296 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
 		4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModelTests.swift; sourceTree = "<group>"; };
+		B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScannerTests.swift; sourceTree = "<group>"; };
+		BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachOHeaderReaderTests.swift; sourceTree = "<group>"; };
 		29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScannerTests.swift; sourceTree = "<group>"; };
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
 		42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewSubviews.swift; sourceTree = "<group>"; };
@@ -421,6 +427,8 @@
 		3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsDashboardSubviews.swift; sourceTree = "<group>"; };
 		FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsView.swift; sourceTree = "<group>"; };
 		FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
+		B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScanner.swift; sourceTree = "<group>"; };
+		1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedApp.swift; sourceTree = "<group>"; };
 		7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScanner.swift; sourceTree = "<group>"; };
 		1D64760E042AC0762B6AC221 /* InstallationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFile.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
@@ -636,6 +644,8 @@
 				3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */,
 				FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */,
 				FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */,
+				B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */,
+				1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */,
 				7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */,
 				1D64760E042AC0762B6AC221 /* InstallationFile.swift */,
 				5E978BB01AD677AEDE122B1C /* Assets.xcassets */,
@@ -830,6 +840,8 @@
 				8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */,
 				42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */,
 				4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */,
+				B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */,
+				BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */,
 				29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */,
 				C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */,
 				E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */,
@@ -1122,6 +1134,8 @@
 				565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */,
 				381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */,
 				6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */,
+				2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */,
+				80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */,
 				3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */,
 				65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */,
 				F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */,
@@ -1250,6 +1264,8 @@
 				E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */,
 				46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */,
 				78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */,
+				3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */,
+				ACDE4A29C6C4E5967C7A9BDA /* UnsupportedApp.swift in Sources */,
 				78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */,
 				82D88268A46FBE614678E869 /* InstallationFile.swift in Sources */,
 				9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */,

--- a/VaderCleaner/AppLeftover.swift
+++ b/VaderCleaner/AppLeftover.swift
@@ -1,0 +1,21 @@
+// AppLeftover.swift
+// Value type describing the orphaned support files of an app that is no longer installed, grouped by bundle ID and surfaced on the Applications dashboard's Leftovers card.
+
+import Foundation
+
+/// All the leftover support files found for one uninstalled app's bundle ID,
+/// aggregated across the scanned `~/Library` roots. `id` keys off the bundle ID
+/// so SwiftUI list identity is stable across scans and after rows are removed.
+struct LeftoverGroup: Identifiable, Hashable, Sendable {
+    /// The reverse-DNS bundle ID these files belong to (e.g. `com.acme.App`).
+    let bundleID: String
+    /// A short human-facing label derived from the bundle ID (its last
+    /// component, e.g. "App"), shown as the row title.
+    let displayName: String
+    /// Every leftover file/directory found for this bundle ID, across roots.
+    let urls: [URL]
+    /// Combined size of all `urls`.
+    let totalBytes: Int64
+
+    var id: String { bundleID }
+}

--- a/VaderCleaner/AppLeftoverScanner.swift
+++ b/VaderCleaner/AppLeftoverScanner.swift
@@ -1,0 +1,191 @@
+// AppLeftoverScanner.swift
+// Walks the standard ~/Library support roots and flags reverse-DNS bundle-ID entries that belong to no installed app — the orphaned files an uninstalled app left behind.
+
+import Foundation
+import os.log
+
+/// Test seam between `ApplicationsViewModel` and the on-disk `~/Library` walk.
+protocol AppLeftoverScanning: Sendable {
+    func scan(installedBundleIDs: Set<String>) async -> [LeftoverGroup]
+}
+
+/// Production scanner — lists the immediate contents of the standard support
+/// roots, derives a candidate bundle ID per entry (each root names its entries
+/// differently), and keeps the ones that belong to no installed app.
+///
+/// This is the highest-risk scanner in the section, so the matching is
+/// deliberately conservative and biased toward false negatives:
+///   - only entries whose name is a well-formed reverse-DNS bundle ID
+///     (≥3 dot-separated alphanumeric/hyphen components) are ever considered —
+///     human-named folders like "Google" are ignored;
+///   - Apple (`com.apple.*`) and app-group (`group.*`) IDs are never flagged;
+///   - an entry is treated as belonging to an installed app if its ID matches
+///     an installed bundle ID *or* is a sub-ID of one (e.g. a helper/XPC
+///     service `com.acme.App.Helper` under installed `com.acme.App`).
+/// Removal stays opt-in and routes to the Trash (restorable).
+struct DefaultAppLeftoverScanner: AppLeftoverScanning {
+
+    /// How a root names its entries, which determines how a bundle ID is
+    /// derived from each one.
+    enum RootKind {
+        /// `~/Library/Preferences`: files named `<bundleID>.plist`.
+        case preferences
+        /// `~/Library/Caches`, `Application Support`, `Logs`: entries named
+        /// exactly `<bundleID>`.
+        case bundleNamedEntry
+        /// `~/Library/Saved Application State`: entries named
+        /// `<bundleID>.savedState`.
+        case savedState
+    }
+
+    private let roots: [(url: URL, kind: RootKind)]
+    private let fileManager: FileManager
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "AppLeftoverScanner")
+
+    init(
+        roots: [(url: URL, kind: RootKind)] = DefaultAppLeftoverScanner.defaultRoots(),
+        fileManager: FileManager = .default
+    ) {
+        self.roots = roots
+        self.fileManager = fileManager
+    }
+
+    static func defaultRoots(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> [(url: URL, kind: RootKind)] {
+        let library = homeDirectory.appendingPathComponent("Library", isDirectory: true)
+        return [
+            (library.appendingPathComponent("Application Support", isDirectory: true), .bundleNamedEntry),
+            (library.appendingPathComponent("Caches", isDirectory: true), .bundleNamedEntry),
+            (library.appendingPathComponent("Preferences", isDirectory: true), .preferences),
+            (library.appendingPathComponent("Logs", isDirectory: true), .bundleNamedEntry),
+            (library.appendingPathComponent("Saved Application State", isDirectory: true), .savedState),
+        ]
+    }
+
+    func scan(installedBundleIDs: Set<String>) async -> [LeftoverGroup] {
+        let roots = roots
+        let fileManager = fileManager
+        let log = log
+        return await Task.detached(priority: .userInitiated) {
+            // Aggregate every matching URL under its bundle ID, preserving a
+            // stable discovery order per root.
+            var urlsByBundleID: [String: [URL]] = [:]
+            var order: [String] = []
+
+            for root in roots {
+                guard let entries = try? fileManager.contentsOfDirectory(
+                    at: root.url,
+                    includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles]
+                ) else { continue }
+
+                for entry in entries {
+                    guard let bundleID = Self.candidateBundleID(for: entry, kind: root.kind) else {
+                        continue
+                    }
+                    guard Self.looksLikeBundleID(bundleID),
+                          !Self.isSystemBundleID(bundleID),
+                          !Self.isCoveredByInstalled(bundleID, installed: installedBundleIDs) else {
+                        continue
+                    }
+                    if urlsByBundleID[bundleID] == nil { order.append(bundleID) }
+                    urlsByBundleID[bundleID, default: []].append(entry)
+                }
+            }
+
+            let groups: [LeftoverGroup] = order.map { bundleID in
+                let urls = urlsByBundleID[bundleID] ?? []
+                let total = urls.reduce(Int64(0)) { $0 + Self.size(at: $1, fileManager: fileManager) }
+                return LeftoverGroup(
+                    bundleID: bundleID,
+                    displayName: bundleID.components(separatedBy: ".").last ?? bundleID,
+                    urls: urls,
+                    totalBytes: total
+                )
+            }
+            // Largest first.
+            .sorted { $0.totalBytes > $1.totalBytes }
+
+            log.debug("Leftover scan flagged \(groups.count, privacy: .public) orphaned bundle(s)")
+            return groups
+        }.value
+    }
+
+    // MARK: - Pure matching helpers
+
+    /// Derives the candidate bundle ID from an entry, given its root's naming
+    /// convention. Returns `nil` when the entry doesn't fit the convention.
+    static func candidateBundleID(for url: URL, kind: RootKind) -> String? {
+        let name = url.lastPathComponent
+        switch kind {
+        case .preferences:
+            guard url.pathExtension.caseInsensitiveCompare("plist") == .orderedSame else { return nil }
+            // `com.acme.App.plist` → `com.acme.App`.
+            return url.deletingPathExtension().lastPathComponent
+        case .bundleNamedEntry:
+            return name
+        case .savedState:
+            let suffix = ".savedState"
+            guard name.hasSuffix(suffix) else { return nil }
+            return String(name.dropLast(suffix.count))
+        }
+    }
+
+    /// Whether a string is a well-formed reverse-DNS bundle ID: at least three
+    /// dot-separated components, each a non-empty run of alphanumerics or
+    /// hyphens. Anything looser (human-named folders, two-component names) is
+    /// rejected so the scanner never offers an ambiguous entry for removal.
+    static func looksLikeBundleID(_ string: String) -> Bool {
+        let components = string.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 3 else { return false }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-")
+        for component in components {
+            guard !component.isEmpty else { return false }
+            guard CharacterSet(charactersIn: String(component)).isSubset(of: allowed) else { return false }
+        }
+        return true
+    }
+
+    /// Apple-owned and app-group IDs are never treated as leftovers — their
+    /// support files are managed by macOS, not us.
+    static func isSystemBundleID(_ string: String) -> Bool {
+        string.hasPrefix("com.apple.") || string.hasPrefix("group.")
+    }
+
+    /// Whether the candidate belongs to an installed app — either an exact
+    /// match, or a sub-ID of an installed app (a helper/XPC service like
+    /// `com.acme.App.Helper` under installed `com.acme.App`).
+    static func isCoveredByInstalled(_ candidate: String, installed: Set<String>) -> Bool {
+        if installed.contains(candidate) { return true }
+        return installed.contains { candidate.hasPrefix($0 + ".") }
+    }
+
+    // MARK: - Sizing
+
+    /// Recursive byte size of a file or directory tree. Errors inside the walk
+    /// are tolerated so a single unreadable child never zeros a group.
+    static func size(at url: URL, fileManager: FileManager) -> Int64 {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return 0 }
+        if !isDirectory.boolValue {
+            let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+            return Int64(values?.fileSize ?? 0)
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [],
+            errorHandler: { _, _ in true }
+        ) else { return 0 }
+        var total: Int64 = 0
+        for case let item as URL in enumerator {
+            let values = try? item.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            if values?.isRegularFile == true, let size = values?.fileSize {
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+}

--- a/VaderCleaner/AppUninstallerView.swift
+++ b/VaderCleaner/AppUninstallerView.swift
@@ -25,7 +25,10 @@ struct AppUninstallerView: View {
             .id(phaseTransitionID)
             .transition(.opacity)
             .animation(.smooth(duration: 0.35), value: phaseTransitionID)
-            .navigationTitle(NavigationSection.appUninstaller.title)
+            .navigationTitle(String(
+                localized: "App Uninstaller",
+                comment: "Navigation title for the App Uninstaller screen, reused as an Applications detail screen."
+            ))
             .task {
                 if viewModel.phase == .idle {
                     await viewModel.loadApps()

--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -14,7 +14,10 @@ struct AppUpdaterView: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .navigationTitle(NavigationSection.appUpdater.title)
+            .navigationTitle(String(
+                localized: "App Updater",
+                comment: "Navigation title for the App Updater screen, reused as an Applications detail screen."
+            ))
             .task {
                 if viewModel.phase == .idle {
                     await viewModel.checkForUpdates()

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -15,6 +15,7 @@ struct ApplicationsDashboardView: View {
     let onOpenInstallationFiles: () -> Void
     let onOpenUnsupported: () -> Void
     let onOpenUnused: () -> Void
+    let onOpenLeftovers: () -> Void
     let onRescan: () -> Void
 
     var body: some View {
@@ -94,6 +95,17 @@ struct ApplicationsDashboardView: View {
                 ),
                 identifier: "applications.card.unsupported",
                 action: onOpenUnsupported
+            )
+            ApplicationsCard(
+                title: leftoversTitle,
+                detail: leftoversDetail,
+                icon: "trash",
+                actionLabel: String(
+                    localized: "Review",
+                    comment: "Applications Leftovers card action that opens the leftover list."
+                ),
+                identifier: "applications.card.leftovers",
+                action: onOpenLeftovers
             )
             ApplicationsCard(
                 title: installationFilesTitle,
@@ -222,6 +234,35 @@ struct ApplicationsDashboardView: View {
             localized: "These apps haven't been opened in over 60 days. Remove the ones you no longer need.",
             comment: "Applications Unused card detail when some are found."
         )
+    }
+
+    private var leftoversTitle: String {
+        if result.leftoversCount == 0 {
+            return String(
+                localized: "No App Leftovers",
+                comment: "Applications Leftovers card title when none are found."
+            )
+        }
+        let format = String(
+            localized: "Leftovers From %lld Apps Found",
+            comment: "Applications Leftovers card title; %lld is the orphaned-app count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.leftoversCount))
+    }
+
+    private var leftoversDetail: String {
+        if result.leftoversCount == 0 {
+            return String(
+                localized: "No support files from uninstalled apps were found.",
+                comment: "Applications Leftovers card detail when none are found."
+            )
+        }
+        let size = smartScanByteFormatter.string(fromByteCount: result.leftoversTotalBytes)
+        let format = String(
+            localized: "Support files left behind by apps you've removed are using %@.",
+            comment: "Applications Leftovers card detail; %@ is the reclaimable size."
+        )
+        return String.localizedStringWithFormat(format, size)
     }
 
     private var unsupportedTitle: String {
@@ -819,6 +860,184 @@ private struct UnusedAppRow: View {
             comment: "Unused-app row subtitle; %@ is a relative date like \"3 months ago\"."
         )
         return String.localizedStringWithFormat(format, relative)
+    }
+}
+
+// MARK: - App Leftovers review
+
+/// The App Leftovers detail screen: a multi-select list of orphaned support-file
+/// groups (one per uninstalled app's bundle ID), with a pinned Move to Trash
+/// bar. Removal is opt-in and restorable (Trash).
+struct AppLeftoversReviewView: View {
+    let groups: [LeftoverGroup]
+    let isSelected: (LeftoverGroup) -> Bool
+    let onToggle: (LeftoverGroup) -> Void
+    let onSelectAll: () -> Void
+    let onClear: () -> Void
+    let isRemoving: Bool
+    let canRemove: Bool
+    let onRemove: () -> Void
+
+    private var selected: [LeftoverGroup] { groups.filter(isSelected) }
+    private var selectedBytes: Int64 { selected.reduce(Int64(0)) { $0 + $1.totalBytes } }
+    private var allSelected: Bool { !groups.isEmpty && selected.count == groups.count }
+
+    var body: some View {
+        if groups.isEmpty {
+            emptyState
+        } else {
+            VStack(spacing: 0) {
+                selectAllBar
+                Divider()
+                List {
+                    ForEach(groups) { group in
+                        LeftoverRow(
+                            group: group,
+                            isSelected: isSelected(group),
+                            onToggle: { onToggle(group) }
+                        )
+                        .accessibilityIdentifier("applications.leftovers.row.\(group.bundleID)")
+                    }
+                }
+                .listStyle(.inset)
+                .scrollContentBackground(.hidden)
+                Divider()
+                removeBar
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("applications.leftovers")
+        }
+    }
+
+    private var selectAllBar: some View {
+        HStack {
+            Toggle(isOn: Binding(
+                get: { allSelected },
+                set: { $0 ? onSelectAll() : onClear() }
+            )) {
+                Text(String(
+                    localized: "Select All",
+                    comment: "Toggle that selects/deselects every leftover group."
+                ))
+            }
+            .toggleStyle(.checkbox)
+            .accessibilityIdentifier("applications.leftovers.selectAll")
+            Spacer()
+            Text(headerCountText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+    }
+
+    private var removeBar: some View {
+        HStack(spacing: 12) {
+            Text(selectionSummary)
+                .font(.callout.weight(.medium))
+            Spacer()
+            if isRemoving {
+                ProgressView().controlSize(.small)
+            }
+            Button(String(
+                localized: "Move to Trash",
+                comment: "Button that moves the selected leftover files to the Trash."
+            ), action: onRemove)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canRemove)
+                .accessibilityIdentifier("applications.leftovers.remove")
+        }
+        .padding(16)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+            Text(String(
+                localized: "No app leftovers",
+                comment: "Empty state on the App Leftovers review."
+            ))
+            .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "No support files from uninstalled apps were found.",
+                comment: "Empty-state detail on the App Leftovers review."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("applications.leftovers.empty")
+    }
+
+    private var headerCountText: String {
+        let total = smartScanByteFormatter.string(fromByteCount: groups.reduce(Int64(0)) { $0 + $1.totalBytes })
+        let format = String(
+            localized: "%lld apps · %@",
+            comment: "App Leftovers header count; %lld is the orphaned-app count, %@ the total size."
+        )
+        return String.localizedStringWithFormat(format, Int64(groups.count), total)
+    }
+
+    private var selectionSummary: String {
+        let size = smartScanByteFormatter.string(fromByteCount: selectedBytes)
+        let format = String(
+            localized: "%lld selected · %@",
+            comment: "App Leftovers remove-bar summary; %lld is the selected count, %@ the selected size."
+        )
+        return String.localizedStringWithFormat(format, Int64(selected.count), size)
+    }
+}
+
+/// One leftover-group row: a checkbox, a folder badge, the derived app name,
+/// the bundle ID and file count, and the reclaimable size.
+private struct LeftoverRow: View {
+    let group: LeftoverGroup
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+
+            Image(systemName: "folder.badge.minus")
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(group.displayName)
+                    .font(.body)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer()
+
+            Text(smartScanByteFormatter.string(fromByteCount: group.totalBytes))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onToggle() }
+        .padding(.vertical, 4)
+    }
+
+    private var subtitle: String {
+        let format = String(
+            localized: "%1$@ · %2$lld items",
+            comment: "Leftover row subtitle; %1$@ is the bundle ID, %2$lld the file count."
+        )
+        return String.localizedStringWithFormat(format, group.bundleID, Int64(group.urls.count))
     }
 }
 

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -13,6 +13,7 @@ struct ApplicationsDashboardView: View {
     let onOpenUpdates: () -> Void
     let onOpenManage: () -> Void
     let onOpenInstallationFiles: () -> Void
+    let onOpenUnsupported: () -> Void
     let onRescan: () -> Void
 
     var body: some View {
@@ -70,6 +71,17 @@ struct ApplicationsDashboardView: View {
                 ),
                 identifier: "applications.card.updates",
                 action: onOpenUpdates
+            )
+            ApplicationsCard(
+                title: unsupportedTitle,
+                detail: unsupportedDetail,
+                icon: "exclamationmark.triangle",
+                actionLabel: String(
+                    localized: "Review",
+                    comment: "Applications Unsupported card action that opens the unsupported-app list."
+                ),
+                identifier: "applications.card.unsupported",
+                action: onOpenUnsupported
             )
             ApplicationsCard(
                 title: installationFilesTitle,
@@ -171,6 +183,33 @@ struct ApplicationsDashboardView: View {
             comment: "Applications Installation Files card detail; %@ is the reclaimable size."
         )
         return String.localizedStringWithFormat(format, size)
+    }
+
+    private var unsupportedTitle: String {
+        if result.unsupportedAppsCount == 0 {
+            return String(
+                localized: "No Unsupported Applications",
+                comment: "Applications Unsupported card title when none are found."
+            )
+        }
+        let format = String(
+            localized: "%lld Unsupported Applications Found",
+            comment: "Applications Unsupported card title; %lld is the count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.unsupportedAppsCount))
+    }
+
+    private var unsupportedDetail: String {
+        if result.unsupportedAppsCount == 0 {
+            return String(
+                localized: "Every installed app can run on this version of macOS.",
+                comment: "Applications Unsupported card detail when none are found."
+            )
+        }
+        return String(
+            localized: "These apps won't run on this version of macOS — their code is built only for older architectures.",
+            comment: "Applications Unsupported card detail when some are found."
+        )
     }
 }
 
@@ -395,6 +434,178 @@ private struct InstallationFileRow: View {
             return String(localized: "Disk image", comment: "Installation file kind label.")
         case .package:
             return String(localized: "Installer package", comment: "Installation file kind label.")
+        }
+    }
+}
+
+// MARK: - Unsupported Applications review
+
+/// The Unsupported Applications detail screen: a multi-select list of apps that
+/// can't run on the current macOS, with a pinned Move to Trash bar. Only the
+/// `.app` bundle is removed here; full associated-file cleanup is available via
+/// Manage (the uninstaller).
+struct UnsupportedAppsReviewView: View {
+    let apps: [UnsupportedApp]
+    let isSelected: (UnsupportedApp) -> Bool
+    let onToggle: (UnsupportedApp) -> Void
+    let onSelectAll: () -> Void
+    let onClear: () -> Void
+    let isRemoving: Bool
+    let canRemove: Bool
+    let onRemove: () -> Void
+
+    private var selectedCount: Int { apps.filter(isSelected).count }
+    private var allSelected: Bool { !apps.isEmpty && selectedCount == apps.count }
+
+    var body: some View {
+        if apps.isEmpty {
+            emptyState
+        } else {
+            VStack(spacing: 0) {
+                selectAllBar
+                Divider()
+                List {
+                    ForEach(apps) { entry in
+                        UnsupportedAppRow(
+                            entry: entry,
+                            isSelected: isSelected(entry),
+                            onToggle: { onToggle(entry) }
+                        )
+                        .accessibilityIdentifier("applications.unsupported.row.\(entry.app.bundleID)")
+                    }
+                }
+                .listStyle(.inset)
+                .scrollContentBackground(.hidden)
+                Divider()
+                removeBar
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("applications.unsupported")
+        }
+    }
+
+    private var selectAllBar: some View {
+        HStack {
+            Toggle(isOn: Binding(
+                get: { allSelected },
+                set: { $0 ? onSelectAll() : onClear() }
+            )) {
+                Text(String(
+                    localized: "Select All",
+                    comment: "Toggle that selects/deselects every unsupported app."
+                ))
+            }
+            .toggleStyle(.checkbox)
+            .accessibilityIdentifier("applications.unsupported.selectAll")
+            Spacer()
+            Text(headerCountText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+    }
+
+    private var removeBar: some View {
+        HStack(spacing: 12) {
+            Text(selectionSummary)
+                .font(.callout.weight(.medium))
+            Spacer()
+            if isRemoving {
+                ProgressView().controlSize(.small)
+            }
+            Button(String(
+                localized: "Move to Trash",
+                comment: "Button that moves the selected unsupported apps to the Trash."
+            ), action: onRemove)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canRemove)
+                .accessibilityIdentifier("applications.unsupported.remove")
+        }
+        .padding(16)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+            Text(String(
+                localized: "No unsupported applications",
+                comment: "Empty state on the Unsupported Applications review."
+            ))
+            .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "Every installed app can run on this version of macOS.",
+                comment: "Empty-state detail on the Unsupported Applications review."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("applications.unsupported.empty")
+    }
+
+    private var headerCountText: String {
+        let format = String(
+            localized: "%lld apps",
+            comment: "Unsupported Applications header count."
+        )
+        return String.localizedStringWithFormat(format, Int64(apps.count))
+    }
+
+    private var selectionSummary: String {
+        let format = String(
+            localized: "%lld selected",
+            comment: "Unsupported Applications remove-bar summary; %lld is the selected count."
+        )
+        return String.localizedStringWithFormat(format, Int64(selectedCount))
+    }
+}
+
+/// One unsupported-app row: a checkbox, an alert badge, the app name, and the
+/// reason it can't run.
+private struct UnsupportedAppRow: View {
+    let entry: UnsupportedApp
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 18))
+                .foregroundStyle(.orange)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.app.name)
+                    .font(.body)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(reasonText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onToggle() }
+        .padding(.vertical, 4)
+    }
+
+    private var reasonText: String {
+        switch entry.reason {
+        case .incompatibleArchitecture:
+            return String(
+                localized: "Won't run on this macOS — built for an older architecture",
+                comment: "Reason label for an unsupported app with no runnable architecture."
+            )
         }
     }
 }

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -1,0 +1,230 @@
+// ApplicationsDashboardSubviews.swift
+// Post-scan dashboard for the Applications section — the "N apps found" header, the summary card grid, and the progress / failed states.
+
+import SwiftUI
+
+// MARK: - Dashboard
+
+/// The Applications landing surface after a scan: a headline count, a "Manage
+/// My Applications" affordance, and the summary cards in an adaptive grid —
+/// mirroring the Optimization dashboard's card layout.
+struct ApplicationsDashboardView: View {
+    let result: ApplicationsScanResult
+    let onOpenUpdates: () -> Void
+    let onOpenManage: () -> Void
+    let onRescan: () -> Void
+
+    var body: some View {
+        VStack(spacing: 28) {
+            header
+            grid
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        .accessibilityIdentifier("applications.dashboard")
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Text(installedCountText)
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("applications.installedCount")
+
+            HStack(spacing: 12) {
+                Button(action: onOpenManage) {
+                    Text(String(
+                        localized: "Manage My Applications",
+                        comment: "Button that opens the full installed-apps management (uninstaller) list."
+                    ))
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("applications.manageMyApplications")
+
+                Button(action: onRescan) {
+                    Text(String(
+                        localized: "Rescan",
+                        comment: "Button that re-runs the Applications scan."
+                    ))
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("applications.rescan")
+            }
+        }
+    }
+
+    private var grid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 260), spacing: 16)],
+            alignment: .leading,
+            spacing: 16
+        ) {
+            ApplicationsCard(
+                title: updatesTitle,
+                detail: updatesDetail,
+                icon: "arrow.triangle.2.circlepath",
+                actionLabel: String(
+                    localized: "Review",
+                    comment: "Applications Updates card action that opens the update list."
+                ),
+                identifier: "applications.card.updates",
+                action: onOpenUpdates
+            )
+            ApplicationsCard(
+                title: String(
+                    localized: "Manage Applications",
+                    comment: "Applications management card title."
+                ),
+                detail: manageDetail,
+                icon: "square.grid.2x2",
+                actionLabel: String(
+                    localized: "Manage",
+                    comment: "Applications management card action."
+                ),
+                identifier: "applications.card.manage",
+                action: onOpenManage
+            )
+        }
+    }
+
+    // MARK: Copy
+
+    private var installedCountText: String {
+        let format = String(
+            localized: "We've found %lld apps on your Mac.",
+            comment: "Applications dashboard headline; %lld is the installed-app count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.installedCount))
+    }
+
+    private var updatesTitle: String {
+        if result.updatesCount == 0 {
+            return String(
+                localized: "No Updates Available",
+                comment: "Applications Updates card title when every app is current."
+            )
+        }
+        let format = String(
+            localized: "%lld Application Updates Available",
+            comment: "Applications Updates card title; %lld is the available-update count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.updatesCount))
+    }
+
+    private var updatesDetail: String {
+        if result.updatesCount == 0 {
+            return String(
+                localized: "All your apps are running the latest version.",
+                comment: "Applications Updates card detail when no updates are available."
+            )
+        }
+        return String(
+            localized: "Update your software to keep up with the latest features and compatibility improvements.",
+            comment: "Applications Updates card detail when updates are available."
+        )
+    }
+
+    private var manageDetail: String {
+        let format = String(
+            localized: "Browse all %lld installed apps and remove the ones you no longer need, along with their leftover files.",
+            comment: "Applications management card detail; %lld is the installed-app count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.installedCount))
+    }
+}
+
+/// A single Applications summary card. Uses the same glass surface and corner
+/// radius as the Optimization / Smart Scan dashboards so the app's card
+/// surfaces stay consistent.
+struct ApplicationsCard: View {
+    let title: String
+    let detail: String
+    let icon: String
+    let actionLabel: String
+    let identifier: String
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Text(title)
+                    .font(.headline)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                Image(systemName: icon)
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+            }
+            Text(detail)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 8)
+            HStack {
+                Spacer()
+                Button(actionLabel, action: action)
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier(identifier)
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+    }
+}
+
+// MARK: - Progress
+
+/// Centered spinner shown while the Applications scan runs.
+struct ApplicationsProgressState: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text(String(
+                localized: "Scanning your applications…",
+                comment: "Progress label shown while the Applications scan runs."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("applications.loading")
+    }
+}
+
+// MARK: - Failed
+
+/// Error state for a failed Applications scan, with a retry that re-runs it.
+struct ApplicationsFailedState: View {
+    let message: String
+    let onTryAgain: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+            Text(String(
+                localized: "Couldn't scan your applications",
+                comment: "Title shown on the Applications scan failure screen."
+            ))
+            .font(.title2.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 460)
+                .accessibilityIdentifier("applications.errorMessage")
+            Button(String(
+                localized: "Try Again",
+                comment: "Retry button on the Applications scan failure screen."
+            ), action: onTryAgain)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("applications.tryAgain")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -526,6 +526,7 @@ private struct InstallationFileRow: View {
 /// Manage (the uninstaller).
 struct UnsupportedAppsReviewView: View {
     let apps: [UnsupportedApp]
+    var iconCache: AppIconCache
     let isSelected: (UnsupportedApp) -> Bool
     let onToggle: (UnsupportedApp) -> Void
     let onSelectAll: () -> Void
@@ -548,6 +549,7 @@ struct UnsupportedAppsReviewView: View {
                     ForEach(apps) { entry in
                         UnsupportedAppRow(
                             entry: entry,
+                            iconCache: iconCache,
                             isSelected: isSelected(entry),
                             onToggle: { onToggle(entry) }
                         )
@@ -561,6 +563,9 @@ struct UnsupportedAppsReviewView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .accessibilityIdentifier("applications.unsupported")
+            .task(id: apps.map(\.id)) {
+                await iconCache.preloadIcons(for: apps.map(\.app.bundleURL))
+            }
         }
     }
 
@@ -648,6 +653,7 @@ struct UnsupportedAppsReviewView: View {
 /// reason it can't run.
 private struct UnsupportedAppRow: View {
     let entry: UnsupportedApp
+    var iconCache: AppIconCache
     let isSelected: Bool
     let onToggle: () -> Void
 
@@ -657,10 +663,9 @@ private struct UnsupportedAppRow: View {
                 .toggleStyle(.checkbox)
                 .labelsHidden()
 
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 18))
-                .foregroundStyle(.orange)
-                .frame(width: 24)
+            Image(nsImage: iconCache.icon(for: entry.app.bundleURL))
+                .resizable()
+                .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(entry.app.name)
@@ -697,6 +702,7 @@ private struct UnsupportedAppRow: View {
 /// bundle is moved here; full associated-file cleanup is available via Manage.
 struct UnusedAppsReviewView: View {
     let apps: [UnusedApp]
+    var iconCache: AppIconCache
     let isSelected: (UnusedApp) -> Bool
     let onToggle: (UnusedApp) -> Void
     let onSelectAll: () -> Void
@@ -719,6 +725,7 @@ struct UnusedAppsReviewView: View {
                     ForEach(apps) { entry in
                         UnusedAppRow(
                             entry: entry,
+                            iconCache: iconCache,
                             isSelected: isSelected(entry),
                             onToggle: { onToggle(entry) }
                         )
@@ -732,6 +739,9 @@ struct UnusedAppsReviewView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .accessibilityIdentifier("applications.unused")
+            .task(id: apps.map(\.id)) {
+                await iconCache.preloadIcons(for: apps.map(\.app.bundleURL))
+            }
         }
     }
 
@@ -816,6 +826,7 @@ struct UnusedAppsReviewView: View {
 /// since it was last opened.
 private struct UnusedAppRow: View {
     let entry: UnusedApp
+    var iconCache: AppIconCache
     let isSelected: Bool
     let onToggle: () -> Void
 
@@ -831,10 +842,9 @@ private struct UnusedAppRow: View {
                 .toggleStyle(.checkbox)
                 .labelsHidden()
 
-            Image(systemName: "moon.zzz.fill")
-                .font(.system(size: 18))
-                .foregroundStyle(.secondary)
-                .frame(width: 24)
+            Image(nsImage: iconCache.icon(for: entry.app.bundleURL))
+                .resizable()
+                .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(entry.app.name)

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -74,55 +74,68 @@ struct ApplicationsDashboardView: View {
         String(localized: "Review", comment: "Applications card action that opens a review list.")
     }
 
-    private var cardSpecs: [CardSpec] {
-        [
-            CardSpec(id: "applications.card.updates", title: updatesTitle, detail: updatesDetail,
-                     icon: "arrow.triangle.2.circlepath", actionLabel: reviewLabel, action: onOpenUpdates),
-            CardSpec(id: "applications.card.unused", title: unusedTitle, detail: unusedDetail,
-                     icon: "moon.zzz", actionLabel: reviewLabel, action: onOpenUnused),
-            CardSpec(id: "applications.card.unsupported", title: unsupportedTitle, detail: unsupportedDetail,
-                     icon: "exclamationmark.triangle", actionLabel: reviewLabel, action: onOpenUnsupported),
-            CardSpec(id: "applications.card.leftovers", title: leftoversTitle, detail: leftoversDetail,
-                     icon: "trash", actionLabel: reviewLabel, action: onOpenLeftovers),
-            CardSpec(id: "applications.card.installationFiles", title: installationFilesTitle,
-                     detail: installationFilesDetail, icon: "shippingbox", actionLabel: reviewLabel,
-                     action: onOpenInstallationFiles),
-            CardSpec(id: "applications.card.manage",
-                     title: String(localized: "Manage Applications", comment: "Applications management card title."),
-                     detail: manageDetail, icon: "square.grid.2x2",
-                     actionLabel: String(localized: "Manage", comment: "Applications management card action."),
-                     action: onOpenManage),
-        ]
+    /// Height of a standard card, and of a tall card — a tall card spans
+    /// exactly two standard cards plus the gap between them, so the two columns
+    /// stay the same total height (each is one tall + two standard + two gaps).
+    private let standardCardHeight: CGFloat = 150
+    private var tallCardHeight: CGFloat { standardCardHeight * 2 + 16 }
+
+    private var updatesSpec: CardSpec {
+        CardSpec(id: "applications.card.updates", title: updatesTitle, detail: updatesDetail,
+                 icon: "arrow.triangle.2.circlepath", actionLabel: reviewLabel, action: onOpenUpdates)
+    }
+    private var unusedSpec: CardSpec {
+        CardSpec(id: "applications.card.unused", title: unusedTitle, detail: unusedDetail,
+                 icon: "moon.zzz", actionLabel: reviewLabel, action: onOpenUnused)
+    }
+    private var unsupportedSpec: CardSpec {
+        CardSpec(id: "applications.card.unsupported", title: unsupportedTitle, detail: unsupportedDetail,
+                 icon: "exclamationmark.triangle", actionLabel: reviewLabel, action: onOpenUnsupported)
+    }
+    private var leftoversSpec: CardSpec {
+        CardSpec(id: "applications.card.leftovers", title: leftoversTitle, detail: leftoversDetail,
+                 icon: "trash", actionLabel: reviewLabel, action: onOpenLeftovers)
+    }
+    private var installationFilesSpec: CardSpec {
+        CardSpec(id: "applications.card.installationFiles", title: installationFilesTitle,
+                 detail: installationFilesDetail, icon: "shippingbox", actionLabel: reviewLabel,
+                 action: onOpenInstallationFiles)
+    }
+    private var manageSpec: CardSpec {
+        CardSpec(id: "applications.card.manage",
+                 title: String(localized: "Manage Applications", comment: "Applications management card title."),
+                 detail: manageDetail, icon: "square.grid.2x2",
+                 actionLabel: String(localized: "Manage", comment: "Applications management card action."),
+                 action: onOpenManage)
     }
 
-    /// A tall hero card on the left (the first spec) beside an adaptive grid of
-    /// the remaining cards, so the cards no longer all share one size.
+    /// Two-column masonry. The left column leads with the tall Updates card
+    /// over two standard cards; the right column mirrors it with two standard
+    /// cards over the tall Leftovers card — so the two tall tiles sit on a
+    /// diagonal and the columns stay equal height.
     private var grid: some View {
         HStack(alignment: .top, spacing: 16) {
-            if let hero = cardSpecs.first {
-                card(hero, isHero: true)
-                    .frame(maxWidth: 320)
+            VStack(spacing: 16) {
+                card(updatesSpec, height: tallCardHeight)
+                card(installationFilesSpec, height: standardCardHeight)
+                card(manageSpec, height: standardCardHeight)
             }
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 260), spacing: 16)],
-                alignment: .leading,
-                spacing: 16
-            ) {
-                ForEach(Array(cardSpecs.dropFirst())) { spec in
-                    card(spec, isHero: false)
-                }
+            VStack(spacing: 16) {
+                card(unusedSpec, height: standardCardHeight)
+                card(unsupportedSpec, height: standardCardHeight)
+                card(leftoversSpec, height: tallCardHeight)
             }
         }
     }
 
-    private func card(_ spec: CardSpec, isHero: Bool) -> some View {
+    private func card(_ spec: CardSpec, height: CGFloat) -> some View {
         ApplicationsCard(
             title: spec.title,
             detail: spec.detail,
             icon: spec.icon,
             actionLabel: spec.actionLabel,
             identifier: spec.id,
-            isHero: isHero,
+            height: height,
             action: spec.action
         )
     }
@@ -294,9 +307,10 @@ struct ApplicationsCard: View {
     let icon: String
     let actionLabel: String
     let identifier: String
-    /// Hero cards render taller (matching the Optimization dashboard's lead
-    /// card) so the grid isn't a uniform row of equal-size tiles.
-    var isHero: Bool = false
+    /// Fixed card height set by the layout — tall cards span two standard cards
+    /// so the grid isn't a uniform row of equal-size tiles. A fixed height (not
+    /// a min) keeps the card from stretching to fill its column.
+    let height: CGFloat
     let action: () -> Void
 
     var body: some View {
@@ -323,7 +337,7 @@ struct ApplicationsCard: View {
             }
         }
         .padding(18)
-        .frame(maxWidth: .infinity, minHeight: isHero ? 260 : 150, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: height, maxHeight: height, alignment: .leading)
         .glassEffect(.regular, in: .rect(cornerRadius: 12))
     }
 }

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -12,6 +12,7 @@ struct ApplicationsDashboardView: View {
     let result: ApplicationsScanResult
     let onOpenUpdates: () -> Void
     let onOpenManage: () -> Void
+    let onOpenInstallationFiles: () -> Void
     let onRescan: () -> Void
 
     var body: some View {
@@ -69,6 +70,17 @@ struct ApplicationsDashboardView: View {
                 ),
                 identifier: "applications.card.updates",
                 action: onOpenUpdates
+            )
+            ApplicationsCard(
+                title: installationFilesTitle,
+                detail: installationFilesDetail,
+                icon: "shippingbox",
+                actionLabel: String(
+                    localized: "Review",
+                    comment: "Applications Installation Files card action that opens the installer list."
+                ),
+                identifier: "applications.card.installationFiles",
+                action: onOpenInstallationFiles
             )
             ApplicationsCard(
                 title: String(
@@ -131,6 +143,35 @@ struct ApplicationsDashboardView: View {
         )
         return String.localizedStringWithFormat(format, Int64(result.installedCount))
     }
+
+    private var installationFilesTitle: String {
+        if result.installationFilesCount == 0 {
+            return String(
+                localized: "No Installation Files",
+                comment: "Applications Installation Files card title when none are found."
+            )
+        }
+        let format = String(
+            localized: "%lld Installation Files Found",
+            comment: "Applications Installation Files card title; %lld is the installer count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.installationFilesCount))
+    }
+
+    private var installationFilesDetail: String {
+        if result.installationFilesCount == 0 {
+            return String(
+                localized: "No leftover disk images or installer packages in your Downloads or Desktop.",
+                comment: "Applications Installation Files card detail when none are found."
+            )
+        }
+        let size = smartScanByteFormatter.string(fromByteCount: result.installationFilesTotalBytes)
+        let format = String(
+            localized: "Leftover disk images and installers in your Downloads and Desktop are using %@. They're safe to remove once an app is installed.",
+            comment: "Applications Installation Files card detail; %@ is the reclaimable size."
+        )
+        return String.localizedStringWithFormat(format, size)
+    }
 }
 
 /// A single Applications summary card. Uses the same glass surface and corner
@@ -170,6 +211,191 @@ struct ApplicationsCard: View {
         .padding(18)
         .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
         .glassEffect(.regular, in: .rect(cornerRadius: 12))
+    }
+}
+
+// MARK: - Installation Files review
+
+/// The Installation Files detail screen: a multi-select list of leftover
+/// installers with a pinned Remove bar that moves the selected ones to the
+/// Trash. Selection is opt-in (destructive), mirroring the Large & Old Files
+/// review.
+struct InstallationFilesReviewView: View {
+    let files: [InstallationFile]
+    let isSelected: (InstallationFile) -> Bool
+    let onToggle: (InstallationFile) -> Void
+    let onSelectAll: () -> Void
+    let onClear: () -> Void
+    let isRemoving: Bool
+    let canRemove: Bool
+    let onRemove: () -> Void
+
+    private var selectedFiles: [InstallationFile] { files.filter(isSelected) }
+    private var selectedBytes: Int64 { selectedFiles.reduce(Int64(0)) { $0 + $1.sizeBytes } }
+    private var allSelected: Bool { !files.isEmpty && selectedFiles.count == files.count }
+
+    var body: some View {
+        if files.isEmpty {
+            emptyState
+        } else {
+            VStack(spacing: 0) {
+                selectAllBar
+                Divider()
+                List {
+                    ForEach(files) { file in
+                        InstallationFileRow(
+                            file: file,
+                            isSelected: isSelected(file),
+                            onToggle: { onToggle(file) }
+                        )
+                        .accessibilityIdentifier("applications.installationFiles.row.\(file.name)")
+                    }
+                }
+                .listStyle(.inset)
+                .scrollContentBackground(.hidden)
+                Divider()
+                removeBar
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("applications.installationFiles")
+        }
+    }
+
+    private var selectAllBar: some View {
+        HStack {
+            Toggle(isOn: Binding(
+                get: { allSelected },
+                set: { $0 ? onSelectAll() : onClear() }
+            )) {
+                Text(String(
+                    localized: "Select All",
+                    comment: "Toggle that selects/deselects every installation file."
+                ))
+            }
+            .toggleStyle(.checkbox)
+            .accessibilityIdentifier("applications.installationFiles.selectAll")
+            Spacer()
+            Text(countText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+    }
+
+    private var removeBar: some View {
+        HStack(spacing: 12) {
+            Text(selectionSummary)
+                .font(.callout.weight(.medium))
+            Spacer()
+            if isRemoving {
+                ProgressView().controlSize(.small)
+            }
+            Button(String(
+                localized: "Move to Trash",
+                comment: "Button that moves the selected installation files to the Trash."
+            ), action: onRemove)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canRemove)
+                .accessibilityIdentifier("applications.installationFiles.remove")
+        }
+        .padding(16)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+            Text(String(
+                localized: "No installation files",
+                comment: "Empty state on the Installation Files review."
+            ))
+            .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "Your Downloads and Desktop have no leftover disk images or installer packages.",
+                comment: "Empty-state detail on the Installation Files review."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("applications.installationFiles.empty")
+    }
+
+    private var countText: String {
+        let total = smartScanByteFormatter.string(fromByteCount: files.reduce(Int64(0)) { $0 + $1.sizeBytes })
+        let format = String(
+            localized: "%lld files · %@",
+            comment: "Installation Files header count; %lld is the count, %@ the total size."
+        )
+        return String.localizedStringWithFormat(format, Int64(files.count), total)
+    }
+
+    private var selectionSummary: String {
+        let size = smartScanByteFormatter.string(fromByteCount: selectedBytes)
+        let format = String(
+            localized: "%lld selected · %@",
+            comment: "Installation Files remove-bar summary; %lld is the selected count, %@ the selected size."
+        )
+        return String.localizedStringWithFormat(format, Int64(selectedFiles.count), size)
+    }
+}
+
+/// One installation-file row: a checkbox, a kind badge, the file name, and its
+/// size.
+private struct InstallationFileRow: View {
+    let file: InstallationFile
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+
+            Image(systemName: kindSymbol)
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(file.name)
+                    .font(.body)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(kindLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(smartScanByteFormatter.string(fromByteCount: file.sizeBytes))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onToggle() }
+        .padding(.vertical, 4)
+    }
+
+    private var kindSymbol: String {
+        switch file.kind {
+        case .diskImage: return "opticaldiscdrive"
+        case .package:   return "shippingbox"
+        }
+    }
+
+    private var kindLabel: String {
+        switch file.kind {
+        case .diskImage:
+            return String(localized: "Disk image", comment: "Installation file kind label.")
+        case .package:
+            return String(localized: "Installer package", comment: "Installation file kind label.")
+        }
     }
 }
 

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -57,82 +57,74 @@ struct ApplicationsDashboardView: View {
         }
     }
 
+    /// One dashboard card's content. Built as data so the layout can promote
+    /// the first one to a tall hero and flow the rest through an adaptive grid
+    /// (mirroring the Optimization dashboard), rather than every card sharing
+    /// one fixed size.
+    private struct CardSpec: Identifiable {
+        let id: String
+        let title: String
+        let detail: String
+        let icon: String
+        let actionLabel: String
+        let action: () -> Void
+    }
+
+    private var reviewLabel: String {
+        String(localized: "Review", comment: "Applications card action that opens a review list.")
+    }
+
+    private var cardSpecs: [CardSpec] {
+        [
+            CardSpec(id: "applications.card.updates", title: updatesTitle, detail: updatesDetail,
+                     icon: "arrow.triangle.2.circlepath", actionLabel: reviewLabel, action: onOpenUpdates),
+            CardSpec(id: "applications.card.unused", title: unusedTitle, detail: unusedDetail,
+                     icon: "moon.zzz", actionLabel: reviewLabel, action: onOpenUnused),
+            CardSpec(id: "applications.card.unsupported", title: unsupportedTitle, detail: unsupportedDetail,
+                     icon: "exclamationmark.triangle", actionLabel: reviewLabel, action: onOpenUnsupported),
+            CardSpec(id: "applications.card.leftovers", title: leftoversTitle, detail: leftoversDetail,
+                     icon: "trash", actionLabel: reviewLabel, action: onOpenLeftovers),
+            CardSpec(id: "applications.card.installationFiles", title: installationFilesTitle,
+                     detail: installationFilesDetail, icon: "shippingbox", actionLabel: reviewLabel,
+                     action: onOpenInstallationFiles),
+            CardSpec(id: "applications.card.manage",
+                     title: String(localized: "Manage Applications", comment: "Applications management card title."),
+                     detail: manageDetail, icon: "square.grid.2x2",
+                     actionLabel: String(localized: "Manage", comment: "Applications management card action."),
+                     action: onOpenManage),
+        ]
+    }
+
+    /// A tall hero card on the left (the first spec) beside an adaptive grid of
+    /// the remaining cards, so the cards no longer all share one size.
     private var grid: some View {
-        LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 260), spacing: 16)],
-            alignment: .leading,
-            spacing: 16
-        ) {
-            ApplicationsCard(
-                title: updatesTitle,
-                detail: updatesDetail,
-                icon: "arrow.triangle.2.circlepath",
-                actionLabel: String(
-                    localized: "Review",
-                    comment: "Applications Updates card action that opens the update list."
-                ),
-                identifier: "applications.card.updates",
-                action: onOpenUpdates
-            )
-            ApplicationsCard(
-                title: unusedTitle,
-                detail: unusedDetail,
-                icon: "moon.zzz",
-                actionLabel: String(
-                    localized: "Review",
-                    comment: "Applications Unused card action that opens the unused-app list."
-                ),
-                identifier: "applications.card.unused",
-                action: onOpenUnused
-            )
-            ApplicationsCard(
-                title: unsupportedTitle,
-                detail: unsupportedDetail,
-                icon: "exclamationmark.triangle",
-                actionLabel: String(
-                    localized: "Review",
-                    comment: "Applications Unsupported card action that opens the unsupported-app list."
-                ),
-                identifier: "applications.card.unsupported",
-                action: onOpenUnsupported
-            )
-            ApplicationsCard(
-                title: leftoversTitle,
-                detail: leftoversDetail,
-                icon: "trash",
-                actionLabel: String(
-                    localized: "Review",
-                    comment: "Applications Leftovers card action that opens the leftover list."
-                ),
-                identifier: "applications.card.leftovers",
-                action: onOpenLeftovers
-            )
-            ApplicationsCard(
-                title: installationFilesTitle,
-                detail: installationFilesDetail,
-                icon: "shippingbox",
-                actionLabel: String(
-                    localized: "Review",
-                    comment: "Applications Installation Files card action that opens the installer list."
-                ),
-                identifier: "applications.card.installationFiles",
-                action: onOpenInstallationFiles
-            )
-            ApplicationsCard(
-                title: String(
-                    localized: "Manage Applications",
-                    comment: "Applications management card title."
-                ),
-                detail: manageDetail,
-                icon: "square.grid.2x2",
-                actionLabel: String(
-                    localized: "Manage",
-                    comment: "Applications management card action."
-                ),
-                identifier: "applications.card.manage",
-                action: onOpenManage
-            )
+        HStack(alignment: .top, spacing: 16) {
+            if let hero = cardSpecs.first {
+                card(hero, isHero: true)
+                    .frame(maxWidth: 320)
+            }
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 260), spacing: 16)],
+                alignment: .leading,
+                spacing: 16
+            ) {
+                ForEach(Array(cardSpecs.dropFirst())) { spec in
+                    card(spec, isHero: false)
+                }
+            }
         }
+    }
+
+    private func card(_ spec: CardSpec, isHero: Bool) -> some View {
+        ApplicationsCard(
+            title: spec.title,
+            detail: spec.detail,
+            icon: spec.icon,
+            actionLabel: spec.actionLabel,
+            identifier: spec.id,
+            isHero: isHero,
+            action: spec.action
+        )
     }
 
     // MARK: Copy
@@ -302,6 +294,9 @@ struct ApplicationsCard: View {
     let icon: String
     let actionLabel: String
     let identifier: String
+    /// Hero cards render taller (matching the Optimization dashboard's lead
+    /// card) so the grid isn't a uniform row of equal-size tiles.
+    var isHero: Bool = false
     let action: () -> Void
 
     var body: some View {
@@ -328,7 +323,7 @@ struct ApplicationsCard: View {
             }
         }
         .padding(18)
-        .frame(maxWidth: .infinity, minHeight: 150, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: isHero ? 260 : 150, alignment: .leading)
         .glassEffect(.regular, in: .rect(cornerRadius: 12))
     }
 }

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -14,6 +14,7 @@ struct ApplicationsDashboardView: View {
     let onOpenManage: () -> Void
     let onOpenInstallationFiles: () -> Void
     let onOpenUnsupported: () -> Void
+    let onOpenUnused: () -> Void
     let onRescan: () -> Void
 
     var body: some View {
@@ -71,6 +72,17 @@ struct ApplicationsDashboardView: View {
                 ),
                 identifier: "applications.card.updates",
                 action: onOpenUpdates
+            )
+            ApplicationsCard(
+                title: unusedTitle,
+                detail: unusedDetail,
+                icon: "moon.zzz",
+                actionLabel: String(
+                    localized: "Review",
+                    comment: "Applications Unused card action that opens the unused-app list."
+                ),
+                identifier: "applications.card.unused",
+                action: onOpenUnused
             )
             ApplicationsCard(
                 title: unsupportedTitle,
@@ -183,6 +195,33 @@ struct ApplicationsDashboardView: View {
             comment: "Applications Installation Files card detail; %@ is the reclaimable size."
         )
         return String.localizedStringWithFormat(format, size)
+    }
+
+    private var unusedTitle: String {
+        if result.unusedAppsCount == 0 {
+            return String(
+                localized: "No Unused Applications",
+                comment: "Applications Unused card title when none are found."
+            )
+        }
+        let format = String(
+            localized: "%lld Unused Applications Found",
+            comment: "Applications Unused card title; %lld is the count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.unusedAppsCount))
+    }
+
+    private var unusedDetail: String {
+        if result.unusedAppsCount == 0 {
+            return String(
+                localized: "Every app has been opened recently.",
+                comment: "Applications Unused card detail when none are found."
+            )
+        }
+        return String(
+            localized: "These apps haven't been opened in over 60 days. Remove the ones you no longer need.",
+            comment: "Applications Unused card detail when some are found."
+        )
     }
 
     private var unsupportedTitle: String {
@@ -607,6 +646,179 @@ private struct UnsupportedAppRow: View {
                 comment: "Reason label for an unsupported app with no runnable architecture."
             )
         }
+    }
+}
+
+// MARK: - Unused Applications review
+
+/// The Unused Applications detail screen: a multi-select list of apps not
+/// opened in a long time, with a pinned Move to Trash bar. Only the `.app`
+/// bundle is moved here; full associated-file cleanup is available via Manage.
+struct UnusedAppsReviewView: View {
+    let apps: [UnusedApp]
+    let isSelected: (UnusedApp) -> Bool
+    let onToggle: (UnusedApp) -> Void
+    let onSelectAll: () -> Void
+    let onClear: () -> Void
+    let isRemoving: Bool
+    let canRemove: Bool
+    let onRemove: () -> Void
+
+    private var selectedCount: Int { apps.filter(isSelected).count }
+    private var allSelected: Bool { !apps.isEmpty && selectedCount == apps.count }
+
+    var body: some View {
+        if apps.isEmpty {
+            emptyState
+        } else {
+            VStack(spacing: 0) {
+                selectAllBar
+                Divider()
+                List {
+                    ForEach(apps) { entry in
+                        UnusedAppRow(
+                            entry: entry,
+                            isSelected: isSelected(entry),
+                            onToggle: { onToggle(entry) }
+                        )
+                        .accessibilityIdentifier("applications.unused.row.\(entry.app.bundleID)")
+                    }
+                }
+                .listStyle(.inset)
+                .scrollContentBackground(.hidden)
+                Divider()
+                removeBar
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("applications.unused")
+        }
+    }
+
+    private var selectAllBar: some View {
+        HStack {
+            Toggle(isOn: Binding(
+                get: { allSelected },
+                set: { $0 ? onSelectAll() : onClear() }
+            )) {
+                Text(String(
+                    localized: "Select All",
+                    comment: "Toggle that selects/deselects every unused app."
+                ))
+            }
+            .toggleStyle(.checkbox)
+            .accessibilityIdentifier("applications.unused.selectAll")
+            Spacer()
+            Text(headerCountText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+    }
+
+    private var removeBar: some View {
+        HStack(spacing: 12) {
+            Text(selectionSummary)
+                .font(.callout.weight(.medium))
+            Spacer()
+            if isRemoving {
+                ProgressView().controlSize(.small)
+            }
+            Button(String(
+                localized: "Move to Trash",
+                comment: "Button that moves the selected unused apps to the Trash."
+            ), action: onRemove)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canRemove)
+                .accessibilityIdentifier("applications.unused.remove")
+        }
+        .padding(16)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+            Text(String(
+                localized: "No unused applications",
+                comment: "Empty state on the Unused Applications review."
+            ))
+            .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "Every installed app has been opened recently.",
+                comment: "Empty-state detail on the Unused Applications review."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 420)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("applications.unused.empty")
+    }
+
+    private var headerCountText: String {
+        let format = String(localized: "%lld apps", comment: "Unused Applications header count.")
+        return String.localizedStringWithFormat(format, Int64(apps.count))
+    }
+
+    private var selectionSummary: String {
+        let format = String(
+            localized: "%lld selected",
+            comment: "Unused Applications remove-bar summary; %lld is the selected count."
+        )
+        return String.localizedStringWithFormat(format, Int64(selectedCount))
+    }
+}
+
+/// One unused-app row: a checkbox, a sleep badge, the app name, and how long
+/// since it was last opened.
+private struct UnusedAppRow: View {
+    let entry: UnusedApp
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .full
+        return f
+    }()
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+
+            Image(systemName: "moon.zzz.fill")
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.app.name)
+                    .font(.body)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(lastUsedText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onToggle() }
+        .padding(.vertical, 4)
+    }
+
+    private var lastUsedText: String {
+        let relative = Self.relativeFormatter.localizedString(for: entry.lastUsedDate, relativeTo: Date())
+        let format = String(
+            localized: "Last opened %@",
+            comment: "Unused-app row subtitle; %@ is a relative date like \"3 months ago\"."
+        )
+        return String.localizedStringWithFormat(format, relative)
     }
 }
 

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -19,11 +19,11 @@ struct ApplicationsDashboardView: View {
     let onRescan: () -> Void
 
     var body: some View {
-        VStack(spacing: 28) {
+        VStack(spacing: 24) {
             header
             grid
         }
-        .frame(maxWidth: .infinity, alignment: .top)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .accessibilityIdentifier("applications.dashboard")
     }
 
@@ -74,11 +74,10 @@ struct ApplicationsDashboardView: View {
         String(localized: "Review", comment: "Applications card action that opens a review list.")
     }
 
-    /// Height of a standard card, and of a tall card — a tall card spans
-    /// exactly two standard cards plus the gap between them, so the two columns
-    /// stay the same total height (each is one tall + two standard + two gaps).
-    private let standardCardHeight: CGFloat = 150
-    private var tallCardHeight: CGFloat { standardCardHeight * 2 + 16 }
+    /// Gap between cards, and the floor a standard card never shrinks below so
+    /// its title + a line of detail + the button stay legible on short windows.
+    private let cardGap: CGFloat = 16
+    private let minStandardCardHeight: CGFloat = 132
 
     private var updatesSpec: CardSpec {
         CardSpec(id: "applications.card.updates", title: updatesTitle, detail: updatesDetail,
@@ -109,22 +108,30 @@ struct ApplicationsDashboardView: View {
                  action: onOpenManage)
     }
 
-    /// Two-column masonry. The left column leads with the tall Updates card
-    /// over two standard cards; the right column mirrors it with two standard
-    /// cards over the tall Leftovers card — so the two tall tiles sit on a
-    /// diagonal and the columns stay equal height.
+    /// Two-column masonry that fills the available height so the dashboard
+    /// never needs to scroll. Each column is one tall card + two standard cards
+    /// + two gaps, and a tall card spans exactly two standard cards plus a gap —
+    /// so a column is four "standard heights" plus three gaps. We solve for the
+    /// standard height that makes the columns exactly fill the height the
+    /// `GeometryReader` reports, flooring it so cards stay legible when the
+    /// window is short (the only case the content can exceed the viewport).
     private var grid: some View {
-        HStack(alignment: .top, spacing: 16) {
-            VStack(spacing: 16) {
-                card(updatesSpec, height: tallCardHeight)
-                card(installationFilesSpec, height: standardCardHeight)
-                card(manageSpec, height: standardCardHeight)
+        GeometryReader { proxy in
+            let standard = max(minStandardCardHeight, (proxy.size.height - cardGap * 3) / 4)
+            let tall = standard * 2 + cardGap
+            HStack(alignment: .top, spacing: cardGap) {
+                VStack(spacing: cardGap) {
+                    card(updatesSpec, height: tall)
+                    card(installationFilesSpec, height: standard)
+                    card(manageSpec, height: standard)
+                }
+                VStack(spacing: cardGap) {
+                    card(unusedSpec, height: standard)
+                    card(unsupportedSpec, height: standard)
+                    card(leftoversSpec, height: tall)
+                }
             }
-            VStack(spacing: 16) {
-                card(unusedSpec, height: standardCardHeight)
-                card(unsupportedSpec, height: standardCardHeight)
-                card(leftoversSpec, height: tallCardHeight)
-            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
     }
 
@@ -324,10 +331,13 @@ struct ApplicationsCard: View {
                     .font(.title2)
                     .foregroundStyle(.tint)
             }
+            // Truncates rather than forcing its full height, so a short card
+            // (on a small window) never overflows its fixed frame.
             Text(detail)
                 .font(.callout)
                 .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+                .lineLimit(4)
+                .multilineTextAlignment(.leading)
             Spacer(minLength: 8)
             HStack {
                 Spacer()

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -28,6 +28,7 @@ struct ApplicationsView: View {
         case updates
         case manage
         case installationFiles
+        case unsupported
     }
 
     init(
@@ -77,6 +78,7 @@ struct ApplicationsView: View {
                     onOpenUpdates: { detail = .updates },
                     onOpenManage: { detail = .manage },
                     onOpenInstallationFiles: { detail = .installationFiles },
+                    onOpenUnsupported: { detail = .unsupported },
                     onRescan: { Task { await viewModel.scan() } }
                 )
                 .padding(24)
@@ -116,6 +118,24 @@ struct ApplicationsView: View {
                     isRemoving: viewModel.isRemovingInstallationFiles,
                     canRemove: viewModel.canRemoveInstallationFiles,
                     onRemove: { Task { await viewModel.deleteSelectedInstallationFiles() } }
+                )
+            }
+        case .unsupported:
+            detailScreen(
+                title: String(
+                    localized: "Unsupported Applications",
+                    comment: "Title of the Applications Unsupported detail screen."
+                )
+            ) {
+                UnsupportedAppsReviewView(
+                    apps: result.unsupportedApps,
+                    isSelected: viewModel.isUnsupportedAppSelected,
+                    onToggle: viewModel.toggleUnsupportedApp,
+                    onSelectAll: viewModel.selectAllUnsupportedApps,
+                    onClear: viewModel.clearUnsupportedAppSelection,
+                    isRemoving: viewModel.isRemovingUnsupportedApps,
+                    canRemove: viewModel.canRemoveUnsupportedApps,
+                    onRemove: { Task { await viewModel.deleteSelectedUnsupportedApps() } }
                 )
             }
         }
@@ -165,6 +185,7 @@ struct ApplicationsView: View {
             discoverApps: { [] },
             checkUpdates: { _ in [] },
             scanInstallationFiles: { [] },
+            scanUnsupportedApps: { _ in [] },
             recycleFiles: { Set($0) }
         ),
         uninstallerViewModel: AppUninstallerViewModel(

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -79,20 +79,20 @@ struct ApplicationsView: View {
     private func resultsContent(_ result: ApplicationsScanResult) -> some View {
         switch detail {
         case .dashboard:
-            ScrollView {
-                ApplicationsDashboardView(
-                    result: result,
-                    onOpenUpdates: { detail = .updates },
-                    onOpenManage: { detail = .manage },
-                    onOpenInstallationFiles: { detail = .installationFiles },
-                    onOpenUnsupported: { detail = .unsupported },
-                    onOpenUnused: { detail = .unused },
-                    onOpenLeftovers: { detail = .leftovers },
-                    onRescan: { Task { await viewModel.scan() } }
-                )
-                .padding(24)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            // No ScrollView: the grid sizes its cards to the available height
+            // so the whole dashboard fits the window without scrolling.
+            ApplicationsDashboardView(
+                result: result,
+                onOpenUpdates: { detail = .updates },
+                onOpenManage: { detail = .manage },
+                onOpenInstallationFiles: { detail = .installationFiles },
+                onOpenUnsupported: { detail = .unsupported },
+                onOpenUnused: { detail = .unused },
+                onOpenLeftovers: { detail = .leftovers },
+                onRescan: { Task { await viewModel.scan() } }
+            )
+            .padding(24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         case .updates:
             detailScreen(
                 title: String(

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -30,6 +30,7 @@ struct ApplicationsView: View {
         case installationFiles
         case unsupported
         case unused
+        case leftovers
     }
 
     init(
@@ -81,6 +82,7 @@ struct ApplicationsView: View {
                     onOpenInstallationFiles: { detail = .installationFiles },
                     onOpenUnsupported: { detail = .unsupported },
                     onOpenUnused: { detail = .unused },
+                    onOpenLeftovers: { detail = .leftovers },
                     onRescan: { Task { await viewModel.scan() } }
                 )
                 .padding(24)
@@ -158,6 +160,24 @@ struct ApplicationsView: View {
                     onRemove: { Task { await viewModel.deleteSelectedUnusedApps() } }
                 )
             }
+        case .leftovers:
+            detailScreen(
+                title: String(
+                    localized: "App Leftovers",
+                    comment: "Title of the Applications Leftovers detail screen."
+                )
+            ) {
+                AppLeftoversReviewView(
+                    groups: result.leftovers,
+                    isSelected: viewModel.isLeftoverSelected,
+                    onToggle: viewModel.toggleLeftover,
+                    onSelectAll: viewModel.selectAllLeftovers,
+                    onClear: viewModel.clearLeftoverSelection,
+                    isRemoving: viewModel.isRemovingLeftovers,
+                    canRemove: viewModel.canRemoveLeftovers,
+                    onRemove: { Task { await viewModel.deleteSelectedLeftovers() } }
+                )
+            }
         }
     }
 
@@ -207,6 +227,7 @@ struct ApplicationsView: View {
             scanInstallationFiles: { [] },
             scanUnsupportedApps: { _ in [] },
             scanUnusedApps: { _ in [] },
+            scanLeftovers: { _ in [] },
             recycleFiles: { Set($0) }
         ),
         uninstallerViewModel: AppUninstallerViewModel(

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -103,14 +103,17 @@ struct ApplicationsView: View {
                 AppUpdaterView(viewModel: updaterViewModel)
             }
         case .manage:
-            detailScreen(
-                title: String(
-                    localized: "Manage Applications",
-                    comment: "Title of the Applications management detail screen."
-                )
-            ) {
-                AppUninstallerView(viewModel: uninstallerViewModel)
-            }
+            // Full multi-pane manager (Uninstaller / Updater / Leftovers),
+            // styled like the Optimization "View All Tasks" catalog — it owns
+            // its own header, so it is not wrapped in `detailScreen`.
+            ApplicationsManagerView(
+                viewModel: viewModel,
+                uninstallerViewModel: uninstallerViewModel,
+                updaterViewModel: updaterViewModel,
+                result: result,
+                iconCache: iconCache,
+                onBack: { detail = .dashboard }
+            )
         case .installationFiles:
             detailScreen(
                 title: String(
@@ -222,6 +225,154 @@ struct ApplicationsView: View {
             Divider()
             screen()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+/// The "Applications Manager" reached from the dashboard's Manage card. Mirrors
+/// the Optimization "View All Tasks" catalog (`OptimizationTaskCatalogView`): a
+/// header with a Back affordance and a centered title, a left sub-navigation,
+/// and a detail pane. The three panes reuse the existing Uninstaller, Updater,
+/// and Leftovers screens so all the management work lives in one place.
+struct ApplicationsManagerView: View {
+
+    private var viewModel: ApplicationsViewModel
+    private var uninstallerViewModel: AppUninstallerViewModel
+    private var updaterViewModel: AppUpdaterViewModel
+    private let result: ApplicationsScanResult
+    private var iconCache: AppIconCache
+    private let onBack: () -> Void
+
+    /// Which sub-section the manager is showing. Local state — it survives the
+    /// view's re-renders while the manager is open, and resets when the user
+    /// returns to the dashboard and comes back.
+    @State private var pane: Pane = .uninstaller
+
+    enum Pane: Hashable {
+        case uninstaller
+        case updater
+        case leftovers
+    }
+
+    init(
+        viewModel: ApplicationsViewModel,
+        uninstallerViewModel: AppUninstallerViewModel,
+        updaterViewModel: AppUpdaterViewModel,
+        result: ApplicationsScanResult,
+        iconCache: AppIconCache,
+        onBack: @escaping () -> Void
+    ) {
+        self.viewModel = viewModel
+        self.uninstallerViewModel = uninstallerViewModel
+        self.updaterViewModel = updaterViewModel
+        self.result = result
+        self.iconCache = iconCache
+        self.onBack = onBack
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            HStack(spacing: 0) {
+                subNavigation
+                    .frame(width: 220)
+                    .padding(16)
+                Divider()
+                detailPane
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("applications.manager")
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack {
+            Button(action: onBack) {
+                // HStack(Image, Text) rather than Label so the control surfaces
+                // reliably in XCUITest.
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text(String(
+                        localized: "Back",
+                        comment: "Back button returning from the Applications Manager to the dashboard."
+                    ))
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("applications.backToDashboard")
+            Spacer()
+            Text(String(
+                localized: "Applications Manager",
+                comment: "Title of the Applications Manager catalog."
+            ))
+            .font(.headline)
+            Spacer()
+            // Balances the leading Back button so the title stays centred.
+            Color.clear.frame(width: 44, height: 1)
+        }
+        .padding(16)
+    }
+
+    // MARK: Sub-navigation
+
+    private var subNavigation: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            navItem(.uninstaller,
+                    String(localized: "Uninstaller", comment: "Applications Manager sub-nav item."),
+                    "applications.manager.nav.uninstaller")
+            navItem(.updater,
+                    String(localized: "Updater", comment: "Applications Manager sub-nav item."),
+                    "applications.manager.nav.updater")
+            navItem(.leftovers,
+                    String(localized: "Leftovers", comment: "Applications Manager sub-nav item."),
+                    "applications.manager.nav.leftovers")
+            Spacer()
+        }
+    }
+
+    private func navItem(_ target: Pane, _ title: String, _ identifier: String) -> some View {
+        Button {
+            pane = target
+        } label: {
+            Text(title)
+                .font(.body.weight(pane == target ? .semibold : .regular))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    pane == target ? Color.primary.opacity(0.10) : .clear,
+                    in: .rect(cornerRadius: 8)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+
+    // MARK: Detail pane
+
+    @ViewBuilder
+    private var detailPane: some View {
+        switch pane {
+        case .uninstaller:
+            AppUninstallerView(viewModel: uninstallerViewModel, iconCache: iconCache)
+        case .updater:
+            AppUpdaterView(viewModel: updaterViewModel)
+        case .leftovers:
+            AppLeftoversReviewView(
+                groups: result.leftovers,
+                isSelected: viewModel.isLeftoverSelected,
+                onToggle: viewModel.toggleLeftover,
+                onSelectAll: viewModel.selectAllLeftovers,
+                onClear: viewModel.clearLeftoverSelection,
+                isRemoving: viewModel.isRemovingLeftovers,
+                canRemove: viewModel.canRemoveLeftovers,
+                onRemove: { Task { await viewModel.deleteSelectedLeftovers() } }
+            )
         }
     }
 }

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -1,0 +1,162 @@
+// ApplicationsView.swift
+// Detail view for the Applications section — renders the post-scan dashboard grid and pushes to the reused App Updater / App Uninstaller screens.
+
+import SwiftUI
+
+/// Detail view shown when the user selects "Applications" in the sidebar and
+/// runs the scan. The intro screen and floating Scan disc are supplied by
+/// `ScannableSectionContent` + `ContentView`; this view owns the `.scanning`,
+/// `.results`, and `.failed` phases.
+///
+/// The summary grid pushes to the existing `AppUpdaterView` and
+/// `AppUninstallerView`, reused unchanged as detail screens — the new
+/// `ApplicationsViewModel` only produces the dashboard metrics.
+struct ApplicationsView: View {
+
+    private var viewModel: ApplicationsViewModel
+    private var uninstallerViewModel: AppUninstallerViewModel
+    private var updaterViewModel: AppUpdaterViewModel
+
+    /// Which screen the results surface is showing — the dashboard grid, or one
+    /// of the pushed detail screens. Owned here so the selection survives the
+    /// brief remount when the underlying detail view loads.
+    @State private var detail: Detail = .dashboard
+
+    /// The results surface's three screens.
+    private enum Detail {
+        case dashboard
+        case updates
+        case manage
+    }
+
+    init(
+        viewModel: ApplicationsViewModel,
+        uninstallerViewModel: AppUninstallerViewModel,
+        updaterViewModel: AppUpdaterViewModel
+    ) {
+        self.viewModel = viewModel
+        self.uninstallerViewModel = uninstallerViewModel
+        self.updaterViewModel = updaterViewModel
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(NavigationSection.applications.title)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.phase {
+        case .idle:
+            // Unreachable: ContentView shows the unified SectionIntroView while
+            // the coordinator reports `.intro` (which `.idle` maps to), so the
+            // detail view is never built in this phase. The arm stays only to
+            // keep the switch exhaustive over `Phase`.
+            EmptyView()
+        case .scanning:
+            ApplicationsProgressState()
+        case .results(let result):
+            resultsContent(result)
+        case .failed(let message):
+            ApplicationsFailedState(
+                message: message,
+                onTryAgain: { Task { await viewModel.scan() } }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func resultsContent(_ result: ApplicationsScanResult) -> some View {
+        switch detail {
+        case .dashboard:
+            ScrollView {
+                ApplicationsDashboardView(
+                    result: result,
+                    onOpenUpdates: { detail = .updates },
+                    onOpenManage: { detail = .manage },
+                    onRescan: { Task { await viewModel.scan() } }
+                )
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .updates:
+            detailScreen(
+                title: String(
+                    localized: "Updates",
+                    comment: "Title of the Applications Updates detail screen."
+                )
+            ) {
+                AppUpdaterView(viewModel: updaterViewModel)
+            }
+        case .manage:
+            detailScreen(
+                title: String(
+                    localized: "Manage Applications",
+                    comment: "Title of the Applications management detail screen."
+                )
+            ) {
+                AppUninstallerView(viewModel: uninstallerViewModel)
+            }
+        }
+    }
+
+    /// Wraps a reused detail screen with a Back bar that returns to the grid.
+    /// Mirrors `OptimizationTaskCatalogView`'s header layout.
+    private func detailScreen<Content: View>(
+        title: String,
+        @ViewBuilder _ screen: () -> Content
+    ) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button {
+                    detail = .dashboard
+                } label: {
+                    // HStack(Image, Text) rather than Label so the control
+                    // surfaces reliably in XCUITest.
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text(String(
+                            localized: "Back",
+                            comment: "Back button returning from an Applications detail screen to the dashboard."
+                        ))
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("applications.backToDashboard")
+                Spacer()
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                // Balances the leading Back button so the title stays centred.
+                Color.clear.frame(width: 44, height: 1)
+            }
+            .padding(16)
+            Divider()
+            screen()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+#Preview {
+    ApplicationsView(
+        viewModel: ApplicationsViewModel(
+            discoverApps: { [] },
+            checkUpdates: { _ in [] }
+        ),
+        uninstallerViewModel: AppUninstallerViewModel(
+            discover: { _ in [] },
+            findFiles: { _ in [] },
+            recycle: { _, _ in AppUninstallerViewModel.RecycleOutcome(bytesFreed: 0, bundlePermanentlyRemoved: false) }
+        ),
+        updaterViewModel: AppUpdaterViewModel(
+            discover: { _ in [] },
+            checkAppStore: { _ in .noResult },
+            checkSparkle: { _ in .noResult },
+            opener: { _ in }
+        )
+    )
+    .frame(width: 900, height: 600)
+    .environment(ExclusionsStore(defaults: UserDefaults(suiteName: "preview")!))
+}

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -29,6 +29,7 @@ struct ApplicationsView: View {
         case manage
         case installationFiles
         case unsupported
+        case unused
     }
 
     init(
@@ -79,6 +80,7 @@ struct ApplicationsView: View {
                     onOpenManage: { detail = .manage },
                     onOpenInstallationFiles: { detail = .installationFiles },
                     onOpenUnsupported: { detail = .unsupported },
+                    onOpenUnused: { detail = .unused },
                     onRescan: { Task { await viewModel.scan() } }
                 )
                 .padding(24)
@@ -138,6 +140,24 @@ struct ApplicationsView: View {
                     onRemove: { Task { await viewModel.deleteSelectedUnsupportedApps() } }
                 )
             }
+        case .unused:
+            detailScreen(
+                title: String(
+                    localized: "Unused Applications",
+                    comment: "Title of the Applications Unused detail screen."
+                )
+            ) {
+                UnusedAppsReviewView(
+                    apps: result.unusedApps,
+                    isSelected: viewModel.isUnusedAppSelected,
+                    onToggle: viewModel.toggleUnusedApp,
+                    onSelectAll: viewModel.selectAllUnusedApps,
+                    onClear: viewModel.clearUnusedAppSelection,
+                    isRemoving: viewModel.isRemovingUnusedApps,
+                    canRemove: viewModel.canRemoveUnusedApps,
+                    onRemove: { Task { await viewModel.deleteSelectedUnusedApps() } }
+                )
+            }
         }
     }
 
@@ -186,6 +206,7 @@ struct ApplicationsView: View {
             checkUpdates: { _ in [] },
             scanInstallationFiles: { [] },
             scanUnsupportedApps: { _ in [] },
+            scanUnusedApps: { _ in [] },
             recycleFiles: { Set($0) }
         ),
         uninstallerViewModel: AppUninstallerViewModel(

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -17,6 +17,11 @@ struct ApplicationsView: View {
     private var uninstallerViewModel: AppUninstallerViewModel
     private var updaterViewModel: AppUpdaterViewModel
 
+    /// Shared icon cache so the Unused / Unsupported review rows show each
+    /// app's real icon instead of a generic glyph. Pre-loaded off the main
+    /// thread by the review screens when they appear.
+    @State private var iconCache = AppIconCache()
+
     /// Which screen the results surface is showing — the dashboard grid, or one
     /// of the pushed detail screens. Owned here so the selection survives the
     /// brief remount when the underlying detail view loads.
@@ -133,6 +138,7 @@ struct ApplicationsView: View {
             ) {
                 UnsupportedAppsReviewView(
                     apps: result.unsupportedApps,
+                    iconCache: iconCache,
                     isSelected: viewModel.isUnsupportedAppSelected,
                     onToggle: viewModel.toggleUnsupportedApp,
                     onSelectAll: viewModel.selectAllUnsupportedApps,
@@ -151,6 +157,7 @@ struct ApplicationsView: View {
             ) {
                 UnusedAppsReviewView(
                     apps: result.unusedApps,
+                    iconCache: iconCache,
                     isSelected: viewModel.isUnusedAppSelected,
                     onToggle: viewModel.toggleUnusedApp,
                     onSelectAll: viewModel.selectAllUnusedApps,

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -22,11 +22,12 @@ struct ApplicationsView: View {
     /// brief remount when the underlying detail view loads.
     @State private var detail: Detail = .dashboard
 
-    /// The results surface's three screens.
+    /// The results surface's screens.
     private enum Detail {
         case dashboard
         case updates
         case manage
+        case installationFiles
     }
 
     init(
@@ -75,6 +76,7 @@ struct ApplicationsView: View {
                     result: result,
                     onOpenUpdates: { detail = .updates },
                     onOpenManage: { detail = .manage },
+                    onOpenInstallationFiles: { detail = .installationFiles },
                     onRescan: { Task { await viewModel.scan() } }
                 )
                 .padding(24)
@@ -97,6 +99,24 @@ struct ApplicationsView: View {
                 )
             ) {
                 AppUninstallerView(viewModel: uninstallerViewModel)
+            }
+        case .installationFiles:
+            detailScreen(
+                title: String(
+                    localized: "Installation Files",
+                    comment: "Title of the Applications Installation Files detail screen."
+                )
+            ) {
+                InstallationFilesReviewView(
+                    files: result.installationFiles,
+                    isSelected: viewModel.isInstallationFileSelected,
+                    onToggle: viewModel.toggleInstallationFile,
+                    onSelectAll: viewModel.selectAllInstallationFiles,
+                    onClear: viewModel.clearInstallationFileSelection,
+                    isRemoving: viewModel.isRemovingInstallationFiles,
+                    canRemove: viewModel.canRemoveInstallationFiles,
+                    onRemove: { Task { await viewModel.deleteSelectedInstallationFiles() } }
+                )
             }
         }
     }
@@ -143,7 +163,9 @@ struct ApplicationsView: View {
     ApplicationsView(
         viewModel: ApplicationsViewModel(
             discoverApps: { [] },
-            checkUpdates: { _ in [] }
+            checkUpdates: { _ in [] },
+            scanInstallationFiles: { [] },
+            recycleFiles: { Set($0) }
         ),
         uninstallerViewModel: AppUninstallerViewModel(
             discover: { _ in [] },

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -19,6 +19,7 @@ struct ApplicationsScanResult: Equatable {
     var installationFiles: [InstallationFile]
     var unsupportedApps: [UnsupportedApp]
     var unusedApps: [UnusedApp]
+    var leftovers: [LeftoverGroup]
 
     /// "We've found N apps on your Mac." headline figure.
     var installedCount: Int { installedApps.count }
@@ -35,6 +36,13 @@ struct ApplicationsScanResult: Equatable {
     var unsupportedAppsCount: Int { unsupportedApps.count }
     /// Unused Applications card count.
     var unusedAppsCount: Int { unusedApps.count }
+    /// App Leftovers card count (one per orphaned bundle ID).
+    var leftoversCount: Int { leftovers.count }
+    /// Sum of every leftover group's size — the Leftovers card's reclaimable
+    /// figure.
+    var leftoversTotalBytes: Int64 {
+        leftovers.reduce(Int64(0)) { $0 + $1.totalBytes }
+    }
 }
 
 /// Drives the Applications feature view (scan → results). Collaborators are
@@ -75,6 +83,10 @@ final class ApplicationsViewModel {
     /// Unused-app scan source over the discovered apps. Non-throwing and
     /// best-effort, same partial-degradation contract as `CheckUpdates`.
     typealias ScanUnusedApps = @Sendable ([AppInfo]) async -> [UnusedApp]
+    /// Leftover scan source. Takes the installed bundle IDs so the scan can
+    /// tell orphaned support files from installed apps'. Non-throwing and
+    /// best-effort, same partial-degradation contract as `CheckUpdates`.
+    typealias ScanLeftovers = @Sendable (Set<String>) async -> [LeftoverGroup]
     /// Moves the given files to the Trash and returns the set of URLs actually
     /// recycled. Partial success is the norm (a locked file must not abort the
     /// batch), so the return is the success set — mirroring
@@ -103,11 +115,18 @@ final class ApplicationsViewModel {
     /// True while an unused-app recycle batch is in flight.
     private(set) var isRemovingUnusedApps = false
 
+    /// Per-group gate for the App Leftovers review screen, keyed by the
+    /// orphaned bundle ID. Seeded *empty* — removal is destructive and opt-in.
+    private(set) var leftoverSelection: Set<String> = []
+    /// True while a leftover recycle batch is in flight.
+    private(set) var isRemovingLeftovers = false
+
     @ObservationIgnored private let discoverApps: DiscoverApps
     @ObservationIgnored private let checkUpdates: CheckUpdates
     @ObservationIgnored private let scanInstallationFiles: ScanInstallationFiles
     @ObservationIgnored private let scanUnsupportedApps: ScanUnsupportedApps
     @ObservationIgnored private let scanUnusedApps: ScanUnusedApps
+    @ObservationIgnored private let scanLeftovers: ScanLeftovers
     @ObservationIgnored private let recycleFiles: RecycleFiles
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "ApplicationsViewModel")
@@ -122,6 +141,7 @@ final class ApplicationsViewModel {
         scanInstallationFiles: @escaping ScanInstallationFiles,
         scanUnsupportedApps: @escaping ScanUnsupportedApps,
         scanUnusedApps: @escaping ScanUnusedApps,
+        scanLeftovers: @escaping ScanLeftovers,
         recycleFiles: @escaping RecycleFiles
     ) {
         self.discoverApps = discoverApps
@@ -129,6 +149,7 @@ final class ApplicationsViewModel {
         self.scanInstallationFiles = scanInstallationFiles
         self.scanUnsupportedApps = scanUnsupportedApps
         self.scanUnusedApps = scanUnusedApps
+        self.scanLeftovers = scanLeftovers
         self.recycleFiles = recycleFiles
     }
 
@@ -153,6 +174,7 @@ final class ApplicationsViewModel {
         installationFileSelection = []
         unsupportedAppSelection = []
         unusedAppSelection = []
+        leftoverSelection = []
 
         do {
             // The installer scan is independent of app discovery, so run it
@@ -160,21 +182,27 @@ final class ApplicationsViewModel {
             async let installersAsync = scanInstallationFiles()
             let apps = try await discoverApps()
             // The update check and the per-app scans all need the discovered
-            // apps, so fan them out concurrently once they're known.
+            // apps, so fan them out concurrently once they're known. The
+            // leftover scan needs the installed bundle IDs to tell orphans
+            // from installed apps' support files.
+            let installedBundleIDs = Set(apps.map(\.bundleID))
             async let updatesAsync = checkUpdates(apps)
             async let unsupportedAsync = scanUnsupportedApps(apps)
             async let unusedAsync = scanUnusedApps(apps)
+            async let leftoversAsync = scanLeftovers(installedBundleIDs)
             let installers = await installersAsync
             let updates = await updatesAsync
             let unsupported = await unsupportedAsync
             let unused = await unusedAsync
+            let leftovers = await leftoversAsync
             guard scanGeneration == generation else { return }
             phase = .results(ApplicationsScanResult(
                 installedApps: apps,
                 availableUpdates: updates,
                 installationFiles: installers,
                 unsupportedApps: unsupported,
-                unusedApps: unused
+                unusedApps: unused,
+                leftovers: leftovers
             ))
         } catch {
             // Privacy: errors may include user-specific paths.
@@ -191,6 +219,7 @@ final class ApplicationsViewModel {
         installationFileSelection = []
         unsupportedAppSelection = []
         unusedAppSelection = []
+        leftoverSelection = []
     }
 
     // MARK: - Installation files selection
@@ -354,6 +383,68 @@ final class ApplicationsViewModel {
         phase = .results(current)
         unusedAppSelection.subtract(removed)
     }
+
+    // MARK: - Leftovers selection
+
+    func isLeftoverSelected(_ group: LeftoverGroup) -> Bool {
+        leftoverSelection.contains(group.bundleID)
+    }
+
+    func toggleLeftover(_ group: LeftoverGroup) {
+        if leftoverSelection.contains(group.bundleID) {
+            leftoverSelection.remove(group.bundleID)
+        } else {
+            leftoverSelection.insert(group.bundleID)
+        }
+    }
+
+    func selectAllLeftovers() {
+        guard case .results(let result) = phase else { return }
+        leftoverSelection = Set(result.leftovers.map(\.bundleID))
+    }
+
+    func clearLeftoverSelection() {
+        leftoverSelection = []
+    }
+
+    /// Whether a Remove press would actually recycle anything right now.
+    var canRemoveLeftovers: Bool {
+        !leftoverSelection.isEmpty && !isRemovingLeftovers
+    }
+
+    // MARK: - Leftovers removal
+
+    /// Moves every file in the selected leftover groups to the Trash and
+    /// rebuilds the payload: a group whose files were all recycled is dropped;
+    /// a partially-recycled group keeps its surviving files (so the user can
+    /// retry). A no-op unless results are showing and at least one group is
+    /// selected.
+    func deleteSelectedLeftovers() async {
+        guard case .results(let result) = phase else { return }
+        let targets = result.leftovers.filter { leftoverSelection.contains($0.bundleID) }
+        guard !targets.isEmpty, !isRemovingLeftovers else { return }
+
+        isRemovingLeftovers = true
+        let removed = await recycleFiles(targets.flatMap { $0.urls })
+        isRemovingLeftovers = false
+
+        guard case .results(var current) = phase else { return }
+        current.leftovers = current.leftovers.compactMap { group in
+            let survivingURLs = group.urls.filter { !removed.contains($0) }
+            if survivingURLs.isEmpty { return nil }
+            if survivingURLs.count == group.urls.count { return group }
+            // Some files moved, some didn't — keep the group with what's left.
+            return LeftoverGroup(
+                bundleID: group.bundleID,
+                displayName: group.displayName,
+                urls: survivingURLs,
+                totalBytes: group.totalBytes
+            )
+        }
+        phase = .results(current)
+        // Drop selections for groups that fully disappeared.
+        leftoverSelection = leftoverSelection.intersection(Set(current.leftovers.map(\.bundleID)))
+    }
 }
 
 // MARK: - Production wiring
@@ -372,6 +463,7 @@ extension ApplicationsViewModel {
         let installerScanner = DefaultInstallationFileScanner()
         let unsupportedScanner = DefaultUnsupportedAppScanner()
         let unusedScanner = DefaultUnusedAppScanner()
+        let leftoverScanner = DefaultAppLeftoverScanner()
         let log = Logger(subsystem: "com.personal.VaderCleaner",
                          category: "ApplicationsViewModel.live")
         return ApplicationsViewModel(
@@ -389,6 +481,9 @@ extension ApplicationsViewModel {
             },
             scanUnusedApps: { apps in
                 await unusedScanner.scan(apps: apps)
+            },
+            scanLeftovers: { installedBundleIDs in
+                await leftoverScanner.scan(installedBundleIDs: installedBundleIDs)
             },
             recycleFiles: { urls in
                 await Self.recycle(urls, log: log)

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -14,11 +14,19 @@ import os.log
 struct ApplicationsScanResult: Equatable {
     let installedApps: [AppInfo]
     let availableUpdates: [UpdateInfo]
+    let installationFiles: [InstallationFile]
 
     /// "We've found N apps on your Mac." headline figure.
     var installedCount: Int { installedApps.count }
     /// Updates card count.
     var updatesCount: Int { availableUpdates.count }
+    /// Installation Files card count.
+    var installationFilesCount: Int { installationFiles.count }
+    /// Sum of the leftover installers' sizes — the Installation Files card's
+    /// "reclaimable" figure.
+    var installationFilesTotalBytes: Int64 {
+        installationFiles.reduce(Int64(0)) { $0 + $1.sizeBytes }
+    }
 }
 
 /// Drives the Applications feature view (scan → results). Collaborators are
@@ -50,11 +58,29 @@ final class ApplicationsViewModel {
     /// `[]` rather than sinking an otherwise-useful scan (the production wiring
     /// swallows per-app failures), matching the Smart Scan Applications tile.
     typealias CheckUpdates = @Sendable ([AppInfo]) async -> [UpdateInfo]
+    /// Installation-file scan source. Non-throwing and best-effort, same
+    /// partial-degradation contract as `CheckUpdates`.
+    typealias ScanInstallationFiles = @Sendable () async -> [InstallationFile]
+    /// Moves the given files to the Trash and returns the set of URLs actually
+    /// recycled. Partial success is the norm (a locked file must not abort the
+    /// batch), so the return is the success set — mirroring
+    /// `LargeOldFilesViewModel.Deleter`.
+    typealias RecycleFiles = @Sendable ([URL]) async -> Set<URL>
 
     private(set) var phase: Phase = .idle
 
+    /// Per-file gate for the Installation Files review screen, keyed by URL.
+    /// Seeded *empty* — removal is destructive, so the user opts each installer
+    /// in explicitly, matching `LargeOldFilesViewModel`.
+    private(set) var installationFileSelection: Set<URL> = []
+    /// True while a recycle batch is in flight, so the review screen can show a
+    /// spinner and disable its Remove button.
+    private(set) var isRemovingInstallationFiles = false
+
     @ObservationIgnored private let discoverApps: DiscoverApps
     @ObservationIgnored private let checkUpdates: CheckUpdates
+    @ObservationIgnored private let scanInstallationFiles: ScanInstallationFiles
+    @ObservationIgnored private let recycleFiles: RecycleFiles
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "ApplicationsViewModel")
 
@@ -64,10 +90,14 @@ final class ApplicationsViewModel {
 
     init(
         discoverApps: @escaping DiscoverApps,
-        checkUpdates: @escaping CheckUpdates
+        checkUpdates: @escaping CheckUpdates,
+        scanInstallationFiles: @escaping ScanInstallationFiles,
+        recycleFiles: @escaping RecycleFiles
     ) {
         self.discoverApps = discoverApps
         self.checkUpdates = checkUpdates
+        self.scanInstallationFiles = scanInstallationFiles
+        self.recycleFiles = recycleFiles
     }
 
     // MARK: - Scan
@@ -88,14 +118,20 @@ final class ApplicationsViewModel {
         phase = .scanning
         scanGeneration &+= 1
         let generation = scanGeneration
+        installationFileSelection = []
 
         do {
+            // The installer scan is independent of app discovery, so run it
+            // concurrently with the discover → update-check chain.
+            async let installersAsync = scanInstallationFiles()
             let apps = try await discoverApps()
             let updates = await checkUpdates(apps)
+            let installers = await installersAsync
             guard scanGeneration == generation else { return }
             phase = .results(ApplicationsScanResult(
                 installedApps: apps,
-                availableUpdates: updates
+                availableUpdates: updates,
+                installationFiles: installers
             ))
         } catch {
             // Privacy: errors may include user-specific paths.
@@ -109,6 +145,69 @@ final class ApplicationsViewModel {
     /// the intro screen.
     func reset() {
         phase = .idle
+        installationFileSelection = []
+    }
+
+    // MARK: - Installation files selection
+
+    func isInstallationFileSelected(_ file: InstallationFile) -> Bool {
+        installationFileSelection.contains(file.url)
+    }
+
+    func toggleInstallationFile(_ file: InstallationFile) {
+        if installationFileSelection.contains(file.url) {
+            installationFileSelection.remove(file.url)
+        } else {
+            installationFileSelection.insert(file.url)
+        }
+    }
+
+    /// Opt every found installer in for removal in one write to the selection
+    /// set, so SwiftUI observes a single publish instead of N.
+    func selectAllInstallationFiles() {
+        guard case .results(let result) = phase else { return }
+        installationFileSelection = Set(result.installationFiles.map(\.url))
+    }
+
+    /// Opt every installer back out — single-write counterpart to
+    /// `selectAllInstallationFiles()`.
+    func clearInstallationFileSelection() {
+        installationFileSelection = []
+    }
+
+    /// Whether a Remove press would actually recycle anything right now.
+    var canRemoveInstallationFiles: Bool {
+        !installationFileSelection.isEmpty && !isRemovingInstallationFiles
+    }
+
+    // MARK: - Installation files removal
+
+    /// Moves the selected installers to the Trash and rebuilds the results
+    /// payload with the survivors, so the dashboard card count and the review
+    /// list both reflect what was actually removed. A no-op unless results are
+    /// showing and at least one installer is selected.
+    func deleteSelectedInstallationFiles() async {
+        guard case .results(let result) = phase else { return }
+        let targets = result.installationFiles.filter {
+            installationFileSelection.contains($0.url)
+        }
+        guard !targets.isEmpty, !isRemovingInstallationFiles else { return }
+
+        isRemovingInstallationFiles = true
+        let removed = await recycleFiles(targets.map(\.url))
+        isRemovingInstallationFiles = false
+
+        // The recycle hop is async; only rewrite the payload if we are still
+        // showing the same kind of results (a `reset()` / rescan during the
+        // batch supersedes it).
+        guard case .results(let current) = phase else { return }
+        let survivors = current.installationFiles.filter { !removed.contains($0.url) }
+        phase = .results(ApplicationsScanResult(
+            installedApps: current.installedApps,
+            availableUpdates: current.availableUpdates,
+            installationFiles: survivors
+        ))
+        installationFileSelection.subtract(removed)
     }
 }
 
@@ -125,6 +224,7 @@ extension ApplicationsViewModel {
         let discovery = DefaultAppDiscovery()
         let appStore = DefaultAppStoreUpdateChecker()
         let sparkle = DefaultSparkleUpdateChecker()
+        let installerScanner = DefaultInstallationFileScanner()
         let log = Logger(subsystem: "com.personal.VaderCleaner",
                          category: "ApplicationsViewModel.live")
         return ApplicationsViewModel(
@@ -133,8 +233,32 @@ extension ApplicationsViewModel {
             },
             checkUpdates: { apps in
                 await Self.fetchUpdates(for: apps, appStore: appStore, sparkle: sparkle, log: log)
+            },
+            scanInstallationFiles: {
+                await installerScanner.scan()
+            },
+            recycleFiles: { urls in
+                await Self.recycle(urls, log: log)
             }
         )
+    }
+
+    /// Default deleter: move each installer to the user's Trash via
+    /// `NSWorkspace.recycle` (restorable) and return the set of URLs that
+    /// actually moved. `NSWorkspace.recycle` Trashes what it can and reports an
+    /// error only when the whole batch fails, so the success set comes from the
+    /// returned original→Trash URL map. Marked `nonisolated` so the batch runs
+    /// off the main actor.
+    nonisolated private static func recycle(_ urls: [URL], log: Logger) async -> Set<URL> {
+        guard !urls.isEmpty else { return [] }
+        return await withCheckedContinuation { continuation in
+            NSWorkspace.shared.recycle(urls) { newURLs, error in
+                if let error {
+                    log.error("Installation-file recycle reported an error: \(String(describing: error), privacy: .public)")
+                }
+                continuation.resume(returning: Set(newURLs.keys.map { $0 }))
+            }
+        }
     }
 
     /// Bounded-concurrency (≤6 in-flight HTTPS requests) discover-and-probe

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -12,10 +12,13 @@ import os.log
 /// updates (Updates card); later phases extend this payload with unused apps,
 /// unsupported apps, leftovers, and installation files.
 struct ApplicationsScanResult: Equatable {
-    let installedApps: [AppInfo]
-    let availableUpdates: [UpdateInfo]
-    let installationFiles: [InstallationFile]
-    let unsupportedApps: [UnsupportedApp]
+    // `var` so the post-delete rebuilds can copy-and-mutate a single field
+    // without re-spelling the whole aggregate (and risking a dropped field).
+    var installedApps: [AppInfo]
+    var availableUpdates: [UpdateInfo]
+    var installationFiles: [InstallationFile]
+    var unsupportedApps: [UnsupportedApp]
+    var unusedApps: [UnusedApp]
 
     /// "We've found N apps on your Mac." headline figure.
     var installedCount: Int { installedApps.count }
@@ -30,6 +33,8 @@ struct ApplicationsScanResult: Equatable {
     }
     /// Unsupported Applications card count.
     var unsupportedAppsCount: Int { unsupportedApps.count }
+    /// Unused Applications card count.
+    var unusedAppsCount: Int { unusedApps.count }
 }
 
 /// Drives the Applications feature view (scan → results). Collaborators are
@@ -67,6 +72,9 @@ final class ApplicationsViewModel {
     /// Unsupported-app scan source over the discovered apps. Non-throwing and
     /// best-effort, same partial-degradation contract as `CheckUpdates`.
     typealias ScanUnsupportedApps = @Sendable ([AppInfo]) async -> [UnsupportedApp]
+    /// Unused-app scan source over the discovered apps. Non-throwing and
+    /// best-effort, same partial-degradation contract as `CheckUpdates`.
+    typealias ScanUnusedApps = @Sendable ([AppInfo]) async -> [UnusedApp]
     /// Moves the given files to the Trash and returns the set of URLs actually
     /// recycled. Partial success is the norm (a locked file must not abort the
     /// batch), so the return is the success set — mirroring
@@ -89,10 +97,17 @@ final class ApplicationsViewModel {
     /// True while an unsupported-app recycle batch is in flight.
     private(set) var isRemovingUnsupportedApps = false
 
+    /// Per-app gate for the Unused Applications review screen, keyed by the
+    /// app's bundle URL. Seeded *empty* — removal is destructive and opt-in.
+    private(set) var unusedAppSelection: Set<URL> = []
+    /// True while an unused-app recycle batch is in flight.
+    private(set) var isRemovingUnusedApps = false
+
     @ObservationIgnored private let discoverApps: DiscoverApps
     @ObservationIgnored private let checkUpdates: CheckUpdates
     @ObservationIgnored private let scanInstallationFiles: ScanInstallationFiles
     @ObservationIgnored private let scanUnsupportedApps: ScanUnsupportedApps
+    @ObservationIgnored private let scanUnusedApps: ScanUnusedApps
     @ObservationIgnored private let recycleFiles: RecycleFiles
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "ApplicationsViewModel")
@@ -106,12 +121,14 @@ final class ApplicationsViewModel {
         checkUpdates: @escaping CheckUpdates,
         scanInstallationFiles: @escaping ScanInstallationFiles,
         scanUnsupportedApps: @escaping ScanUnsupportedApps,
+        scanUnusedApps: @escaping ScanUnusedApps,
         recycleFiles: @escaping RecycleFiles
     ) {
         self.discoverApps = discoverApps
         self.checkUpdates = checkUpdates
         self.scanInstallationFiles = scanInstallationFiles
         self.scanUnsupportedApps = scanUnsupportedApps
+        self.scanUnusedApps = scanUnusedApps
         self.recycleFiles = recycleFiles
     }
 
@@ -135,25 +152,29 @@ final class ApplicationsViewModel {
         let generation = scanGeneration
         installationFileSelection = []
         unsupportedAppSelection = []
+        unusedAppSelection = []
 
         do {
             // The installer scan is independent of app discovery, so run it
             // concurrently with the discover → update-check chain.
             async let installersAsync = scanInstallationFiles()
             let apps = try await discoverApps()
-            // The update check and the unsupported-app scan both need the
-            // discovered apps, so fan them out concurrently once they're known.
+            // The update check and the per-app scans all need the discovered
+            // apps, so fan them out concurrently once they're known.
             async let updatesAsync = checkUpdates(apps)
             async let unsupportedAsync = scanUnsupportedApps(apps)
+            async let unusedAsync = scanUnusedApps(apps)
             let installers = await installersAsync
             let updates = await updatesAsync
             let unsupported = await unsupportedAsync
+            let unused = await unusedAsync
             guard scanGeneration == generation else { return }
             phase = .results(ApplicationsScanResult(
                 installedApps: apps,
                 availableUpdates: updates,
                 installationFiles: installers,
-                unsupportedApps: unsupported
+                unsupportedApps: unsupported,
+                unusedApps: unused
             ))
         } catch {
             // Privacy: errors may include user-specific paths.
@@ -169,6 +190,7 @@ final class ApplicationsViewModel {
         phase = .idle
         installationFileSelection = []
         unsupportedAppSelection = []
+        unusedAppSelection = []
     }
 
     // MARK: - Installation files selection
@@ -223,14 +245,9 @@ final class ApplicationsViewModel {
         // The recycle hop is async; only rewrite the payload if we are still
         // showing the same kind of results (a `reset()` / rescan during the
         // batch supersedes it).
-        guard case .results(let current) = phase else { return }
-        let survivors = current.installationFiles.filter { !removed.contains($0.url) }
-        phase = .results(ApplicationsScanResult(
-            installedApps: current.installedApps,
-            availableUpdates: current.availableUpdates,
-            installationFiles: survivors,
-            unsupportedApps: current.unsupportedApps
-        ))
+        guard case .results(var current) = phase else { return }
+        current.installationFiles.removeAll { removed.contains($0.url) }
+        phase = .results(current)
         installationFileSelection.subtract(removed)
     }
 
@@ -280,15 +297,62 @@ final class ApplicationsViewModel {
         let removed = await recycleFiles(targets.map(\.app.bundleURL))
         isRemovingUnsupportedApps = false
 
-        guard case .results(let current) = phase else { return }
-        let survivors = current.unsupportedApps.filter { !removed.contains($0.app.bundleURL) }
-        phase = .results(ApplicationsScanResult(
-            installedApps: current.installedApps,
-            availableUpdates: current.availableUpdates,
-            installationFiles: current.installationFiles,
-            unsupportedApps: survivors
-        ))
+        guard case .results(var current) = phase else { return }
+        current.unsupportedApps.removeAll { removed.contains($0.app.bundleURL) }
+        phase = .results(current)
         unsupportedAppSelection.subtract(removed)
+    }
+
+    // MARK: - Unused apps selection
+
+    func isUnusedAppSelected(_ entry: UnusedApp) -> Bool {
+        unusedAppSelection.contains(entry.app.bundleURL)
+    }
+
+    func toggleUnusedApp(_ entry: UnusedApp) {
+        if unusedAppSelection.contains(entry.app.bundleURL) {
+            unusedAppSelection.remove(entry.app.bundleURL)
+        } else {
+            unusedAppSelection.insert(entry.app.bundleURL)
+        }
+    }
+
+    func selectAllUnusedApps() {
+        guard case .results(let result) = phase else { return }
+        unusedAppSelection = Set(result.unusedApps.map(\.app.bundleURL))
+    }
+
+    func clearUnusedAppSelection() {
+        unusedAppSelection = []
+    }
+
+    /// Whether a Remove press would actually recycle anything right now.
+    var canRemoveUnusedApps: Bool {
+        !unusedAppSelection.isEmpty && !isRemovingUnusedApps
+    }
+
+    // MARK: - Unused apps removal
+
+    /// Moves the selected unused app bundles to the Trash and rebuilds the
+    /// results payload with the survivors. Like the unsupported path, only the
+    /// `.app` bundle is moved here; full associated-file cleanup remains
+    /// available via Manage (the uninstaller). A no-op unless results are
+    /// showing and at least one app is selected.
+    func deleteSelectedUnusedApps() async {
+        guard case .results(let result) = phase else { return }
+        let targets = result.unusedApps.filter {
+            unusedAppSelection.contains($0.app.bundleURL)
+        }
+        guard !targets.isEmpty, !isRemovingUnusedApps else { return }
+
+        isRemovingUnusedApps = true
+        let removed = await recycleFiles(targets.map(\.app.bundleURL))
+        isRemovingUnusedApps = false
+
+        guard case .results(var current) = phase else { return }
+        current.unusedApps.removeAll { removed.contains($0.app.bundleURL) }
+        phase = .results(current)
+        unusedAppSelection.subtract(removed)
     }
 }
 
@@ -307,6 +371,7 @@ extension ApplicationsViewModel {
         let sparkle = DefaultSparkleUpdateChecker()
         let installerScanner = DefaultInstallationFileScanner()
         let unsupportedScanner = DefaultUnsupportedAppScanner()
+        let unusedScanner = DefaultUnusedAppScanner()
         let log = Logger(subsystem: "com.personal.VaderCleaner",
                          category: "ApplicationsViewModel.live")
         return ApplicationsViewModel(
@@ -321,6 +386,9 @@ extension ApplicationsViewModel {
             },
             scanUnsupportedApps: { apps in
                 await unsupportedScanner.scan(apps: apps)
+            },
+            scanUnusedApps: { apps in
+                await unusedScanner.scan(apps: apps)
             },
             recycleFiles: { urls in
                 await Self.recycle(urls, log: log)

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -15,6 +15,7 @@ struct ApplicationsScanResult: Equatable {
     let installedApps: [AppInfo]
     let availableUpdates: [UpdateInfo]
     let installationFiles: [InstallationFile]
+    let unsupportedApps: [UnsupportedApp]
 
     /// "We've found N apps on your Mac." headline figure.
     var installedCount: Int { installedApps.count }
@@ -27,6 +28,8 @@ struct ApplicationsScanResult: Equatable {
     var installationFilesTotalBytes: Int64 {
         installationFiles.reduce(Int64(0)) { $0 + $1.sizeBytes }
     }
+    /// Unsupported Applications card count.
+    var unsupportedAppsCount: Int { unsupportedApps.count }
 }
 
 /// Drives the Applications feature view (scan → results). Collaborators are
@@ -61,6 +64,9 @@ final class ApplicationsViewModel {
     /// Installation-file scan source. Non-throwing and best-effort, same
     /// partial-degradation contract as `CheckUpdates`.
     typealias ScanInstallationFiles = @Sendable () async -> [InstallationFile]
+    /// Unsupported-app scan source over the discovered apps. Non-throwing and
+    /// best-effort, same partial-degradation contract as `CheckUpdates`.
+    typealias ScanUnsupportedApps = @Sendable ([AppInfo]) async -> [UnsupportedApp]
     /// Moves the given files to the Trash and returns the set of URLs actually
     /// recycled. Partial success is the norm (a locked file must not abort the
     /// batch), so the return is the success set — mirroring
@@ -77,9 +83,16 @@ final class ApplicationsViewModel {
     /// spinner and disable its Remove button.
     private(set) var isRemovingInstallationFiles = false
 
+    /// Per-app gate for the Unsupported Applications review screen, keyed by the
+    /// app's bundle URL. Seeded *empty* — removal is destructive and opt-in.
+    private(set) var unsupportedAppSelection: Set<URL> = []
+    /// True while an unsupported-app recycle batch is in flight.
+    private(set) var isRemovingUnsupportedApps = false
+
     @ObservationIgnored private let discoverApps: DiscoverApps
     @ObservationIgnored private let checkUpdates: CheckUpdates
     @ObservationIgnored private let scanInstallationFiles: ScanInstallationFiles
+    @ObservationIgnored private let scanUnsupportedApps: ScanUnsupportedApps
     @ObservationIgnored private let recycleFiles: RecycleFiles
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
                                                  category: "ApplicationsViewModel")
@@ -92,11 +105,13 @@ final class ApplicationsViewModel {
         discoverApps: @escaping DiscoverApps,
         checkUpdates: @escaping CheckUpdates,
         scanInstallationFiles: @escaping ScanInstallationFiles,
+        scanUnsupportedApps: @escaping ScanUnsupportedApps,
         recycleFiles: @escaping RecycleFiles
     ) {
         self.discoverApps = discoverApps
         self.checkUpdates = checkUpdates
         self.scanInstallationFiles = scanInstallationFiles
+        self.scanUnsupportedApps = scanUnsupportedApps
         self.recycleFiles = recycleFiles
     }
 
@@ -119,19 +134,26 @@ final class ApplicationsViewModel {
         scanGeneration &+= 1
         let generation = scanGeneration
         installationFileSelection = []
+        unsupportedAppSelection = []
 
         do {
             // The installer scan is independent of app discovery, so run it
             // concurrently with the discover → update-check chain.
             async let installersAsync = scanInstallationFiles()
             let apps = try await discoverApps()
-            let updates = await checkUpdates(apps)
+            // The update check and the unsupported-app scan both need the
+            // discovered apps, so fan them out concurrently once they're known.
+            async let updatesAsync = checkUpdates(apps)
+            async let unsupportedAsync = scanUnsupportedApps(apps)
             let installers = await installersAsync
+            let updates = await updatesAsync
+            let unsupported = await unsupportedAsync
             guard scanGeneration == generation else { return }
             phase = .results(ApplicationsScanResult(
                 installedApps: apps,
                 availableUpdates: updates,
-                installationFiles: installers
+                installationFiles: installers,
+                unsupportedApps: unsupported
             ))
         } catch {
             // Privacy: errors may include user-specific paths.
@@ -146,6 +168,7 @@ final class ApplicationsViewModel {
     func reset() {
         phase = .idle
         installationFileSelection = []
+        unsupportedAppSelection = []
     }
 
     // MARK: - Installation files selection
@@ -205,9 +228,67 @@ final class ApplicationsViewModel {
         phase = .results(ApplicationsScanResult(
             installedApps: current.installedApps,
             availableUpdates: current.availableUpdates,
-            installationFiles: survivors
+            installationFiles: survivors,
+            unsupportedApps: current.unsupportedApps
         ))
         installationFileSelection.subtract(removed)
+    }
+
+    // MARK: - Unsupported apps selection
+
+    func isUnsupportedAppSelected(_ entry: UnsupportedApp) -> Bool {
+        unsupportedAppSelection.contains(entry.app.bundleURL)
+    }
+
+    func toggleUnsupportedApp(_ entry: UnsupportedApp) {
+        if unsupportedAppSelection.contains(entry.app.bundleURL) {
+            unsupportedAppSelection.remove(entry.app.bundleURL)
+        } else {
+            unsupportedAppSelection.insert(entry.app.bundleURL)
+        }
+    }
+
+    func selectAllUnsupportedApps() {
+        guard case .results(let result) = phase else { return }
+        unsupportedAppSelection = Set(result.unsupportedApps.map(\.app.bundleURL))
+    }
+
+    func clearUnsupportedAppSelection() {
+        unsupportedAppSelection = []
+    }
+
+    /// Whether a Remove press would actually recycle anything right now.
+    var canRemoveUnsupportedApps: Bool {
+        !unsupportedAppSelection.isEmpty && !isRemovingUnsupportedApps
+    }
+
+    // MARK: - Unsupported apps removal
+
+    /// Moves the selected unsupported app bundles to the Trash and rebuilds the
+    /// results payload with the survivors. Reuses the same recycle path as the
+    /// installation files — only the app `.app` bundle is moved here; full
+    /// associated-file cleanup remains available via Manage (the uninstaller).
+    /// A no-op unless results are showing and at least one app is selected.
+    func deleteSelectedUnsupportedApps() async {
+        guard case .results(let result) = phase else { return }
+        let targets = result.unsupportedApps.filter {
+            unsupportedAppSelection.contains($0.app.bundleURL)
+        }
+        guard !targets.isEmpty, !isRemovingUnsupportedApps else { return }
+
+        isRemovingUnsupportedApps = true
+        let removed = await recycleFiles(targets.map(\.app.bundleURL))
+        isRemovingUnsupportedApps = false
+
+        guard case .results(let current) = phase else { return }
+        let survivors = current.unsupportedApps.filter { !removed.contains($0.app.bundleURL) }
+        phase = .results(ApplicationsScanResult(
+            installedApps: current.installedApps,
+            availableUpdates: current.availableUpdates,
+            installationFiles: current.installationFiles,
+            unsupportedApps: survivors
+        ))
+        unsupportedAppSelection.subtract(removed)
     }
 }
 
@@ -225,6 +306,7 @@ extension ApplicationsViewModel {
         let appStore = DefaultAppStoreUpdateChecker()
         let sparkle = DefaultSparkleUpdateChecker()
         let installerScanner = DefaultInstallationFileScanner()
+        let unsupportedScanner = DefaultUnsupportedAppScanner()
         let log = Logger(subsystem: "com.personal.VaderCleaner",
                          category: "ApplicationsViewModel.live")
         return ApplicationsViewModel(
@@ -236,6 +318,9 @@ extension ApplicationsViewModel {
             },
             scanInstallationFiles: {
                 await installerScanner.scan()
+            },
+            scanUnsupportedApps: { apps in
+                await unsupportedScanner.scan(apps: apps)
             },
             recycleFiles: { urls in
                 await Self.recycle(urls, log: log)

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -1,0 +1,245 @@
+// ApplicationsViewModel.swift
+// Scannable aggregator behind the Applications section — discovers installed apps and checks for updates, then drives the post-scan dashboard grid.
+
+import AppKit
+import Foundation
+import Observation
+import os.log
+
+/// One aggregated Applications scan result, holding the discovered apps and the
+/// available updates so the dashboard grid can render a card per finding. Phase
+/// 0 carries the installed apps (Manage My Applications card) and the available
+/// updates (Updates card); later phases extend this payload with unused apps,
+/// unsupported apps, leftovers, and installation files.
+struct ApplicationsScanResult: Equatable {
+    let installedApps: [AppInfo]
+    let availableUpdates: [UpdateInfo]
+
+    /// "We've found N apps on your Mac." headline figure.
+    var installedCount: Int { installedApps.count }
+    /// Updates card count.
+    var updatesCount: Int { availableUpdates.count }
+}
+
+/// Drives the Applications feature view (scan → results). Collaborators are
+/// injected as closures so unit tests can exercise every transition without
+/// touching the real filesystem or network. Production wiring lives in
+/// `ApplicationsViewModel.live()`.
+///
+/// This view-model is purely additive — it produces the post-scan dashboard
+/// metrics. The actual uninstall and update side-effects stay owned by the
+/// existing `AppUninstallerViewModel` / `AppUpdaterViewModel`, which the
+/// dashboard reuses unchanged as its detail screens.
+@MainActor
+@Observable
+final class ApplicationsViewModel {
+
+    /// Discrete phases the view binds to. The happy path is
+    /// `idle → scanning → results`; `failed` carries a message to surface.
+    enum Phase: Equatable {
+        case idle
+        case scanning
+        case results(ApplicationsScanResult)
+        case failed(message: String)
+    }
+
+    /// Installed-app discovery source. Throwing: a failed discovery fails the
+    /// whole scan, mirroring `AppUninstallerViewModel.loadApps`.
+    typealias DiscoverApps = @Sendable () async throws -> [AppInfo]
+    /// Update-check source. Non-throwing and best-effort: a network blip yields
+    /// `[]` rather than sinking an otherwise-useful scan (the production wiring
+    /// swallows per-app failures), matching the Smart Scan Applications tile.
+    typealias CheckUpdates = @Sendable ([AppInfo]) async -> [UpdateInfo]
+
+    private(set) var phase: Phase = .idle
+
+    @ObservationIgnored private let discoverApps: DiscoverApps
+    @ObservationIgnored private let checkUpdates: CheckUpdates
+    @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                                                 category: "ApplicationsViewModel")
+
+    /// Incremented at the start of every scan so a result that resolves after a
+    /// newer scan (or a `reset()`) began is dropped instead of overwriting it.
+    @ObservationIgnored private var scanGeneration = 0
+
+    init(
+        discoverApps: @escaping DiscoverApps,
+        checkUpdates: @escaping CheckUpdates
+    ) {
+        self.discoverApps = discoverApps
+        self.checkUpdates = checkUpdates
+    }
+
+    // MARK: - Scan
+
+    /// Discovers installed apps, then checks each for an available update, and
+    /// lands `.results` (or `.failed` if discovery throws). Re-entrant calls
+    /// while a scan is already in flight are ignored — the guard is read
+    /// synchronously before the first `await`, so it is reliable under
+    /// `@MainActor`.
+    func scan() async {
+        switch phase {
+        case .scanning:
+            return
+        case .idle, .results, .failed:
+            break
+        }
+
+        phase = .scanning
+        scanGeneration &+= 1
+        let generation = scanGeneration
+
+        do {
+            let apps = try await discoverApps()
+            let updates = await checkUpdates(apps)
+            guard scanGeneration == generation else { return }
+            phase = .results(ApplicationsScanResult(
+                installedApps: apps,
+                availableUpdates: updates
+            ))
+        } catch {
+            // Privacy: errors may include user-specific paths.
+            log.error("Applications scan failed: \(String(describing: error), privacy: .private)")
+            guard scanGeneration == generation else { return }
+            phase = .failed(message: error.localizedDescription)
+        }
+    }
+
+    /// Returns to idle from a terminal phase so the user can start over from
+    /// the intro screen.
+    func reset() {
+        phase = .idle
+    }
+}
+
+// MARK: - Production wiring
+
+extension ApplicationsViewModel {
+
+    /// Builds a view-model wired to the real `DefaultAppDiscovery` and the App
+    /// Store / Sparkle update checkers — the same collaborators
+    /// `AppUpdaterViewModel.live` uses, so the dashboard's update count matches
+    /// the updater list it opens.
+    @MainActor
+    static func live() -> ApplicationsViewModel {
+        let discovery = DefaultAppDiscovery()
+        let appStore = DefaultAppStoreUpdateChecker()
+        let sparkle = DefaultSparkleUpdateChecker()
+        let log = Logger(subsystem: "com.personal.VaderCleaner",
+                         category: "ApplicationsViewModel.live")
+        return ApplicationsViewModel(
+            discoverApps: {
+                try await discovery.installedApps(includingSystemApps: false)
+            },
+            checkUpdates: { apps in
+                await Self.fetchUpdates(for: apps, appStore: appStore, sparkle: sparkle, log: log)
+            }
+        )
+    }
+
+    /// Bounded-concurrency (≤6 in-flight HTTPS requests) discover-and-probe
+    /// loop over already-discovered apps. Mirrors
+    /// `AppUpdaterViewModel.checkForUpdates`'s sliding window so a heavily-
+    /// installed machine never stampedes the iTunes Search API or assorted
+    /// Sparkle hosts. Marked `nonisolated` so the HTTP fan-out runs off the
+    /// main actor instead of serializing on the UI thread.
+    nonisolated private static func fetchUpdates(
+        for apps: [AppInfo],
+        appStore: DefaultAppStoreUpdateChecker,
+        sparkle: DefaultSparkleUpdateChecker,
+        log: Logger
+    ) async -> [UpdateInfo] {
+        let updates = await withTaskGroup(of: UpdateInfo?.self) { group -> [UpdateInfo] in
+            var nextIndex = 0
+            let maxInFlight = 6
+            while nextIndex < apps.count, nextIndex < maxInFlight {
+                let app = apps[nextIndex]
+                group.addTask {
+                    await Self.checkUpdate(for: app, appStore: appStore, sparkle: sparkle)
+                }
+                nextIndex += 1
+            }
+            var results: [UpdateInfo] = []
+            while let result = await group.next() {
+                if let info = result { results.append(info) }
+                if nextIndex < apps.count {
+                    let app = apps[nextIndex]
+                    group.addTask {
+                        await Self.checkUpdate(for: app, appStore: appStore, sparkle: sparkle)
+                    }
+                    nextIndex += 1
+                }
+            }
+            return results
+        }
+        return updates.sorted {
+            $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
+        }
+    }
+
+    /// Routes a single installed app to its update channel and returns an
+    /// `UpdateInfo` only when the remote version is strictly newer. Every
+    /// failure — network, decode, missing feed — is swallowed to `nil` so one
+    /// bad app can never blank the whole list.
+    nonisolated private static func checkUpdate(
+        for app: AppInfo,
+        appStore: DefaultAppStoreUpdateChecker,
+        sparkle: DefaultSparkleUpdateChecker
+    ) async -> UpdateInfo? {
+        if app.isAppStore {
+            guard let lookup = (try? await appStore.latestVersion(forBundleID: app.bundleID)) ?? nil else {
+                return nil
+            }
+            let installed = app.version ?? "0"
+            guard VersionComparator.isNewer(version: lookup.version, than: installed) else { return nil }
+            return UpdateInfo(
+                appName: app.name,
+                bundleID: app.bundleID,
+                bundleURL: app.bundleURL,
+                installedVersion: installed,
+                latestVersion: lookup.version,
+                source: .appStore,
+                updateURL: lookup.appStoreURL
+            )
+        } else {
+            guard let feedURL = sparkle.feedURL(for: app) else { return nil }
+            guard let item = (try? await sparkle.fetchAppcast(feedURL: feedURL)) ?? nil else {
+                return nil
+            }
+            let installed = app.version ?? "0"
+            guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else { return nil }
+            return UpdateInfo(
+                appName: app.name,
+                bundleID: app.bundleID,
+                bundleURL: app.bundleURL,
+                installedVersion: installed,
+                latestVersion: item.shortVersion,
+                source: .sparkle,
+                updateURL: item.downloadURL
+            )
+        }
+    }
+}
+
+// MARK: - ScanCoordinating
+
+extension ApplicationsViewModel: ScanCoordinating {
+
+    /// Projects the rich `Phase` onto the three coarse phases ContentView
+    /// switches on. `.results`/`.failed` both want the section's own detail UI,
+    /// whose internal switch renders the specifics (grid vs. failed state).
+    var scanPresentation: ScanPresentation {
+        switch phase {
+        case .idle:
+            return .intro
+        case .scanning:
+            return .working
+        case .results, .failed:
+            return .results
+        }
+    }
+
+    func beginScan() {
+        Task { await scan() }
+    }
+}

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
     private let privacyViewModel: PrivacyViewModel
     private let appUninstallerViewModel: AppUninstallerViewModel
     private let appUpdaterViewModel: AppUpdaterViewModel
+    private let applicationsViewModel: ApplicationsViewModel
     private let extensionsManagerViewModel: ExtensionsManagerViewModel
     private let optimizationViewModel: OptimizationViewModel
     private let malwareViewModel: MalwareViewModel
@@ -54,6 +55,7 @@ struct ContentView: View {
         privacyViewModel: PrivacyViewModel,
         appUninstallerViewModel: AppUninstallerViewModel,
         appUpdaterViewModel: AppUpdaterViewModel,
+        applicationsViewModel: ApplicationsViewModel,
         extensionsManagerViewModel: ExtensionsManagerViewModel,
         optimizationViewModel: OptimizationViewModel,
         malwareViewModel: MalwareViewModel,
@@ -66,6 +68,7 @@ struct ContentView: View {
         self.privacyViewModel = privacyViewModel
         self.appUninstallerViewModel = appUninstallerViewModel
         self.appUpdaterViewModel = appUpdaterViewModel
+        self.applicationsViewModel = applicationsViewModel
         self.extensionsManagerViewModel = extensionsManagerViewModel
         self.optimizationViewModel = optimizationViewModel
         self.malwareViewModel = malwareViewModel
@@ -77,7 +80,8 @@ struct ContentView: View {
             spaceLensViewModel: spaceLensViewModel,
             optimizationViewModel: optimizationViewModel,
             malwareViewModel: malwareViewModel,
-            privacyViewModel: privacyViewModel
+            privacyViewModel: privacyViewModel,
+            applicationsViewModel: applicationsViewModel
         ))
     }
 
@@ -272,10 +276,14 @@ struct ContentView: View {
             ScannableSectionContent(coordinator: privacyViewModel, section: section) {
                 PrivacyView(viewModel: privacyViewModel)
             }
-        case .appUninstaller:
-            AppUninstallerView(viewModel: appUninstallerViewModel)
-        case .appUpdater:
-            AppUpdaterView(viewModel: appUpdaterViewModel)
+        case .applications:
+            ScannableSectionContent(coordinator: applicationsViewModel, section: section) {
+                ApplicationsView(
+                    viewModel: applicationsViewModel,
+                    uninstallerViewModel: appUninstallerViewModel,
+                    updaterViewModel: appUpdaterViewModel
+                )
+            }
         case .extensions:
             ExtensionsManagerView(viewModel: extensionsManagerViewModel)
         case .optimization:
@@ -349,6 +357,7 @@ private extension AnyTransition {
         privacyViewModel: PrivacyViewModel.live(),
         appUninstallerViewModel: AppUninstallerViewModel.live(exclusions: exclusions),
         appUpdaterViewModel: AppUpdaterViewModel.live(),
+        applicationsViewModel: ApplicationsViewModel.live(),
         extensionsManagerViewModel: ExtensionsManagerViewModel.live(),
         optimizationViewModel: OptimizationViewModel.live(systemStats: stats, preferences: prefs),
         malwareViewModel: MalwareViewModel.live(

--- a/VaderCleaner/InstallationFile.swift
+++ b/VaderCleaner/InstallationFile.swift
@@ -1,0 +1,33 @@
+// InstallationFile.swift
+// Value type describing a leftover installer (disk image or package) discovered in the user's Downloads / Desktop and surfaced on the Applications dashboard.
+
+import Foundation
+
+/// What kind of installer an `InstallationFile` is, used for the row badge and
+/// the explanatory copy. Disk images (`.dmg`, `.iso`) and flat installer
+/// packages (`.pkg`) are the two shapes the scanner surfaces.
+enum InstallationFileKind: String, Hashable, Sendable {
+    case diskImage
+    case package
+
+    /// Classifies a lowercased file extension, or `nil` when the extension is
+    /// not one of the installer types the scanner collects.
+    static func forExtension(_ ext: String) -> InstallationFileKind? {
+        switch ext.lowercased() {
+        case "dmg", "iso": return .diskImage
+        case "pkg":        return .package
+        default:           return nil
+        }
+    }
+}
+
+/// A single leftover installer file. `id` keys off the path so SwiftUI list
+/// identity stays stable across repeated scans and after rows are removed.
+struct InstallationFile: Identifiable, Hashable, Sendable {
+    let url: URL
+    let name: String
+    let sizeBytes: Int64
+    let kind: InstallationFileKind
+
+    var id: String { url.path }
+}

--- a/VaderCleaner/InstallationFileScanner.swift
+++ b/VaderCleaner/InstallationFileScanner.swift
@@ -1,0 +1,98 @@
+// InstallationFileScanner.swift
+// Shallow-scans the user's Downloads and Desktop for leftover installers (.dmg / .pkg / .iso) and returns them largest-first for the Applications dashboard.
+
+import Foundation
+import os.log
+
+/// Test seam between `ApplicationsViewModel` and the real Downloads / Desktop
+/// directories. Returns ready-to-display `InstallationFile` records so the
+/// view-model never walks the filesystem directly.
+protocol InstallationFileScanning: Sendable {
+    func scan() async -> [InstallationFile]
+}
+
+/// Production scanner — lists the immediate contents of the user's Downloads
+/// and Desktop folders and keeps the disk images and installer packages.
+///
+/// The scan is intentionally **shallow** (one level per root, no recursion):
+/// downloaded installers land directly in Downloads/Desktop, and a recursive
+/// walk would risk pulling installers bundled *inside* unrelated folders the
+/// user organized on purpose. Keeping it to the top level matches where these
+/// files actually accumulate and keeps the scan fast and predictable.
+struct DefaultInstallationFileScanner: InstallationFileScanning {
+
+    private let roots: [URL]
+    private let fileManager: FileManager
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "InstallationFileScanner")
+
+    /// - Parameter roots: directories to scan, one level deep. Defaults to the
+    ///   user's Downloads and Desktop; tests inject temp fixture roots so the
+    ///   suite never touches the real folders.
+    init(
+        roots: [URL] = DefaultInstallationFileScanner.defaultRoots(),
+        fileManager: FileManager = .default
+    ) {
+        self.roots = roots
+        self.fileManager = fileManager
+    }
+
+    /// The user's Downloads and Desktop folders — where downloaded installers
+    /// accumulate.
+    static func defaultRoots(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> [URL] {
+        [
+            homeDirectory.appendingPathComponent("Downloads", isDirectory: true),
+            homeDirectory.appendingPathComponent("Desktop", isDirectory: true),
+        ]
+    }
+
+    func scan() async -> [InstallationFile] {
+        // Hop off the calling actor so the directory listing and per-file stats
+        // don't pin the main thread when a Downloads folder holds many items.
+        let roots = roots
+        let fileManager = fileManager
+        let log = log
+        return await Task.detached(priority: .userInitiated) {
+            var files: [InstallationFile] = []
+            var seen = Set<String>()
+            for root in roots {
+                guard let entries = try? fileManager.contentsOfDirectory(
+                    at: root,
+                    includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+                    options: [.skipsHiddenFiles]
+                ) else {
+                    // A missing or unreadable root (e.g. no Desktop) must not
+                    // sink the rest of the scan.
+                    continue
+                }
+                for entry in entries {
+                    guard let kind = InstallationFileKind.forExtension(entry.pathExtension) else {
+                        continue
+                    }
+                    let values = try? entry.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+                    // `.pkg` / `.dmg` / `.iso` are flat files; skip anything
+                    // that isn't a regular file (e.g. a folder a user named
+                    // "foo.dmg") so we never compute a directory size or offer
+                    // to Trash a real folder.
+                    guard values?.isRegularFile == true else { continue }
+                    // Dedup by path in case a root is listed twice.
+                    guard seen.insert(entry.path).inserted else { continue }
+                    let size = Int64(values?.fileSize ?? 0)
+                    files.append(InstallationFile(
+                        url: entry,
+                        name: entry.lastPathComponent,
+                        sizeBytes: size,
+                        kind: kind
+                    ))
+                }
+            }
+            // Largest first — the biggest reclaimable installer is what the
+            // user most wants to see.
+            files.sort { $0.sizeBytes > $1.sizeBytes }
+            log.debug("Installation-file scan found \(files.count, privacy: .public) installer(s)")
+            return files
+        }.value
+    }
+}

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -12,8 +12,7 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
     case optimization
     case privacy
     case extensions
-    case appUninstaller
-    case appUpdater
+    case applications
     case healthMonitor
 
     var id: Self { self }
@@ -28,8 +27,7 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .optimization:    return String(localized: "Optimization")
         case .privacy:         return String(localized: "Privacy")
         case .extensions:      return String(localized: "Extensions")
-        case .appUninstaller:  return String(localized: "App Uninstaller")
-        case .appUpdater:      return String(localized: "App Updater")
+        case .applications:    return String(localized: "Applications")
         case .healthMonitor:   return String(localized: "Health Monitor")
         }
     }
@@ -48,8 +46,7 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .optimization:    return "sidebar.optimization"
         case .privacy:         return "sidebar.privacy"
         case .extensions:      return "sidebar.extensions"
-        case .appUninstaller:  return "sidebar.appUninstaller"
-        case .appUpdater:      return "sidebar.appUpdater"
+        case .applications:    return "sidebar.applications"
         case .healthMonitor:   return "sidebar.healthMonitor"
         }
     }
@@ -77,8 +74,7 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .optimization:    return "gauge.with.needle"
         case .privacy:         return "lock.shield"
         case .extensions:      return "puzzlepiece.extension"
-        case .appUninstaller:  return "xmark.app"
-        case .appUpdater:      return "arrow.triangle.2.circlepath.circle"
+        case .applications:    return "square.grid.2x2"
         case .healthMonitor:   return "heart.text.square"
         }
     }
@@ -91,10 +87,10 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
     var isScannable: Bool {
         switch self {
         case .smartScan, .systemJunk, .largeOldFiles,
-             .spaceLens, .malwareRemoval, .optimization, .privacy:
+             .spaceLens, .malwareRemoval, .optimization, .privacy,
+             .applications:
             return true
-        case .extensions, .appUninstaller,
-             .appUpdater, .healthMonitor:
+        case .extensions, .healthMonitor:
             return false
         }
     }
@@ -112,7 +108,7 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
              .spaceLens, .malwareRemoval, .privacy:
             return true
         case .optimization, .extensions,
-             .appUninstaller, .appUpdater, .healthMonitor:
+             .applications, .healthMonitor:
             return false
         }
     }

--- a/VaderCleaner/ScanDiscHostView.swift
+++ b/VaderCleaner/ScanDiscHostView.swift
@@ -44,7 +44,9 @@ struct ScanDiscHostView: View {
             overlay(controller.malwareViewModel, .malwareRemoval)
         case .privacy:
             overlay(controller.privacyViewModel, .privacy)
-        case .extensions, .appUninstaller, .appUpdater, .healthMonitor:
+        case .applications:
+            overlay(controller.applicationsViewModel, .applications)
+        case .extensions, .healthMonitor:
             // Non-scannable sections never show a disc — keep the panel hidden.
             Color.clear
                 .onAppear { controller.setDiscVisible(false) }

--- a/VaderCleaner/ScanDiscWindowController.swift
+++ b/VaderCleaner/ScanDiscWindowController.swift
@@ -29,6 +29,7 @@ final class ScanDiscWindowController {
     @ObservationIgnored let optimizationViewModel: OptimizationViewModel
     @ObservationIgnored let malwareViewModel: MalwareViewModel
     @ObservationIgnored let privacyViewModel: PrivacyViewModel
+    @ObservationIgnored let applicationsViewModel: ApplicationsViewModel
 
     /// Diameter of the disc itself — the single shared constant the disc, this
     /// panel, and the placement maths all key off.
@@ -55,7 +56,8 @@ final class ScanDiscWindowController {
         spaceLensViewModel: DiskScannerViewModel,
         optimizationViewModel: OptimizationViewModel,
         malwareViewModel: MalwareViewModel,
-        privacyViewModel: PrivacyViewModel
+        privacyViewModel: PrivacyViewModel,
+        applicationsViewModel: ApplicationsViewModel
     ) {
         self.smartScanViewModel = smartScanViewModel
         self.systemJunkViewModel = systemJunkViewModel
@@ -64,6 +66,7 @@ final class ScanDiscWindowController {
         self.optimizationViewModel = optimizationViewModel
         self.malwareViewModel = malwareViewModel
         self.privacyViewModel = privacyViewModel
+        self.applicationsViewModel = applicationsViewModel
     }
 
     /// Attaches the disc panel as a child of the app's main window. Idempotent:

--- a/VaderCleaner/SectionPresentation.swift
+++ b/VaderCleaner/SectionPresentation.swift
@@ -242,7 +242,40 @@ struct SectionPresentation {
                     ),
                 ]
             )
-        case .extensions, .appUninstaller, .appUpdater, .healthMonitor:
+        case .applications:
+            // No bespoke USDZ hero ships for Applications yet, so it uses the
+            // SF Symbol hero fallback (`heroModelName: nil`). The feature rows
+            // preview the cards the post-scan grid surfaces.
+            return SectionPresentation(
+                heroSymbol: "square.grid.2x2.fill",
+                heroAssetName: nil,
+                heroModelName: nil,
+                heroModelScale: 1.0,
+                accent: section.theme.accent,
+                tagline: String(
+                    localized: "Review updates, unused apps, and leftovers in one place.",
+                    comment: "Applications intro tagline."
+                ),
+                features: [
+                    SectionFeature(
+                        symbol: "arrow.triangle.2.circlepath",
+                        title: String(localized: "Updates", comment: "Applications feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "moon.zzz",
+                        title: String(localized: "Unused Apps", comment: "Applications feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "exclamationmark.triangle",
+                        title: String(localized: "Unsupported Apps", comment: "Applications feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "trash",
+                        title: String(localized: "Leftovers", comment: "Applications feature row.")
+                    ),
+                ]
+            )
+        case .extensions, .healthMonitor:
             return nil
         }
     }

--- a/VaderCleaner/SectionTheme.swift
+++ b/VaderCleaner/SectionTheme.swift
@@ -73,17 +73,11 @@ extension NavigationSection {
                 backdropTop: Color(red: 0.04, green: 0.07, blue: 0.15),
                 backdropBottom: Color(red: 0.07, green: 0.17, blue: 0.39)
             )
-        case .appUninstaller:
+        case .applications:
             return SectionTheme(
                 accent: Color(red: 0.52, green: 0.50, blue: 0.95),
                 backdropTop: Color(red: 0.07, green: 0.06, blue: 0.16),
                 backdropBottom: Color(red: 0.16, green: 0.14, blue: 0.37)
-            )
-        case .appUpdater:
-            return SectionTheme(
-                accent: Color(red: 0.24, green: 0.76, blue: 0.93),
-                backdropTop: Color(red: 0.03, green: 0.09, blue: 0.13),
-                backdropBottom: Color(red: 0.05, green: 0.23, blue: 0.33)
             )
         case .healthMonitor:
             return SectionTheme(

--- a/VaderCleaner/UnsupportedApp.swift
+++ b/VaderCleaner/UnsupportedApp.swift
@@ -1,0 +1,22 @@
+// UnsupportedApp.swift
+// Value type pairing an installed app with the reason it can't run on the current macOS, surfaced on the Applications dashboard's Unsupported card.
+
+import Foundation
+
+/// Why an installed app is flagged as unsupported. Phase 3 detects the
+/// clearest "won't launch" signal — an executable with no architecture the
+/// current macOS can run (no `arm64` and no `x86_64` slice, e.g. a 32-bit
+/// Intel or PowerPC binary).
+enum UnsupportedAppReason: String, Hashable, Sendable {
+    case incompatibleArchitecture
+}
+
+/// A single installed app the scanner believes cannot run on this Mac. `id`
+/// keys off the underlying `AppInfo.id` (the bundle path) so SwiftUI list
+/// identity stays stable across scans and after rows are removed.
+struct UnsupportedApp: Identifiable, Hashable, Sendable {
+    let app: AppInfo
+    let reason: UnsupportedAppReason
+
+    var id: String { app.id }
+}

--- a/VaderCleaner/UnsupportedAppScanner.swift
+++ b/VaderCleaner/UnsupportedAppScanner.swift
@@ -1,0 +1,157 @@
+// UnsupportedAppScanner.swift
+// Reads each installed app's Mach-O executable to find its CPU architectures and flags the apps with no slice the current macOS can run (no arm64 / x86_64).
+
+import Foundation
+import os.log
+
+/// Mach-O CPU type constants (subset). Values match `<mach/machine.h>`:
+/// the 64-bit ABI bit (`0x0100_0000`) OR'd with the base type.
+enum MachOCPUType {
+    static let x86_64: UInt32 = 0x0100_0007
+    static let arm64: UInt32  = 0x0100_000C
+}
+
+/// Decides whether a set of executable architectures is runnable on the
+/// current macOS. `arm64` runs natively on Apple Silicon; `x86_64` runs
+/// natively on Intel and under Rosetta 2 on Apple Silicon. Anything with only
+/// 32-bit Intel (`i386`) or PowerPC slices can't launch on a modern macOS.
+enum UnsupportedAppClassifier {
+
+    /// Architectures the current macOS can run.
+    static let runnableCPUTypes: Set<UInt32> = [MachOCPUType.x86_64, MachOCPUType.arm64]
+
+    /// True when the executable has architectures *and none of them* is
+    /// runnable. An empty/unknown list returns `false` — we never flag an app
+    /// we couldn't actually read, biasing toward false negatives so a parse
+    /// miss never offers a working app for removal.
+    static func isUnsupported(cpuTypes: [UInt32]) -> Bool {
+        guard !cpuTypes.isEmpty else { return false }
+        return Set(cpuTypes).isDisjoint(with: runnableCPUTypes)
+    }
+}
+
+/// Parses the CPU architectures out of a Mach-O or universal ("fat") binary
+/// header. Pure byte parsing with no I/O, so it is exhaustively unit-tested
+/// against synthetic header fixtures.
+enum MachOHeaderReader {
+
+    private static let fatMagic: UInt32    = 0xCAFE_BABE
+    private static let fatMagic64: UInt32  = 0xCAFE_BABF
+    private static let machMagic: UInt32   = 0xFEED_FACE
+    private static let machMagic64: UInt32 = 0xFEED_FACF
+
+    /// Returns the CPU types declared in the header, or `nil` when `data` is
+    /// not a recognizable Mach-O / universal binary.
+    static func cpuTypes(in data: Data) -> [UInt32]? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 8 else { return nil }
+
+        func u32(_ offset: Int, bigEndian: Bool) -> UInt32? {
+            guard offset >= 0, offset + 4 <= bytes.count else { return nil }
+            let value = UInt32(bytes[offset]) << 24
+                | UInt32(bytes[offset + 1]) << 16
+                | UInt32(bytes[offset + 2]) << 8
+                | UInt32(bytes[offset + 3])
+            return bigEndian ? value : value.byteSwapped
+        }
+
+        // Universal binaries store their header big-endian on disk.
+        let beMagic = u32(0, bigEndian: true)
+        if beMagic == fatMagic || beMagic == fatMagic64 {
+            guard let nfat = u32(4, bigEndian: true), nfat <= 64 else { return nil }
+            let is64 = beMagic == fatMagic64
+            // fat_arch is 20 bytes, fat_arch_64 is 32 bytes; `cputype` is the
+            // first 4 bytes of either, so the entry stride is all that differs.
+            let entryStride = is64 ? 32 : 20
+            var types: [UInt32] = []
+            var offset = 8
+            for _ in 0..<nfat {
+                guard let cpuType = u32(offset, bigEndian: true) else { return nil }
+                types.append(cpuType)
+                offset += entryStride
+            }
+            return types
+        }
+
+        // Thin Mach-O: the magic's byte order tells us how to read `cputype`
+        // (the field immediately after the magic).
+        if let le = u32(0, bigEndian: false), le == machMagic || le == machMagic64 {
+            guard let cpuType = u32(4, bigEndian: false) else { return nil }
+            return [cpuType]
+        }
+        if beMagic == machMagic || beMagic == machMagic64 {
+            guard let cpuType = u32(4, bigEndian: true) else { return nil }
+            return [cpuType]
+        }
+        return nil
+    }
+}
+
+/// Test seam between `ApplicationsViewModel` and the on-disk Mach-O parsing.
+protocol UnsupportedAppScanning: Sendable {
+    func scan(apps: [AppInfo]) async -> [UnsupportedApp]
+}
+
+/// Production scanner — resolves each app's main executable, reads its Mach-O
+/// header, and flags the ones with no runnable architecture.
+struct DefaultUnsupportedAppScanner: UnsupportedAppScanning {
+
+    /// Resolves the CPU types of an app's main executable, or `nil` when it
+    /// can't be read. Injected so tests drive classification without real
+    /// binaries.
+    private let cpuTypesForApp: @Sendable (AppInfo) -> [UInt32]?
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "UnsupportedAppScanner")
+
+    init(cpuTypesForApp: @escaping @Sendable (AppInfo) -> [UInt32]? = DefaultUnsupportedAppScanner.readCPUTypes) {
+        self.cpuTypesForApp = cpuTypesForApp
+    }
+
+    func scan(apps: [AppInfo]) async -> [UnsupportedApp] {
+        let provider = cpuTypesForApp
+        let log = log
+        return await Task.detached(priority: .userInitiated) {
+            let unsupported = apps.compactMap { app -> UnsupportedApp? in
+                guard let types = provider(app),
+                      UnsupportedAppClassifier.isUnsupported(cpuTypes: types) else {
+                    return nil
+                }
+                return UnsupportedApp(app: app, reason: .incompatibleArchitecture)
+            }
+            log.debug("Unsupported-app scan flagged \(unsupported.count, privacy: .public) app(s)")
+            return unsupported
+        }.value
+    }
+
+    /// Default provider: read the first 64 KB of the app's main executable
+    /// (enough for the fat header + its arch table, or a thin Mach-O header)
+    /// and parse out the architectures. Returns `nil` on any failure so the
+    /// classifier treats it as "unknown — don't flag".
+    static func readCPUTypes(_ app: AppInfo) -> [UInt32]? {
+        let contents = app.bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let executableName = executableName(forBundleAt: app.bundleURL)
+            ?? app.bundleURL.deletingPathExtension().lastPathComponent
+        let executableURL = contents
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent(executableName)
+
+        guard let handle = try? FileHandle(forReadingFrom: executableURL) else { return nil }
+        defer { try? handle.close() }
+        let data = (try? handle.read(upToCount: 64 * 1024)) ?? Data()
+        return MachOHeaderReader.cpuTypes(in: data)
+    }
+
+    /// Reads `CFBundleExecutable` from the bundle's `Info.plist`.
+    private static func executableName(forBundleAt bundleURL: URL) -> String? {
+        let infoPlist = bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: infoPlist),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
+              let name = plist["CFBundleExecutable"] as? String,
+              !name.isEmpty else {
+            return nil
+        }
+        return name
+    }
+}

--- a/VaderCleaner/UnusedApp.swift
+++ b/VaderCleaner/UnusedApp.swift
@@ -1,0 +1,16 @@
+// UnusedApp.swift
+// Value type pairing an installed app with the date it was last used, surfaced on the Applications dashboard's Unused card.
+
+import Foundation
+
+/// A single installed app that hasn't been opened in a long time. `id` keys off
+/// the underlying `AppInfo.id` (the bundle path) so SwiftUI list identity stays
+/// stable across scans and after rows are removed. Only apps with a *known*
+/// last-used date older than the threshold are surfaced, so `lastUsedDate` is
+/// always present.
+struct UnusedApp: Identifiable, Hashable, Sendable {
+    let app: AppInfo
+    let lastUsedDate: Date
+
+    var id: String { app.id }
+}

--- a/VaderCleaner/UnusedAppScanner.swift
+++ b/VaderCleaner/UnusedAppScanner.swift
@@ -1,0 +1,75 @@
+// UnusedAppScanner.swift
+// Flags installed apps that haven't been opened in a long time, reading each app's Spotlight kMDItemLastUsedDate and comparing it against a threshold (default 60 days).
+
+import CoreServices
+import Foundation
+import os.log
+
+/// Test seam between `ApplicationsViewModel` and the on-disk last-used metadata.
+protocol UnusedAppScanning: Sendable {
+    func scan(apps: [AppInfo]) async -> [UnusedApp]
+}
+
+/// Production scanner — reads each app's Spotlight last-used date and flags the
+/// ones not opened within the threshold window (default 60 days).
+///
+/// Apps with **no** known last-used date are deliberately *not* flagged: a
+/// missing `kMDItemLastUsedDate` means Spotlight has no usage record, not
+/// necessarily that the app was never opened, so flagging it would risk a
+/// false positive on an app the user actually relies on. The scanner biases
+/// toward false negatives, only surfacing apps it can prove are stale.
+struct DefaultUnusedAppScanner: UnusedAppScanning {
+
+    /// Apps not opened within this many days are considered unused. 60 days
+    /// matches the reference design's default.
+    static let defaultThresholdDays = 60
+
+    private let thresholdSeconds: TimeInterval
+    private let lastUsedDate: @Sendable (AppInfo) -> Date?
+    private let now: @Sendable () -> Date
+    private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                             category: "UnusedAppScanner")
+
+    /// - Parameters:
+    ///   - thresholdDays: how stale an app must be to be flagged.
+    ///   - lastUsedDate: resolves an app's last-used date, or `nil` when
+    ///     unknown. Injected so tests drive classification with synthetic dates.
+    ///   - now: the reference "now" for the staleness cutoff; injected so age
+    ///     assertions don't depend on real time.
+    init(
+        thresholdDays: Int = DefaultUnusedAppScanner.defaultThresholdDays,
+        lastUsedDate: @escaping @Sendable (AppInfo) -> Date? = DefaultUnusedAppScanner.spotlightLastUsedDate,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.thresholdSeconds = TimeInterval(thresholdDays) * 24 * 60 * 60
+        self.lastUsedDate = lastUsedDate
+        self.now = now
+    }
+
+    func scan(apps: [AppInfo]) async -> [UnusedApp] {
+        let provider = lastUsedDate
+        let cutoff = now().addingTimeInterval(-thresholdSeconds)
+        let log = log
+        return await Task.detached(priority: .userInitiated) {
+            let unused = apps.compactMap { app -> UnusedApp? in
+                // Inclusive: an app last used exactly at the cutoff has not been
+                // opened *within* the window, so it qualifies.
+                guard let used = provider(app), used <= cutoff else { return nil }
+                return UnusedApp(app: app, lastUsedDate: used)
+            }
+            // Oldest first — the longest-unused app is what the user most wants
+            // to see.
+            .sorted { $0.lastUsedDate < $1.lastUsedDate }
+            log.debug("Unused-app scan flagged \(unused.count, privacy: .public) app(s)")
+            return unused
+        }.value
+    }
+
+    /// Default provider: Spotlight's `kMDItemLastUsedDate` for the app bundle,
+    /// or `nil` when Spotlight has no record.
+    static func spotlightLastUsedDate(_ app: AppInfo) -> Date? {
+        guard let item = MDItemCreate(nil, app.bundleURL.path as CFString) else { return nil }
+        guard let attribute = MDItemCopyAttribute(item, kMDItemLastUsedDate) else { return nil }
+        return attribute as? Date
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -33,6 +33,7 @@ struct VaderCleanerApp: App {
     @State private var privacyViewModel: PrivacyViewModel
     @State private var appUninstallerViewModel: AppUninstallerViewModel
     @State private var appUpdaterViewModel: AppUpdaterViewModel
+    @State private var applicationsViewModel: ApplicationsViewModel
     @State private var extensionsManagerViewModel: ExtensionsManagerViewModel
     @State private var optimizationViewModel: OptimizationViewModel
     @State private var malwareViewModel: MalwareViewModel
@@ -91,6 +92,10 @@ struct VaderCleanerApp: App {
             initialValue: AppUninstallerViewModel.live(exclusions: exclusions)
         )
         _appUpdaterViewModel = State(initialValue: AppUpdaterViewModel.live())
+        // The Applications dashboard's own scan (installed-app count + update
+        // count). The uninstall / update side-effects stay owned by the two
+        // view models above, which the dashboard reuses as detail screens.
+        _applicationsViewModel = State(initialValue: ApplicationsViewModel.live())
         _extensionsManagerViewModel = State(initialValue: ExtensionsManagerViewModel.live())
         // Construct the polling service and the menu bar view-model in the
         // same init so both `@StateObject` wrappers reference the *same*
@@ -204,6 +209,7 @@ struct VaderCleanerApp: App {
                 privacyViewModel: privacyViewModel,
                 appUninstallerViewModel: appUninstallerViewModel,
                 appUpdaterViewModel: appUpdaterViewModel,
+                applicationsViewModel: applicationsViewModel,
                 extensionsManagerViewModel: extensionsManagerViewModel,
                 optimizationViewModel: optimizationViewModel,
                 malwareViewModel: malwareViewModel,

--- a/VaderCleanerTests/AppLeftoverScannerTests.swift
+++ b/VaderCleanerTests/AppLeftoverScannerTests.swift
@@ -1,0 +1,159 @@
+// AppLeftoverScannerTests.swift
+// Pins DefaultAppLeftoverScanner's pure matching helpers and drives the full scan against temp ~/Library fixtures — covering per-root bundle-ID derivation, the reverse-DNS / Apple / installed-sub-ID guards, grouping across roots, and sizing. Hermetic.
+
+import XCTest
+@testable import VaderCleaner
+
+final class AppLeftoverScannerTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot { TestHelpers.tearDownTempDirectory(tempRoot) }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    private func makeDir(_ name: String) throws -> URL {
+        let url = tempRoot.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    // MARK: - Pure helpers
+
+    func test_looksLikeBundleID() {
+        XCTAssertTrue(DefaultAppLeftoverScanner.looksLikeBundleID("com.acme.App"))
+        XCTAssertTrue(DefaultAppLeftoverScanner.looksLikeBundleID("com.acme.App-Beta"))
+        XCTAssertTrue(DefaultAppLeftoverScanner.looksLikeBundleID("com.apple.dt.Xcode"))
+        // Too few components / human names / malformed.
+        XCTAssertFalse(DefaultAppLeftoverScanner.looksLikeBundleID("Google"))
+        XCTAssertFalse(DefaultAppLeftoverScanner.looksLikeBundleID("com.acme"))
+        XCTAssertFalse(DefaultAppLeftoverScanner.looksLikeBundleID("com..App"))
+        XCTAssertFalse(DefaultAppLeftoverScanner.looksLikeBundleID("com.acme.App!"))
+    }
+
+    func test_isSystemBundleID() {
+        XCTAssertTrue(DefaultAppLeftoverScanner.isSystemBundleID("com.apple.finder"))
+        XCTAssertTrue(DefaultAppLeftoverScanner.isSystemBundleID("group.com.acme.shared"))
+        XCTAssertFalse(DefaultAppLeftoverScanner.isSystemBundleID("com.acme.App"))
+    }
+
+    func test_isCoveredByInstalled_matchesExactAndSubIDs() {
+        let installed: Set<String> = ["com.acme.App"]
+        XCTAssertTrue(DefaultAppLeftoverScanner.isCoveredByInstalled("com.acme.App", installed: installed))
+        // A helper/XPC sub-ID of an installed app is covered.
+        XCTAssertTrue(DefaultAppLeftoverScanner.isCoveredByInstalled("com.acme.App.Helper", installed: installed))
+        // An unrelated ID is not.
+        XCTAssertFalse(DefaultAppLeftoverScanner.isCoveredByInstalled("com.other.App", installed: installed))
+        // A prefix that isn't a dot-boundary is not a sub-ID.
+        XCTAssertFalse(DefaultAppLeftoverScanner.isCoveredByInstalled("com.acme.AppExtra", installed: installed))
+    }
+
+    func test_candidateBundleID_perRootKind() {
+        XCTAssertEqual(
+            DefaultAppLeftoverScanner.candidateBundleID(
+                for: URL(fileURLWithPath: "/x/com.acme.App.plist"), kind: .preferences),
+            "com.acme.App"
+        )
+        XCTAssertNil(
+            DefaultAppLeftoverScanner.candidateBundleID(
+                for: URL(fileURLWithPath: "/x/com.acme.App"), kind: .preferences),
+            "A non-plist entry in Preferences yields no candidate"
+        )
+        XCTAssertEqual(
+            DefaultAppLeftoverScanner.candidateBundleID(
+                for: URL(fileURLWithPath: "/x/com.acme.App"), kind: .bundleNamedEntry),
+            "com.acme.App"
+        )
+        XCTAssertEqual(
+            DefaultAppLeftoverScanner.candidateBundleID(
+                for: URL(fileURLWithPath: "/x/com.acme.App.savedState"), kind: .savedState),
+            "com.acme.App"
+        )
+        XCTAssertNil(
+            DefaultAppLeftoverScanner.candidateBundleID(
+                for: URL(fileURLWithPath: "/x/com.acme.App"), kind: .savedState)
+        )
+    }
+
+    // MARK: - Full scan
+
+    func test_scan_flagsOrphansAndGroupsAcrossRoots() async throws {
+        let appSupport = try makeDir("ApplicationSupport")
+        let prefs = try makeDir("Preferences")
+
+        // Orphan present in two roots → one group with both URLs.
+        try FileManager.default.createDirectory(
+            at: appSupport.appendingPathComponent("com.orphan.App", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try TestHelpers.createDummyFile(named: "com.orphan.App.plist", size: 100, in: prefs)
+        // Installed app's support files → not flagged.
+        try FileManager.default.createDirectory(
+            at: appSupport.appendingPathComponent("com.installed.App", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        // Apple + human-named → never flagged.
+        try TestHelpers.createDummyFile(named: "com.apple.finder.plist", size: 100, in: prefs)
+        try FileManager.default.createDirectory(
+            at: appSupport.appendingPathComponent("Google", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let scanner = DefaultAppLeftoverScanner(roots: [
+            (appSupport, .bundleNamedEntry),
+            (prefs, .preferences),
+        ])
+
+        let groups = await scanner.scan(installedBundleIDs: ["com.installed.App"])
+
+        XCTAssertEqual(groups.map(\.bundleID), ["com.orphan.App"])
+        XCTAssertEqual(groups.first?.displayName, "App")
+        XCTAssertEqual(groups.first?.urls.count, 2,
+                       "Both roots' entries for the orphan must group together")
+    }
+
+    func test_scan_doesNotFlagInstalledHelperSubID() async throws {
+        let appSupport = try makeDir("ApplicationSupport")
+        try FileManager.default.createDirectory(
+            at: appSupport.appendingPathComponent("com.acme.App.Helper", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let scanner = DefaultAppLeftoverScanner(roots: [(appSupport, .bundleNamedEntry)])
+        let groups = await scanner.scan(installedBundleIDs: ["com.acme.App"])
+
+        XCTAssertTrue(groups.isEmpty,
+                      "A helper sub-ID of an installed app must not be flagged")
+    }
+
+    func test_scan_sizesAndSortsLargestFirst() async throws {
+        let caches = try makeDir("Caches")
+        let small = caches.appendingPathComponent("com.small.App", isDirectory: true)
+        let big = caches.appendingPathComponent("com.big.App", isDirectory: true)
+        try FileManager.default.createDirectory(at: small, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: big, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "a.bin", size: 100, in: small)
+        try TestHelpers.createDummyFile(named: "b.bin", size: 5_000, in: big)
+
+        let scanner = DefaultAppLeftoverScanner(roots: [(caches, .bundleNamedEntry)])
+        let groups = await scanner.scan(installedBundleIDs: [])
+
+        XCTAssertEqual(groups.map(\.bundleID), ["com.big.App", "com.small.App"])
+        XCTAssertEqual(groups.first?.totalBytes, 5_000)
+        XCTAssertEqual(groups.last?.totalBytes, 100)
+    }
+
+    func test_scan_toleratesMissingRoot() async {
+        let missing = tempRoot.appendingPathComponent("nope", isDirectory: true)
+        let scanner = DefaultAppLeftoverScanner(roots: [(missing, .bundleNamedEntry)])
+        let groups = await scanner.scan(installedBundleIDs: [])
+        XCTAssertTrue(groups.isEmpty)
+    }
+}

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -72,6 +72,15 @@ final class ApplicationsViewModelTests: XCTestCase {
         )
     }
 
+    nonisolated private func makeLeftover(bundleID: String, paths: [String], bytes: Int64) -> LeftoverGroup {
+        LeftoverGroup(
+            bundleID: bundleID,
+            displayName: bundleID.components(separatedBy: ".").last ?? bundleID,
+            urls: paths.map { URL(fileURLWithPath: $0) },
+            totalBytes: bytes
+        )
+    }
+
     /// Builds a view-model with injected collaborators. Sub-scans default to
     /// empty and recycling to "removes everything asked" so the existing tests
     /// stay focused on the discover → update path.
@@ -81,6 +90,7 @@ final class ApplicationsViewModelTests: XCTestCase {
         installers: @escaping ApplicationsViewModel.ScanInstallationFiles = { [] },
         unsupported: @escaping ApplicationsViewModel.ScanUnsupportedApps = { _ in [] },
         unused: @escaping ApplicationsViewModel.ScanUnusedApps = { _ in [] },
+        leftovers: @escaping ApplicationsViewModel.ScanLeftovers = { _ in [] },
         recycle: @escaping ApplicationsViewModel.RecycleFiles = { Set($0) }
     ) -> ApplicationsViewModel {
         ApplicationsViewModel(
@@ -89,6 +99,7 @@ final class ApplicationsViewModelTests: XCTestCase {
             scanInstallationFiles: installers,
             scanUnsupportedApps: unsupported,
             scanUnusedApps: unused,
+            scanLeftovers: leftovers,
             recycleFiles: recycle
         )
     }
@@ -528,6 +539,91 @@ final class ApplicationsViewModelTests: XCTestCase {
         XCTAssertTrue(result.unusedApps.isEmpty)
         XCTAssertEqual(result.installationFiles, [installer])
         XCTAssertEqual(result.unsupportedApps, [unsupported])
+    }
+
+    // MARK: - Leftovers
+
+    func test_scan_passesInstalledBundleIDsToLeftoverScan() async {
+        let apps = [
+            makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app"),
+            makeApp(name: "Beta", bundleID: "com.beta.app", path: "/Applications/Beta.app"),
+        ]
+        var received: Set<String> = []
+        let vm = makeViewModel(
+            discover: { apps },
+            leftovers: { installed in
+                received = installed
+                return []
+            }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(received, ["com.acme.app", "com.beta.app"],
+                       "The leftover scan must receive the installed bundle IDs")
+    }
+
+    func test_scan_carriesLeftoversIntoResults() async {
+        let group = makeLeftover(bundleID: "com.orphan.app",
+                                 paths: ["/L/com.orphan.app"], bytes: 2_048)
+        let vm = makeViewModel(discover: { [] }, leftovers: { _ in [group] })
+
+        await vm.scan()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.leftovers, [group])
+        XCTAssertEqual(result.leftoversCount, 1)
+        XCTAssertEqual(result.leftoversTotalBytes, 2_048)
+    }
+
+    func test_deleteSelectedLeftovers_recyclesAllGroupURLsAndDropsGroup() async {
+        let a = makeLeftover(bundleID: "com.a.app", paths: ["/L/com.a.app", "/P/com.a.app.plist"], bytes: 100)
+        let b = makeLeftover(bundleID: "com.b.app", paths: ["/L/com.b.app"], bytes: 50)
+        var recycled: [URL] = []
+        let vm = makeViewModel(
+            discover: { [] },
+            leftovers: { _ in [a, b] },
+            recycle: { urls in recycled = urls; return Set(urls) }
+        )
+        await vm.scan()
+        vm.toggleLeftover(a)
+
+        await vm.deleteSelectedLeftovers()
+
+        XCTAssertEqual(Set(recycled), Set(a.urls), "Every file in the selected group is recycled")
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.leftovers, [b], "A fully-recycled group is dropped")
+        XCTAssertFalse(vm.leftoverSelection.contains("com.a.app"))
+    }
+
+    func test_deleteSelectedLeftovers_keepsPartiallyRemovedGroupWithSurvivors() async {
+        let kept = URL(fileURLWithPath: "/L/com.a.app")
+        let gone = URL(fileURLWithPath: "/P/com.a.app.plist")
+        let a = LeftoverGroup(bundleID: "com.a.app", displayName: "app",
+                              urls: [kept, gone], totalBytes: 100)
+        let vm = makeViewModel(
+            discover: { [] },
+            leftovers: { _ in [a] },
+            // Only one of the two files could be Trashed.
+            recycle: { _ in [gone] }
+        )
+        await vm.scan()
+        vm.selectAllLeftovers()
+
+        await vm.deleteSelectedLeftovers()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.leftovers.count, 1)
+        XCTAssertEqual(result.leftovers.first?.urls, [kept],
+                       "A partially-removed group keeps only its surviving files")
+        XCTAssertTrue(vm.leftoverSelection.contains("com.a.app"),
+                      "The still-present group stays selected so the user can retry")
     }
 }
 

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -37,12 +37,30 @@ final class ApplicationsViewModelTests: XCTestCase {
         )
     }
 
-    /// Builds a view-model with injected discovery + update collaborators.
+    nonisolated private func makeInstaller(name: String, size: Int64, kind: InstallationFileKind = .diskImage) -> InstallationFile {
+        InstallationFile(
+            url: URL(fileURLWithPath: "/Users/test/Downloads/\(name)"),
+            name: name,
+            sizeBytes: size,
+            kind: kind
+        )
+    }
+
+    /// Builds a view-model with injected collaborators. Installation-file
+    /// scanning defaults to empty and recycling to "removes everything asked"
+    /// so the existing tests stay focused on the discover → update path.
     private func makeViewModel(
         discover: @escaping ApplicationsViewModel.DiscoverApps,
-        check: @escaping ApplicationsViewModel.CheckUpdates = { _ in [] }
+        check: @escaping ApplicationsViewModel.CheckUpdates = { _ in [] },
+        installers: @escaping ApplicationsViewModel.ScanInstallationFiles = { [] },
+        recycle: @escaping ApplicationsViewModel.RecycleFiles = { Set($0) }
     ) -> ApplicationsViewModel {
-        ApplicationsViewModel(discoverApps: discover, checkUpdates: check)
+        ApplicationsViewModel(
+            discoverApps: discover,
+            checkUpdates: check,
+            scanInstallationFiles: installers,
+            recycleFiles: recycle
+        )
     }
 
     // MARK: - Initial state
@@ -173,6 +191,119 @@ final class ApplicationsViewModelTests: XCTestCase {
 
         XCTAssertEqual(vm.phase, .idle)
         XCTAssertEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - Installation files
+
+    func test_scan_carriesInstallationFilesIntoResults() async {
+        let installers = [
+            makeInstaller(name: "Big.dmg", size: 5_000),
+            makeInstaller(name: "Small.pkg", size: 100, kind: .package),
+        ]
+        let vm = makeViewModel(discover: { [] }, installers: { installers })
+
+        await vm.scan()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.installationFiles, installers)
+        XCTAssertEqual(result.installationFilesCount, 2)
+        XCTAssertEqual(result.installationFilesTotalBytes, 5_100)
+    }
+
+    func test_installationFileSelection_isEmptyAfterScan() async {
+        let vm = makeViewModel(
+            discover: { [] },
+            installers: { [self.makeInstaller(name: "Big.dmg", size: 5_000)] }
+        )
+        await vm.scan()
+        XCTAssertTrue(vm.installationFileSelection.isEmpty,
+                      "Destructive removal is opt-in, so nothing starts selected")
+        XCTAssertFalse(vm.canRemoveInstallationFiles)
+    }
+
+    func test_toggleAndSelectAll_driveSelection() async {
+        let a = makeInstaller(name: "A.dmg", size: 5_000)
+        let b = makeInstaller(name: "B.pkg", size: 100, kind: .package)
+        let vm = makeViewModel(discover: { [] }, installers: { [a, b] })
+        await vm.scan()
+
+        vm.toggleInstallationFile(a)
+        XCTAssertTrue(vm.isInstallationFileSelected(a))
+        XCTAssertFalse(vm.isInstallationFileSelected(b))
+        XCTAssertTrue(vm.canRemoveInstallationFiles)
+
+        vm.selectAllInstallationFiles()
+        XCTAssertTrue(vm.isInstallationFileSelected(a))
+        XCTAssertTrue(vm.isInstallationFileSelected(b))
+
+        vm.clearInstallationFileSelection()
+        XCTAssertTrue(vm.installationFileSelection.isEmpty)
+    }
+
+    func test_deleteSelectedInstallationFiles_removesRecycledAndRebuildsPayload() async {
+        let a = makeInstaller(name: "A.dmg", size: 5_000)
+        let b = makeInstaller(name: "B.pkg", size: 100, kind: .package)
+        var recycled: [URL] = []
+        let vm = makeViewModel(
+            discover: { [] },
+            installers: { [a, b] },
+            recycle: { urls in
+                recycled = urls
+                return Set(urls)
+            }
+        )
+        await vm.scan()
+        vm.toggleInstallationFile(a)
+
+        await vm.deleteSelectedInstallationFiles()
+
+        XCTAssertEqual(recycled, [a.url], "Only the selected installer is recycled")
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.installationFiles, [b],
+                       "The recycled installer must be dropped from the payload")
+        XCTAssertFalse(vm.installationFileSelection.contains(a.url))
+        XCTAssertFalse(vm.isRemovingInstallationFiles)
+    }
+
+    func test_deleteSelectedInstallationFiles_keepsFilesThatFailedToRecycle() async {
+        let a = makeInstaller(name: "A.dmg", size: 5_000)
+        let b = makeInstaller(name: "B.pkg", size: 100, kind: .package)
+        let vm = makeViewModel(
+            discover: { [] },
+            installers: { [a, b] },
+            // The recycler only manages to Trash one of the two selected.
+            recycle: { _ in [a.url] }
+        )
+        await vm.scan()
+        vm.selectAllInstallationFiles()
+
+        await vm.deleteSelectedInstallationFiles()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.installationFiles, [b],
+                       "A file the recycler couldn't move must stay in the list")
+        XCTAssertTrue(vm.installationFileSelection.contains(b.url),
+                      "The still-present file's selection survives so the user can retry")
+    }
+
+    func test_deleteSelectedInstallationFiles_withNoSelection_isNoOp() async {
+        var recycleCalls = 0
+        let vm = makeViewModel(
+            discover: { [] },
+            installers: { [self.makeInstaller(name: "A.dmg", size: 5_000)] },
+            recycle: { urls in recycleCalls += 1; return Set(urls) }
+        )
+        await vm.scan()
+
+        await vm.deleteSelectedInstallationFiles()
+
+        XCTAssertEqual(recycleCalls, 0, "Nothing selected → the recycler is never called")
     }
 }
 

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -1,0 +1,196 @@
+// ApplicationsViewModelTests.swift
+// Drives every ApplicationsViewModel transition (idle → scanning → results / failed) and pins its ScanCoordinating projection, all via injected closures.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class ApplicationsViewModelTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeApp(
+        name: String,
+        bundleID: String,
+        path: String,
+        version: String? = "1.0",
+        isAppStore: Bool = false
+    ) -> AppInfo {
+        AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: version,
+            bundleURL: URL(fileURLWithPath: path),
+            isAppStore: isAppStore
+        )
+    }
+
+    private func makeUpdate(name: String, bundleID: String, path: String) -> UpdateInfo {
+        UpdateInfo(
+            appName: name,
+            bundleID: bundleID,
+            bundleURL: URL(fileURLWithPath: path),
+            installedVersion: "1.0",
+            latestVersion: "2.0",
+            source: .appStore,
+            updateURL: URL(string: "https://apps.apple.com/app/id1")!
+        )
+    }
+
+    /// Builds a view-model with injected discovery + update collaborators.
+    private func makeViewModel(
+        discover: @escaping ApplicationsViewModel.DiscoverApps,
+        check: @escaping ApplicationsViewModel.CheckUpdates = { _ in [] }
+    ) -> ApplicationsViewModel {
+        ApplicationsViewModel(discoverApps: discover, checkUpdates: check)
+    }
+
+    // MARK: - Initial state
+
+    func test_initialPhase_isIdle_andPresentsIntro() {
+        let vm = makeViewModel(discover: { [] })
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.scanPresentation, .intro)
+    }
+
+    // MARK: - Happy path
+
+    func test_scan_landsResultsWithAppsAndUpdates() async {
+        let apps = [
+            makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app"),
+            makeApp(name: "Beta", bundleID: "com.beta.app", path: "/Applications/Beta.app"),
+        ]
+        let updates = [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        let vm = makeViewModel(discover: { apps }, check: { _ in updates })
+
+        await vm.scan()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.installedApps, apps)
+        XCTAssertEqual(result.availableUpdates, updates)
+        XCTAssertEqual(result.installedCount, 2)
+        XCTAssertEqual(result.updatesCount, 1)
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    func test_scan_passesDiscoveredAppsToTheUpdateChecker() async {
+        let apps = [makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        var received: [AppInfo] = []
+        let vm = makeViewModel(
+            discover: { apps },
+            check: { discovered in
+                received = discovered
+                return []
+            }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(received, apps, "The update checker must receive the discovered apps")
+    }
+
+    func test_scan_withNoUpdates_stillLandsResults() async {
+        let apps = [makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        let vm = makeViewModel(discover: { apps }, check: { _ in [] })
+
+        await vm.scan()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertTrue(result.availableUpdates.isEmpty)
+        XCTAssertEqual(result.updatesCount, 0)
+    }
+
+    // MARK: - Failure
+
+    func test_scan_whenDiscoveryThrows_landsFailed() async {
+        struct DiscoveryError: Error {}
+        let vm = makeViewModel(discover: { throw DiscoveryError() })
+
+        await vm.scan()
+
+        guard case .failed = vm.phase else {
+            return XCTFail("Expected .failed, got \(vm.phase)")
+        }
+        // A failed scan still shows the section's own detail UI (the failed
+        // state), not the intro.
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    // MARK: - Working projection
+
+    func test_scanPresentation_isWorkingWhileScanning() async {
+        // Gate the discovery so the scan parks in `.scanning` long enough to
+        // observe the projection before it resolves.
+        let gate = AsyncGate()
+        let vm = makeViewModel(discover: {
+            await gate.wait()
+            return []
+        })
+
+        let task = Task { await vm.scan() }
+        // Yield until the synchronous `phase = .scanning` write lands.
+        while vm.phase != .scanning { await Task.yield() }
+        XCTAssertEqual(vm.scanPresentation, .working)
+
+        await gate.open()
+        await task.value
+        XCTAssertEqual(vm.scanPresentation, .results)
+    }
+
+    // MARK: - Re-entrancy
+
+    func test_secondScanWhileScanning_isIgnored() async {
+        let gate = AsyncGate()
+        var discoverCalls = 0
+        let vm = makeViewModel(discover: {
+            discoverCalls += 1
+            await gate.wait()
+            return []
+        })
+
+        let first = Task { await vm.scan() }
+        while vm.phase != .scanning { await Task.yield() }
+        // A second scan while the first is in flight must be a no-op.
+        await vm.scan()
+        XCTAssertEqual(discoverCalls, 1, "A re-entrant scan must not start a second discovery")
+
+        await gate.open()
+        await first.value
+    }
+
+    // MARK: - Reset
+
+    func test_reset_returnsToIdle() async {
+        let vm = makeViewModel(discover: { [] })
+        await vm.scan()
+        XCTAssertEqual(vm.scanPresentation, .results)
+
+        vm.reset()
+
+        XCTAssertEqual(vm.phase, .idle)
+        XCTAssertEqual(vm.scanPresentation, .intro)
+    }
+}
+
+/// A one-shot async gate so a test can hold an injected closure inside
+/// `.scanning` until it chooses to release it. Real concurrency, no mocks.
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for continuation in pending { continuation.resume() }
+    }
+}

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -59,6 +59,19 @@ final class ApplicationsViewModelTests: XCTestCase {
         )
     }
 
+    nonisolated private func makeUnused(name: String, bundleID: String) -> UnusedApp {
+        UnusedApp(
+            app: AppInfo(
+                name: name,
+                bundleID: bundleID,
+                version: "1.0",
+                bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+                isAppStore: false
+            ),
+            lastUsedDate: Date(timeIntervalSince1970: 1_600_000_000)
+        )
+    }
+
     /// Builds a view-model with injected collaborators. Sub-scans default to
     /// empty and recycling to "removes everything asked" so the existing tests
     /// stay focused on the discover → update path.
@@ -67,6 +80,7 @@ final class ApplicationsViewModelTests: XCTestCase {
         check: @escaping ApplicationsViewModel.CheckUpdates = { _ in [] },
         installers: @escaping ApplicationsViewModel.ScanInstallationFiles = { [] },
         unsupported: @escaping ApplicationsViewModel.ScanUnsupportedApps = { _ in [] },
+        unused: @escaping ApplicationsViewModel.ScanUnusedApps = { _ in [] },
         recycle: @escaping ApplicationsViewModel.RecycleFiles = { Set($0) }
     ) -> ApplicationsViewModel {
         ApplicationsViewModel(
@@ -74,6 +88,7 @@ final class ApplicationsViewModelTests: XCTestCase {
             checkUpdates: check,
             scanInstallationFiles: installers,
             scanUnsupportedApps: unsupported,
+            scanUnusedApps: unused,
             recycleFiles: recycle
         )
     }
@@ -435,6 +450,84 @@ final class ApplicationsViewModelTests: XCTestCase {
         XCTAssertTrue(result.installationFiles.isEmpty)
         XCTAssertEqual(result.unsupportedApps, [unsupported],
                        "Unrelated payload must survive an installer delete")
+    }
+
+    // MARK: - Unused apps
+
+    func test_scan_carriesUnusedAppsIntoResults() async {
+        let unused = [makeUnused(name: "Dusty", bundleID: "com.dusty.app")]
+        let vm = makeViewModel(discover: { [] }, unused: { _ in unused })
+
+        await vm.scan()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.unusedApps, unused)
+        XCTAssertEqual(result.unusedAppsCount, 1)
+    }
+
+    func test_scan_passesDiscoveredAppsToTheUnusedScan() async {
+        let apps = [makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        var received: [AppInfo] = []
+        let vm = makeViewModel(
+            discover: { apps },
+            unused: { discovered in
+                received = discovered
+                return []
+            }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(received, apps, "The unused scan must receive the discovered apps")
+    }
+
+    func test_deleteSelectedUnusedApps_recyclesBundlesAndRebuildsPayload() async {
+        let a = makeUnused(name: "Dusty", bundleID: "com.dusty.app")
+        let b = makeUnused(name: "Stale", bundleID: "com.stale.app")
+        var recycled: [URL] = []
+        let vm = makeViewModel(
+            discover: { [] },
+            unused: { _ in [a, b] },
+            recycle: { urls in recycled = urls; return Set(urls) }
+        )
+        await vm.scan()
+        vm.toggleUnusedApp(a)
+
+        await vm.deleteSelectedUnusedApps()
+
+        XCTAssertEqual(recycled, [a.app.bundleURL], "Only the selected app bundle is recycled")
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.unusedApps, [b],
+                       "The recycled app must be dropped from the payload")
+        XCTAssertFalse(vm.isRemovingUnusedApps)
+    }
+
+    func test_unusedAppDelete_preservesOtherPayload() async {
+        // Removing an unused app must not touch installers / unsupported.
+        let unused = makeUnused(name: "Dusty", bundleID: "com.dusty.app")
+        let installer = makeInstaller(name: "A.dmg", size: 5_000)
+        let unsupported = makeUnsupported(name: "Old", bundleID: "com.old.app")
+        let vm = makeViewModel(
+            discover: { [] },
+            installers: { [installer] },
+            unsupported: { _ in [unsupported] },
+            unused: { _ in [unused] }
+        )
+        await vm.scan()
+        vm.selectAllUnusedApps()
+
+        await vm.deleteSelectedUnusedApps()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertTrue(result.unusedApps.isEmpty)
+        XCTAssertEqual(result.installationFiles, [installer])
+        XCTAssertEqual(result.unsupportedApps, [unsupported])
     }
 }
 

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -46,19 +46,34 @@ final class ApplicationsViewModelTests: XCTestCase {
         )
     }
 
-    /// Builds a view-model with injected collaborators. Installation-file
-    /// scanning defaults to empty and recycling to "removes everything asked"
-    /// so the existing tests stay focused on the discover → update path.
+    nonisolated private func makeUnsupported(name: String, bundleID: String) -> UnsupportedApp {
+        UnsupportedApp(
+            app: AppInfo(
+                name: name,
+                bundleID: bundleID,
+                version: "1.0",
+                bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+                isAppStore: false
+            ),
+            reason: .incompatibleArchitecture
+        )
+    }
+
+    /// Builds a view-model with injected collaborators. Sub-scans default to
+    /// empty and recycling to "removes everything asked" so the existing tests
+    /// stay focused on the discover → update path.
     private func makeViewModel(
         discover: @escaping ApplicationsViewModel.DiscoverApps,
         check: @escaping ApplicationsViewModel.CheckUpdates = { _ in [] },
         installers: @escaping ApplicationsViewModel.ScanInstallationFiles = { [] },
+        unsupported: @escaping ApplicationsViewModel.ScanUnsupportedApps = { _ in [] },
         recycle: @escaping ApplicationsViewModel.RecycleFiles = { Set($0) }
     ) -> ApplicationsViewModel {
         ApplicationsViewModel(
             discoverApps: discover,
             checkUpdates: check,
             scanInstallationFiles: installers,
+            scanUnsupportedApps: unsupported,
             recycleFiles: recycle
         )
     }
@@ -172,12 +187,18 @@ final class ApplicationsViewModelTests: XCTestCase {
 
         let first = Task { await vm.scan() }
         while vm.phase != .scanning { await Task.yield() }
-        // A second scan while the first is in flight must be a no-op.
+        // A second scan while the first is in flight must be a no-op — the
+        // phase is still `.scanning` and it returns without starting work.
         await vm.scan()
-        XCTAssertEqual(discoverCalls, 1, "A re-entrant scan must not start a second discovery")
+        XCTAssertEqual(vm.phase, .scanning, "A re-entrant scan must not change the phase")
 
         await gate.open()
         await first.value
+
+        // Asserted after completion (not mid-flight) so it doesn't depend on
+        // exactly when the first scan reaches discovery: across both calls,
+        // discovery must have run exactly once.
+        XCTAssertEqual(discoverCalls, 1, "A re-entrant scan must not start a second discovery")
     }
 
     // MARK: - Reset
@@ -304,6 +325,116 @@ final class ApplicationsViewModelTests: XCTestCase {
         await vm.deleteSelectedInstallationFiles()
 
         XCTAssertEqual(recycleCalls, 0, "Nothing selected → the recycler is never called")
+    }
+
+    // MARK: - Unsupported apps
+
+    func test_scan_carriesUnsupportedAppsIntoResults() async {
+        let unsupported = [
+            makeUnsupported(name: "Old32Bit", bundleID: "com.legacy.app"),
+        ]
+        let vm = makeViewModel(discover: { [] }, unsupported: { _ in unsupported })
+
+        await vm.scan()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.unsupportedApps, unsupported)
+        XCTAssertEqual(result.unsupportedAppsCount, 1)
+    }
+
+    func test_scan_passesDiscoveredAppsToTheUnsupportedScan() async {
+        let apps = [makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        var received: [AppInfo] = []
+        let vm = makeViewModel(
+            discover: { apps },
+            unsupported: { discovered in
+                received = discovered
+                return []
+            }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(received, apps, "The unsupported scan must receive the discovered apps")
+    }
+
+    func test_unsupportedAppSelection_isEmptyAfterScan() async {
+        let vm = makeViewModel(
+            discover: { [] },
+            unsupported: { _ in [self.makeUnsupported(name: "Old", bundleID: "com.old.app")] }
+        )
+        await vm.scan()
+        XCTAssertTrue(vm.unsupportedAppSelection.isEmpty)
+        XCTAssertFalse(vm.canRemoveUnsupportedApps)
+    }
+
+    func test_deleteSelectedUnsupportedApps_recyclesBundlesAndRebuildsPayload() async {
+        let a = makeUnsupported(name: "Old", bundleID: "com.old.app")
+        let b = makeUnsupported(name: "Ancient", bundleID: "com.ancient.app")
+        var recycled: [URL] = []
+        let vm = makeViewModel(
+            discover: { [] },
+            unsupported: { _ in [a, b] },
+            recycle: { urls in recycled = urls; return Set(urls) }
+        )
+        await vm.scan()
+        vm.toggleUnsupportedApp(a)
+
+        await vm.deleteSelectedUnsupportedApps()
+
+        XCTAssertEqual(recycled, [a.app.bundleURL], "Only the selected app bundle is recycled")
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.unsupportedApps, [b],
+                       "The recycled app must be dropped from the payload")
+        XCTAssertFalse(vm.isRemovingUnsupportedApps)
+    }
+
+    func test_deleteSelectedUnsupportedApps_keepsBundlesThatFailedToRecycle() async {
+        let a = makeUnsupported(name: "Old", bundleID: "com.old.app")
+        let b = makeUnsupported(name: "Ancient", bundleID: "com.ancient.app")
+        let vm = makeViewModel(
+            discover: { [] },
+            unsupported: { _ in [a, b] },
+            // The recycler (e.g. a root-owned bundle) only manages to move one.
+            recycle: { _ in [a.app.bundleURL] }
+        )
+        await vm.scan()
+        vm.selectAllUnsupportedApps()
+
+        await vm.deleteSelectedUnsupportedApps()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertEqual(result.unsupportedApps, [b],
+                       "A bundle the recycler couldn't move must stay in the list")
+        XCTAssertTrue(vm.unsupportedAppSelection.contains(b.app.bundleURL))
+    }
+
+    func test_installationFileDelete_preservesUnsupportedApps() async {
+        // Removing an installer must not drop the unsupported-apps payload.
+        let installer = makeInstaller(name: "A.dmg", size: 5_000)
+        let unsupported = makeUnsupported(name: "Old", bundleID: "com.old.app")
+        let vm = makeViewModel(
+            discover: { [] },
+            installers: { [installer] },
+            unsupported: { _ in [unsupported] }
+        )
+        await vm.scan()
+        vm.toggleInstallationFile(installer)
+
+        await vm.deleteSelectedInstallationFiles()
+
+        guard case .results(let result) = vm.phase else {
+            return XCTFail("Expected .results, got \(vm.phase)")
+        }
+        XCTAssertTrue(result.installationFiles.isEmpty)
+        XCTAssertEqual(result.unsupportedApps, [unsupported],
+                       "Unrelated payload must survive an installer delete")
     }
 }
 

--- a/VaderCleanerTests/InstallationFileScannerTests.swift
+++ b/VaderCleanerTests/InstallationFileScannerTests.swift
@@ -1,0 +1,152 @@
+// InstallationFileScannerTests.swift
+// Drives DefaultInstallationFileScanner against temp fixture roots, covering extension filtering, multi-root aggregation, size-descending order, the regular-file guard, and missing-root tolerance — all hermetic, never touching the real Downloads/Desktop.
+
+import XCTest
+@testable import VaderCleaner
+
+final class InstallationFileScannerTests: XCTestCase {
+
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = try TestHelpers.createTempDirectory()
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            TestHelpers.tearDownTempDirectory(tempRoot)
+        }
+        tempRoot = nil
+        super.tearDown()
+    }
+
+    private func makeRoot(_ name: String) throws -> URL {
+        let root = tempRoot.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    // MARK: - Extension filtering
+
+    func test_scan_keepsOnlyInstallerExtensions() async throws {
+        let root = try makeRoot("downloads")
+        try TestHelpers.createDummyFile(named: "Installer.dmg", size: 100, in: root)
+        try TestHelpers.createDummyFile(named: "App.pkg", size: 100, in: root)
+        try TestHelpers.createDummyFile(named: "Ubuntu.iso", size: 100, in: root)
+        try TestHelpers.createDummyFile(named: "notes.txt", size: 100, in: root)
+        try TestHelpers.createDummyFile(named: "photo.png", size: 100, in: root)
+
+        let scanner = DefaultInstallationFileScanner(roots: [root])
+        let files = await scanner.scan()
+
+        XCTAssertEqual(
+            Set(files.map(\.name)),
+            ["Installer.dmg", "App.pkg", "Ubuntu.iso"],
+            "Only .dmg / .pkg / .iso files must be surfaced"
+        )
+    }
+
+    func test_scan_classifiesKinds() async throws {
+        let root = try makeRoot("downloads")
+        try TestHelpers.createDummyFile(named: "Installer.dmg", size: 10, in: root)
+        try TestHelpers.createDummyFile(named: "Ubuntu.iso", size: 10, in: root)
+        try TestHelpers.createDummyFile(named: "App.pkg", size: 10, in: root)
+
+        let scanner = DefaultInstallationFileScanner(roots: [root])
+        let files = await scanner.scan()
+        let byName = Dictionary(uniqueKeysWithValues: files.map { ($0.name, $0.kind) })
+
+        XCTAssertEqual(byName["Installer.dmg"], .diskImage)
+        XCTAssertEqual(byName["Ubuntu.iso"], .diskImage)
+        XCTAssertEqual(byName["App.pkg"], .package)
+    }
+
+    func test_scan_isCaseInsensitiveOnExtension() async throws {
+        let root = try makeRoot("downloads")
+        try TestHelpers.createDummyFile(named: "Installer.DMG", size: 10, in: root)
+
+        let scanner = DefaultInstallationFileScanner(roots: [root])
+        let files = await scanner.scan()
+
+        XCTAssertEqual(files.map(\.name), ["Installer.DMG"])
+    }
+
+    // MARK: - Multi-root + ordering
+
+    func test_scan_aggregatesAcrossRootsAndSortsBySizeDescending() async throws {
+        let downloads = try makeRoot("downloads")
+        let desktop = try makeRoot("desktop")
+        try TestHelpers.createDummyFile(named: "small.dmg", size: 100, in: downloads)
+        try TestHelpers.createDummyFile(named: "big.pkg", size: 5_000, in: desktop)
+        try TestHelpers.createDummyFile(named: "medium.iso", size: 1_000, in: downloads)
+
+        let scanner = DefaultInstallationFileScanner(roots: [downloads, desktop])
+        let files = await scanner.scan()
+
+        XCTAssertEqual(
+            files.map(\.name),
+            ["big.pkg", "medium.iso", "small.dmg"],
+            "Files from both roots must be merged and ordered largest-first"
+        )
+        XCTAssertEqual(files.first?.sizeBytes, 5_000)
+    }
+
+    // MARK: - Guards
+
+    func test_scan_ignoresDirectoriesNamedLikeInstallers() async throws {
+        let root = try makeRoot("downloads")
+        // A folder a user happened to name "Project.dmg" must never be offered
+        // for removal as an installer.
+        let folder = root.appendingPathComponent("Project.dmg", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "real.dmg", size: 10, in: root)
+
+        let scanner = DefaultInstallationFileScanner(roots: [root])
+        let files = await scanner.scan()
+
+        XCTAssertEqual(files.map(\.name), ["real.dmg"],
+                       "Directories must be skipped even when named like an installer")
+    }
+
+    func test_scan_isShallow_doesNotRecurseIntoSubfolders() async throws {
+        let root = try makeRoot("downloads")
+        let nested = root.appendingPathComponent("Old Installers", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try TestHelpers.createDummyFile(named: "nested.dmg", size: 10, in: nested)
+        try TestHelpers.createDummyFile(named: "top.dmg", size: 10, in: root)
+
+        let scanner = DefaultInstallationFileScanner(roots: [root])
+        let files = await scanner.scan()
+
+        XCTAssertEqual(files.map(\.name), ["top.dmg"],
+                       "The scan must stay one level deep and not descend into subfolders")
+    }
+
+    func test_scan_toleratesMissingRoot() async throws {
+        let present = try makeRoot("downloads")
+        try TestHelpers.createDummyFile(named: "Installer.dmg", size: 10, in: present)
+        let missing = tempRoot.appendingPathComponent("does-not-exist", isDirectory: true)
+
+        let scanner = DefaultInstallationFileScanner(roots: [present, missing])
+        let files = await scanner.scan()
+
+        XCTAssertEqual(files.map(\.name), ["Installer.dmg"],
+                       "A missing root must not sink the rest of the scan")
+    }
+
+    func test_scan_emptyRoots_returnsEmpty() async throws {
+        let root = try makeRoot("downloads")
+        let scanner = DefaultInstallationFileScanner(roots: [root])
+        let files = await scanner.scan()
+        XCTAssertTrue(files.isEmpty)
+    }
+
+    // MARK: - Default roots
+
+    func test_defaultRoots_areDownloadsAndDesktop() {
+        let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+        let roots = DefaultInstallationFileScanner.defaultRoots(homeDirectory: home)
+        XCTAssertEqual(roots.map(\.lastPathComponent), ["Downloads", "Desktop"])
+    }
+}

--- a/VaderCleanerTests/MachOHeaderReaderTests.swift
+++ b/VaderCleanerTests/MachOHeaderReaderTests.swift
@@ -1,0 +1,109 @@
+// MachOHeaderReaderTests.swift
+// Drives MachOHeaderReader against synthetic Mach-O / universal header bytes and pins UnsupportedAppClassifier's runnable-architecture rule — fully hermetic, no real binaries.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MachOHeaderReaderTests: XCTestCase {
+
+    // MARK: - Byte builders
+
+    private func be32(_ v: UInt32) -> [UInt8] {
+        [UInt8(v >> 24 & 0xFF), UInt8(v >> 16 & 0xFF), UInt8(v >> 8 & 0xFF), UInt8(v & 0xFF)]
+    }
+    private func le32(_ v: UInt32) -> [UInt8] { be32(v).reversed() }
+    private let pad16 = [UInt8](repeating: 0, count: 16)
+    private let pad28 = [UInt8](repeating: 0, count: 28)
+
+    private let i386: UInt32 = 7
+    private let powerpc: UInt32 = 18
+
+    // MARK: - Thin Mach-O
+
+    func test_thinLittleEndian_arm64() {
+        // MH_MAGIC_64 (0xFEEDFACF) stored little-endian, then arm64 cputype.
+        let data = Data(le32(0xFEED_FACF) + le32(MachOCPUType.arm64))
+        XCTAssertEqual(MachOHeaderReader.cpuTypes(in: data), [MachOCPUType.arm64])
+    }
+
+    func test_thinLittleEndian_x86_64() {
+        let data = Data(le32(0xFEED_FACF) + le32(MachOCPUType.x86_64))
+        XCTAssertEqual(MachOHeaderReader.cpuTypes(in: data), [MachOCPUType.x86_64])
+    }
+
+    func test_thinLittleEndian_i386_32bit() {
+        // MH_MAGIC (0xFEEDFACE) — 32-bit header — with the i386 cputype.
+        let data = Data(le32(0xFEED_FACE) + le32(i386))
+        XCTAssertEqual(MachOHeaderReader.cpuTypes(in: data), [i386])
+    }
+
+    // MARK: - Universal (fat) binaries
+
+    func test_fatBigEndian_x86_64_and_arm64() {
+        let data = Data(
+            be32(0xCAFE_BABE) + be32(2)
+            + be32(MachOCPUType.x86_64) + pad16
+            + be32(MachOCPUType.arm64) + pad16
+        )
+        XCTAssertEqual(
+            MachOHeaderReader.cpuTypes(in: data),
+            [MachOCPUType.x86_64, MachOCPUType.arm64]
+        )
+    }
+
+    func test_fatBigEndian_legacyOnly_i386_and_powerpc() {
+        let data = Data(
+            be32(0xCAFE_BABE) + be32(2)
+            + be32(i386) + pad16
+            + be32(powerpc) + pad16
+        )
+        XCTAssertEqual(MachOHeaderReader.cpuTypes(in: data), [i386, powerpc])
+    }
+
+    func test_fat64_singleSlice() {
+        // FAT_MAGIC_64 uses 32-byte arch entries (cputype + 28 bytes).
+        let data = Data(be32(0xCAFE_BABF) + be32(1) + be32(MachOCPUType.x86_64) + pad28)
+        XCTAssertEqual(MachOHeaderReader.cpuTypes(in: data), [MachOCPUType.x86_64])
+    }
+
+    // MARK: - Non-Mach-O / malformed
+
+    func test_unrecognizedMagic_returnsNil() {
+        let data = Data([0x50, 0x4B, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00]) // "PK.." (a zip)
+        XCTAssertNil(MachOHeaderReader.cpuTypes(in: data))
+    }
+
+    func test_tooShort_returnsNil() {
+        XCTAssertNil(MachOHeaderReader.cpuTypes(in: Data([0xCF, 0xFA])))
+    }
+
+    func test_fatWithAbsurdArchCount_returnsNil() {
+        let data = Data(be32(0xCAFE_BABE) + be32(9999))
+        XCTAssertNil(MachOHeaderReader.cpuTypes(in: data),
+                     "An implausible nfat_arch must be rejected, not trusted")
+    }
+
+    // MARK: - Classifier
+
+    func test_classifier_emptyIsNotUnsupported() {
+        XCTAssertFalse(UnsupportedAppClassifier.isUnsupported(cpuTypes: []))
+    }
+
+    func test_classifier_runnableSlicesAreSupported() {
+        XCTAssertFalse(UnsupportedAppClassifier.isUnsupported(cpuTypes: [MachOCPUType.arm64]))
+        XCTAssertFalse(UnsupportedAppClassifier.isUnsupported(cpuTypes: [MachOCPUType.x86_64]))
+        XCTAssertFalse(UnsupportedAppClassifier.isUnsupported(
+            cpuTypes: [MachOCPUType.x86_64, MachOCPUType.arm64]
+        ))
+    }
+
+    func test_classifier_legacyOnlyIsUnsupported() {
+        XCTAssertTrue(UnsupportedAppClassifier.isUnsupported(cpuTypes: [i386]))
+        XCTAssertTrue(UnsupportedAppClassifier.isUnsupported(cpuTypes: [i386, powerpc]))
+    }
+
+    func test_classifier_anyRunnableSliceMakesItSupported() {
+        // A fat binary that still ships an x86_64 slice runs under Rosetta.
+        XCTAssertFalse(UnsupportedAppClassifier.isUnsupported(cpuTypes: [i386, MachOCPUType.x86_64]))
+    }
+}

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -7,8 +7,8 @@ import AppKit
 
 final class NavigationSectionTests: XCTestCase {
 
-    func test_allCasesCount_is11() {
-        XCTAssertEqual(NavigationSection.allCases.count, 11)
+    func test_allCasesCount_is10() {
+        XCTAssertEqual(NavigationSection.allCases.count, 10)
     }
 
     func test_firstCase_isSmartScan() {
@@ -33,8 +33,7 @@ final class NavigationSectionTests: XCTestCase {
             .malwareRemoval: "sidebar.malwareRemoval",
             .privacy: "sidebar.privacy",
             .extensions: "sidebar.extensions",
-            .appUninstaller: "sidebar.appUninstaller",
-            .appUpdater: "sidebar.appUpdater",
+            .applications: "sidebar.applications",
             .optimization: "sidebar.optimization",
             .healthMonitor: "sidebar.healthMonitor",
         ]
@@ -61,8 +60,7 @@ final class NavigationSectionTests: XCTestCase {
             .malwareRemoval: "section.malwareRemoval.scan",
             .privacy: "section.privacy.scan",
             .extensions: "section.extensions.scan",
-            .appUninstaller: "section.appUninstaller.scan",
-            .appUpdater: "section.appUpdater.scan",
+            .applications: "section.applications.scan",
             .optimization: "section.optimization.scan",
             .healthMonitor: "section.healthMonitor.scan",
         ]
@@ -93,8 +91,7 @@ final class NavigationSectionTests: XCTestCase {
             .optimization: false,    // launchctl / login items / RAM
             .privacy: true,          // Safari data lives in TCC-protected paths
             .extensions: false,
-            .appUninstaller: false,
-            .appUpdater: false,
+            .applications: false,    // app discovery + update checks; no FDA-gated paths
             .healthMonitor: false,
         ]
         for section in NavigationSection.allCases {

--- a/VaderCleanerTests/SectionIntroViewTests.swift
+++ b/VaderCleanerTests/SectionIntroViewTests.swift
@@ -21,6 +21,7 @@ final class SectionIntroViewTests: XCTestCase {
         .malwareRemoval: "malwareremoval",
         .optimization: "optimization",
         .privacy: "privacy",
+        .applications: "applications",
     ]
 
     func test_buildsFromEveryScannableSectionPresentation() throws {

--- a/VaderCleanerTests/SectionPresentationTests.swift
+++ b/VaderCleanerTests/SectionPresentationTests.swift
@@ -8,15 +8,25 @@ import SwiftUI
 
 final class SectionPresentationTests: XCTestCase {
 
-    /// The seven sections that drive a scan/load and therefore get the unified
+    /// The eight sections that drive a scan/load and therefore get the unified
     /// intro screen + floating Scan button. Pinned here so a drift in
     /// `isScannable` or `SectionPresentation.for(_:)` fails loudly.
     private let scannableSections: Set<NavigationSection> = [
         .smartScan, .systemJunk, .largeOldFiles,
         .spaceLens, .malwareRemoval, .optimization, .privacy,
+        .applications,
     ]
 
-    func test_isScannable_isTrueForExactlyTheSevenScannableSections() {
+    /// The scannable sections that ship a bespoke USDZ 3D hero model named
+    /// after their enum case. `.applications` is intentionally excluded — it
+    /// uses the SF Symbol hero fallback (`heroModelName: nil`) until a model
+    /// is designed for it.
+    private let sectionsWithHeroModel: Set<NavigationSection> = [
+        .smartScan, .systemJunk, .largeOldFiles,
+        .spaceLens, .malwareRemoval, .optimization, .privacy,
+    ]
+
+    func test_isScannable_isTrueForExactlyTheEightScannableSections() {
         for section in NavigationSection.allCases {
             let expected = scannableSections.contains(section)
             XCTAssertEqual(
@@ -27,9 +37,9 @@ final class SectionPresentationTests: XCTestCase {
         }
     }
 
-    func test_isScannable_countIsExactlySeven() {
+    func test_isScannable_countIsExactlyEight() {
         let count = NavigationSection.allCases.filter(\.isScannable).count
-        XCTAssertEqual(count, 7, "Exactly seven sections must be scannable")
+        XCTAssertEqual(count, 8, "Exactly eight sections must be scannable")
     }
 
     func test_presentationFor_isNonNilForScannableAndNilOtherwise() {
@@ -114,13 +124,26 @@ final class SectionPresentationTests: XCTestCase {
     /// its enum case name (e.g. `.smartScan` → `"smartScan"`). The naming is
     /// the contract that lets `SectionIntroView` resolve the right asset
     /// without a per-section switch.
-    func test_everyScannablePresentation_hasHeroModelNameMatchingSectionCase() throws {
-        for section in scannableSections {
+    func test_everyModelBearingPresentation_hasHeroModelNameMatchingSectionCase() throws {
+        for section in sectionsWithHeroModel {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))
             XCTAssertEqual(
                 presentation.heroModelName,
                 String(describing: section),
                 "Section \(section) must declare heroModelName \"\(String(describing: section))\""
+            )
+        }
+    }
+
+    /// Sections that intentionally have no USDZ hero must declare
+    /// `heroModelName: nil` so `SectionIntroView` takes the SF Symbol fallback
+    /// rather than trying to load a missing model.
+    func test_sectionsWithoutHeroModel_declareNilModelName() throws {
+        for section in scannableSections.subtracting(sectionsWithHeroModel) {
+            let presentation = try XCTUnwrap(SectionPresentation.for(section))
+            XCTAssertNil(
+                presentation.heroModelName,
+                "Section \(section) ships no USDZ, so heroModelName must be nil"
             )
         }
     }
@@ -134,7 +157,7 @@ final class SectionPresentationTests: XCTestCase {
         // here is the host app's bundle — the same one Model3D(named:)
         // queries at runtime.
         let bundle = Bundle.main
-        for section in scannableSections {
+        for section in sectionsWithHeroModel {
             let presentation = try XCTUnwrap(SectionPresentation.for(section))
             let modelName = try XCTUnwrap(
                 presentation.heroModelName,

--- a/VaderCleanerTests/UnsupportedAppScannerTests.swift
+++ b/VaderCleanerTests/UnsupportedAppScannerTests.swift
@@ -1,0 +1,59 @@
+// UnsupportedAppScannerTests.swift
+// Drives DefaultUnsupportedAppScanner with an injected CPU-type provider so classification is exercised without real Mach-O binaries.
+
+import XCTest
+@testable import VaderCleaner
+
+final class UnsupportedAppScannerTests: XCTestCase {
+
+    private func makeApp(_ name: String, bundleID: String) -> AppInfo {
+        AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: "1.0",
+            bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+            isAppStore: false
+        )
+    }
+
+    func test_scan_flagsAppsWithNoRunnableArchitecture() async {
+        let legacy = makeApp("Legacy", bundleID: "com.legacy.app")
+        let modern = makeApp("Modern", bundleID: "com.modern.app")
+        let scanner = DefaultUnsupportedAppScanner { app in
+            app.bundleID == "com.legacy.app" ? [7] : [MachOCPUType.arm64]
+        }
+
+        let result = await scanner.scan(apps: [legacy, modern])
+
+        XCTAssertEqual(result.map(\.app.bundleID), ["com.legacy.app"])
+        XCTAssertEqual(result.first?.reason, .incompatibleArchitecture)
+    }
+
+    func test_scan_doesNotFlagAppsWhoseArchitectureCannotBeRead() async {
+        let unknown = makeApp("Unknown", bundleID: "com.unknown.app")
+        let scanner = DefaultUnsupportedAppScanner { _ in nil }
+
+        let result = await scanner.scan(apps: [unknown])
+
+        XCTAssertTrue(result.isEmpty, "An unreadable executable must never be flagged")
+    }
+
+    func test_scan_keepsOnlyUnsupportedAppsAndPreservesOrder() async {
+        let a = makeApp("A", bundleID: "a")   // legacy
+        let b = makeApp("B", bundleID: "b")   // modern
+        let c = makeApp("C", bundleID: "c")   // legacy
+        let scanner = DefaultUnsupportedAppScanner { app in
+            app.bundleID == "b" ? [MachOCPUType.x86_64] : [7, 18]
+        }
+
+        let result = await scanner.scan(apps: [a, b, c])
+
+        XCTAssertEqual(result.map(\.app.bundleID), ["a", "c"])
+    }
+
+    func test_scan_emptyInput_returnsEmpty() async {
+        let scanner = DefaultUnsupportedAppScanner { _ in [7] }
+        let result = await scanner.scan(apps: [])
+        XCTAssertTrue(result.isEmpty)
+    }
+}

--- a/VaderCleanerTests/UnusedAppScannerTests.swift
+++ b/VaderCleanerTests/UnusedAppScannerTests.swift
@@ -1,0 +1,108 @@
+// UnusedAppScannerTests.swift
+// Drives DefaultUnusedAppScanner with injected last-used dates and a fixed "now", covering the threshold boundary, the unknown-date guard, oldest-first ordering, and threshold configuration — fully hermetic.
+
+import XCTest
+@testable import VaderCleaner
+
+final class UnusedAppScannerTests: XCTestCase {
+
+    /// Fixed reference "now" so age assertions don't depend on real time.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let day: TimeInterval = 24 * 60 * 60
+
+    private func makeApp(_ name: String, bundleID: String) -> AppInfo {
+        AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: "1.0",
+            bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+            isAppStore: false
+        )
+    }
+
+    private func scanner(
+        thresholdDays: Int = DefaultUnusedAppScanner.defaultThresholdDays,
+        dates: [String: Date?]
+    ) -> DefaultUnusedAppScanner {
+        DefaultUnusedAppScanner(
+            thresholdDays: thresholdDays,
+            lastUsedDate: { app in dates[app.bundleID] ?? nil },
+            now: { self.now }
+        )
+    }
+
+    func test_scan_flagsAppsOlderThanThreshold() async {
+        let stale = makeApp("Stale", bundleID: "com.stale.app")
+        let fresh = makeApp("Fresh", bundleID: "com.fresh.app")
+        let s = scanner(dates: [
+            "com.stale.app": now.addingTimeInterval(-90 * day),
+            "com.fresh.app": now.addingTimeInterval(-3 * day),
+        ])
+
+        let result = await s.scan(apps: [stale, fresh])
+
+        XCTAssertEqual(result.map(\.app.bundleID), ["com.stale.app"])
+        XCTAssertEqual(result.first?.lastUsedDate, now.addingTimeInterval(-90 * day))
+    }
+
+    func test_scan_doesNotFlagAppsWithNoKnownLastUsedDate() async {
+        let unknown = makeApp("Unknown", bundleID: "com.unknown.app")
+        let s = scanner(dates: ["com.unknown.app": Optional<Date>.none])
+
+        let result = await s.scan(apps: [unknown])
+
+        XCTAssertTrue(result.isEmpty, "An app with no usage record must never be flagged")
+    }
+
+    func test_scan_thresholdBoundaryIsInclusive() async {
+        // Exactly 60 days old → not used within the window → flagged.
+        let boundary = makeApp("Boundary", bundleID: "com.boundary.app")
+        let s = scanner(dates: ["com.boundary.app": now.addingTimeInterval(-60 * day)])
+
+        let result = await s.scan(apps: [boundary])
+
+        XCTAssertEqual(result.map(\.app.bundleID), ["com.boundary.app"])
+    }
+
+    func test_scan_justInsideThreshold_isNotFlagged() async {
+        let recent = makeApp("Recent", bundleID: "com.recent.app")
+        let s = scanner(dates: ["com.recent.app": now.addingTimeInterval(-59 * day)])
+
+        let result = await s.scan(apps: [recent])
+
+        XCTAssertTrue(result.isEmpty, "An app used within the window must not be flagged")
+    }
+
+    func test_scan_ordersOldestFirst() async {
+        let a = makeApp("A", bundleID: "a")
+        let b = makeApp("B", bundleID: "b")
+        let c = makeApp("C", bundleID: "c")
+        let s = scanner(dates: [
+            "a": now.addingTimeInterval(-70 * day),
+            "b": now.addingTimeInterval(-200 * day),
+            "c": now.addingTimeInterval(-90 * day),
+        ])
+
+        let result = await s.scan(apps: [a, b, c])
+
+        XCTAssertEqual(result.map(\.app.bundleID), ["b", "c", "a"],
+                       "Most-stale app must come first")
+    }
+
+    func test_scan_honorsCustomThreshold() async {
+        let app = makeApp("App", bundleID: "com.app")
+        // 10 days old: unused under a 7-day threshold, fine under 60.
+        let s7 = scanner(thresholdDays: 7, dates: ["com.app": now.addingTimeInterval(-10 * day)])
+        let s60 = scanner(thresholdDays: 60, dates: ["com.app": now.addingTimeInterval(-10 * day)])
+
+        let under7 = await s7.scan(apps: [app])
+        let under60 = await s60.scan(apps: [app])
+
+        XCTAssertEqual(under7.map(\.app.bundleID), ["com.app"])
+        XCTAssertTrue(under60.isEmpty)
+    }
+
+    func test_defaultThreshold_is60Days() {
+        XCTAssertEqual(DefaultUnusedAppScanner.defaultThresholdDays, 60)
+    }
+}

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -96,6 +96,46 @@ final class ApplicationsUITests: XCTestCase {
         )
     }
 
+    /// The Manage card opens the Applications Manager catalog with its
+    /// Uninstaller / Updater / Leftovers sub-navigation; switching panes works
+    /// and Back returns to the dashboard.
+    func test_applications_manageOpensManagerCatalog() throws {
+        dismissOnboardingIfNeeded()
+        openApplicationsAndScan()
+
+        let manageCard = app.buttons["applications.card.manage"]
+        XCTAssertTrue(manageCard.waitForExistence(timeout: 90),
+                      "Expected the Manage card after the scan")
+        manageCard.click()
+
+        XCTAssertTrue(app.descendants(matching: .any)["applications.manager"].waitForExistence(timeout: 10),
+                      "Expected the Applications Manager catalog")
+        for navID in ["applications.manager.nav.uninstaller",
+                      "applications.manager.nav.updater",
+                      "applications.manager.nav.leftovers"] {
+            XCTAssertTrue(app.buttons[navID].waitForExistence(timeout: 5),
+                          "Expected sub-nav item \(navID)")
+        }
+
+        // Switch to the Updater pane — the reused updater screen renders.
+        app.buttons["applications.manager.nav.updater"].click()
+        let updaterState = app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier IN {'appUpdater.loading', 'appUpdater.upToDate', 'appUpdater.check', 'appUpdater.errorMessage'}"
+            ))
+            .firstMatch
+        XCTAssertTrue(updaterState.waitForExistence(timeout: 30),
+                      "Expected the Updater pane to render the reused App Updater screen")
+
+        let back = app.buttons["applications.backToDashboard"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        back.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["applications.dashboard"].waitForExistence(timeout: 5),
+            "Expected Back to return to the dashboard grid"
+        )
+    }
+
     /// The Updates card opens the reused App Updater screen, and Back returns
     /// to the dashboard.
     func test_applications_updatesCardOpensUpdaterAndBackReturns() throws {

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -60,6 +60,8 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the Installation Files card on the dashboard")
         XCTAssertTrue(app.buttons["applications.card.unsupported"].exists,
                       "Expected the Unsupported Applications card on the dashboard")
+        XCTAssertTrue(app.buttons["applications.card.unused"].exists,
+                      "Expected the Unused Applications card on the dashboard")
     }
 
     /// The Installation Files card opens its review screen, and Back returns to

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -58,6 +58,8 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the Manage card on the dashboard")
         XCTAssertTrue(app.buttons["applications.card.installationFiles"].exists,
                       "Expected the Installation Files card on the dashboard")
+        XCTAssertTrue(app.buttons["applications.card.unsupported"].exists,
+                      "Expected the Unsupported Applications card on the dashboard")
     }
 
     /// The Installation Files card opens its review screen, and Back returns to

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -62,6 +62,8 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the Unsupported Applications card on the dashboard")
         XCTAssertTrue(app.buttons["applications.card.unused"].exists,
                       "Expected the Unused Applications card on the dashboard")
+        XCTAssertTrue(app.buttons["applications.card.leftovers"].exists,
+                      "Expected the App Leftovers card on the dashboard")
     }
 
     /// The Installation Files card opens its review screen, and Back returns to

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -56,6 +56,38 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the Updates card on the dashboard")
         XCTAssertTrue(app.buttons["applications.card.manage"].exists,
                       "Expected the Manage card on the dashboard")
+        XCTAssertTrue(app.buttons["applications.card.installationFiles"].exists,
+                      "Expected the Installation Files card on the dashboard")
+    }
+
+    /// The Installation Files card opens its review screen, and Back returns to
+    /// the dashboard.
+    func test_applications_installationFilesCardOpensReviewAndBackReturns() throws {
+        dismissOnboardingIfNeeded()
+        openApplicationsAndScan()
+
+        let card = app.buttons["applications.card.installationFiles"]
+        XCTAssertTrue(card.waitForExistence(timeout: 90),
+                      "Expected the Installation Files card after the scan")
+        card.click()
+
+        // Either the installer list or its empty state must render — both are
+        // valid display states depending on what's in Downloads/Desktop.
+        let reviewState = app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier IN {'applications.installationFiles', 'applications.installationFiles.empty'}"
+            ))
+            .firstMatch
+        XCTAssertTrue(reviewState.waitForExistence(timeout: 10),
+                      "Expected the Installation Files review screen to render")
+
+        let back = app.buttons["applications.backToDashboard"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        back.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["applications.dashboard"].waitForExistence(timeout: 5),
+            "Expected Back to return to the dashboard grid"
+        )
     }
 
     /// The Updates card opens the reused App Updater screen, and Back returns

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -1,0 +1,121 @@
+// ApplicationsUITests.swift
+// End-to-end coverage for the merged Applications section — intro → Scan → dashboard grid → reused detail screens — exercised against the real app process.
+
+import XCTest
+
+/// These tests never trigger destructive controls. They drive the scan and
+/// open the dashboard's detail screens, but stop at display states — the
+/// uninstall / update side-effects are covered by the view-model unit tests.
+final class ApplicationsUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    /// Selecting Applications lands on the unified scan intro (it is a
+    /// scannable section now), with its per-section intro identifier and the
+    /// floating Scan button — not a list that auto-loads.
+    func test_applications_showsScanIntro() throws {
+        dismissOnboardingIfNeeded()
+
+        let row = app.buttons["sidebar.applications"].firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "Expected Applications row in sidebar")
+        row.click()
+
+        let intro = app.descendants(matching: .any)["section.intro"]
+        XCTAssertTrue(intro.waitForExistence(timeout: 5),
+                      "Expected the unified intro screen for Applications")
+        let applicationsIntro = app.descendants(matching: .any)["section.intro.applications"]
+        XCTAssertTrue(applicationsIntro.waitForExistence(timeout: 5),
+                      "Expected the Applications-specific intro identifier")
+        let scan = app.buttons["section.applications.scan"]
+        XCTAssertTrue(scan.waitForExistence(timeout: 5),
+                      "Expected the floating Scan button on the Applications intro")
+    }
+
+    /// Scan → the dashboard grid appears with the Updates and Manage cards.
+    func test_applications_scanShowsDashboardGrid() throws {
+        dismissOnboardingIfNeeded()
+        openApplicationsAndScan()
+
+        let dashboard = app.descendants(matching: .any)["applications.dashboard"]
+        XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
+                      "Expected the Applications dashboard grid after the scan")
+
+        XCTAssertTrue(app.buttons["applications.card.updates"].waitForExistence(timeout: 5),
+                      "Expected the Updates card on the dashboard")
+        XCTAssertTrue(app.buttons["applications.card.manage"].exists,
+                      "Expected the Manage card on the dashboard")
+    }
+
+    /// The Updates card opens the reused App Updater screen, and Back returns
+    /// to the dashboard.
+    func test_applications_updatesCardOpensUpdaterAndBackReturns() throws {
+        dismissOnboardingIfNeeded()
+        openApplicationsAndScan()
+
+        let updatesCard = app.buttons["applications.card.updates"]
+        XCTAssertTrue(updatesCard.waitForExistence(timeout: 90),
+                      "Expected the Updates card after the scan")
+        updatesCard.click()
+
+        // The reused App Updater screen reaches one of its display states.
+        let updaterState = app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier IN {'appUpdater.loading', 'appUpdater.upToDate', 'appUpdater.check', 'appUpdater.errorMessage'}"
+            ))
+            .firstMatch
+        XCTAssertTrue(updaterState.waitForExistence(timeout: 30),
+                      "Expected the reused App Updater screen to render")
+
+        let back = app.buttons["applications.backToDashboard"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        back.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["applications.dashboard"].waitForExistence(timeout: 5),
+            "Expected Back to return to the dashboard grid"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Navigate to Applications and trigger the scan via the floating button.
+    private func openApplicationsAndScan() {
+        let row = app.buttons["sidebar.applications"].firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "Expected Applications row in sidebar")
+        row.click()
+
+        let scan = app.buttons["section.applications.scan"]
+        XCTAssertTrue(scan.waitForExistence(timeout: 5),
+                      "Expected the floating Scan button on the Applications intro")
+        scan.click()
+        proceedPastScanAccessPopoverIfNeeded()
+    }
+
+    private func dismissOnboardingIfNeeded() {
+        let continueWithout = app.buttons["Continue Without Access"]
+        if continueWithout.waitForExistence(timeout: 2) {
+            continueWithout.click()
+        }
+    }
+
+    /// Applications is not Full-Disk-Access-gated, so the access popover should
+    /// not appear — but tap "Scan Anyway" defensively if it ever does.
+    private func proceedPastScanAccessPopoverIfNeeded() {
+        let scanAnyway = app.buttons["fda.popover.scanAnyway"]
+        if scanAnyway.waitForExistence(timeout: 3) {
+            scanAnyway.click()
+        }
+    }
+}

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -11,7 +11,7 @@ final class FinalPolishUITests: XCTestCase {
 
     private var app: XCUIApplication!
 
-    /// The eleven sidebar row identifiers, in `NavigationSection` order. Rows
+    /// The ten sidebar row identifiers, in `NavigationSection` order. Rows
     /// are located by identifier rather than visible label so the locators
     /// survive rail restyles; these mirror
     /// `NavigationSection.accessibilityIdentifier`. Hard-coded because the
@@ -25,8 +25,7 @@ final class FinalPolishUITests: XCTestCase {
         "sidebar.malwareRemoval",
         "sidebar.privacy",
         "sidebar.extensions",
-        "sidebar.appUninstaller",
-        "sidebar.appUpdater",
+        "sidebar.applications",
         "sidebar.optimization",
         "sidebar.healthMonitor",
     ]
@@ -44,8 +43,8 @@ final class FinalPolishUITests: XCTestCase {
 
     // MARK: - Sidebar
 
-    /// Launch → every one of the eleven sections is present in the sidebar.
-    func test_launch_sidebarShowsAllElevenSections() throws {
+    /// Launch → every one of the ten sections is present in the sidebar.
+    func test_launch_sidebarShowsAllTenSections() throws {
         dismissOnboardingIfNeeded()
 
         for identifier in sectionIdentifiers {
@@ -58,11 +57,11 @@ final class FinalPolishUITests: XCTestCase {
     }
 
     /// The rail must stay anchored: switching between a short detail screen
-    /// (App Updater, two rows) and a tall one (App Uninstaller, a search
-    /// field plus a long scrolling list) must not move the sidebar rows
-    /// vertically. Regression guard for the rail floating when the detail
-    /// column's effective height changes. The window is not resized, so the
-    /// `sidebar.smartScan` button's absolute Y must be identical in both.
+    /// (Extensions, a compact list) and a tall one (Health Monitor, a grid of
+    /// stat cards) must not move the sidebar rows vertically. Regression guard
+    /// for the rail floating when the detail column's effective height changes.
+    /// The window is not resized, so the `sidebar.smartScan` button's absolute
+    /// Y must be identical in both.
     func test_railRowPosition_isStableAcrossDetailScreens() throws {
         dismissOnboardingIfNeeded()
 
@@ -70,30 +69,30 @@ final class FinalPolishUITests: XCTestCase {
         XCTAssertTrue(anchor.waitForExistence(timeout: 5),
                       "Expected Smart Scan row in sidebar")
 
-        let updaterRow = app.buttons["sidebar.appUpdater"].firstMatch
-        XCTAssertTrue(updaterRow.waitForExistence(timeout: 5),
-                      "Expected App Updater row in sidebar")
-        updaterRow.click()
+        let extensionsRow = app.buttons["sidebar.extensions"].firstMatch
+        XCTAssertTrue(extensionsRow.waitForExistence(timeout: 5),
+                      "Expected Extensions row in sidebar")
+        extensionsRow.click()
         // Wait until the clicked row reports selection before measuring. The
         // anchor row exists regardless of selection, so waiting on it would
         // return immediately and could sample Y mid-transition; the
         // `.isSelected` trait only flips once the navigation has taken
         // effect and the rail re-rendered.
-        waitUntilSelected(updaterRow)
+        waitUntilSelected(extensionsRow)
         let yShortDetail = anchor.frame.origin.y
 
-        let uninstallerRow = app.buttons["sidebar.appUninstaller"].firstMatch
-        XCTAssertTrue(uninstallerRow.waitForExistence(timeout: 5),
-                      "Expected App Uninstaller row in sidebar")
-        uninstallerRow.click()
-        waitUntilSelected(uninstallerRow)
+        let healthRow = app.buttons["sidebar.healthMonitor"].firstMatch
+        XCTAssertTrue(healthRow.waitForExistence(timeout: 5),
+                      "Expected Health Monitor row in sidebar")
+        healthRow.click()
+        waitUntilSelected(healthRow)
         let yTallDetail = anchor.frame.origin.y
 
         XCTAssertEqual(
             yShortDetail, yTallDetail, accuracy: 1.0,
             "Sidebar rows must not shift vertically when the detail screen "
-            + "changes height (was \(yShortDetail) on App Updater, "
-            + "\(yTallDetail) on App Uninstaller)"
+            + "changes height (was \(yShortDetail) on Extensions, "
+            + "\(yTallDetail) on Health Monitor)"
         )
     }
 
@@ -206,18 +205,34 @@ final class FinalPolishUITests: XCTestCase {
         )
     }
 
-    // MARK: - App Uninstaller
+    // MARK: - Applications → Manage (App Uninstaller)
 
-    /// Sidebar → App Uninstaller auto-loads the installed-app list on
-    /// appearance. Any real Mac has well over five apps in /Applications,
-    /// so the list must contain at least five rows.
-    func test_navigateToAppUninstaller_listLoadsWithAtLeastFiveApps() throws {
+    /// Sidebar → Applications → Scan → Manage opens the reused App Uninstaller
+    /// list. Any real Mac has well over five apps in /Applications, so the list
+    /// must contain at least five rows. This proves the merged Applications
+    /// section's scan → dashboard → detail wiring end to end.
+    func test_applications_manageOpensUninstallerListWithAtLeastFiveApps() throws {
         dismissOnboardingIfNeeded()
 
-        let row = app.buttons["sidebar.appUninstaller"].firstMatch
+        let row = app.buttons["sidebar.applications"].firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 5),
-                      "Expected App Uninstaller row in sidebar")
+                      "Expected Applications row in sidebar")
         row.click()
+
+        // Scannable section: land on the unified intro, then trigger the scan
+        // via the floating Scan button.
+        let scan = app.buttons["section.applications.scan"]
+        XCTAssertTrue(scan.waitForExistence(timeout: 5),
+                      "Expected the floating Scan button on the Applications intro")
+        scan.click()
+        proceedPastScanAccessPopoverIfNeeded()
+
+        // The scan discovers installed apps and checks for updates; allow a
+        // generous window for the dashboard to land before opening Manage.
+        let manage = app.buttons["applications.manageMyApplications"]
+        XCTAssertTrue(manage.waitForExistence(timeout: 90),
+                      "Expected the Applications dashboard after the scan")
+        manage.click()
 
         // Rows are namespaced `appUninstaller.row.<bundleID>`. Discovery
         // shells out and inspects bundles, so allow a generous window for
@@ -226,14 +241,14 @@ final class FinalPolishUITests: XCTestCase {
             .matching(NSPredicate(format: "identifier BEGINSWITH 'appUninstaller.row.'"))
             .firstMatch
         XCTAssertTrue(firstRow.waitForExistence(timeout: 45),
-                      "Expected App Uninstaller to load the installed-app list")
+                      "Expected the Manage screen to load the installed-app list")
 
         let rowCount = app.descendants(matching: .any)
             .matching(NSPredicate(format: "identifier BEGINSWITH 'appUninstaller.row.'"))
             .count
         XCTAssertGreaterThanOrEqual(
             rowCount, 5,
-            "Expected at least five installed apps in the App Uninstaller list, found \(rowCount)"
+            "Expected at least five installed apps in the Manage list, found \(rowCount)"
         )
     }
 


### PR DESCRIPTION
## What & why

Collapses the separate **App Uninstaller** and **App Updater** sidebar sections into one unified, scannable **Applications** section: a section intro screen with the floating Scan disc, and a post-scan **dashboard card grid** styled like the Optimization section (and the CleanMyMac reference). Each card opens a detail/review screen.

Delivered in phases, all on this branch:

| Phase | Card | Backing |
|------|------|---------|
| 0 | **Updates** + **Manage My Applications** | existing App Updater / Uninstaller (reused unchanged as detail screens) |
| 1 | **Installation Files** | new `DefaultInstallationFileScanner` — `.dmg/.pkg/.iso` in Downloads + Desktop |
| 2 | **Unused Applications** | new `DefaultUnusedAppScanner` — Spotlight `kMDItemLastUsedDate`, 60-day threshold |
| 3 | **Unsupported Applications** | new `MachOHeaderReader` + `DefaultUnsupportedAppScanner` — no arm64/x86_64 slice |
| 4 | **App Leftovers** | new `DefaultAppLeftoverScanner` — orphaned `~/Library` support files |

`ApplicationsViewModel` is an additive `ScanCoordinating` aggregator (modeled on `SmartScanViewModel`): it discovers apps once, fans the sub-scans out concurrently, and owns opt-in selection + **Move-to-Trash** (restorable) for each destructive card. The existing uninstall/update logic is untouched and reused as detail screens.

## Design notes / safety

- All new scanners take injected providers (roots / date / CPU-type / installed-IDs) so they're **hermetically unit-tested** (no real disk, network, or binaries).
- Removal is always **opt-in** (nothing pre-selected) and routes to the **Trash**, with partial-failure survivors kept for retry.
- Scanners bias toward **false negatives**: unknown architecture/date → not flagged; leftovers only match well-formed reverse-DNS IDs, never `com.apple.*`/`group.*`, and treat helper/XPC sub-IDs of installed apps as installed.
- The post-delete payload rebuilds copy-and-mutate a single field of the result struct (fields made `var`) so a growing aggregate can't silently drop a field.

## Verification

- ✅ **971 unit tests pass**; app + both test targets compile (`CODE_SIGNING_ALLOWED=NO`).
- ⚠️ **Runtime UI flow pending manual check.** The UI tests that drive select → Scan → grid → open each card → Move to Trash can't bootstrap headless in this environment (`ApplicationsUITests` are ready to run in Xcode). Highest-risk paths to smoke-test: **Manage** (reads `@Environment(ExclusionsStore.self)`) and the **App Leftovers** removal (verify the matched groups are genuinely orphaned before trusting Select All).

## Reviewer notes / known follow-ups

- Reused detail views still set their own `.navigationTitle` (redundant with the Back-bar title; likely invisible under `.hiddenTitleBar`).
- Unsupported/Unused/Leftovers removal moves only the `.app` bundle (or the leftover files); full associated-file cleanup for an installed app remains via **Manage**.
- The update check runs twice (dashboard card count + opening the Updates screen) — acceptable.
- `.applications` uses the SF Symbol hero (no bespoke USDZ ships for it yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified Applications section: dashboard with updates, manage, installer-file review, unsupported apps, unused apps, and leftovers; multi-select removal and rescan flows.
* **UI**
  * Applications added to sidebar/detail flow; new dashboard cards, review screens, progress/failed states, and localized navigation titles.
* **Bug Fixes**
  * Improved scan resiliency, deterministic update probing, and safer failure handling.
* **Tests**
  * Extensive unit and UI tests exercising Applications scanning, classifiers, scanners, review selection, and removal behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->