### PR TITLE
feat(health-monitor): add Mac Health hero card with overall verdict

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -10,13 +10,17 @@
 		00EA71EF4E372CADB9F1BDCD /* MaintenanceRunLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */; };
 		024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */; };
 		03546E424E99155428A6D25F /* HelperConnectionErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E776BF468380DFF621C6063C /* HelperConnectionErrorTests.swift */; };
+		03E56C4EFC8903CA9291A959 /* InstallationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C612F641A894AE10ADDA8F /* InstallationFile.swift */; };
 		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
 		04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */; };
+		0849175D7723A3D6B17FACF1 /* ApplicationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FD7F60311101E723D73E11 /* ApplicationsUITests.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
 		09756E0B2E09D8BF521C1141 /* MalwareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7315AD5A081B0855C316F00F /* MalwareView.swift */; };
+		09F3933E9C2A8A09E3E8BAEB /* UnsupportedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF58D340F13A253CAAB153AC /* UnsupportedApp.swift */; };
 		0CB34F6C9EDA3A4723026B5C /* SunburstLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6387590A274A5888D9BF28D /* SunburstLayoutTests.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */; };
+		10262DDD8C0BD95D484F5215 /* AppLeftover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D631EBC782CB95D9221AD977 /* AppLeftover.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
 		1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */; };
 		109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */; };
@@ -34,7 +38,6 @@
 		196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */; };
 		1B75D7EEFFDD8BBC248C628E /* PreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */; };
 		1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */; };
-		8116760AAB4F16FFC4961ABD /* ApplicationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8463E125473BA9EFD1E6CABF /* ApplicationsUITests.swift */; };
 		1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */; };
 		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
 		1F7B67D271BC88E4A13A1AE8 /* MaintenanceTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */; };
@@ -71,12 +74,6 @@
 		3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */; };
 		37E2425A63454881A4FA4481 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A5713F5928025F9FE34A43 /* main.swift */; };
 		381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */; };
-		6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */; };
-		01CFFFFADF27CFAF76D12B1C /* AppLeftoverScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDFC65352C381CB235B98DF /* AppLeftoverScannerTests.swift */; };
-		4334DC58726B62F185A4000F /* UnusedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */; };
-		2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */; };
-		80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */; };
-		3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */; };
 		390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
 		3A0AAEEE22026F9D96D875B2 /* PrivacyCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */; };
@@ -96,20 +93,10 @@
 		472FECDAABC513309987AA5E /* SmartScanJunkReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67824DA18085247812F6E08 /* SmartScanJunkReview.swift */; };
 		483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */; };
 		486889584CC330C197D3641C /* SunburstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E22C1BDB2BEFB0F5CF93927 /* SunburstView.swift */; };
+		48EF0257049EE6954E00E936 /* UnusedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382745ACB652CA50CA393BD5 /* UnusedAppScannerTests.swift */; };
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
 		4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */; };
-		E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */; };
-		46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */; };
-		78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */; };
-		4D011CE9F968899A237FA7A7 /* AppLeftoverScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FB57D743C8DF7C3C6BBA87 /* AppLeftoverScanner.swift */; };
-		447CF7856E99CCA9C3F5CF8D /* AppLeftover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4D12F02A9A3B4645982B84 /* AppLeftover.swift */; };
-		9677B436710A0E80C747C781 /* UnusedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */; };
-		7023CA5C3D691ED6403E827B /* UnusedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0159742E841F81FCA30D03 /* UnusedApp.swift */; };
-		3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */; };
-		ACDE4A29C6C4E5967C7A9BDA /* UnsupportedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */; };
-		78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */; };
-		82D88268A46FBE614678E869 /* InstallationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D64760E042AC0762B6AC221 /* InstallationFile.swift */; };
 		4E3164CA58AE90EB4A350C67 /* ExtensionsManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */; };
@@ -117,12 +104,16 @@
 		50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */; };
 		52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */; };
 		5325F2401AF35C69086E2056 /* NavigationRailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */; };
+		533BAE450469983F721BF936 /* UnsupportedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0976ECD3B6F65080DAE55EF5 /* UnsupportedAppScanner.swift */; };
+		54CE70675B89E50A9CE2F24C /* ApplicationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9DFF25BC5EA4D224DDF42B /* ApplicationsViewModelTests.swift */; };
+		55B6AD3998807918EE9FD2AF /* InstallationFileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574D2DD309CA4FA07640FAA0 /* InstallationFileScanner.swift */; };
 		55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
 		565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */; };
 		567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */; };
 		57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */; };
 		5B5767BC82C24D92B50032FE /* MalwareOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */; };
 		5C240506F97A777E37CA25B2 /* PrivacyViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */; };
+		5CA2A4BED5346B2FD4ADE096 /* MachOHeaderReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E49583606C1454E9F0AF2C /* MachOHeaderReaderTests.swift */; };
 		5DF68FC234F70DA478496658 /* SystemStatsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */; };
 		5DFC3E9A2E5B6A578312E485 /* HelperConnectionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F973B5B33642739FB9D7D004 /* HelperConnectionError.swift */; };
 		5EB593DAA9232D5B705166E7 /* LocalSnapshotCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */; };
@@ -134,11 +125,13 @@
 		6370C48606EABFE1E9343565 /* ExtensionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */; };
 		63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */; };
 		65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD8C98E8253953444DD99F /* NotificationManager.swift */; };
+		652B6EC5C57CE9B03E4C85AE /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7220D06D757039BF087D7F50 /* ApplicationsViewModel.swift */; };
 		65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */; };
 		67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */; };
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
 		6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */; };
+		6D2476F58F6EDCF6C12C844D /* UnusedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */; };
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
 		6E0D8F255BA67DF884857717 /* PerformanceRecommendationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31CF01651B0768E98E36F3E /* PerformanceRecommendationEngine.swift */; };
 		6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */; };
@@ -179,6 +172,7 @@
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
 		9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */; };
 		948B522FF71E5F5417EC78E6 /* SunburstLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D42C1D0E2A41D26EF168F1 /* SunburstLayout.swift */; };
+		9686BE4A7CD0C6399070CC1B /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC2C4931BAD804306463545 /* ApplicationsDashboardSubviews.swift */; };
 		97F42752FD75E7F3E6CAF219 /* SpaceLensHoverCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */; };
 		99B965EE0BB2762D13896FF6 /* EmptyStateFullDiskAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */; };
 		99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC50A90E584320709971BCB /* ScanCategoryTests.swift */; };
@@ -187,15 +181,18 @@
 		9CA467B702E12F278B7BE6DC /* HelperConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43596249B222D18142F961E2 /* HelperConnectionManager.swift */; };
 		9D44F12D7502363B814F2DF9 /* SectionIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */; };
 		9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */; };
+		9E74FE072F11650D0D3767A4 /* AppLeftoverScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDD7952FD571534DD4C2C91 /* AppLeftoverScannerTests.swift */; };
 		9EE876001E49F0F02842C221 /* SmartScanReviewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3962EE8953C511312F780F55 /* SmartScanReviewHeader.swift */; };
 		A0EC713F911D8C73493A2912 /* ExclusionsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */; };
 		A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */; };
 		A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */; };
+		A62CE19905649237426F1C83 /* AppLeftoverScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8EF86413DFB7292BDA49F9 /* AppLeftoverScanner.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
 		A91615BDF2CBB95FF6444C46 /* MaintenanceRunLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */; };
 		A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */; };
 		ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */; };
 		AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EC67B639248BC5EA1F5473 /* ScanCategory.swift */; };
