### PR TITLE
feat(applications): rank recommendation tiles and add an Updates tile

### DIFF
--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -14,6 +14,7 @@ struct ApplicationsDashboardView: View {
     let onOpenInstallationFiles: () -> Void
     let onOpenUnsupported: () -> Void
     let onOpenUnused: () -> Void
+    let onOpenUpdates: () -> Void
     let onOpenLeftovers: () -> Void
     let onRescan: () -> Void
 
@@ -67,6 +68,10 @@ struct ApplicationsDashboardView: View {
     private struct CardSpec: Identifiable {
         let id: String
         let title: String
+        /// A short, emphasized magnitude — reclaimable size for space
+        /// categories, item count for app/update categories — surfaced as the
+        /// card's headline number above its supporting detail.
+        let metric: String
         let detail: String
         let icon: String
         let actionLabel: String
@@ -79,19 +84,24 @@ struct ApplicationsDashboardView: View {
 
     private func spec(for recommendation: ApplicationsScanResult.Recommendation) -> CardSpec {
         switch recommendation {
-        case .unused:
-            return CardSpec(id: "applications.card.unused", title: unusedTitle, detail: unusedDetail,
-                            icon: "moon.zzz", actionLabel: reviewLabel, action: onOpenUnused)
         case .unsupported:
-            return CardSpec(id: "applications.card.unsupported", title: unsupportedTitle, detail: unsupportedDetail,
-                            icon: "exclamationmark.triangle", actionLabel: reviewLabel, action: onOpenUnsupported)
+            return CardSpec(id: "applications.card.unsupported", title: unsupportedTitle, metric: unsupportedMetric,
+                            detail: unsupportedDetail, icon: "exclamationmark.triangle",
+                            actionLabel: reviewLabel, action: onOpenUnsupported)
+        case .unused:
+            return CardSpec(id: "applications.card.unused", title: unusedTitle, metric: unusedMetric,
+                            detail: unusedDetail, icon: "moon.zzz", actionLabel: reviewLabel, action: onOpenUnused)
+        case .updates:
+            return CardSpec(id: "applications.card.updates", title: updatesTitle, metric: updatesMetric,
+                            detail: updatesDetail, icon: "arrow.down.circle", actionLabel: updateLabel,
+                            action: onOpenUpdates)
         case .leftovers:
-            return CardSpec(id: "applications.card.leftovers", title: leftoversTitle, detail: leftoversDetail,
-                            icon: "trash", actionLabel: reviewLabel, action: onOpenLeftovers)
+            return CardSpec(id: "applications.card.leftovers", title: leftoversTitle, metric: leftoversMetric,
+                            detail: leftoversDetail, icon: "trash", actionLabel: reviewLabel, action: onOpenLeftovers)
         case .installationFiles:
             return CardSpec(id: "applications.card.installationFiles", title: installationFilesTitle,
-                            detail: installationFilesDetail, icon: "shippingbox", actionLabel: reviewLabel,
-                            action: onOpenInstallationFiles)
+                            metric: installationFilesMetric, detail: installationFilesDetail, icon: "shippingbox",
+                            actionLabel: reviewLabel, action: onOpenInstallationFiles)
         }
     }
 
@@ -126,6 +136,7 @@ struct ApplicationsDashboardView: View {
     private func card(_ spec: CardSpec, isHero: Bool) -> some View {
         ApplicationsCard(
             title: spec.title,
+            metric: spec.metric,
             detail: spec.detail,
             icon: spec.icon,
             actionLabel: spec.actionLabel,
@@ -149,8 +160,8 @@ struct ApplicationsDashboardView: View {
             ))
             .font(.title3.weight(.semibold))
             Text(String(
-                localized: "No unused or unsupported apps, leftovers, or installer files to review. Open Manage My Applications for available updates and to browse everything you have installed.",
-                comment: "Applications dashboard all-clear detail; points to Manage for updates since they are not shown on the dashboard."
+                localized: "No unused or unsupported apps, available updates, leftovers, or installer files to review. Open Manage My Applications to browse everything you have installed.",
+                comment: "Applications dashboard all-clear detail shown when no recommendation category has findings."
             ))
             .font(.callout)
             .foregroundStyle(.secondary)
@@ -172,6 +183,17 @@ struct ApplicationsDashboardView: View {
         return String.localizedStringWithFormat(format, Int64(result.installedCount))
     }
 
+    private var updateLabel: String {
+        String(localized: "Update", comment: "Applications Updates card action that opens the Updater pane.")
+    }
+
+    /// Localized "N apps" count, used as the metric on the app categories
+    /// (unused / unsupported) where there is no on-disk size to show.
+    private func appCountText(_ count: Int) -> String {
+        let format = String(localized: "%lld apps", comment: "Applications card metric; %lld is an app count.")
+        return String.localizedStringWithFormat(format, Int64(count))
+    }
+
     private var installationFilesTitle: String {
         if result.installationFilesCount == 0 {
             return String(
@@ -179,11 +201,14 @@ struct ApplicationsDashboardView: View {
                 comment: "Applications Installation Files card title when none are found."
             )
         }
-        let format = String(
-            localized: "%lld Installation Files Found",
-            comment: "Applications Installation Files card title; %lld is the installer count."
+        return String(
+            localized: "Installation Files",
+            comment: "Applications Installation Files card title."
         )
-        return String.localizedStringWithFormat(format, Int64(result.installationFilesCount))
+    }
+
+    private var installationFilesMetric: String {
+        smartScanByteFormatter.string(fromByteCount: result.installationFilesTotalBytes)
     }
 
     private var installationFilesDetail: String {
@@ -193,12 +218,10 @@ struct ApplicationsDashboardView: View {
                 comment: "Applications Installation Files card detail when none are found."
             )
         }
-        let size = smartScanByteFormatter.string(fromByteCount: result.installationFilesTotalBytes)
-        let format = String(
-            localized: "Leftover disk images and installers in your Downloads and Desktop are using %@. They're safe to remove once an app is installed.",
-            comment: "Applications Installation Files card detail; %@ is the reclaimable size."
+        return String(
+            localized: "Leftover disk images and installers in your Downloads and Desktop. They're safe to remove once an app is installed.",
+            comment: "Applications Installation Files card detail when some are found."
         )
-        return String.localizedStringWithFormat(format, size)
     }
 
     private var unusedTitle: String {
@@ -208,12 +231,13 @@ struct ApplicationsDashboardView: View {
                 comment: "Applications Unused card title when none are found."
             )
         }
-        let format = String(
-            localized: "%lld Unused Applications Found",
-            comment: "Applications Unused card title; %lld is the count."
+        return String(
+            localized: "Unused Applications",
+            comment: "Applications Unused card title."
         )
-        return String.localizedStringWithFormat(format, Int64(result.unusedAppsCount))
     }
+
+    private var unusedMetric: String { appCountText(result.unusedAppsCount) }
 
     private var unusedDetail: String {
         if result.unusedAppsCount == 0 {
@@ -228,6 +252,40 @@ struct ApplicationsDashboardView: View {
         )
     }
 
+    private var updatesTitle: String {
+        if result.updatesCount == 0 {
+            return String(
+                localized: "No Updates Available",
+                comment: "Applications Updates card title when none are found."
+            )
+        }
+        return String(
+            localized: "Updates Available",
+            comment: "Applications Updates card title."
+        )
+    }
+
+    private var updatesMetric: String {
+        let format = String(
+            localized: "%lld updates",
+            comment: "Applications Updates card metric; %lld is the available-update count."
+        )
+        return String.localizedStringWithFormat(format, Int64(result.updatesCount))
+    }
+
+    private var updatesDetail: String {
+        if result.updatesCount == 0 {
+            return String(
+                localized: "Every app is up to date.",
+                comment: "Applications Updates card detail when none are found."
+            )
+        }
+        return String(
+            localized: "These apps have newer versions available. Update them to get the latest fixes.",
+            comment: "Applications Updates card detail when some are found."
+        )
+    }
+
     private var leftoversTitle: String {
         if result.leftoversCount == 0 {
             return String(
@@ -235,11 +293,14 @@ struct ApplicationsDashboardView: View {
                 comment: "Applications Leftovers card title when none are found."
             )
         }
-        let format = String(
-            localized: "Leftovers From %lld Apps Found",
-            comment: "Applications Leftovers card title; %lld is the orphaned-app count."
+        return String(
+            localized: "App Leftovers",
+            comment: "Applications Leftovers card title."
         )
-        return String.localizedStringWithFormat(format, Int64(result.leftoversCount))
+    }
+
+    private var leftoversMetric: String {
+        smartScanByteFormatter.string(fromByteCount: result.leftoversTotalBytes)
     }
 
     private var leftoversDetail: String {
@@ -249,12 +310,10 @@ struct ApplicationsDashboardView: View {
                 comment: "Applications Leftovers card detail when none are found."
             )
         }
-        let size = smartScanByteFormatter.string(fromByteCount: result.leftoversTotalBytes)
-        let format = String(
-            localized: "Support files left behind by apps you've removed are using %@.",
-            comment: "Applications Leftovers card detail; %@ is the reclaimable size."
+        return String(
+            localized: "Support files left behind by apps you've removed.",
+            comment: "Applications Leftovers card detail when some are found."
         )
-        return String.localizedStringWithFormat(format, size)
     }
 
     private var unsupportedTitle: String {
@@ -264,12 +323,13 @@ struct ApplicationsDashboardView: View {
                 comment: "Applications Unsupported card title when none are found."
             )
         }
-        let format = String(
-            localized: "%lld Unsupported Applications Found",
-            comment: "Applications Unsupported card title; %lld is the count."
+        return String(
+            localized: "Unsupported Applications",
+            comment: "Applications Unsupported card title."
         )
-        return String.localizedStringWithFormat(format, Int64(result.unsupportedAppsCount))
     }
+
+    private var unsupportedMetric: String { appCountText(result.unsupportedAppsCount) }
 
     private var unsupportedDetail: String {
         if result.unsupportedAppsCount == 0 {
@@ -290,6 +350,9 @@ struct ApplicationsDashboardView: View {
 /// surfaces stay consistent.
 struct ApplicationsCard: View {
     let title: String
+    /// Short, emphasized magnitude (reclaimable size or item count) shown as the
+    /// card's headline number beneath the title.
+    let metric: String
     let detail: String
     let icon: String
     let actionLabel: String
@@ -310,6 +373,10 @@ struct ApplicationsCard: View {
                     .font(.title2)
                     .foregroundStyle(.tint)
             }
+            Text(metric)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.tint)
+                .fixedSize(horizontal: false, vertical: true)
             Text(detail)
                 .font(.callout)
                 .foregroundStyle(.secondary)

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -33,7 +33,9 @@ struct ApplicationsView: View {
     /// screen.
     private enum Detail {
         case dashboard
-        case manage
+        /// The full Manager, opened on a specific pane — the Manage button opens
+        /// it on the Uninstaller, the Updates card deep-links to the Updater.
+        case manage(ApplicationsManagerView.Pane)
         case installationFiles
         case unsupported
         case unused
@@ -89,20 +91,22 @@ struct ApplicationsView: View {
             ScrollView {
                 ApplicationsDashboardView(
                     result: result,
-                    onOpenManage: { detail = .manage },
+                    onOpenManage: { detail = .manage(.uninstaller) },
                     onOpenInstallationFiles: { detail = .installationFiles },
                     onOpenUnsupported: { detail = .unsupported },
                     onOpenUnused: { detail = .unused },
+                    onOpenUpdates: { detail = .manage(.updater) },
                     onOpenLeftovers: { detail = .leftovers },
                     onRescan: { Task { await viewModel.scan() } }
                 )
                 .padding(24)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-        case .manage:
+        case .manage(let pane):
             // Full multi-pane manager (Uninstaller / Updater / Leftovers),
             // styled like the Optimization "View All Tasks" catalog — it owns
-            // its own header, so it is not wrapped in `detailScreen`.
+            // its own header, so it is not wrapped in `detailScreen`. Opens on
+            // `pane` so the Updates card can deep-link straight to the Updater.
             ApplicationsManagerView(
                 viewModel: viewModel,
                 uninstallerViewModel: uninstallerViewModel,
@@ -110,6 +114,7 @@ struct ApplicationsView: View {
                 extensionsManagerViewModel: extensionsManagerViewModel,
                 result: result,
                 iconCache: iconCache,
+                initialPane: pane,
                 onBack: { detail = .dashboard }
             )
         case .installationFiles:
@@ -244,8 +249,9 @@ struct ApplicationsManagerView: View {
 
     /// Which sub-section the manager is showing. Local state — it survives the
     /// view's re-renders while the manager is open, and resets when the user
-    /// returns to the dashboard and comes back.
-    @State private var pane: Pane = .uninstaller
+    /// returns to the dashboard and comes back. Seeded from `initialPane` so a
+    /// caller can deep-link straight to a pane (e.g. the Updates card → Updater).
+    @State private var pane: Pane
 
     enum Pane: Hashable {
         case uninstaller
@@ -261,6 +267,7 @@ struct ApplicationsManagerView: View {
         extensionsManagerViewModel: ExtensionsManagerViewModel,
         result: ApplicationsScanResult,
         iconCache: AppIconCache,
+        initialPane: Pane = .uninstaller,
         onBack: @escaping () -> Void
     ) {
         self.viewModel = viewModel
@@ -269,6 +276,7 @@ struct ApplicationsManagerView: View {
         self.extensionsManagerViewModel = extensionsManagerViewModel
         self.result = result
         self.iconCache = iconCache
+        self._pane = State(initialValue: initialPane)
         self.onBack = onBack
     }
 

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -44,25 +44,29 @@ struct ApplicationsScanResult: Equatable {
         leftovers.reduce(Int64(0)) { $0 + $1.totalBytes }
     }
 
-    /// A cleanup category the dashboard can recommend acting on. The dashboard
-    /// grid renders one card per recommendation, in this declaration order.
+    /// A category the dashboard can recommend acting on. The grid renders one
+    /// card per recommendation, in this declaration order — which is the
+    /// severity / actionability ranking, so the hero (first) card is always the
+    /// finding that most warrants attention: apps that can't run, then stale
+    /// apps, then available updates, then orphaned files and installer cruft.
     enum Recommendation: CaseIterable {
-        case unused
         case unsupported
+        case unused
+        case updates
         case leftovers
         case installationFiles
     }
 
-    /// The cleanup categories that currently have findings, in display order.
-    /// Installed apps and available updates are deliberately excluded — the
-    /// grid surfaces only quick-win review-and-removal work; updates and the
-    /// full app list live under "Manage My Applications". An empty result
-    /// drives the dashboard's "all clear" state.
+    /// The categories that currently have findings, ranked by severity (the
+    /// `Recommendation` declaration order). The full installed-app list is
+    /// deliberately excluded — it lives under "Manage My Applications", not as a
+    /// cleanup card. An empty result drives the dashboard's "all clear" state.
     var recommendations: [Recommendation] {
         Recommendation.allCases.filter { recommendation in
             switch recommendation {
-            case .unused:            return unusedAppsCount > 0
             case .unsupported:       return unsupportedAppsCount > 0
+            case .unused:            return unusedAppsCount > 0
+            case .updates:           return updatesCount > 0
             case .leftovers:         return leftoversCount > 0
             case .installationFiles: return installationFilesCount > 0
             }

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -628,18 +628,20 @@ final class ApplicationsViewModelTests: XCTestCase {
 
     // MARK: - Dashboard recommendations
 
-    /// Builds a result with the given findings. Installed apps and available
-    /// updates are fixed non-empty values to prove they never influence the
-    /// cleanup recommendations.
+    /// Builds a result with the given findings. Installed apps are a fixed
+    /// non-empty value to prove the full app list never influences the cleanup
+    /// recommendations; available updates default to empty (they are now a
+    /// recommendation category, so tests opt them in explicitly).
     private func makeResult(
         installers: [InstallationFile] = [],
         unsupported: [UnsupportedApp] = [],
         unused: [UnusedApp] = [],
-        leftovers: [LeftoverGroup] = []
+        leftovers: [LeftoverGroup] = [],
+        updates: [UpdateInfo] = []
     ) -> ApplicationsScanResult {
         ApplicationsScanResult(
             installedApps: [makeApp(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")],
-            availableUpdates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")],
+            availableUpdates: updates,
             installationFiles: installers,
             unsupportedApps: unsupported,
             unusedApps: unused,
@@ -647,7 +649,7 @@ final class ApplicationsViewModelTests: XCTestCase {
         )
     }
 
-    /// No cleanup findings → no recommendations, even though apps and updates
+    /// No cleanup findings → no recommendations, even though installed apps
     /// exist. Drives the dashboard's "all clear" state.
     func test_recommendations_emptyWhenNoCleanupFindings() {
         XCTAssertEqual(makeResult().recommendations, [])
@@ -661,19 +663,39 @@ final class ApplicationsViewModelTests: XCTestCase {
         XCTAssertEqual(result.recommendations, [.unused])
     }
 
-    /// When every category has findings they appear in the fixed display
-    /// order: unused, unsupported, leftovers, installation files.
+    /// Available updates surface as their own recommendation category.
+    func test_recommendations_includesUpdatesWhenPresent() {
+        let result = makeResult(
+            updates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        )
+        XCTAssertEqual(result.recommendations, [.updates])
+    }
+
+    /// When every category has findings they appear in the severity ranking:
+    /// unsupported, unused, updates, leftovers, installation files.
     func test_recommendations_areOrderedDeterministically() {
         let result = makeResult(
             installers: [makeInstaller(name: "Setup.dmg", size: 1_000)],
             unsupported: [makeUnsupported(name: "Legacy", bundleID: "com.legacy.app")],
             unused: [makeUnused(name: "Old", bundleID: "com.old.app")],
-            leftovers: [makeLeftover(bundleID: "com.gone.app", paths: ["/tmp/a"], bytes: 10)]
+            leftovers: [makeLeftover(bundleID: "com.gone.app", paths: ["/tmp/a"], bytes: 10)],
+            updates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
         )
         XCTAssertEqual(
             result.recommendations,
-            [.unused, .unsupported, .leftovers, .installationFiles]
+            [.unsupported, .unused, .updates, .leftovers, .installationFiles]
         )
+    }
+
+    /// Updates rank third — after the app-removal categories, before the
+    /// space-reclaim cruft — when only a subset of categories has findings.
+    func test_recommendations_rankUpdatesThird() {
+        let result = makeResult(
+            installers: [makeInstaller(name: "Setup.dmg", size: 1_000)],
+            unused: [makeUnused(name: "Old", bundleID: "com.old.app")],
+            updates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        )
+        XCTAssertEqual(result.recommendations, [.unused, .updates, .installationFiles])
     }
 }
 

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -43,9 +43,10 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the floating Scan button on the Applications intro")
     }
 
-    /// Scan → the dashboard appears showing only cleanup recommendation cards
-    /// (or the all-clear state when nothing needs attention). The old Updates
-    /// and Manage cards are gone — Manage lives behind the header button now.
+    /// Scan → the dashboard appears showing only recommendation cards (or the
+    /// all-clear state when nothing needs attention). Updates is one of the
+    /// ranked cards now; the old standalone Manage card is gone — Manage lives
+    /// behind the header button.
     func test_applications_scanShowsDashboard() throws {
         dismissOnboardingIfNeeded()
         openApplicationsAndScan()
@@ -54,25 +55,22 @@ final class ApplicationsUITests: XCTestCase {
         XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
                       "Expected the Applications dashboard after the scan")
 
-        // Which cleanup cards appear depends on the machine, so assert the
-        // dashboard reaches a valid state: at least one recommendation card,
+        // Which recommendation cards appear depends on the machine, so assert
+        // the dashboard reaches a valid state: at least one recommendation card,
         // or the all-clear state.
         let validState = app.descendants(matching: .any)
             .matching(NSPredicate(format: "identifier IN {"
-                + "'applications.card.unused','applications.card.unsupported',"
-                + "'applications.card.leftovers','applications.card.installationFiles',"
+                + "'applications.card.unsupported','applications.card.unused',"
+                + "'applications.card.updates','applications.card.leftovers',"
+                + "'applications.card.installationFiles',"
                 + "'applications.dashboard.allClear'}"))
             .firstMatch
         XCTAssertTrue(validState.waitForExistence(timeout: 10),
                       "Expected a recommendation card or the all-clear state")
 
-        // The removed cards must not be present.
-        XCTAssertFalse(app.buttons["applications.card.updates"].exists,
-                       "Updates moved into the Manager's Updater pane")
+        // The standalone Manage card is gone — Manage is the header button now.
         XCTAssertFalse(app.buttons["applications.card.manage"].exists,
                        "The Manage card was replaced by the header button")
-
-        // Manage is reachable from the header button instead.
         XCTAssertTrue(app.buttons["applications.manageMyApplications"].waitForExistence(timeout: 5),
                       "Expected the Manage My Applications header button")
     }
@@ -187,6 +185,45 @@ final class ApplicationsUITests: XCTestCase {
             .firstMatch
         XCTAssertTrue(extensionsState.waitForExistence(timeout: 30),
                       "Expected the Extensions Manager screen to render")
+
+        let back = app.buttons["applications.backToDashboard"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        back.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["applications.dashboard"].waitForExistence(timeout: 5),
+            "Expected Back to return to the dashboard grid"
+        )
+    }
+
+    /// The Updates recommendation card deep-links into the Manager's Updater
+    /// pane (rather than its own review screen), and Back returns to the
+    /// dashboard. Whether updates exist depends on the host, so the test accepts
+    /// the card's absence — mirroring the other host-dependent guards.
+    func test_applications_updatesCardOpensUpdaterPane() throws {
+        dismissOnboardingIfNeeded()
+        openApplicationsAndScan()
+
+        let dashboard = app.descendants(matching: .any)["applications.dashboard"]
+        XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
+                      "Expected the Applications dashboard after the scan")
+
+        let updatesCard = app.buttons["applications.card.updates"]
+        guard updatesCard.waitForExistence(timeout: 10) else {
+            // No updates available on this host → no Updates card to open.
+            return
+        }
+
+        updatesCard.click()
+
+        // The deep-link lands on the reused App Updater screen inside the
+        // Manager, in one of its display states.
+        let updaterState = app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier IN {'appUpdater.loading', 'appUpdater.upToDate', 'appUpdater.check', 'appUpdater.errorMessage'}"
+            ))
+            .firstMatch
+        XCTAssertTrue(updaterState.waitForExistence(timeout: 30),
+                      "Expected the Updates card to deep-link into the Updater pane")
 
         let back = app.buttons["applications.backToDashboard"]
         XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")


### PR DESCRIPTION
## What & why

The Applications dashboard's recommended cleanup tiles were rendered in a **fixed declaration order**, so whichever category came first always became the big hero card regardless of importance — and available updates were deliberately kept off the grid. This reworks the recommended tiles along four directions.

### 1. Rank by impact (severity order)
Tiles are now ranked by actionability so the hero is always the most important *present* finding:
`unsupported → unused → updates → leftovers → installationFiles`.
Encoded simply as the `Recommendation` enum declaration order (the computed property already filters `allCases`) — no scoring or magic weights. Byte-ranking was deliberately rejected: unused/unsupported apps carry no on-disk size, and computing it would re-introduce the multi-second bundle-sizing `AppInfo` documents avoiding at scan time.

### 2. Add an Updates tile (new 5th category)
Available updates now surface as their own tile (`applications.card.updates`) that **deep-links straight into the Manager's Updater pane** via a new `ApplicationsManagerView.initialPane` and a `Detail.manage(Pane)` case. This reverses a prior *documented* exclusion (updates used to live only behind Manage) — done with explicit sign-off. The all-clear copy and the recommendation doc comment were updated to match.

### 3. Richer tile content
Each card gains a prominent tinted **metric** line — reclaimable size for space categories, item count for app/update categories — and a clean noun-phrase title, with the magnitude moved out of the title to avoid redundancy.

### 4. Visual/layout polish
The hero + adaptive grid is preserved, but the hero now means something and the metric sharpens scannability. The shared glass surface / corner radius / hero heights are untouched, so the Optimization & Smart Scan dashboards stay consistent.

## Tests
- **Unit (`ApplicationsViewModelTests`):** updated the ordering/empty tests for the new ranking; added `test_recommendations_includesUpdatesWhenPresent` and `test_recommendations_rankUpdatesThird`. Full suite green (33 tests, 0 failures) via the `clean test` + `CODE_SIGNING_ALLOWED=NO` workaround.
- **UI (`ApplicationsUITests`):** inverted the assertion that the Updates card must *not* exist, added it to the valid-state predicate, and added a host-tolerant `test_applications_updatesCardOpensUpdaterPane`.

## Reviewer notes
- All targets compile; **UI tests can't bootstrap from a terminal** in this environment — please run `ApplicationsUITests` in Xcode.
- The visual balance of the standard (non-hero) cards — now title + metric + detail + button — is the one thing no test covers; worth an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updates are now displayed as a dedicated recommendation card in the Applications dashboard.
  * Recommendation cards now display additional metrics beneath their titles.

* **Improvements**
  * Category titles and metrics have been updated for clarity.
  * Empty-state messaging was revised with improved guidance.
  * Recommendation cards now provide direct navigation to specific management screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->