### PR TITLE
Merge Extensions into Applications; curate the dashboard to Optimization's layout

### DIFF
--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -144,13 +144,13 @@ struct ApplicationsDashboardView: View {
                 .font(.system(size: 48))
                 .foregroundStyle(.tint)
             Text(String(
-                localized: "Your applications are in good shape",
-                comment: "Applications dashboard all-clear title when nothing needs cleanup."
+                localized: "No cleanup needed right now",
+                comment: "Applications dashboard all-clear title when no cleanup recommendations remain."
             ))
             .font(.title3.weight(.semibold))
             Text(String(
-                localized: "No unused or unsupported apps, leftovers, or installer files to review. Open Manage My Applications to browse everything you have installed.",
-                comment: "Applications dashboard all-clear detail."
+                localized: "No unused or unsupported apps, leftovers, or installer files to review. Open Manage My Applications for available updates and to browse everything you have installed.",
+                comment: "Applications dashboard all-clear detail; points to Manage for updates since they are not shown on the dashboard."
             ))
             .font(.callout)
             .foregroundStyle(.secondary)

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -10,7 +10,6 @@ import SwiftUI
 /// mirroring the Optimization dashboard's card layout.
 struct ApplicationsDashboardView: View {
     let result: ApplicationsScanResult
-    let onOpenUpdates: () -> Void
     let onOpenManage: () -> Void
     let onOpenInstallationFiles: () -> Void
     let onOpenUnsupported: () -> Void
@@ -19,11 +18,15 @@ struct ApplicationsDashboardView: View {
     let onRescan: () -> Void
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: 28) {
             header
-            grid
+            if result.recommendations.isEmpty {
+                allClear
+            } else {
+                cardLayout
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .frame(maxWidth: .infinity, alignment: .top)
         .accessibilityIdentifier("applications.dashboard")
     }
 
@@ -74,77 +77,89 @@ struct ApplicationsDashboardView: View {
         String(localized: "Review", comment: "Applications card action that opens a review list.")
     }
 
-    /// Gap between cards, and the floor a standard card never shrinks below so
-    /// its title + a line of detail + the button stay legible on short windows.
-    private let cardGap: CGFloat = 16
-    private let minStandardCardHeight: CGFloat = 132
-
-    private var updatesSpec: CardSpec {
-        CardSpec(id: "applications.card.updates", title: updatesTitle, detail: updatesDetail,
-                 icon: "arrow.triangle.2.circlepath", actionLabel: reviewLabel, action: onOpenUpdates)
-    }
-    private var unusedSpec: CardSpec {
-        CardSpec(id: "applications.card.unused", title: unusedTitle, detail: unusedDetail,
-                 icon: "moon.zzz", actionLabel: reviewLabel, action: onOpenUnused)
-    }
-    private var unsupportedSpec: CardSpec {
-        CardSpec(id: "applications.card.unsupported", title: unsupportedTitle, detail: unsupportedDetail,
-                 icon: "exclamationmark.triangle", actionLabel: reviewLabel, action: onOpenUnsupported)
-    }
-    private var leftoversSpec: CardSpec {
-        CardSpec(id: "applications.card.leftovers", title: leftoversTitle, detail: leftoversDetail,
-                 icon: "trash", actionLabel: reviewLabel, action: onOpenLeftovers)
-    }
-    private var installationFilesSpec: CardSpec {
-        CardSpec(id: "applications.card.installationFiles", title: installationFilesTitle,
-                 detail: installationFilesDetail, icon: "shippingbox", actionLabel: reviewLabel,
-                 action: onOpenInstallationFiles)
-    }
-    private var manageSpec: CardSpec {
-        CardSpec(id: "applications.card.manage",
-                 title: String(localized: "Manage Applications", comment: "Applications management card title."),
-                 detail: manageDetail, icon: "square.grid.2x2",
-                 actionLabel: String(localized: "Manage", comment: "Applications management card action."),
-                 action: onOpenManage)
-    }
-
-    /// Two-column masonry that fills the available height so the dashboard
-    /// never needs to scroll. Each column is one tall card + two standard cards
-    /// + two gaps, and a tall card spans exactly two standard cards plus a gap —
-    /// so a column is four "standard heights" plus three gaps. We solve for the
-    /// standard height that makes the columns exactly fill the height the
-    /// `GeometryReader` reports, flooring it so cards stay legible when the
-    /// window is short (the only case the content can exceed the viewport).
-    private var grid: some View {
-        GeometryReader { proxy in
-            let standard = max(minStandardCardHeight, (proxy.size.height - cardGap * 3) / 4)
-            let tall = standard * 2 + cardGap
-            HStack(alignment: .top, spacing: cardGap) {
-                VStack(spacing: cardGap) {
-                    card(updatesSpec, height: tall)
-                    card(installationFilesSpec, height: standard)
-                    card(manageSpec, height: standard)
-                }
-                VStack(spacing: cardGap) {
-                    card(unusedSpec, height: standard)
-                    card(unsupportedSpec, height: standard)
-                    card(leftoversSpec, height: tall)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    private func spec(for recommendation: ApplicationsScanResult.Recommendation) -> CardSpec {
+        switch recommendation {
+        case .unused:
+            return CardSpec(id: "applications.card.unused", title: unusedTitle, detail: unusedDetail,
+                            icon: "moon.zzz", actionLabel: reviewLabel, action: onOpenUnused)
+        case .unsupported:
+            return CardSpec(id: "applications.card.unsupported", title: unsupportedTitle, detail: unsupportedDetail,
+                            icon: "exclamationmark.triangle", actionLabel: reviewLabel, action: onOpenUnsupported)
+        case .leftovers:
+            return CardSpec(id: "applications.card.leftovers", title: leftoversTitle, detail: leftoversDetail,
+                            icon: "trash", actionLabel: reviewLabel, action: onOpenLeftovers)
+        case .installationFiles:
+            return CardSpec(id: "applications.card.installationFiles", title: installationFilesTitle,
+                            detail: installationFilesDetail, icon: "shippingbox", actionLabel: reviewLabel,
+                            action: onOpenInstallationFiles)
         }
     }
 
-    private func card(_ spec: CardSpec, height: CGFloat) -> some View {
+    /// One card per cleanup recommendation that has findings, in display order.
+    private var recommendationSpecs: [CardSpec] {
+        result.recommendations.map(spec(for:))
+    }
+
+    /// The card layout, mirroring the Optimization dashboard exactly so the two
+    /// share one look and identical tile widths: the first recommendation is a
+    /// tall hero card capped at 320pt on the left, and the rest flow through an
+    /// adaptive `LazyVGrid` whose columns match Optimization's (minimum 260pt,
+    /// 16pt gaps).
+    private var cardLayout: some View {
+        HStack(alignment: .top, spacing: 16) {
+            if let hero = recommendationSpecs.first {
+                card(hero, isHero: true)
+                    .frame(maxWidth: 320)
+            }
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 260), spacing: 16)],
+                alignment: .leading,
+                spacing: 16
+            ) {
+                ForEach(recommendationSpecs.dropFirst()) { spec in
+                    card(spec, isHero: false)
+                }
+            }
+        }
+    }
+
+    private func card(_ spec: CardSpec, isHero: Bool) -> some View {
         ApplicationsCard(
             title: spec.title,
             detail: spec.detail,
             icon: spec.icon,
             actionLabel: spec.actionLabel,
             identifier: spec.id,
-            height: height,
+            isHero: isHero,
             action: spec.action
         )
+    }
+
+    /// Shown when no cleanup category has findings — the curated grid would
+    /// otherwise be empty. The header (count + Manage / Rescan) stays above.
+    /// Mirrors the Optimization dashboard's empty state.
+    private var allClear: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+            Text(String(
+                localized: "Your applications are in good shape",
+                comment: "Applications dashboard all-clear title when nothing needs cleanup."
+            ))
+            .font(.title3.weight(.semibold))
+            Text(String(
+                localized: "No unused or unsupported apps, leftovers, or installer files to review. Open Manage My Applications to browse everything you have installed.",
+                comment: "Applications dashboard all-clear detail."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 460)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 24)
+        .accessibilityIdentifier("applications.dashboard.allClear")
     }
 
     // MARK: Copy
@@ -153,41 +168,6 @@ struct ApplicationsDashboardView: View {
         let format = String(
             localized: "We've found %lld apps on your Mac.",
             comment: "Applications dashboard headline; %lld is the installed-app count."
-        )
-        return String.localizedStringWithFormat(format, Int64(result.installedCount))
-    }
-
-    private var updatesTitle: String {
-        if result.updatesCount == 0 {
-            return String(
-                localized: "No Updates Available",
-                comment: "Applications Updates card title when every app is current."
-            )
-        }
-        let format = String(
-            localized: "%lld Application Updates Available",
-            comment: "Applications Updates card title; %lld is the available-update count."
-        )
-        return String.localizedStringWithFormat(format, Int64(result.updatesCount))
-    }
-
-    private var updatesDetail: String {
-        if result.updatesCount == 0 {
-            return String(
-                localized: "All your apps are running the latest version.",
-                comment: "Applications Updates card detail when no updates are available."
-            )
-        }
-        return String(
-            localized: "Update your software to keep up with the latest features and compatibility improvements.",
-            comment: "Applications Updates card detail when updates are available."
-        )
-    }
-
-    private var manageDetail: String {
-        let format = String(
-            localized: "Browse all %lld installed apps and remove the ones you no longer need, along with their leftover files.",
-            comment: "Applications management card detail; %lld is the installed-app count."
         )
         return String.localizedStringWithFormat(format, Int64(result.installedCount))
     }
@@ -314,10 +294,9 @@ struct ApplicationsCard: View {
     let icon: String
     let actionLabel: String
     let identifier: String
-    /// Fixed card height set by the layout — tall cards span two standard cards
-    /// so the grid isn't a uniform row of equal-size tiles. A fixed height (not
-    /// a min) keeps the card from stretching to fill its column.
-    let height: CGFloat
+    /// Hero cards render taller, matching the Optimization dashboard's hero /
+    /// standard `minHeight` (260 / 150) so the two dashboards share one look.
+    let isHero: Bool
     let action: () -> Void
 
     var body: some View {
@@ -331,13 +310,10 @@ struct ApplicationsCard: View {
                     .font(.title2)
                     .foregroundStyle(.tint)
             }
-            // Truncates rather than forcing its full height, so a short card
-            // (on a small window) never overflows its fixed frame.
             Text(detail)
                 .font(.callout)
                 .foregroundStyle(.secondary)
-                .lineLimit(4)
-                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 8)
             HStack {
                 Spacer()
@@ -347,7 +323,7 @@ struct ApplicationsCard: View {
             }
         }
         .padding(18)
-        .frame(maxWidth: .infinity, minHeight: height, maxHeight: height, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: isHero ? 260 : 150, alignment: .leading)
         .glassEffect(.regular, in: .rect(cornerRadius: 12))
     }
 }

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -16,6 +16,7 @@ struct ApplicationsView: View {
     private var viewModel: ApplicationsViewModel
     private var uninstallerViewModel: AppUninstallerViewModel
     private var updaterViewModel: AppUpdaterViewModel
+    private var extensionsManagerViewModel: ExtensionsManagerViewModel
 
     /// Shared icon cache so the Unused / Unsupported review rows show each
     /// app's real icon instead of a generic glyph. Pre-loaded off the main
@@ -27,10 +28,11 @@ struct ApplicationsView: View {
     /// brief remount when the underlying detail view loads.
     @State private var detail: Detail = .dashboard
 
-    /// The results surface's screens.
+    /// The results surface's screens. Updates are reached through the Manager's
+    /// Updater pane, so the dashboard no longer pushes a standalone Updates
+    /// screen.
     private enum Detail {
         case dashboard
-        case updates
         case manage
         case installationFiles
         case unsupported
@@ -41,11 +43,13 @@ struct ApplicationsView: View {
     init(
         viewModel: ApplicationsViewModel,
         uninstallerViewModel: AppUninstallerViewModel,
-        updaterViewModel: AppUpdaterViewModel
+        updaterViewModel: AppUpdaterViewModel,
+        extensionsManagerViewModel: ExtensionsManagerViewModel
     ) {
         self.viewModel = viewModel
         self.uninstallerViewModel = uninstallerViewModel
         self.updaterViewModel = updaterViewModel
+        self.extensionsManagerViewModel = extensionsManagerViewModel
     }
 
     var body: some View {
@@ -79,28 +83,21 @@ struct ApplicationsView: View {
     private func resultsContent(_ result: ApplicationsScanResult) -> some View {
         switch detail {
         case .dashboard:
-            // No ScrollView: the grid sizes its cards to the available height
-            // so the whole dashboard fits the window without scrolling.
-            ApplicationsDashboardView(
-                result: result,
-                onOpenUpdates: { detail = .updates },
-                onOpenManage: { detail = .manage },
-                onOpenInstallationFiles: { detail = .installationFiles },
-                onOpenUnsupported: { detail = .unsupported },
-                onOpenUnused: { detail = .unused },
-                onOpenLeftovers: { detail = .leftovers },
-                onRescan: { Task { await viewModel.scan() } }
-            )
-            .padding(24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        case .updates:
-            detailScreen(
-                title: String(
-                    localized: "Updates",
-                    comment: "Title of the Applications Updates detail screen."
+            // Mirrors the Optimization dashboard host: a scrolling hero +
+            // adaptive card grid, so the two dashboards share one look and the
+            // tiles share one width.
+            ScrollView {
+                ApplicationsDashboardView(
+                    result: result,
+                    onOpenManage: { detail = .manage },
+                    onOpenInstallationFiles: { detail = .installationFiles },
+                    onOpenUnsupported: { detail = .unsupported },
+                    onOpenUnused: { detail = .unused },
+                    onOpenLeftovers: { detail = .leftovers },
+                    onRescan: { Task { await viewModel.scan() } }
                 )
-            ) {
-                AppUpdaterView(viewModel: updaterViewModel)
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         case .manage:
             // Full multi-pane manager (Uninstaller / Updater / Leftovers),
@@ -110,6 +107,7 @@ struct ApplicationsView: View {
                 viewModel: viewModel,
                 uninstallerViewModel: uninstallerViewModel,
                 updaterViewModel: updaterViewModel,
+                extensionsManagerViewModel: extensionsManagerViewModel,
                 result: result,
                 iconCache: iconCache,
                 onBack: { detail = .dashboard }
@@ -239,6 +237,7 @@ struct ApplicationsManagerView: View {
     private var viewModel: ApplicationsViewModel
     private var uninstallerViewModel: AppUninstallerViewModel
     private var updaterViewModel: AppUpdaterViewModel
+    private var extensionsManagerViewModel: ExtensionsManagerViewModel
     private let result: ApplicationsScanResult
     private var iconCache: AppIconCache
     private let onBack: () -> Void
@@ -251,6 +250,7 @@ struct ApplicationsManagerView: View {
     enum Pane: Hashable {
         case uninstaller
         case updater
+        case extensions
         case leftovers
     }
 
@@ -258,6 +258,7 @@ struct ApplicationsManagerView: View {
         viewModel: ApplicationsViewModel,
         uninstallerViewModel: AppUninstallerViewModel,
         updaterViewModel: AppUpdaterViewModel,
+        extensionsManagerViewModel: ExtensionsManagerViewModel,
         result: ApplicationsScanResult,
         iconCache: AppIconCache,
         onBack: @escaping () -> Void
@@ -265,6 +266,7 @@ struct ApplicationsManagerView: View {
         self.viewModel = viewModel
         self.uninstallerViewModel = uninstallerViewModel
         self.updaterViewModel = updaterViewModel
+        self.extensionsManagerViewModel = extensionsManagerViewModel
         self.result = result
         self.iconCache = iconCache
         self.onBack = onBack
@@ -327,6 +329,9 @@ struct ApplicationsManagerView: View {
             navItem(.updater,
                     String(localized: "Updater", comment: "Applications Manager sub-nav item."),
                     "applications.manager.nav.updater")
+            navItem(.extensions,
+                    String(localized: "Extensions", comment: "Applications Manager sub-nav item."),
+                    "applications.manager.nav.extensions")
             navItem(.leftovers,
                     String(localized: "Leftovers", comment: "Applications Manager sub-nav item."),
                     "applications.manager.nav.leftovers")
@@ -362,6 +367,8 @@ struct ApplicationsManagerView: View {
             AppUninstallerView(viewModel: uninstallerViewModel, iconCache: iconCache)
         case .updater:
             AppUpdaterView(viewModel: updaterViewModel)
+        case .extensions:
+            ExtensionsManagerView(viewModel: extensionsManagerViewModel)
         case .leftovers:
             AppLeftoversReviewView(
                 groups: result.leftovers,
@@ -398,6 +405,10 @@ struct ApplicationsManagerView: View {
             checkAppStore: { _ in .noResult },
             checkSparkle: { _ in .noResult },
             opener: { _ in }
+        ),
+        extensionsManagerViewModel: ExtensionsManagerViewModel(
+            discover: { [] },
+            remove: { _ in }
         )
     )
     .frame(width: 900, height: 600)

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -43,6 +43,31 @@ struct ApplicationsScanResult: Equatable {
     var leftoversTotalBytes: Int64 {
         leftovers.reduce(Int64(0)) { $0 + $1.totalBytes }
     }
+
+    /// A cleanup category the dashboard can recommend acting on. The dashboard
+    /// grid renders one card per recommendation, in this declaration order.
+    enum Recommendation: CaseIterable {
+        case unused
+        case unsupported
+        case leftovers
+        case installationFiles
+    }
+
+    /// The cleanup categories that currently have findings, in display order.
+    /// Installed apps and available updates are deliberately excluded — the
+    /// grid surfaces only quick-win review-and-removal work; updates and the
+    /// full app list live under "Manage My Applications". An empty result
+    /// drives the dashboard's "all clear" state.
+    var recommendations: [Recommendation] {
+        Recommendation.allCases.filter { recommendation in
+            switch recommendation {
+            case .unused:            return unusedAppsCount > 0
+            case .unsupported:       return unsupportedAppsCount > 0
+            case .leftovers:         return leftoversCount > 0
+            case .installationFiles: return installationFilesCount > 0
+            }
+        }
+    }
 }
 
 /// Drives the Applications feature view (scan → results). Collaborators are

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -281,11 +281,10 @@ struct ContentView: View {
                 ApplicationsView(
                     viewModel: applicationsViewModel,
                     uninstallerViewModel: appUninstallerViewModel,
-                    updaterViewModel: appUpdaterViewModel
+                    updaterViewModel: appUpdaterViewModel,
+                    extensionsManagerViewModel: extensionsManagerViewModel
                 )
             }
-        case .extensions:
-            ExtensionsManagerView(viewModel: extensionsManagerViewModel)
         case .optimization:
             ScannableSectionContent(coordinator: optimizationViewModel, section: section) {
                 OptimizationView(viewModel: optimizationViewModel)

--- a/VaderCleaner/ExtensionDiscovery.swift
+++ b/VaderCleaner/ExtensionDiscovery.swift
@@ -1,5 +1,5 @@
 // ExtensionDiscovery.swift
-// The five Extensions Manager discovery types — Safari, browser, Mail-plugin, internet-plug-in, and launch-agent scanners — plus the shared protocol and sizing helper they emit ExtensionItems through.
+// The Extensions Manager discovery types — Safari, browser, Mail-plugin, and internet-plug-in scanners — plus the shared protocol and sizing helper they emit ExtensionItems through.
 
 import Foundation
 
@@ -357,78 +357,3 @@ struct InternetPluginDiscovery: ExtensionDiscovering {
     }
 }
 
-// MARK: - Launch agents / login items
-
-/// Reads `~/Library/LaunchAgents` plists. These are the discoverable
-/// surface for third-party login items — `SMAppService` cannot enumerate
-/// items registered by other apps.
-struct LaunchAgentDiscovery: ExtensionDiscovering {
-
-    private let roots: [URL]
-    private let fileManager: FileManager
-
-    init(
-        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        systemRoots: [URL] = [
-            URL(fileURLWithPath: "/Library/LaunchAgents", isDirectory: true),
-            URL(fileURLWithPath: "/Library/LaunchDaemons", isDirectory: true)
-        ],
-        fileManager: FileManager = .default
-    ) {
-        self.roots = [
-            homeDirectory.appendingPathComponent("Library/LaunchAgents", isDirectory: true)
-        ] + systemRoots
-        self.fileManager = fileManager
-    }
-
-    /// Every `*.plist` under the user's `~/Library/LaunchAgents` plus the
-    /// system `/Library/LaunchAgents` and `/Library/LaunchDaemons` roots,
-    /// deduped by path. `name` comes from the `Label` key (falling back to
-    /// the filename); `isEnabled` is the inverse of the `Disabled` key —
-    /// launchd's authoritative source. The system roots are removable: the
-    /// privileged helper's allowlist permits direct-child plists under both,
-    /// and `requiresHelper` routes those paths through it.
-    func userAgents() async -> [ExtensionItem] {
-        let roots = roots
-        let fileManager = fileManager
-        return await Task.detached(priority: .userInitiated) {
-            var seen = Set<String>()
-            var items: [ExtensionItem] = []
-            for dir in roots {
-                guard fileManager.fileExists(atPath: dir.path) else { continue }
-                let entries = (try? fileManager.contentsOfDirectory(
-                    at: dir, includingPropertiesForKeys: nil,
-                    options: [.skipsHiddenFiles]
-                )) ?? []
-                for entry in entries where entry.pathExtension.lowercased() == "plist" {
-                    guard seen.insert(entry.path).inserted else { continue }
-                    let plist = (try? Data(contentsOf: entry)).flatMap {
-                        try? PropertyListSerialization.propertyList(
-                            from: $0, options: [], format: nil
-                        ) as? [String: Any]
-                    } ?? [:]
-                    let label = (plist["Label"] as? String).flatMap {
-                        $0.isEmpty ? nil : $0
-                    }
-                    let disabled = (plist["Disabled"] as? Bool) ?? false
-                    items.append(ExtensionItem(
-                        name: label ?? entry.deletingPathExtension().lastPathComponent,
-                        path: entry,
-                        bundleID: nil,
-                        type: .loginItemFromApp,
-                        isEnabled: !disabled,
-                        size: ExtensionArtifactSizer.size(at: entry, fileManager: fileManager)
-                    ))
-                }
-            }
-            // Not sorted here: ExtensionsManagerViewModel.groupedByType
-            // sorts each bucket by name before display, so ordering the
-            // raw discovery output would be redundant work.
-            return items
-        }.value
-    }
-
-    func extensions() async -> [ExtensionItem] {
-        await userAgents()
-    }
-}

--- a/VaderCleaner/ExtensionItem.swift
+++ b/VaderCleaner/ExtensionItem.swift
@@ -1,5 +1,5 @@
 // ExtensionItem.swift
-// Value type for a single discovered extension / plugin / login-item launch agent, plus the ExtensionType enum the Extensions Manager groups them under.
+// Value type for a single discovered extension / plugin, plus the ExtensionType enum the Extensions Manager groups them under.
 
 import Foundation
 
@@ -14,7 +14,6 @@ enum ExtensionType: String, CaseIterable, Identifiable, Sendable {
     case firefoxExtension
     case mailPlugin
     case internetPlugin
-    case loginItemFromApp
 
     var id: String { rawValue }
 
@@ -28,13 +27,12 @@ enum ExtensionType: String, CaseIterable, Identifiable, Sendable {
         case .firefoxExtension: return "Firefox Extensions"
         case .mailPlugin:       return "Mail Plugins"
         case .internetPlugin:   return "Internet Plug-ins"
-        case .loginItemFromApp: return "Login Items & Launch Agents"
         }
     }
 }
 
 /// A single discovered extension artifact: a Safari/browser extension, a Mail
-/// plugin, an internet plug-in, or a login-item launch agent.
+/// plugin, or an internet plug-in.
 ///
 /// `Identifiable` by `path` so SwiftUI list identity stays stable across
 /// re-discovery passes that re-emit the same item; `Hashable` so the
@@ -46,13 +44,11 @@ struct ExtensionItem: Identifiable, Hashable, Sendable {
     /// Absolute on-disk location that removal acts on.
     let path: URL
     /// Owning bundle identifier when one is available (Mail plugins,
-    /// internet plug-ins). `nil` for bare launch agents and legacy
-    /// `.safariextz` archives.
+    /// internet plug-ins). `nil` for legacy `.safariextz` archives.
     let bundleID: String?
     let type: ExtensionType
-    /// Best-effort enabled state. Authoritative only for launch agents
-    /// (inverse of the plist `Disabled` key); other sources default to
-    /// `true` because macOS exposes no queryable per-extension state.
+    /// Best-effort enabled state. Defaults to `true` because macOS exposes
+    /// no queryable per-extension state for these artifact types.
     let isEnabled: Bool
     /// Recursive byte size of the artifact, used for the row's size label.
     let size: Int64

--- a/VaderCleaner/ExtensionItem.swift
+++ b/VaderCleaner/ExtensionItem.swift
@@ -43,8 +43,9 @@ struct ExtensionItem: Identifiable, Hashable, Sendable {
     let name: String
     /// Absolute on-disk location that removal acts on.
     let path: URL
-    /// Owning bundle identifier when one is available (Mail plugins,
-    /// internet plug-ins). `nil` for legacy `.safariextz` archives.
+    /// Owning bundle identifier when one is available — Chrome/Firefox
+    /// extensions, `.appex` Safari extensions, Mail plugins, and internet
+    /// plug-ins all carry one. `nil` for legacy `.safariextz` archives.
     let bundleID: String?
     let type: ExtensionType
     /// Best-effort enabled state. Defaults to `true` because macOS exposes

--- a/VaderCleaner/ExtensionsManagerView.swift
+++ b/VaderCleaner/ExtensionsManagerView.swift
@@ -18,7 +18,10 @@ struct ExtensionsManagerView: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .navigationTitle(NavigationSection.extensions.title)
+            .navigationTitle(String(
+                localized: "Extensions",
+                comment: "Navigation title of the Extensions Manager screen."
+            ))
             .task {
                 if viewModel.phase == .idle {
                     await viewModel.refresh()
@@ -130,10 +133,10 @@ struct ExtensionsManagerView: View {
                               type: .chromeExtension,
                               isEnabled: true,
                               size: 5_242_880),
-                ExtensionItem(name: "com.acme.updater",
-                              path: URL(fileURLWithPath: "/tmp/com.acme.updater.plist"),
-                              bundleID: nil,
-                              type: .loginItemFromApp,
+                ExtensionItem(name: "GPGMail",
+                              path: URL(fileURLWithPath: "/tmp/GPGMail.mailbundle"),
+                              bundleID: "org.gpgtools.gpgmail",
+                              type: .mailPlugin,
                               isEnabled: false,
                               size: 2_048)
             ]

--- a/VaderCleaner/ExtensionsManagerViewModel.swift
+++ b/VaderCleaner/ExtensionsManagerViewModel.swift
@@ -1,5 +1,5 @@
 // ExtensionsManagerViewModel.swift
-// State machine behind the Extensions Manager view — runs the five discoverers concurrently, groups results by ExtensionType, and routes removal between FileManager (user paths) and the privileged helper (/Library paths).
+// State machine behind the Extensions Manager view — runs the discoverers concurrently, groups results by ExtensionType, and routes removal between FileManager (user paths) and the privileged helper (/Library paths).
 
 import Foundation
 import Observation
@@ -130,8 +130,8 @@ final class ExtensionsManagerViewModel {
 
 extension ExtensionsManagerViewModel {
 
-    /// Builds a view-model wired to the five real discoverers (run
-    /// concurrently) and the path-routed removal pipeline.
+    /// Builds a view-model wired to the real discoverers (run concurrently)
+    /// and the path-routed removal pipeline.
     @MainActor
     static func live() -> ExtensionsManagerViewModel {
         ExtensionsManagerViewModel(
@@ -140,10 +140,9 @@ extension ExtensionsManagerViewModel {
                 async let browser  = BrowserExtensionDiscovery().extensions()
                 async let mail     = MailPluginDiscovery().extensions()
                 async let internet = InternetPluginDiscovery().extensions()
-                async let agents   = LaunchAgentDiscovery().extensions()
                 // Not sorted here: `groupedByType` sorts each bucket by
                 // name before the data reaches the UI.
-                return await safari + browser + mail + internet + agents
+                return await safari + browser + mail + internet
             },
             remove: { item in
                 try await Self.removeItem(item)
@@ -151,26 +150,18 @@ extension ExtensionsManagerViewModel {
         )
     }
 
-    /// Routes removal by privilege need. User-writable paths (`~/Library/…`,
-    /// including `~/Library/LaunchAgents`) are removed in-process. Paths
-    /// under `/Library` or `/System` (system Mail bundles, system internet
-    /// plug-ins) go through the privileged helper — launch-agent plists via
-    /// the dedicated `removeLaunchAgent(path:)`, everything else via the
-    /// batched `deleteFiles(_:)`.
+    /// Routes removal by privilege need. User-writable paths (`~/Library/…`)
+    /// are removed in-process. Paths under `/Library` or `/System` (system
+    /// Mail bundles, system internet plug-ins) go through the privileged
+    /// helper via the batched `deleteFiles(_:)`.
     private nonisolated static func removeItem(_ item: ExtensionItem) async throws {
         let path = item.path.path
         guard SystemJunkDeleter.requiresHelper(path: path) else {
             try FileManager.default.removeItem(at: item.path)
             return
         }
-        if item.type == .loginItemFromApp {
-            try await helperCall { helper, done in
-                helper.removeLaunchAgent(path: path, reply: done)
-            }
-        } else {
-            try await helperCall { helper, done in
-                helper.deleteFiles([path], reply: done)
-            }
+        try await helperCall { helper, done in
+            helper.deleteFiles([path], reply: done)
         }
     }
 

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -11,7 +11,6 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
     case malwareRemoval
     case optimization
     case privacy
-    case extensions
     case applications
     case healthMonitor
 
@@ -26,7 +25,6 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .malwareRemoval:  return String(localized: "Malware Removal")
         case .optimization:    return String(localized: "Optimization")
         case .privacy:         return String(localized: "Privacy")
-        case .extensions:      return String(localized: "Extensions")
         case .applications:    return String(localized: "Applications")
         case .healthMonitor:   return String(localized: "Health Monitor")
         }
@@ -45,7 +43,6 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .malwareRemoval:  return "sidebar.malwareRemoval"
         case .optimization:    return "sidebar.optimization"
         case .privacy:         return "sidebar.privacy"
-        case .extensions:      return "sidebar.extensions"
         case .applications:    return "sidebar.applications"
         case .healthMonitor:   return "sidebar.healthMonitor"
         }
@@ -73,7 +70,6 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .malwareRemoval:  return "shield.lefthalf.filled"
         case .optimization:    return "gauge.with.needle"
         case .privacy:         return "lock.shield"
-        case .extensions:      return "puzzlepiece.extension"
         case .applications:    return "square.grid.2x2"
         case .healthMonitor:   return "heart.text.square"
         }
@@ -90,7 +86,7 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
              .spaceLens, .malwareRemoval, .optimization, .privacy,
              .applications:
             return true
-        case .extensions, .healthMonitor:
+        case .healthMonitor:
             return false
         }
     }
@@ -107,7 +103,7 @@ enum NavigationSection: CaseIterable, Hashable, Identifiable {
         case .smartScan, .systemJunk, .largeOldFiles,
              .spaceLens, .malwareRemoval, .privacy:
             return true
-        case .optimization, .extensions,
+        case .optimization,
              .applications, .healthMonitor:
             return false
         }

--- a/VaderCleaner/ScanDiscHostView.swift
+++ b/VaderCleaner/ScanDiscHostView.swift
@@ -46,7 +46,7 @@ struct ScanDiscHostView: View {
             overlay(controller.privacyViewModel, .privacy)
         case .applications:
             overlay(controller.applicationsViewModel, .applications)
-        case .extensions, .healthMonitor:
+        case .healthMonitor:
             // Non-scannable sections never show a disc — keep the panel hidden.
             Color.clear
                 .onAppear { controller.setDiscVisible(false) }

--- a/VaderCleaner/SectionPresentation.swift
+++ b/VaderCleaner/SectionPresentation.swift
@@ -275,7 +275,7 @@ struct SectionPresentation {
                     ),
                 ]
             )
-        case .extensions, .healthMonitor:
+        case .healthMonitor:
             return nil
         }
     }

--- a/VaderCleaner/SectionTheme.swift
+++ b/VaderCleaner/SectionTheme.swift
@@ -67,12 +67,6 @@ extension NavigationSection {
                 backdropTop: Color(red: 0.13, green: 0.04, blue: 0.09),
                 backdropBottom: Color(red: 0.33, green: 0.08, blue: 0.21)
             )
-        case .extensions:
-            return SectionTheme(
-                accent: Color(red: 0.30, green: 0.59, blue: 0.99),
-                backdropTop: Color(red: 0.04, green: 0.07, blue: 0.15),
-                backdropBottom: Color(red: 0.07, green: 0.17, blue: 0.39)
-            )
         case .applications:
             return SectionTheme(
                 accent: Color(red: 0.52, green: 0.50, blue: 0.95),

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -625,6 +625,56 @@ final class ApplicationsViewModelTests: XCTestCase {
         XCTAssertTrue(vm.leftoverSelection.contains("com.a.app"),
                       "The still-present group stays selected so the user can retry")
     }
+
+    // MARK: - Dashboard recommendations
+
+    /// Builds a result with the given findings. Installed apps and available
+    /// updates are fixed non-empty values to prove they never influence the
+    /// cleanup recommendations.
+    private func makeResult(
+        installers: [InstallationFile] = [],
+        unsupported: [UnsupportedApp] = [],
+        unused: [UnusedApp] = [],
+        leftovers: [LeftoverGroup] = []
+    ) -> ApplicationsScanResult {
+        ApplicationsScanResult(
+            installedApps: [makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")],
+            availableUpdates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")],
+            installationFiles: installers,
+            unsupportedApps: unsupported,
+            unusedApps: unused,
+            leftovers: leftovers
+        )
+    }
+
+    /// No cleanup findings → no recommendations, even though apps and updates
+    /// exist. Drives the dashboard's "all clear" state.
+    func test_recommendations_emptyWhenNoCleanupFindings() {
+        XCTAssertEqual(makeResult().recommendations, [])
+    }
+
+    /// Only the categories that have findings are recommended.
+    func test_recommendations_includesOnlyNonEmptyCategories() {
+        let result = makeResult(
+            unused: [makeUnused(name: "Old", bundleID: "com.old.app")]
+        )
+        XCTAssertEqual(result.recommendations, [.unused])
+    }
+
+    /// When every category has findings they appear in the fixed display
+    /// order: unused, unsupported, leftovers, installation files.
+    func test_recommendations_areOrderedDeterministically() {
+        let result = makeResult(
+            installers: [makeInstaller(name: "Setup.dmg", size: 1_000)],
+            unsupported: [makeUnsupported(name: "Legacy", bundleID: "com.legacy.app")],
+            unused: [makeUnused(name: "Old", bundleID: "com.old.app")],
+            leftovers: [makeLeftover(bundleID: "com.gone.app", paths: ["/tmp/a"], bytes: 10)]
+        )
+        XCTAssertEqual(
+            result.recommendations,
+            [.unused, .unsupported, .leftovers, .installationFiles]
+        )
+    }
 }
 
 /// A one-shot async gate so a test can hold an injected closure inside

--- a/VaderCleanerTests/ExtensionDiscoveryTests.swift
+++ b/VaderCleanerTests/ExtensionDiscoveryTests.swift
@@ -1,5 +1,5 @@
 // ExtensionDiscoveryTests.swift
-// Exercises the five Extensions Manager discovery types against hermetic temp-directory fixtures so no real Safari/Mail/launch-agent state is touched.
+// Exercises the Extensions Manager discovery types against hermetic temp-directory fixtures so no real Safari/Mail/browser state is touched.
 
 import XCTest
 @testable import VaderCleaner
@@ -51,129 +51,6 @@ final class ExtensionDiscoveryTests: XCTestCase {
         XCTAssertEqual(item.name, "AdBlock")
         XCTAssertEqual(item.type, .safariExtension)
         XCTAssertEqual(item.size, 2048)
-    }
-
-    // MARK: - Launch agents
-
-    /// `userAgents()` reads every plist under `~/Library/LaunchAgents` and
-    /// derives `name` from the `Label` key.
-    func test_launchAgents_userAgentsReadsLabelAndPath() async throws {
-        let agentsDir = tempHome
-            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: agentsDir, withIntermediateDirectories: true
-        )
-        try writePlist(
-            ["Label": "com.acme.updater",
-             "ProgramArguments": ["/usr/local/bin/acme"]],
-            to: agentsDir.appendingPathComponent("com.acme.updater.plist")
-        )
-
-        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome, systemRoots: [])
-        let agents = await discovery.userAgents()
-
-        XCTAssertEqual(agents.count, 1)
-        let agent = try XCTUnwrap(agents.first)
-        XCTAssertEqual(agent.name, "com.acme.updater")
-        XCTAssertEqual(agent.type, .loginItemFromApp)
-        XCTAssertTrue(agent.isEnabled)
-        XCTAssertEqual(
-            agent.path.lastPathComponent, "com.acme.updater.plist"
-        )
-    }
-
-    /// `Disabled = true` in the plist flips `isEnabled` to `false` — that
-    /// key is the authoritative launchd source.
-    func test_launchAgents_disabledKeyFlipsIsEnabled() async throws {
-        let agentsDir = tempHome
-            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: agentsDir, withIntermediateDirectories: true
-        )
-        try writePlist(
-            ["Label": "com.acme.enabled"],
-            to: agentsDir.appendingPathComponent("com.acme.enabled.plist")
-        )
-        try writePlist(
-            ["Label": "com.acme.disabled", "Disabled": true],
-            to: agentsDir.appendingPathComponent("com.acme.disabled.plist")
-        )
-
-        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome, systemRoots: [])
-        let byName = Dictionary(
-            uniqueKeysWithValues: await discovery.userAgents().map { ($0.name, $0) }
-        )
-
-        XCTAssertEqual(byName["com.acme.enabled"]?.isEnabled, true)
-        XCTAssertEqual(byName["com.acme.disabled"]?.isEnabled, false)
-    }
-
-    /// `extensions()` is the protocol surface; for launch agents it must
-    /// return the same set as `userAgents()`.
-    func test_launchAgents_extensionsMirrorsUserAgents() async throws {
-        let agentsDir = tempHome
-            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: agentsDir, withIntermediateDirectories: true
-        )
-        try writePlist(
-            ["Label": "com.acme.one"],
-            to: agentsDir.appendingPathComponent("com.acme.one.plist")
-        )
-
-        let discovery = LaunchAgentDiscovery(homeDirectory: tempHome, systemRoots: [])
-        let viaProtocol = await discovery.extensions()
-        let viaUserAgents = await discovery.userAgents()
-        XCTAssertEqual(viaProtocol, viaUserAgents)
-    }
-
-    /// System-wide launch agents and daemons under `/Library/LaunchAgents`
-    /// and `/Library/LaunchDaemons` are surfaced alongside the user's, so
-    /// the "Login Items & Launch Agents" section doesn't miss common
-    /// third-party background items.
-    func test_launchAgents_surfacesSystemAgentsAndDaemons() async throws {
-        let userDir = tempHome
-            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
-        let sysAgents = tempSystem.appendingPathComponent("LaunchAgents", isDirectory: true)
-        let sysDaemons = tempSystem.appendingPathComponent("LaunchDaemons", isDirectory: true)
-        for dir in [userDir, sysAgents, sysDaemons] {
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        }
-        try writePlist(
-            ["Label": "com.user.agent"],
-            to: userDir.appendingPathComponent("com.user.agent.plist")
-        )
-        try writePlist(
-            ["Label": "com.system.agent"],
-            to: sysAgents.appendingPathComponent("com.system.agent.plist")
-        )
-        try writePlist(
-            ["Label": "com.system.daemon", "Disabled": true],
-            to: sysDaemons.appendingPathComponent("com.system.daemon.plist")
-        )
-
-        let discovery = LaunchAgentDiscovery(
-            homeDirectory: tempHome,
-            systemRoots: [sysAgents, sysDaemons]
-        )
-        let byName = Dictionary(
-            uniqueKeysWithValues: await discovery.userAgents().map { ($0.name, $0) }
-        )
-
-        XCTAssertEqual(
-            Set(byName.keys),
-            ["com.user.agent", "com.system.agent", "com.system.daemon"]
-        )
-        XCTAssertEqual(byName["com.system.agent"]?.type, .loginItemFromApp)
-        XCTAssertEqual(byName["com.system.daemon"]?.isEnabled, false)
-        XCTAssertEqual(
-            byName["com.system.agent"]?.path.lastPathComponent,
-            "com.system.agent.plist"
-        )
-        XCTAssertEqual(
-            byName["com.system.agent"]?.path.deletingLastPathComponent().lastPathComponent,
-            "LaunchAgents"
-        )
     }
 
     // MARK: - Mail plugins
@@ -259,13 +136,6 @@ final class ExtensionDiscoveryTests: XCTestCase {
     }
 
     // MARK: - Fixture helpers
-
-    private func writePlist(_ dict: [String: Any], to url: URL) throws {
-        let data = try PropertyListSerialization.data(
-            fromPropertyList: dict, format: .xml, options: 0
-        )
-        try data.write(to: url)
-    }
 
     /// Creates a minimal `.bundle`-style directory with a Contents/ child so
     /// the size walk has something to sum.

--- a/VaderCleanerTests/ExtensionItemTests.swift
+++ b/VaderCleanerTests/ExtensionItemTests.swift
@@ -11,20 +11,20 @@ final class ExtensionItemTests: XCTestCase {
     /// The struct must expose the properties the discovery layer and UI bind
     /// to: name, path, type, isEnabled (plus optional bundleID and size).
     func test_extensionItem_exposesRequiredProperties() {
-        let url = URL(fileURLWithPath: "/Users/x/Library/LaunchAgents/com.acme.agent.plist")
+        let url = URL(fileURLWithPath: "/Library/Internet Plug-Ins/Acme.plugin")
         let item = ExtensionItem(
-            name: "Acme Agent",
+            name: "Acme Plugin",
             path: url,
-            bundleID: "com.acme.agent",
-            type: .loginItemFromApp,
+            bundleID: "com.acme.plugin",
+            type: .internetPlugin,
             isEnabled: true,
             size: 4096
         )
 
-        XCTAssertEqual(item.name, "Acme Agent")
+        XCTAssertEqual(item.name, "Acme Plugin")
         XCTAssertEqual(item.path, url)
-        XCTAssertEqual(item.bundleID, "com.acme.agent")
-        XCTAssertEqual(item.type, .loginItemFromApp)
+        XCTAssertEqual(item.bundleID, "com.acme.plugin")
+        XCTAssertEqual(item.type, .internetPlugin)
         XCTAssertTrue(item.isEnabled)
         XCTAssertEqual(item.size, 4096)
     }
@@ -60,13 +60,15 @@ final class ExtensionItemTests: XCTestCase {
 
     // MARK: - ExtensionType
 
-    /// All six categories the plan enumerates must be present.
-    func test_extensionType_hasAllSixCases() {
-        XCTAssertEqual(ExtensionType.allCases.count, 6)
+    /// All five categories the Extensions Manager surfaces must be present.
+    /// Login items / launch agents are owned by the Optimization section, so
+    /// they are intentionally absent here.
+    func test_extensionType_hasAllFiveCases() {
+        XCTAssertEqual(ExtensionType.allCases.count, 5)
         XCTAssertEqual(
             Set(ExtensionType.allCases),
             [.safariExtension, .chromeExtension, .firefoxExtension,
-             .mailPlugin, .internetPlugin, .loginItemFromApp]
+             .mailPlugin, .internetPlugin]
         )
     }
 
@@ -78,7 +80,6 @@ final class ExtensionItemTests: XCTestCase {
         XCTAssertEqual(ExtensionType.firefoxExtension.rawValue, "firefoxExtension")
         XCTAssertEqual(ExtensionType.mailPlugin.rawValue, "mailPlugin")
         XCTAssertEqual(ExtensionType.internetPlugin.rawValue, "internetPlugin")
-        XCTAssertEqual(ExtensionType.loginItemFromApp.rawValue, "loginItemFromApp")
     }
 
     /// `id` mirrors the raw value so `ForEach` over `allCases` is stable.

--- a/VaderCleanerTests/ExtensionsManagerViewModelTests.swift
+++ b/VaderCleanerTests/ExtensionsManagerViewModelTests.swift
@@ -49,7 +49,7 @@ final class ExtensionsManagerViewModelTests: XCTestCase {
     func test_groupedByType_bucketsInAllCasesOrder() async {
         let vm = makeViewModel(discover: {
             [
-                Self.item(name: "Login", type: .loginItemFromApp),
+                Self.item(name: "Plugin", type: .internetPlugin),
                 Self.item(name: "Safari1", type: .safariExtension),
                 Self.item(name: "Mail1", type: .mailPlugin),
                 Self.item(name: "Safari2", type: .safariExtension)
@@ -59,7 +59,7 @@ final class ExtensionsManagerViewModelTests: XCTestCase {
 
         let grouped = vm.groupedByType
         XCTAssertEqual(grouped.map(\.0),
-                       [.safariExtension, .mailPlugin, .loginItemFromApp])
+                       [.safariExtension, .mailPlugin, .internetPlugin])
         XCTAssertEqual(grouped.first?.1.map(\.name), ["Safari1", "Safari2"])
     }
 

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -7,8 +7,8 @@ import AppKit
 
 final class NavigationSectionTests: XCTestCase {
 
-    func test_allCasesCount_is10() {
-        XCTAssertEqual(NavigationSection.allCases.count, 10)
+    func test_allCasesCount_is9() {
+        XCTAssertEqual(NavigationSection.allCases.count, 9)
     }
 
     func test_firstCase_isSmartScan() {
@@ -32,7 +32,6 @@ final class NavigationSectionTests: XCTestCase {
             .spaceLens: "sidebar.spaceLens",
             .malwareRemoval: "sidebar.malwareRemoval",
             .privacy: "sidebar.privacy",
-            .extensions: "sidebar.extensions",
             .applications: "sidebar.applications",
             .optimization: "sidebar.optimization",
             .healthMonitor: "sidebar.healthMonitor",
@@ -59,7 +58,6 @@ final class NavigationSectionTests: XCTestCase {
             .spaceLens: "section.spaceLens.scan",
             .malwareRemoval: "section.malwareRemoval.scan",
             .privacy: "section.privacy.scan",
-            .extensions: "section.extensions.scan",
             .applications: "section.applications.scan",
             .optimization: "section.optimization.scan",
             .healthMonitor: "section.healthMonitor.scan",
@@ -90,7 +88,6 @@ final class NavigationSectionTests: XCTestCase {
             .malwareRemoval: true,   // ClamAV scan
             .optimization: false,    // launchctl / login items / RAM
             .privacy: true,          // Safari data lives in TCC-protected paths
-            .extensions: false,
             .applications: false,    // app discovery + update checks; no FDA-gated paths
             .healthMonitor: false,
         ]

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -43,27 +43,38 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the floating Scan button on the Applications intro")
     }
 
-    /// Scan → the dashboard grid appears with the Updates and Manage cards.
-    func test_applications_scanShowsDashboardGrid() throws {
+    /// Scan → the dashboard appears showing only cleanup recommendation cards
+    /// (or the all-clear state when nothing needs attention). The old Updates
+    /// and Manage cards are gone — Manage lives behind the header button now.
+    func test_applications_scanShowsDashboard() throws {
         dismissOnboardingIfNeeded()
         openApplicationsAndScan()
 
         let dashboard = app.descendants(matching: .any)["applications.dashboard"]
         XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
-                      "Expected the Applications dashboard grid after the scan")
+                      "Expected the Applications dashboard after the scan")
 
-        XCTAssertTrue(app.buttons["applications.card.updates"].waitForExistence(timeout: 5),
-                      "Expected the Updates card on the dashboard")
-        XCTAssertTrue(app.buttons["applications.card.manage"].exists,
-                      "Expected the Manage card on the dashboard")
-        XCTAssertTrue(app.buttons["applications.card.installationFiles"].exists,
-                      "Expected the Installation Files card on the dashboard")
-        XCTAssertTrue(app.buttons["applications.card.unsupported"].exists,
-                      "Expected the Unsupported Applications card on the dashboard")
-        XCTAssertTrue(app.buttons["applications.card.unused"].exists,
-                      "Expected the Unused Applications card on the dashboard")
-        XCTAssertTrue(app.buttons["applications.card.leftovers"].exists,
-                      "Expected the App Leftovers card on the dashboard")
+        // Which cleanup cards appear depends on the machine, so assert the
+        // dashboard reaches a valid state: at least one recommendation card,
+        // or the all-clear state.
+        let validState = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier IN {"
+                + "'applications.card.unused','applications.card.unsupported',"
+                + "'applications.card.leftovers','applications.card.installationFiles',"
+                + "'applications.dashboard.allClear'}"))
+            .firstMatch
+        XCTAssertTrue(validState.waitForExistence(timeout: 10),
+                      "Expected a recommendation card or the all-clear state")
+
+        // The removed cards must not be present.
+        XCTAssertFalse(app.buttons["applications.card.updates"].exists,
+                       "Updates moved into the Manager's Updater pane")
+        XCTAssertFalse(app.buttons["applications.card.manage"].exists,
+                       "The Manage card was replaced by the header button")
+
+        // Manage is reachable from the header button instead.
+        XCTAssertTrue(app.buttons["applications.manageMyApplications"].waitForExistence(timeout: 5),
+                      "Expected the Manage My Applications header button")
     }
 
     /// The Installation Files card opens its review screen, and Back returns to
@@ -96,22 +107,23 @@ final class ApplicationsUITests: XCTestCase {
         )
     }
 
-    /// The Manage card opens the Applications Manager catalog with its
-    /// Uninstaller / Updater / Leftovers sub-navigation; switching panes works
-    /// and Back returns to the dashboard.
+    /// The Manage My Applications button opens the Applications Manager catalog
+    /// with its Uninstaller / Updater / Extensions / Leftovers sub-navigation;
+    /// switching panes works and Back returns to the dashboard.
     func test_applications_manageOpensManagerCatalog() throws {
         dismissOnboardingIfNeeded()
         openApplicationsAndScan()
 
-        let manageCard = app.buttons["applications.card.manage"]
-        XCTAssertTrue(manageCard.waitForExistence(timeout: 90),
-                      "Expected the Manage card after the scan")
-        manageCard.click()
+        let manage = app.buttons["applications.manageMyApplications"]
+        XCTAssertTrue(manage.waitForExistence(timeout: 90),
+                      "Expected the Manage My Applications button after the scan")
+        manage.click()
 
         XCTAssertTrue(app.descendants(matching: .any)["applications.manager"].waitForExistence(timeout: 10),
                       "Expected the Applications Manager catalog")
         for navID in ["applications.manager.nav.uninstaller",
                       "applications.manager.nav.updater",
+                      "applications.manager.nav.extensions",
                       "applications.manager.nav.leftovers"] {
             XCTAssertTrue(app.buttons[navID].waitForExistence(timeout: 5),
                           "Expected sub-nav item \(navID)")
@@ -136,25 +148,33 @@ final class ApplicationsUITests: XCTestCase {
         )
     }
 
-    /// The Updates card opens the reused App Updater screen, and Back returns
-    /// to the dashboard.
-    func test_applications_updatesCardOpensUpdaterAndBackReturns() throws {
+    /// The Manager's Extensions pane renders the reused Extensions Manager
+    /// screen, and Back returns to the dashboard. (Extensions used to be a
+    /// top-level sidebar section; it now lives inside Manage My Applications.)
+    func test_applications_manageExtensionsPaneRenders() throws {
         dismissOnboardingIfNeeded()
         openApplicationsAndScan()
 
-        let updatesCard = app.buttons["applications.card.updates"]
-        XCTAssertTrue(updatesCard.waitForExistence(timeout: 90),
-                      "Expected the Updates card after the scan")
-        updatesCard.click()
+        let manage = app.buttons["applications.manageMyApplications"]
+        XCTAssertTrue(manage.waitForExistence(timeout: 90),
+                      "Expected the Manage My Applications button after the scan")
+        manage.click()
 
-        // The reused App Updater screen reaches one of its display states.
-        let updaterState = app.descendants(matching: .any)
+        let extensionsNav = app.buttons["applications.manager.nav.extensions"]
+        XCTAssertTrue(extensionsNav.waitForExistence(timeout: 10),
+                      "Expected the Extensions sub-nav item")
+        extensionsNav.click()
+
+        // The reused Extensions Manager screen reaches a display state:
+        // scanning, the empty state, or a populated list (which carries the
+        // Refresh control).
+        let extensionsState = app.descendants(matching: .any)
             .matching(NSPredicate(
-                format: "identifier IN {'appUpdater.loading', 'appUpdater.upToDate', 'appUpdater.check', 'appUpdater.errorMessage'}"
+                format: "identifier IN {'extensions.loading', 'extensions.empty', 'extensions.refresh'}"
             ))
             .firstMatch
-        XCTAssertTrue(updaterState.waitForExistence(timeout: 30),
-                      "Expected the reused App Updater screen to render")
+        XCTAssertTrue(extensionsState.waitForExistence(timeout: 30),
+                      "Expected the Extensions Manager screen to render")
 
         let back = app.buttons["applications.backToDashboard"]
         XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -77,33 +77,45 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the Manage My Applications header button")
     }
 
-    /// The Installation Files card opens its review screen, and Back returns to
-    /// the dashboard.
-    func test_applications_installationFilesCardOpensReviewAndBackReturns() throws {
+    /// A recommendation card opens its review screen, and Back returns to the
+    /// dashboard. The dashboard now shows only cleanup categories that have
+    /// findings, so the exact cards depend on the host — this exercises
+    /// whichever recommendation card is present rather than assuming a specific
+    /// one. On a host with nothing to clean up the dashboard shows the all-clear
+    /// state and there is no card to open, which the test accepts.
+    func test_applications_recommendationCardOpensReviewAndBackReturns() throws {
         dismissOnboardingIfNeeded()
         openApplicationsAndScan()
 
-        let card = app.buttons["applications.card.installationFiles"]
-        XCTAssertTrue(card.waitForExistence(timeout: 90),
-                      "Expected the Installation Files card after the scan")
+        let dashboard = app.descendants(matching: .any)["applications.dashboard"]
+        XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
+                      "Expected the Applications dashboard after the scan")
+
+        let card = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier IN {"
+                + "'applications.card.unused','applications.card.unsupported',"
+                + "'applications.card.leftovers','applications.card.installationFiles'}"))
+            .firstMatch
+
+        guard card.waitForExistence(timeout: 10) else {
+            // No findings → the all-clear state; there is no card to open.
+            XCTAssertTrue(
+                app.descendants(matching: .any)["applications.dashboard.allClear"].exists,
+                "With no recommendation cards the dashboard must show the all-clear state"
+            )
+            return
+        }
+
         card.click()
 
-        // Either the installer list or its empty state must render — both are
-        // valid display states depending on what's in Downloads/Desktop.
-        let reviewState = app.descendants(matching: .any)
-            .matching(NSPredicate(
-                format: "identifier IN {'applications.installationFiles', 'applications.installationFiles.empty'}"
-            ))
-            .firstMatch
-        XCTAssertTrue(reviewState.waitForExistence(timeout: 10),
-                      "Expected the Installation Files review screen to render")
-
+        // Whichever review screen opened, it carries the shared Back control.
         let back = app.buttons["applications.backToDashboard"]
-        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        XCTAssertTrue(back.waitForExistence(timeout: 10),
+                      "Expected a recommendation card to open a review screen with a Back control")
         back.click()
         XCTAssertTrue(
             app.descendants(matching: .any)["applications.dashboard"].waitForExistence(timeout: 5),
-            "Expected Back to return to the dashboard grid"
+            "Expected Back to return to the dashboard"
         )
     }
 

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -55,6 +55,14 @@ final class FinalPolishUITests: XCTestCase {
                 "Expected sidebar to list the \"\(identifier)\" section"
             )
         }
+
+        // The Extensions section was folded into Applications → Manage, so its
+        // top-level row must be gone. Asserting the nine rows exist isn't enough
+        // — that still passes if a stale Extensions row renders as a tenth.
+        XCTAssertFalse(
+            app.buttons["sidebar.extensions"].waitForExistence(timeout: 2),
+            "Extensions must no longer be a top-level sidebar section"
+        )
     }
 
     /// The rail must stay anchored: navigating between detail screens must not

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -11,12 +11,14 @@ final class FinalPolishUITests: XCTestCase {
 
     private var app: XCUIApplication!
 
-    /// The ten sidebar row identifiers, in `NavigationSection` order. Rows
+    /// The nine sidebar row identifiers, in `NavigationSection` order. Rows
     /// are located by identifier rather than visible label so the locators
     /// survive rail restyles; these mirror
     /// `NavigationSection.accessibilityIdentifier`. Hard-coded because the
     /// UI-test bundle runs out-of-process and cannot import the app enum;
     /// `NavigationSectionTests` pins the enum side, this pins the rendered side.
+    /// Extensions is no longer a top-level section — it lives inside
+    /// Applications → Manage My Applications.
     private let sectionIdentifiers = [
         "sidebar.smartScan",
         "sidebar.systemJunk",
@@ -24,7 +26,6 @@ final class FinalPolishUITests: XCTestCase {
         "sidebar.spaceLens",
         "sidebar.malwareRemoval",
         "sidebar.privacy",
-        "sidebar.extensions",
         "sidebar.applications",
         "sidebar.optimization",
         "sidebar.healthMonitor",
@@ -43,8 +44,8 @@ final class FinalPolishUITests: XCTestCase {
 
     // MARK: - Sidebar
 
-    /// Launch → every one of the ten sections is present in the sidebar.
-    func test_launch_sidebarShowsAllTenSections() throws {
+    /// Launch → every one of the nine sections is present in the sidebar.
+    func test_launch_sidebarShowsAllNineSections() throws {
         dismissOnboardingIfNeeded()
 
         for identifier in sectionIdentifiers {
@@ -56,12 +57,20 @@ final class FinalPolishUITests: XCTestCase {
         }
     }
 
-    /// The rail must stay anchored: switching between a short detail screen
-    /// (Extensions, a compact list) and a tall one (Health Monitor, a grid of
-    /// stat cards) must not move the sidebar rows vertically. Regression guard
-    /// for the rail floating when the detail column's effective height changes.
-    /// The window is not resized, so the `sidebar.smartScan` button's absolute
-    /// Y must be identical in both.
+    /// The rail must stay anchored: navigating between detail screens must not
+    /// move the sidebar rows vertically. The window is not resized, so the
+    /// `sidebar.smartScan` button's absolute Y must be identical before and
+    /// after navigating.
+    ///
+    /// NOTE: this originally contrasted a *short* detail (Extensions, a compact
+    /// list) against a *tall* one (Health Monitor's grid) to guard the rail
+    /// floating when the detail is short. Extensions is no longer a top-level
+    /// section, and every remaining section's detail fills the window height
+    /// (scan intros and the Health grid alike), so the short-vs-tall contrast
+    /// is gone — this now only smoke-checks that navigation doesn't shift the
+    /// rail. Re-pointing it at a genuinely short surface (e.g. the Applications
+    /// all-clear dashboard or the Extensions pane) would require running a scan
+    /// inside the test.
     func test_railRowPosition_isStableAcrossDetailScreens() throws {
         dismissOnboardingIfNeeded()
 
@@ -69,30 +78,30 @@ final class FinalPolishUITests: XCTestCase {
         XCTAssertTrue(anchor.waitForExistence(timeout: 5),
                       "Expected Smart Scan row in sidebar")
 
-        let extensionsRow = app.buttons["sidebar.extensions"].firstMatch
-        XCTAssertTrue(extensionsRow.waitForExistence(timeout: 5),
-                      "Expected Extensions row in sidebar")
-        extensionsRow.click()
+        let privacyRow = app.buttons["sidebar.privacy"].firstMatch
+        XCTAssertTrue(privacyRow.waitForExistence(timeout: 5),
+                      "Expected Privacy row in sidebar")
+        privacyRow.click()
         // Wait until the clicked row reports selection before measuring. The
         // anchor row exists regardless of selection, so waiting on it would
         // return immediately and could sample Y mid-transition; the
         // `.isSelected` trait only flips once the navigation has taken
         // effect and the rail re-rendered.
-        waitUntilSelected(extensionsRow)
-        let yShortDetail = anchor.frame.origin.y
+        waitUntilSelected(privacyRow)
+        let yIntroDetail = anchor.frame.origin.y
 
         let healthRow = app.buttons["sidebar.healthMonitor"].firstMatch
         XCTAssertTrue(healthRow.waitForExistence(timeout: 5),
                       "Expected Health Monitor row in sidebar")
         healthRow.click()
         waitUntilSelected(healthRow)
-        let yTallDetail = anchor.frame.origin.y
+        let yGridDetail = anchor.frame.origin.y
 
         XCTAssertEqual(
-            yShortDetail, yTallDetail, accuracy: 1.0,
+            yIntroDetail, yGridDetail, accuracy: 1.0,
             "Sidebar rows must not shift vertically when the detail screen "
-            + "changes height (was \(yShortDetail) on Extensions, "
-            + "\(yTallDetail) on Health Monitor)"
+            + "changes (was \(yIntroDetail) on Privacy, "
+            + "\(yGridDetail) on Health Monitor)"
         )
     }
 


### PR DESCRIPTION
## What & why

The standalone **Extensions** sidebar section managed app appendages (browser/Safari/Mail extensions, internet plug-ins, login-item launch agents) that conceptually belong with **Applications** — and its launch-agent discovery duplicated Optimization's. This PR folds Extensions into Applications and reshapes the post-scan dashboard to surface only actionable cleanup recommendations.

## Changes

**Extensions → Applications**
- Removed Extensions from the sidebar rail (`NavigationSection` + every exhaustive switch: `SectionTheme`, `ScanDiscHostView`, `SectionPresentation`).
- Extensions now lives as a pane inside **Manage My Applications** (Uninstaller / Updater / **Extensions** / Leftovers), reusing `ExtensionsManagerView` unchanged.

**Login items / launch agents de-duplication**
- Dropped `loginItemFromApp` from `ExtensionType` and deleted the now-duplicate `LaunchAgentDiscovery`.
- Verified Optimization's `LaunchAgentManager` scans the **identical** roots (`~/Library/LaunchAgents`, `/Library/LaunchAgents`, `/Library/LaunchDaemons`) with richer controls (enable/disable, loaded status, orphan detection), so it's the sole home now — **no coverage lost**. Also confirmed `removeLaunchAgent` is still used by Optimization (not orphaned).

**Curated, Optimization-style dashboard**
- New tested model seam `ApplicationsScanResult.recommendations` returns only cleanup categories with findings, in display order.
- Grid renders one card per recommendation, hiding empties, with an **all-clear** state when none.
- Updates moved into the Manager's Updater pane; the redundant Manage card replaced by the header button.
- Layout now mirrors the Optimization dashboard exactly — a 320pt hero card + adaptive `LazyVGrid(minimum: 260, spacing: 16)` in a `ScrollView` — so the two dashboards share one look and tile width.

## Tests
- Added `ApplicationsScanResult.recommendations` unit coverage (empty / only-non-empty / deterministic order).
- Slimmed `ExtensionType` (5 cases) and `NavigationSection` (9 sections) suites; removed the launch-agent discovery tests.
- Retargeted the affected UI tests off the removed Extensions section and dashboard cards; repurposed the Updates-card test into an Extensions-pane test.

**Verification:** `xcodebuild build-for-testing` clean (app + both test bundles); `xcodebuild test -only-testing:VaderCleanerTests CODE_SIGNING_ALLOWED=NO` passes, output pristine.

## Reviewer notes
- **UI test changes are compile-verified only** — XCUITests can't bootstrap from the dev terminal here, so the edited `ApplicationsUITests` (4) and `FinalPolishUITests` (2) need a run in Xcode, along with a visual pass: dashboard shows only cards-with-findings + all-clear; Manage → Extensions pane lists/removes; Optimization still lists the same launch agents.
- **`FinalPolishUITests.test_railRowPosition_isStableAcrossDetailScreens` lost its teeth**: it originally contrasted Extensions' *short* compact list against Health Monitor's *tall* grid. Extensions is gone and every remaining section's detail fills the window, so there's no short surface left to contrast — it's now only a navigation smoke-check (documented in the test). Open to deleting it or re-pointing it at a scan-dependent short surface.
- The Optimization-style dashboard intentionally supersedes the earlier "fits without scrolling" behavior (commit bd8c2dc), per the request to match Optimization's look and tile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recommendation-based Applications dashboard with an “all clear” state, a hero card and adaptive grid of recommendation cards.
  * Extensions pane added to the Applications Manager.

* **Refactor**
  * Applications dashboard and card presentation redesigned for flexible sizing and layout.
  * Extensions removed as a top-level sidebar section.

* **Chores / Tests**
  * Removed login-item/launch-agent discovery surface and updated unit and UI tests to match the new dashboard and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->