+		AF573F2D6363CF0CDA72E5A4 /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5334403C48811B372CBEB19A /* ApplicationsView.swift */; };
 		B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */; };
 		B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39407E2EA6D045893F1BA4B /* DiskNode.swift */; };
 		B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */; };
@@ -206,6 +203,7 @@
 		B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */; };
 		B6B4FF9883F54E8F60010ACB /* VaderCleanerHelper in Embed Dependencies */ = {isa = PBXBuildFile; fileRef = 6CBCA8999E04715E502AB892 /* VaderCleanerHelper */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B7DADC9127C373029FC8198A /* AppUninstallerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D62624319B764770F02292 /* AppUninstallerViewModel.swift */; };
+		B86DA7DFDECF401C5BCCAC24 /* InstallationFileScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF1BAC0B12BDB540F250299 /* InstallationFileScannerTests.swift */; };
 		B9E44C0566F7DFAFAF8A6071 /* MalwareThreat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5741874005D8A34BB7D82287 /* MalwareThreat.swift */; };
 		B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */; };
 		BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2B92863509818189F46CD /* MenuBarContent.swift */; };
@@ -226,6 +224,7 @@
 		C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */; };
 		C3F9A86A896DAD3A63EB8F9F /* ExclusionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6085B6A39985DFF334821551 /* ExclusionsStore.swift */; };
 		C75E96295ED70F91F6B2A0F1 /* SectionTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */; };
+		C7CC2B5E09E8E3A89C39815E /* MacHealthStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BF07D3C75C31A0EA7E9037 /* MacHealthStatus.swift */; };
 		C848FD080F1DED2282ADC12E /* LocalSnapshotCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */; };
 		C9DB75A7B6E045D306393638 /* PrivacyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */; };
 		CF68F2891382E3F3D4CA5474 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */; };
@@ -254,6 +253,7 @@
 		EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */; };
 		EC99895496A545FE0F9A9222 /* FullDiskAccessPromptCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */; };
 		EE62512542BF54B5D6ADFA9D /* FloatingScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */; };
+		EF0D76FCD2FBEB20D8C9E7FA /* UnusedAppScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D85C87621345FBF7CDC41 /* UnusedAppScanner.swift */; };
 		EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4E92A146A223EA836C156D /* ScanResultTests.swift */; };
 		F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */; };
 		F0838C9B10FFB6AD75523D0A /* PrivacyPermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */; };
@@ -261,6 +261,7 @@
 		F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */; };
 		F2999D60141F92BE8DA1180B /* systemJunk.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 168266DA7B9E9A25E0B56A8C /* systemJunk.usdz */; };
 		F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */; };
+		F4BF8822B044CE3445A144E7 /* UnsupportedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */; };
 		F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8635D102B895AF349A13D /* AppUpdaterView.swift */; };
 		F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */; };
 		F7CA4D7A9B843507613DEEBE /* BundledClamAVRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282664DFAA58CB5A5C87FFE /* BundledClamAVRuntime.swift */; };
@@ -325,11 +326,13 @@
 		02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsFormatters.swift; sourceTree = "<group>"; };
 		02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicy.swift; sourceTree = "<group>"; };
 		0282664DFAA58CB5A5C87FFE /* BundledClamAVRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledClamAVRuntime.swift; sourceTree = "<group>"; };
+		02E49583606C1454E9F0AF2C /* MachOHeaderReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachOHeaderReaderTests.swift; sourceTree = "<group>"; };
 		04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerView.swift; sourceTree = "<group>"; };
 		06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocator.swift; sourceTree = "<group>"; };
 		06E8635D102B895AF349A13D /* AppUpdaterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterView.swift; sourceTree = "<group>"; };
 		072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionChecker.swift; sourceTree = "<group>"; };
 		0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManagerTests.swift; sourceTree = "<group>"; };
+		0976ECD3B6F65080DAE55EF5 /* UnsupportedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScanner.swift; sourceTree = "<group>"; };
 		0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyCategory.swift; sourceTree = "<group>"; };
 		0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitor.swift; sourceTree = "<group>"; };
 		0D4E92A146A223EA836C156D /* ScanResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResultTests.swift; sourceTree = "<group>"; };
@@ -347,6 +350,7 @@
 		16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleter.swift; sourceTree = "<group>"; };
 		1A06928276134E79D8ADFBF5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparatorTests.swift; sourceTree = "<group>"; };
+		1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScannerTests.swift; sourceTree = "<group>"; };
 		1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocatorTests.swift; sourceTree = "<group>"; };
 		1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManagerTests.swift; sourceTree = "<group>"; };
 		215EFDDDC81E5E7C6DBD72AB /* SmartScanApplicationsReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanApplicationsReview.swift; sourceTree = "<group>"; };
@@ -369,12 +373,14 @@
 		2E84F0638DA0F8B325C4035F /* SystemJunkScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkScannerTests.swift; sourceTree = "<group>"; };
 		2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentation.swift; sourceTree = "<group>"; };
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
+		32BF07D3C75C31A0EA7E9037 /* MacHealthStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacHealthStatus.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
 		3631D872F6AA2F98BA133922 /* SpaceLensViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewMode.swift; sourceTree = "<group>"; };
 		3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscHostView.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
 		374A11FF89347AF05A14498B /* ScannableSectionContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannableSectionContent.swift; sourceTree = "<group>"; };
 		3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinatingConformanceTests.swift; sourceTree = "<group>"; };
+		382745ACB652CA50CA393BD5 /* UnusedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScannerTests.swift; sourceTree = "<group>"; };
 		3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdaterTests.swift; sourceTree = "<group>"; };
 		3962EE8953C511312F780F55 /* SmartScanReviewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanReviewHeader.swift; sourceTree = "<group>"; };
 		3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerTests.swift; sourceTree = "<group>"; };
@@ -383,12 +389,6 @@
 		3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanView.swift; sourceTree = "<group>"; };
 		416D1869BE7C552C78714296 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
-		4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModelTests.swift; sourceTree = "<group>"; };
-		4EDFC65352C381CB235B98DF /* AppLeftoverScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftoverScannerTests.swift; sourceTree = "<group>"; };
-		9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScannerTests.swift; sourceTree = "<group>"; };
-		B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScannerTests.swift; sourceTree = "<group>"; };
-		BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachOHeaderReaderTests.swift; sourceTree = "<group>"; };
-		29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScannerTests.swift; sourceTree = "<group>"; };
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
 		42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewSubviews.swift; sourceTree = "<group>"; };
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
@@ -409,9 +409,11 @@
 		50BDB24525760C96625DD266 /* TreemapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreemapView.swift; sourceTree = "<group>"; };
 		5163E14892EAA1E30C3EFFE5 /* VaderCleanerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VaderCleanerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManager.swift; sourceTree = "<group>"; };
+		5334403C48811B372CBEB19A /* ApplicationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsView.swift; sourceTree = "<group>"; };
 		5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecision.swift; sourceTree = "<group>"; };
 		55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPermissionCheckerTests.swift; sourceTree = "<group>"; };
 		5741874005D8A34BB7D82287 /* MalwareThreat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreat.swift; sourceTree = "<group>"; };
+		574D2DD309CA4FA07640FAA0 /* InstallationFileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScanner.swift; sourceTree = "<group>"; };
 		57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFile.swift; sourceTree = "<group>"; };
 		59C47AD889D249E865B928C8 /* OptimizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationView.swift; sourceTree = "<group>"; };
 		5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessPromptCard.swift; sourceTree = "<group>"; };
@@ -432,26 +434,19 @@
 		67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewSubviews.swift; sourceTree = "<group>"; };
 		673CA7922445475111927C0B /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModel.swift; sourceTree = "<group>"; };
-		3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsDashboardSubviews.swift; sourceTree = "<group>"; };
-		FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsView.swift; sourceTree = "<group>"; };
-		FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
-		C7FB57D743C8DF7C3C6BBA87 /* AppLeftoverScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftoverScanner.swift; sourceTree = "<group>"; };
-		6F4D12F02A9A3B4645982B84 /* AppLeftover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftover.swift; sourceTree = "<group>"; };
-		935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScanner.swift; sourceTree = "<group>"; };
-		8E0159742E841F81FCA30D03 /* UnusedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedApp.swift; sourceTree = "<group>"; };
-		B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScanner.swift; sourceTree = "<group>"; };
-		1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedApp.swift; sourceTree = "<group>"; };
-		7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScanner.swift; sourceTree = "<group>"; };
-		1D64760E042AC0762B6AC221 /* InstallationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFile.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
 		6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroViewTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
 		6BD871C2C2002760DD923686 /* VaderCleanerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerUITests.swift; sourceTree = "<group>"; };
+		6BDD7952FD571534DD4C2C91 /* AppLeftoverScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftoverScannerTests.swift; sourceTree = "<group>"; };
 		6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		6CBCA8999E04715E502AB892 /* VaderCleanerHelper */ = {isa = PBXFileReference; includeInIndex = 0; path = VaderCleanerHelper; sourceTree = BUILT_PRODUCTS_DIR; };
+		6CC2C4931BAD804306463545 /* ApplicationsDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsDashboardSubviews.swift; sourceTree = "<group>"; };
 		6DDE71332468CC343A9C6091 /* OptimizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationViewModel.swift; sourceTree = "<group>"; };
+		6F9DFF25BC5EA4D224DDF42B /* ApplicationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModelTests.swift; sourceTree = "<group>"; };
 		6FE66C634D06A8A842F49852 /* PermissionOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingView.swift; sourceTree = "<group>"; };
 		7174CD853A7D947268E17C33 /* ProcessLineStreamer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamer.swift; sourceTree = "<group>"; };
+		7220D06D757039BF087D7F50 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
 		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
@@ -475,6 +470,7 @@
 		8B18E28D449EF4D5FB1D6E0B /* SmartScanUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanUITests.swift; sourceTree = "<group>"; };
 		8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinder.swift; sourceTree = "<group>"; };
 		8C76CE861C998A697164C552 /* AppUpdaterError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterError.swift; sourceTree = "<group>"; };
+		8C8EF86413DFB7292BDA49F9 /* AppLeftoverScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftoverScanner.swift; sourceTree = "<group>"; };
 		8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDiscoveryTests.swift; sourceTree = "<group>"; };
 		8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterErrorTests.swift; sourceTree = "<group>"; };
 		8E77DD34548C2014EE7262F5 /* ExtensionsManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerView.swift; sourceTree = "<group>"; };
@@ -489,6 +485,7 @@
 		9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionThemeTests.swift; sourceTree = "<group>"; };
 		98D7B18095634307C5D7223D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9B77D1A002F58496087AF3E3 /* SmartScanByteFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanByteFormatter.swift; sourceTree = "<group>"; };
+		9C1D85C87621345FBF7CDC41 /* UnusedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScanner.swift; sourceTree = "<group>"; };
 		9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItem.swift; sourceTree = "<group>"; };
 		9D5CB08F96767D10B1271970 /* RAMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManager.swift; sourceTree = "<group>"; };
@@ -531,6 +528,7 @@
 		C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinderTests.swift; sourceTree = "<group>"; };
 		C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScanner.swift; sourceTree = "<group>"; };
 		C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C5FD7F60311101E723D73E11 /* ApplicationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsUITests.swift; sourceTree = "<group>"; };
 		C6387590A274A5888D9BF28D /* SunburstLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunburstLayoutTests.swift; sourceTree = "<group>"; };
 		C751F5671E4A4657944A7DFC /* PrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyView.swift; sourceTree = "<group>"; };
 		C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStoreTests.swift; sourceTree = "<group>"; };
@@ -542,6 +540,7 @@
 		CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateChecker.swift; sourceTree = "<group>"; };
 		CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModelTests.swift; sourceTree = "<group>"; };
 		CFD3CFDAD89263D0CAE10471 /* PerformanceRecommendationEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceRecommendationEngineTests.swift; sourceTree = "<group>"; };
+		CFF1BAC0B12BDB540F250299 /* InstallationFileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScannerTests.swift; sourceTree = "<group>"; };
 		D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingRunOverlay.swift; sourceTree = "<group>"; };
 		D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVOutputParser.swift; sourceTree = "<group>"; };
 		D1CC391B523110720320AD89 /* SystemPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPathProviding.swift; sourceTree = "<group>"; };
@@ -551,6 +550,7 @@
 		D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanViewModel.swift; sourceTree = "<group>"; };
 		D2A9C2E47C91B66B79030BE7 /* MalwareViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModelTests.swift; sourceTree = "<group>"; };
 		D2C2B92863509818189F46CD /* MenuBarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContent.swift; sourceTree = "<group>"; };
+		D631EBC782CB95D9221AD977 /* AppLeftover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftover.swift; sourceTree = "<group>"; };
 		D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRailView.swift; sourceTree = "<group>"; };
 		DB0558BA919F5FF29A56051C /* OptimizationDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationDashboardSubviews.swift; sourceTree = "<group>"; };
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
@@ -560,7 +560,6 @@
 		DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItemTests.swift; sourceTree = "<group>"; };
 		DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitorTests.swift; sourceTree = "<group>"; };
 		E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalPolishUITests.swift; sourceTree = "<group>"; };
-		8463E125473BA9EFD1E6CABF /* ApplicationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsUITests.swift; sourceTree = "<group>"; };
 		E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStore.swift; sourceTree = "<group>"; };
 		E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModel.swift; sourceTree = "<group>"; };
 		E2017911CF02D2B89E8BF865 /* MailReindexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailReindexer.swift; sourceTree = "<group>"; };
@@ -575,8 +574,11 @@
 		EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatTests.swift; sourceTree = "<group>"; };
 		EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSystemPathProviderTests.swift; sourceTree = "<group>"; };
 		ED94C765380BDFB1F3533672 /* SystemJunkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModel.swift; sourceTree = "<group>"; };
+		EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedApp.swift; sourceTree = "<group>"; };
+		EF58D340F13A253CAAB153AC /* UnsupportedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedApp.swift; sourceTree = "<group>"; };
 		F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunnerTests.swift; sourceTree = "<group>"; };
 		F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManagerTests.swift; sourceTree = "<group>"; };
+		F2C612F641A894AE10ADDA8F /* InstallationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFile.swift; sourceTree = "<group>"; };
 		F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleterTests.swift; sourceTree = "<group>"; };
 		F31CF01651B0768E98E36F3E /* PerformanceRecommendationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceRecommendationEngine.swift; sourceTree = "<group>"; };
 		F421495C84A41EDEF253EBD6 /* FileCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCategory.swift; sourceTree = "<group>"; };
@@ -626,8 +628,8 @@
 		6A2D96C9C63AD506553F0BE0 /* VaderCleanerUITests */ = {
 			isa = PBXGroup;
 			children = (
+				C5FD7F60311101E723D73E11 /* ApplicationsUITests.swift */,
 				E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */,
-				8463E125473BA9EFD1E6CABF /* ApplicationsUITests.swift */,
 				A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */,
 				22622AEBD53221D89CB1439D /* OptimizationUITests.swift */,
 				8B18E28D449EF4D5FB1D6E0B /* SmartScanUITests.swift */,
@@ -645,6 +647,11 @@
 				B79E0766E335360E04FC6A53 /* AppDiscovery.swift */,
 				7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */,
 				673CA7922445475111927C0B /* AppInfo.swift */,
+				D631EBC782CB95D9221AD977 /* AppLeftover.swift */,
+				8C8EF86413DFB7292BDA49F9 /* AppLeftoverScanner.swift */,
+				6CC2C4931BAD804306463545 /* ApplicationsDashboardSubviews.swift */,
+				5334403C48811B372CBEB19A /* ApplicationsView.swift */,
+				7220D06D757039BF087D7F50 /* ApplicationsViewModel.swift */,
 				FE6697CA6EEE719B2E2D46CE /* AppState.swift */,
 				65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */,
 				04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */,
@@ -653,17 +660,6 @@
 				8C76CE861C998A697164C552 /* AppUpdaterError.swift */,
 				06E8635D102B895AF349A13D /* AppUpdaterView.swift */,
 				68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */,
-				3FBE8A0677464479DE0FD752 /* ApplicationsDashboardSubviews.swift */,
-				FA9C79107DE7F816FC0F18E9 /* ApplicationsView.swift */,
-				FFC192117688E170E8EBF0E5 /* ApplicationsViewModel.swift */,
-				C7FB57D743C8DF7C3C6BBA87 /* AppLeftoverScanner.swift */,
-				6F4D12F02A9A3B4645982B84 /* AppLeftover.swift */,
-				935A5DCA9ED2462549A5816C /* UnusedAppScanner.swift */,
-				8E0159742E841F81FCA30D03 /* UnusedApp.swift */,
-				B354400B4535811BFEBF9157 /* UnsupportedAppScanner.swift */,
-				1A0AD9C33C3840757A14827B /* UnsupportedApp.swift */,
-				7523A64D93FDD6AAC6097871 /* InstallationFileScanner.swift */,
-				1D64760E042AC0762B6AC221 /* InstallationFile.swift */,
 				5E978BB01AD677AEDE122B1C /* Assets.xcassets */,
 				57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */,
 				8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */,
@@ -700,6 +696,8 @@
 				22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */,
 				4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */,
 				98D7B18095634307C5D7223D /* Info.plist */,
+				F2C612F641A894AE10ADDA8F /* InstallationFile.swift */,
+				574D2DD309CA4FA07640FAA0 /* InstallationFileScanner.swift */,
 				06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */,
 				8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */,
 				93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */,
@@ -709,6 +707,7 @@
 				82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */,
 				27F1DC062C52C51730548216 /* LoginItem.swift */,
 				5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */,
+				32BF07D3C75C31A0EA7E9037 /* MacHealthStatus.swift */,
 				E2017911CF02D2B89E8BF865 /* MailReindexer.swift */,
 				FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */,
 				AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */,
@@ -782,6 +781,10 @@
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
 				4B3588FF5E9D8258268C2322 /* TreemapLayout.swift */,
 				50BDB24525760C96625DD266 /* TreemapView.swift */,
+				EF58D340F13A253CAAB153AC /* UnsupportedApp.swift */,
+				0976ECD3B6F65080DAE55EF5 /* UnsupportedAppScanner.swift */,
+				EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */,
+				9C1D85C87621345FBF7CDC41 /* UnusedAppScanner.swift */,
 				2617BC26104D5196DEDB3589 /* UpdateInfo.swift */,
 				9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */,
 				FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */,
@@ -850,17 +853,13 @@
 			children = (
 				25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */,
 				8F9E69A9E86DBFFA19FC2EA5 /* AppDiscoveryTests.swift */,
+				6BDD7952FD571534DD4C2C91 /* AppLeftoverScannerTests.swift */,
+				6F9DFF25BC5EA4D224DDF42B /* ApplicationsViewModelTests.swift */,
 				9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */,
 				4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */,
 				31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */,
 				8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */,
 				42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */,
-				4787FF068AC55B87F4B0260A /* ApplicationsViewModelTests.swift */,
-				4EDFC65352C381CB235B98DF /* AppLeftoverScannerTests.swift */,
-				9ACE1F88201346EB276CE2FA /* UnusedAppScannerTests.swift */,
-				B093527570CA88FA3AAA1452 /* UnsupportedAppScannerTests.swift */,
-				BB3A22CD300FD3F33FD5A89F /* MachOHeaderReaderTests.swift */,
-				29089AE97E076BCFBE67843D /* InstallationFileScannerTests.swift */,
 				C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */,
 				E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */,
 				A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */,
@@ -888,6 +887,7 @@
 				0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */,
 				2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */,
 				811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */,
+				CFF1BAC0B12BDB540F250299 /* InstallationFileScannerTests.swift */,
 				1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */,
 				603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */,
 				BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */,
@@ -895,6 +895,7 @@
 				C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */,
 				1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */,
 				5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */,
+				02E49583606C1454E9F0AF2C /* MachOHeaderReaderTests.swift */,
 				933E3B42C683C14A7398939F /* MailReindexerTests.swift */,
 				DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */,
 				F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */,
@@ -938,6 +939,8 @@
 				6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */,
 				46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */,
 				80802F3A6BA3E2094B87A97D /* TreemapLayoutTests.swift */,
+				1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */,
+				382745ACB652CA50CA393BD5 /* UnusedAppScannerTests.swift */,
 				B46943B264F72B3753075A8C /* UpdateInfoTests.swift */,
 				1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */,
 				E149BD1FE4E65D6589292B84 /* Helpers */,
@@ -1146,17 +1149,13 @@
 			files = (
 				6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */,
 				B1AB400FD37E84D643FBFA5B /* AppDiscoveryTests.swift in Sources */,
+				9E74FE072F11650D0D3767A4 /* AppLeftoverScannerTests.swift in Sources */,
 				3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */,
 				E7B7C87B22F9328A45CC6A4B /* AppStoreUpdateCheckerTests.swift in Sources */,
 				11ADC2311FFC4AFD650E0EB3 /* AppUninstallerViewModelTests.swift in Sources */,
 				565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */,
 				381B0722743E849AE519579F /* AppUpdaterViewModelTests.swift in Sources */,
-				6C5227024433B92415DE7750 /* ApplicationsViewModelTests.swift in Sources */,
-				01CFFFFADF27CFAF76D12B1C /* AppLeftoverScannerTests.swift in Sources */,
-				4334DC58726B62F185A4000F /* UnusedAppScannerTests.swift in Sources */,
-				2055C966FBD3DA00DA27B7EC /* UnsupportedAppScannerTests.swift in Sources */,
-				80F39E688374E6371F67A496 /* MachOHeaderReaderTests.swift in Sources */,
-				3CC382D4C10A296B3837653A /* InstallationFileScannerTests.swift in Sources */,
+				54CE70675B89E50A9CE2F24C /* ApplicationsViewModelTests.swift in Sources */,
 				65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */,
 				F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */,
 				B6493A8047381998C7892982 /* BrowserDataPathProviderTests.swift in Sources */,
@@ -1184,6 +1183,7 @@
 				6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */,
 				04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */,
 				17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */,
+				B86DA7DFDECF401C5BCCAC24 /* InstallationFileScannerTests.swift in Sources */,
 				57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */,
 				50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */,
 				2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */,
@@ -1191,6 +1191,7 @@
 				C848FD080F1DED2282ADC12E /* LocalSnapshotCounterTests.swift in Sources */,
 				8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */,
 				406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */,
+				5CA2A4BED5346B2FD4ADE096 /* MachOHeaderReaderTests.swift in Sources */,
 				1F88CDFF1571AB8A8DCB3F7D /* MailReindexerTests.swift in Sources */,
 				00EA71EF4E372CADB9F1BDCD /* MaintenanceRunLogTests.swift in Sources */,
 				1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */,
@@ -1235,6 +1236,8 @@
 				C26E98922A61A57DB9369C60 /* TestHelpers.swift in Sources */,
 				109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */,
 				BD430047F461946B8AF82858 /* TreemapLayoutTests.swift in Sources */,
+				F4BF8822B044CE3445A144E7 /* UnsupportedAppScannerTests.swift in Sources */,
+				48EF0257049EE6954E00E936 /* UnusedAppScannerTests.swift in Sources */,
 				218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */,
 				3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */,
 			);
@@ -1254,8 +1257,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0849175D7723A3D6B17FACF1 /* ApplicationsUITests.swift in Sources */,
 				1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */,
-				8116760AAB4F16FFC4961ABD /* ApplicationsUITests.swift in Sources */,
 				82DB89EC1E0EAFD90FB6018D /* MalwareUITests.swift in Sources */,
 				7B4A89F26C67D0A6372E2A78 /* OptimizationUITests.swift in Sources */,
 				2D5B0C45DB5F5EA679AF4131 /* SmartScanUITests.swift in Sources */,
@@ -1273,6 +1276,8 @@
 				A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */,
 				E370FDA389CDFEC249437640 /* AppIconCache.swift in Sources */,
 				2EEC95B2AE1AD9F7D8CFACCE /* AppInfo.swift in Sources */,
+				10262DDD8C0BD95D484F5215 /* AppLeftover.swift in Sources */,
+				A62CE19905649237426F1C83 /* AppLeftoverScanner.swift in Sources */,
 				3333EAE03C7A7783D12F68D7 /* AppState.swift in Sources */,
 				BABEDA3326E05DC3A8356E3D /* AppStoreUpdateChecker.swift in Sources */,
 				26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */,
@@ -1281,17 +1286,9 @@
 				BB6D9635C62A1D0635E2799F /* AppUpdaterError.swift in Sources */,
 				F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */,
 				4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */,
-				E0B3DAB35C617E079EE99193 /* ApplicationsDashboardSubviews.swift in Sources */,
-				46099BE66642636783BC1C0E /* ApplicationsView.swift in Sources */,
-				78FC2ED576A5A33C05C29162 /* ApplicationsViewModel.swift in Sources */,
-				4D011CE9F968899A237FA7A7 /* AppLeftoverScanner.swift in Sources */,
-				447CF7856E99CCA9C3F5CF8D /* AppLeftover.swift in Sources */,
-				9677B436710A0E80C747C781 /* UnusedAppScanner.swift in Sources */,
-				7023CA5C3D691ED6403E827B /* UnusedApp.swift in Sources */,
-				3BD002D195969A7B76774AD2 /* UnsupportedAppScanner.swift in Sources */,
-				ACDE4A29C6C4E5967C7A9BDA /* UnsupportedApp.swift in Sources */,
-				78C348D42C63B21B6EE2108E /* InstallationFileScanner.swift in Sources */,
-				82D88268A46FBE614678E869 /* InstallationFile.swift in Sources */,
+				9686BE4A7CD0C6399070CC1B /* ApplicationsDashboardSubviews.swift in Sources */,
+				AF573F2D6363CF0CDA72E5A4 /* ApplicationsView.swift in Sources */,
+				652B6EC5C57CE9B03E4C85AE /* ApplicationsViewModel.swift in Sources */,
 				9BAB88FDC4D085FF175191FF /* AssociatedFile.swift in Sources */,
 				EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */,
 				3328707476CC1411FA1270D0 /* Browser.swift in Sources */,
@@ -1328,6 +1325,8 @@
 				65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */,
 				55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */,
 				2DD748D16E344D435A5C3E24 /* HelperRegistration.swift in Sources */,
+				03E56C4EFC8903CA9291A959 /* InstallationFile.swift in Sources */,
+				55B6AD3998807918EE9FD2AF /* InstallationFileScanner.swift in Sources */,
 				D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */,
 				1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */,
 				E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */,
@@ -1337,6 +1336,7 @@
 				5EB593DAA9232D5B705166E7 /* LocalSnapshotCounter.swift in Sources */,
 				2CF8285ADDBEB285A1DB56AC /* LoginItem.swift in Sources */,
 				EBC2663030A949FB8EF82710 /* LoginItemManager.swift in Sources */,
+				C7CC2B5E09E8E3A89C39815E /* MacHealthStatus.swift in Sources */,
 				D25319BADD929D75CA704136 /* MailReindexer.swift in Sources */,
 				A91615BDF2CBB95FF6444C46 /* MaintenanceRunLog.swift in Sources */,
 				A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */,
@@ -1410,6 +1410,10 @@
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
 				1947460A68C713844C308694 /* TreemapLayout.swift in Sources */,
 				35F306676A3412253929EF55 /* TreemapView.swift in Sources */,
+				09F3933E9C2A8A09E3E8BAEB /* UnsupportedApp.swift in Sources */,
+				533BAE450469983F721BF936 /* UnsupportedAppScanner.swift in Sources */,
+				6D2476F58F6EDCF6C12C844D /* UnusedApp.swift in Sources */,
+				EF0D76FCD2FBEB20D8C9E7FA /* UnusedAppScanner.swift in Sources */,
 				7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */,
 				6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */,
 				BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */,

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -24,6 +24,15 @@ struct HealthMonitorView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
+                // The hero card leads with one overall verdict and the boot
+                // volume's fill, mirroring the dashboard "Mac Health" panel.
+                // The per-metric cards below remain the detailed breakdown.
+                MacHealthHero(
+                    status: viewModel.macHealth,
+                    volumeName: viewModel.diskVolumeName,
+                    diskUsageDetail: viewModel.diskUsageDetail,
+                    diskRatio: viewModel.diskRatio
+                )
                 // Group the tiles in one container so adjacent glass cards
                 // sample each other and refract consistently as the grid
                 // reflows on resize.
@@ -164,6 +173,196 @@ struct HealthMonitorView: View {
 
 }
 
+// MARK: - Mac Health hero
+
+/// The dashboard-style hero card: a glowing ring around a laptop, the single
+/// overall verdict, and the boot volume's fill. Always rendered dark (like the
+/// reference design) so it reads as the focal element regardless of system
+/// appearance; text colors are therefore pinned light rather than semantic.
+private struct MacHealthHero: View {
+    /// `nil` means the boot volume hasn't been measured yet — the card shows a
+    /// neutral "Measuring…" state instead of a confident verdict.
+    let status: MacHealthStatus?
+    let volumeName: String
+    let diskUsageDetail: String
+    let diskRatio: Double
+
+    /// The status's signature color (gray while measuring). Drives the ring,
+    /// the title, the laptop tint, the disk bar, and the background glow.
+    private var accent: Color { status?.accentColor ?? Color(white: 0.55) }
+
+    private var titleText: String {
+        status?.title ?? String(localized: "Measuring…")
+    }
+
+    private var summaryText: String {
+        status?.summary ?? String(localized: "Checking your Mac's health…")
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 24) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Mac Health:")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.7))
+                Text(titleText)
+                    .font(.system(size: 34, weight: .bold))
+                    .foregroundStyle(accent)
+                    .padding(.top, 2)
+                    .accessibilityIdentifier("health.hero.status")
+                Text(summaryText)
+                    .font(.callout)
+                    .foregroundStyle(.white.opacity(0.6))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 8)
+
+                Spacer(minLength: 24)
+
+                // While measuring (status == nil) the disk reads zero bytes, so
+                // hide the block rather than show "Zero KB of Zero KB used".
+                if status != nil {
+                    diskBlock
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            HealthRing(color: accent, isMeasuring: status == nil)
+                .frame(width: 190, height: 190)
+                .overlay { laptop }
+                .accessibilityIdentifier("health.hero.ring")
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, minHeight: 250, alignment: .topLeading)
+        .background(heroBackground)
+        .clipShape(.rect(cornerRadius: 20))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("health.hero")
+    }
+
+    /// Boot-volume name with its "used of total" fill below a slim bar.
+    private var diskBlock: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(volumeName)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Spacer()
+                Text(diskUsageDetail)
+                    .font(.subheadline)
+                    .foregroundStyle(.white.opacity(0.7))
+                    .accessibilityIdentifier("health.hero.diskusage")
+            }
+            ProgressView(value: diskRatio)
+                .progressViewStyle(.linear)
+                .tint(accent)
+                .accessibilityIdentifier("health.hero.diskbar")
+        }
+    }
+
+    /// Laptop glyph centered inside the ring.
+    private var laptop: some View {
+        Image(systemName: "laptopcomputer")
+            .font(.system(size: 56, weight: .light))
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [.white.opacity(0.95), accent.opacity(0.85)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .accessibilityHidden(true)
+    }
+
+    /// Fixed dark gradient with the accent glow concentrated behind the ring,
+    /// matching the reference design's always-dark hero panel.
+    private var heroBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.10, green: 0.09, blue: 0.16),
+                    Color(red: 0.17, green: 0.13, blue: 0.27)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            RadialGradient(
+                colors: [accent.opacity(0.30), .clear],
+                center: UnitPoint(x: 0.82, y: 0.42),
+                startRadius: 8,
+                endRadius: 300
+            )
+        }
+    }
+}
+
+/// The glowing health ring. Isolated to take only `color` and a measuring flag
+/// so its `.repeatForever` rotation keeps a stable identity and is not reset by
+/// the surrounding view re-evaluating on every system-telemetry tick.
+private struct HealthRing: View {
+    let color: Color
+    let isMeasuring: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var spin = false
+
+    var body: some View {
+        ZStack {
+            // Soft outer bloom.
+            Circle()
+                .stroke(color.opacity(0.35), lineWidth: 14)
+                .blur(radius: 24)
+            // Dim full-circle track.
+            Circle()
+                .stroke(color.opacity(0.18), lineWidth: 6)
+            // Bright sweeping arc — hidden while measuring so the ring reads as
+            // neutral until a verdict lands.
+            Circle()
+                .trim(from: 0.0, to: 0.72)
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [
+                            color.opacity(0.0), color, .white.opacity(0.9), color, color.opacity(0.0)
+                        ]),
+                        center: .center
+                    ),
+                    style: StrokeStyle(lineWidth: 6, lineCap: .round)
+                )
+                .blur(radius: 0.5)
+                .opacity(isMeasuring ? 0.0 : 1.0)
+                .rotationEffect(.degrees(spin ? 360 : 0))
+        }
+        .onAppear { startSpinIfNeeded() }
+        // The real app starts measuring (nil) and resolves on the first tick;
+        // kick off the rotation when the verdict arrives, not just on appear.
+        // NOTE: this `.repeatForever` rotation means the Health Monitor screen
+        // never reaches animation-idle — a UI test that taps an element on this
+        // screen will stall in wait-for-idle. Query/assert only (no taps here).
+        .onChange(of: isMeasuring) { _, _ in startSpinIfNeeded() }
+    }
+
+    private func startSpinIfNeeded() {
+        guard !isMeasuring, !reduceMotion, !spin else { return }
+        withAnimation(.linear(duration: 9).repeatForever(autoreverses: false)) {
+            spin = true
+        }
+    }
+}
+
+private extension MacHealthStatus {
+    /// Signature color per tier, matching the reference design's ramp from a
+    /// warm critical red through amber and teal to a confident blue.
+    var accentColor: Color {
+        switch self {
+        case .critical:          return Color(red: 1.00, green: 0.45, blue: 0.38)
+        case .requiresAttention: return Color(red: 0.99, green: 0.78, blue: 0.34)
+        case .fair:              return Color(red: 0.40, green: 0.85, blue: 0.78)
+        case .good:              return Color(red: 0.52, green: 0.80, blue: 0.99)
+        case .excellent:         return Color(red: 0.34, green: 0.66, blue: 1.00)
+        }
+    }
+}
+
 // MARK: - Subviews
 
 /// Reusable card wrapper. Keeps card geometry consistent across the grid so
@@ -239,7 +438,25 @@ extension StatusColor {
     }
 }
 
-#Preview {
+#Preview("Health Monitor") {
     HealthMonitorView(service: SystemStatsService(autostart: false))
         .frame(width: 900, height: 600)
+}
+
+/// Renders the hero card across the verdict tiers so the design is inspectable
+/// without live telemetry (the live `SystemStatsService(autostart: false)`
+/// preview above only ever shows the "Measuring…" state off its empty disk).
+#Preview("Mac Health states") {
+    ScrollView {
+        VStack(spacing: 16) {
+            MacHealthHero(status: nil, volumeName: "Macintosh HD", diskUsageDetail: "", diskRatio: 0.0)
+            MacHealthHero(status: .excellent, volumeName: "Macintosh HD", diskUsageDetail: "121 GB of 494 GB used", diskRatio: 0.24)
+            MacHealthHero(status: .good, volumeName: "Macintosh HD", diskUsageDetail: "270 GB of 494 GB used", diskRatio: 0.55)
+            MacHealthHero(status: .fair, volumeName: "Macintosh HD", diskUsageDetail: "380 GB of 494 GB used", diskRatio: 0.77)
+            MacHealthHero(status: .requiresAttention, volumeName: "Macintosh HD", diskUsageDetail: "430 GB of 494 GB used", diskRatio: 0.87)
+            MacHealthHero(status: .critical, volumeName: "Macintosh HD", diskUsageDetail: "479 GB of 494 GB used", diskRatio: 0.97)
+        }
+        .padding(20)
+    }
+    .frame(width: 740, height: 720)
 }

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -33,6 +33,11 @@ final class HealthMonitorViewModel {
         self.service = service
     }
 
+    /// Name of the boot volume (e.g. "Macintosh HD"), read once at creation —
+    /// it never changes for the life of the view-model and the hero card
+    /// shows it on every render, so resolving it per-render would be wasteful.
+    let diskVolumeName: String = HealthMonitorViewModel.rootVolumeName()
+
     // MARK: - Live-bound display values
 
     var cpuPercent: String { Self.cpuPercentString(service.cpuUsage) }
@@ -60,7 +65,87 @@ final class HealthMonitorViewModel {
     var fileVaultLabel: String { Self.fileVaultLabel(for: fileVaultState) }
     var fileVaultColor: StatusColor { Self.fileVaultColor(for: fileVaultState) }
 
+    // MARK: - Mac Health hero verdict
+
+    /// Single overall verdict the hero card renders, or `nil` while the boot
+    /// volume is still unmeasured (so the hero shows "Measuring…" instead of
+    /// a confident verdict off zero data on the first tick).
+    var macHealth: MacHealthStatus? {
+        Self.macHealthStatus(disk: service.diskSpace, signals: nudgeSignals)
+    }
+
+    /// The non-disk signals that can nudge the disk-driven base verdict down.
+    /// Disk fullness is excluded here because it already sets the base tier —
+    /// folding it in again would double-count it.
+    private var nudgeSignals: [StatusColor] {
+        [batteryColor, smartColor, ramPressureColor, cpuColor, fileVaultColor]
+    }
+
+    /// "121 GB of 494 GB used" line shown beneath the volume name in the hero.
+    var diskUsageDetail: String { Self.diskUsageDetailString(service.diskSpace) }
+
     // MARK: - Pure formatters / color rules
+
+    /// Derives the overall Mac Health verdict.
+    ///
+    /// Disk fullness sets the base tier (this is a disk-cleaning app, so
+    /// reclaimable space is the headline concern). The other health signals
+    /// then *nudge* that base down: each `.red` signal (failing SMART, battery
+    /// service, critical RAM/CPU) drops two tiers, and the presence of any
+    /// `.yellow` drops one more. `.gray` ("no opinion", the startup state) and
+    /// `.green` never penalize. The result clamps to `.critical` so a near-full
+    /// disk plus a failing component can't underflow.
+    ///
+    /// Reds are allowed to override the disk base on purpose: a failing drive
+    /// *should* be able to force "Critical" even on a near-empty disk.
+    ///
+    /// Returns `nil` when the volume is unmeasured (`totalBytes == 0`) so the
+    /// hero can show a neutral measuring state rather than defaulting to
+    /// "Excellent" off a zero reading.
+    static func macHealthStatus(disk: DiskStats, signals: [StatusColor]) -> MacHealthStatus? {
+        guard disk.totalBytes > 0 else { return nil }
+
+        let base = diskHealthTier(for: disk)
+        let redCount = signals.filter { $0 == .red }.count
+        let anyYellow = signals.contains(.yellow)
+        let penalty = redCount * 2 + (anyYellow ? 1 : 0)
+
+        let index = max(MacHealthStatus.critical.rawValue, base.rawValue - penalty)
+        return MacHealthStatus(rawValue: index) ?? .critical
+    }
+
+    /// Maps disk fullness to a base verdict tier. Boundaries are inclusive at
+    /// the lower bound. The 0.80 / 0.95 edges line up with
+    /// `diskWarningThreshold` / `diskCriticalThreshold` so the hero verdict and
+    /// the Disk Space card's status dot never tell contradictory stories.
+    static func diskHealthTier(for stats: DiskStats) -> MacHealthStatus {
+        let ratio = diskUsageRatio(stats)
+        if ratio >= diskCriticalThreshold { return .critical }
+        if ratio >= diskWarningThreshold { return .requiresAttention }
+        if ratio >= 0.70 { return .fair }
+        if ratio >= 0.55 { return .good }
+        return .excellent
+    }
+
+    /// "121 GB of 494 GB used" — the hero's disk line. Phrased as
+    /// "used of total" (rather than the cards' "used / total") to match the
+    /// dashboard hero layout.
+    static func diskUsageDetailString(_ stats: DiskStats) -> String {
+        let used = SystemStatsFormatters.byteString(stats.usedBytes)
+        let total = SystemStatsFormatters.byteString(stats.totalBytes)
+        let format = String(
+            localized: "%@ of %@ used",
+            comment: "Hero disk usage line, for example 121 GB of 494 GB used"
+        )
+        return String(format: format, used, total)
+    }
+
+    /// Reads the boot volume's display name from the filesystem. Falls back to
+    /// the conventional default if the lookup fails (it shouldn't for "/").
+    static func rootVolumeName() -> String {
+        let values = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeNameKey])
+        return values?.volumeName ?? "Macintosh HD"
+    }
 
     /// Formats a unit-interval CPU usage to an integer percentage. Inputs
     /// outside `[0, 1]` clamp at the boundary — the service is expected to

--- a/VaderCleaner/MacHealthStatus.swift
+++ b/VaderCleaner/MacHealthStatus.swift
@@ -1,0 +1,50 @@
+// MacHealthStatus.swift
+// Overall "Mac Health" verdict (five tiers) with display title and summary copy for the Health Monitor hero card.
+
+import Foundation
+
+/// The single at-a-glance verdict the Health Monitor hero card renders.
+///
+/// Ordered worst-to-best so the raw values double as a severity index the
+/// derivation rule in `HealthMonitorViewModel` can clamp against. The type is
+/// deliberately SwiftUI-free — like `StatusColor`, the view layer maps each
+/// case to a `Color` once at the leaf so the view-model and its tests need no
+/// SwiftUI import.
+enum MacHealthStatus: Int, CaseIterable, Comparable {
+    case critical = 0
+    case requiresAttention = 1
+    case fair = 2
+    case good = 3
+    case excellent = 4
+
+    static func < (lhs: MacHealthStatus, rhs: MacHealthStatus) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// Short headline word shown large and tinted in the hero card.
+    var title: String {
+        switch self {
+        case .critical:          return String(localized: "Critical")
+        case .requiresAttention: return String(localized: "Requires Attention")
+        case .fair:              return String(localized: "Fair")
+        case .good:              return String(localized: "Good")
+        case .excellent:         return String(localized: "Excellent")
+        }
+    }
+
+    /// One-line plain-language explanation shown beneath the title.
+    var summary: String {
+        switch self {
+        case .critical:
+            return String(localized: "We strongly recommend taking action to bring your Mac back to normal.")
+        case .requiresAttention:
+            return String(localized: "Your Mac is not doing well. Run some maintenance to bring it back into shape.")
+        case .fair:
+            return String(localized: "Your Mac is OK, but some maintenance is recommended to avoid performance issues.")
+        case .good:
+            return String(localized: "Your Mac is in good shape. Run some maintenance to perform even better.")
+        case .excellent:
+            return String(localized: "Your Mac is doing great. Run regular maintenance to keep it this way.")
+        }
+    }
+}

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -298,4 +298,78 @@ final class HealthMonitorViewModelTests: XCTestCase {
             "Mutating service.ramUsage must invalidate views observing vm.ramUsage"
         )
     }
+
+    // MARK: - Mac Health verdict (hero card)
+
+    /// Builds a `DiskStats` at a target fullness ratio against a fixed total
+    /// so the derivation thresholds read clearly in each test.
+    private func disk(ratio: Double) -> DiskStats {
+        let total: UInt64 = 1_000_000_000_000
+        return DiskStats(usedBytes: UInt64(Double(total) * ratio), totalBytes: total)
+    }
+
+    /// The very first service tick carries `DiskStats.empty` (zero total).
+    /// The hero must NOT resolve to a confident "Excellent" off zero data —
+    /// it returns `nil` so the view can render a neutral "Measuring…" state.
+    func test_macHealthStatus_isNilWhileDiskUnmeasured() {
+        XCTAssertNil(HealthMonitorViewModel.macHealthStatus(disk: .empty, signals: []))
+    }
+
+    /// Disk fullness drives the base verdict when no other signal is alarming.
+    /// Pins each tier boundary so the ramp can't silently shift.
+    func test_macHealthStatus_diskDrivesBaseTier_whenSignalsHealthy() {
+        let healthy: [StatusColor] = [.green, .green, .green, .green, .green]
+        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: healthy), .excellent)
+        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.60), signals: healthy), .good)
+        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.75), signals: healthy), .fair)
+        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.88), signals: healthy), .requiresAttention)
+        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.97), signals: healthy), .critical)
+    }
+
+    /// Unknown / neutral signals (the startup state) must not penalize the
+    /// verdict — a `.gray` reading is "no opinion", not "bad".
+    func test_macHealthStatus_grayAndGreenSignalsDoNotPenalize() {
+        let neutral: [StatusColor] = [.gray, .gray, .green, .green, .gray]
+        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: neutral), .excellent)
+    }
+
+    /// A single yellow nudge drops the base verdict by one tier.
+    func test_macHealthStatus_yellowSignalNudgesDownOneTier() {
+        // good (disk 0.60) − 1 (one yellow) → fair
+        let signals: [StatusColor] = [.green, .yellow, .green, .green, .green]
+        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.60), signals: signals), .fair)
+    }
+
+    /// A red signal (e.g. failing SMART) deliberately overrides the
+    /// disk-driven base: hardware-failure indicators outrank disk fullness.
+    /// One red on an otherwise-excellent (30%-full) disk drops two tiers to
+    /// Fair; two reds drive it to Critical even on an empty disk.
+    func test_macHealthStatus_redSignalsOverrideDiskBase() {
+        XCTAssertEqual(
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: [.red]),
+            .fair
+        )
+        XCTAssertEqual(
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: [.red, .red]),
+            .critical
+        )
+    }
+
+    /// Nudges clamp at the worst tier — a near-full disk plus a red signal
+    /// can't underflow past `.critical`.
+    func test_macHealthStatus_nudgeClampsAtCritical() {
+        // requiresAttention (disk 0.88) − 2 (one red) → clamps to critical
+        XCTAssertEqual(
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.88), signals: [.red]),
+            .critical
+        )
+    }
+
+    /// The hero title and summary are user-facing strings; pin one tier so a
+    /// typo or accidental copy change is caught.
+    func test_macHealthStatus_titleAndSummaryCopy() {
+        XCTAssertEqual(MacHealthStatus.good.title, "Good")
+        XCTAssertTrue(MacHealthStatus.good.summary.contains("good shape"))
+        XCTAssertEqual(MacHealthStatus.excellent.title, "Excellent")
+    }
 }

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -136,6 +136,27 @@ final class FinalPolishUITests: XCTestCase {
         }
     }
 
+    /// Health Monitor must lead with the Mac Health hero card: the overall
+    /// verdict and the boot-volume fill bar. Asserts the hero, its status
+    /// title, and its disk bar render above the per-metric grid.
+    func test_navigateToHealthMonitor_showsMacHealthHero() throws {
+        dismissOnboardingIfNeeded()
+
+        let row = app.buttons["sidebar.healthMonitor"].firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "Expected Health Monitor row in sidebar")
+        row.click()
+
+        let heroElements = ["health.hero", "health.hero.status", "health.hero.diskbar"]
+        for identifier in heroElements {
+            let element = app.descendants(matching: .any)[identifier]
+            XCTAssertTrue(
+                element.waitForExistence(timeout: 10),
+                "Expected Mac Health hero element \"\(identifier)\" to be visible"
+            )
+        }
+    }
+
     /// Health Monitor is a non-scannable section: it must keep its bespoke
     /// live-stats UI and must NOT pick up the scan-centric shell — no unified
     /// intro screen and no floating Scan button. Regression guard that the


### PR DESCRIPTION
## Overview

Redesigns the Health Monitor to lead with a CleanMyMac-style **Mac Health** hero card — a glowing ring around a laptop, a single overall verdict, and the boot volume's fill — matching the requested look-and-feel. The existing per-metric cards (Battery, Disk, RAM, CPU, Disk Space) stay below as the detailed breakdown, and the FileVault footer is unchanged.

## What changed

- **New `MacHealthStatus`** (`VaderCleaner/MacHealthStatus.swift`) — a SwiftUI-free 5-tier verdict (`Critical → Requires Attention → Fair → Good → Excellent`) with a display `title` and plain-language `summary` for each tier. Kept SwiftUI-free like the existing `StatusColor`; the view layer maps each case to a `Color` at the leaf.
- **Disk-driven derivation** (`HealthMonitorViewModel.macHealthStatus`) — disk fullness sets the base tier; the other signals (SMART, battery, RAM, CPU, FileVault) nudge it down. Each `.red` drops two tiers, any `.yellow` drops one more, `.gray`/`.green` never penalize, and the result clamps at `.critical`. Reds deliberately override the disk base so a failing drive can force Critical even on a near-empty disk. Returns `nil` while the volume is unmeasured (`totalBytes == 0`) so the hero shows a neutral **"Measuring…"** state instead of flashing a confident verdict off the first zero-byte tick.
- **Hero card** (`HealthMonitorView`) — an isolated `HealthRing` subview that takes only `color` (so polling ticks don't reset its `.repeatForever` rotation) and is gated on Reduce Motion, a laptop glyph, the tinted verdict + summary, and the volume name with a "121 GB of 494 GB used" fill bar. The per-tier color ramp matches the reference design. The disk block is hidden while measuring so it never reads "Zero KB of Zero KB used".

## Testing

- **Unit tests** (`HealthMonitorViewModelTests`): pin the disk-driven base tiers, the yellow/red nudges, the red-override behavior, the clamp at Critical, the gray/green no-penalty rule, the nil measuring state, and the title/summary copy. **36/36 pass** (`xcodebuild test`, codesign disabled).
- **UI test** (`FinalPolishUITests.test_navigateToHealthMonitor_showsMacHealthHero`): asserts the hero, its status title, and its disk bar surface. **Compiles, but unrun** — XCUITests can't bootstrap from the terminal in this environment, so it needs a local/CI run. The `health.hero` container identifier is the one most likely to need adjustment if it doesn't surface.
- Added a **"Mac Health states"** SwiftUI preview rendering all five tiers + Measuring, since the live preview only ever shows the measuring state off its empty disk.

## Reviewer notes

- The hero is intentionally **always-dark** (the reference design is) sitting above the adaptive `.glassEffect` cards — worth eyeballing in **Light mode**.
- The ring's `.repeatForever` animation means this screen never reaches animation-idle; current tests only query (no taps), but any future test that taps an element here would stall in wait-for-idle. Flagged in a code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Mac Health status card to Health Monitor section displaying overall system health verdict based on disk usage and system signals
  * Shows boot volume name, disk usage details, and visual health indicator with multiple tiers
  * Includes accessibility support for reduced motion preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->