### PR TITLE
fix(space-lens): replace misleading progress bar with open-ended scan spinner

### DIFF
--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -1,5 +1,5 @@
 // DiskScannerViewModel.swift
-// State machine and progress tracker behind Space Lens — drives idle/scanning/ready/error transitions and clamps the injected scanner's progress callbacks into a 0–1 published value.
+// State machine and progress tracker behind Space Lens — drives idle/scanning/ready/error transitions and translates the injected scanner's progress callbacks into a throttled, published walked-file count for the open-ended scanning spinner.
 
 import Foundation
 import Observation
@@ -40,11 +40,14 @@ final class DiskScannerViewModel {
 
     private(set) var phase: Phase = .idle
 
-    /// 0.0 – 1.0 progress for the currently-running scan. Clamped to 1.0
-    /// so an under-estimated `estimatedFileCount` (typical on volumes
-    /// with more files than the default heuristic) doesn't push the bar
-    /// past full. Resets to 0 when a new scan starts and on `.error`.
-    private(set) var scanProgress: Double = 0
+    /// Running count of files the in-flight scan has walked. The disk total
+    /// is unknowable mid-walk (an upfront count would double the wall-clock
+    /// cost), so Space Lens shows an open-ended indeterminate spinner plus
+    /// this live count — the same "Scanned N items…" feedback the other
+    /// open-ended scans use — rather than a fraction that would misreport
+    /// completion. Completion is signaled by `phase` landing on `.ready`.
+    /// Resets to 0 when a new scan starts, on `.error`, and on cancellation.
+    private(set) var scannedItemCount: Int = 0
 
     /// Breadcrumb stack the treemap (Prompt 17) will use to record the
     /// user's drill-down path. Kept here because the navigation state
@@ -149,14 +152,14 @@ final class DiskScannerViewModel {
         navigationPath = Array(navigationPath.prefix(through: index))
     }
 
-    /// Smallest fractional change worth republishing. A real-volume scan
-    /// can fire the progress callback hundreds of thousands of times;
-    /// without this gate every call would queue a `Task` on the main
-    /// actor and starve the UI thread. 0.5% (200 buckets across the 0–1
-    /// range) is fine-grained enough that the bar never visibly jumps
-    /// while keeping the queued-task count to a couple hundred for the
-    /// largest volumes. The terminal value (`1.0`) bypasses the gate so
-    /// the bar definitely reaches full.
+    /// Width of one progress-update bucket, as a fraction of the estimate. A
+    /// real-volume scan can fire the progress callback millions of times;
+    /// without this gate every call would queue a `Task` on the main actor
+    /// and starve the UI thread. The 0.5% bucket width (the estimate divided
+    /// into 200 steps) is fine-grained enough that the live count never
+    /// visibly stutters, while bounding the queued-task count to (files
+    /// processed ÷ bucket width) — ~200 tasks up to the estimate, and a few
+    /// thousand for a volume several times larger.
     private static let progressUpdateThreshold: Double = 0.005
 
     /// Reference-typed bucket tracker so the off-actor progress closure
@@ -167,16 +170,8 @@ final class DiskScannerViewModel {
     /// avoid. Single-threaded access: `DiskScanner.buildNode` invokes
     /// the closure from one recursive task chain, so no synchronization
     /// is required.
-    ///
-    /// `didScheduleTerminal` latches once the count crosses the
-    /// estimate so a real scan with more files than the default
-    /// estimate (e.g. 1M files on a 250k-file estimate) doesn't keep
-    /// scheduling a Task per file after the bar is already pinned at
-    /// 1.0. Without the latch, every post-estimate file would bypass
-    /// the bucket gate via the `isTerminal` branch.
     private final class ProgressGate {
         var lastScheduledBucket: Int = -1
-        var didScheduleTerminal: Bool = false
     }
 
     /// Monotonically increasing token bumped at the start of every
@@ -226,7 +221,7 @@ final class DiskScannerViewModel {
         currentScanTask = nil
         scanGeneration += 1
         if case .scanning = phase {
-            scanProgress = 0
+            scannedItemCount = 0
             phase = .idle
         }
     }
@@ -236,12 +231,12 @@ final class DiskScannerViewModel {
     /// outcome. The selection / breadcrumb stack is reset because the
     /// previous tree is no longer valid.
     ///
-    /// `estimatedFileCount` is the divisor for `scanProgress`. The
-    /// scanner doesn't know the total ahead of time (an upfront walk
-    /// would double the wall-clock cost), so we settle for an estimate
-    /// and clamp the bar at 1.0 once it reaches the ceiling. The bar is
-    /// for the user's sense of motion — actual completion is signaled by
-    /// the phase landing on `.ready`, not by progress hitting 1.0.
+    /// `estimatedFileCount` only sizes the progress-update throttle bucket
+    /// (see `progressUpdateThreshold`) — it is *not* a completion target.
+    /// The scan reports an open-ended walked count, not a fraction, so the
+    /// estimate being off just makes the count update a little more or less
+    /// often; it never caps the count or the scan. Completion is signaled by
+    /// the phase landing on `.ready`.
     func startScan(root: URL, estimatedFileCount: Int = 250_000) async {
         // Cancel any walk still in flight from a previous startScan.
         // Cancellation is cooperative — `DiskScanner.buildNode` checks
@@ -254,56 +249,43 @@ final class DiskScannerViewModel {
         let myGeneration = scanGeneration
 
         phase = .scanning
-        scanProgress = 0
+        scannedItemCount = 0
         navigationPath = []
 
         let divisor = max(1, estimatedFileCount)
         // Width (in files) of one throttle bucket. With the default
         // 0.5% threshold and a 250 000-file estimate this is 1 250 —
-        // i.e. at most ~200 main-actor Tasks per scan. `ceil` so the
-        // bucket is at least 1 even for tiny estimates (the test suite
-        // uses divisors of 100 and below).
+        // i.e. roughly one main-actor Task per 1 250 files walked. `ceil`
+        // so the bucket is at least 1 even for tiny estimates (the test
+        // suite uses divisors of 100 and below).
         let bucketSize = max(1, Int((Double(divisor) * Self.progressUpdateThreshold).rounded(.up)))
         let gate = ProgressGate()
 
         // Wrap the synchronous `progress` callback the scanner will fire
         // off-actor. The throttle gate runs *here*, before the main-actor
-        // hop, so a 250 000-file scan only ever schedules ~200 Tasks
-        // (one per crossed bucket plus the terminal write). Each
-        // scheduled Task still re-checks generation + phase on the main
-        // actor for two defense-in-depth reasons:
+        // hop, so the scan schedules at most one Task per crossed bucket
+        // for the whole walk, however large the volume. Each scheduled Task
+        // still re-checks generation + phase on the main actor for two
+        // defense-in-depth reasons:
         //
         //   1. the scan that produced it must still be the current one
         //      (`scanGeneration` match — guards against concurrent
         //      `startScan` calls), and
         //   2. the phase must still be `.scanning` (guards against late
         //      progress writes that would otherwise regress a final
-        //      `.ready` state back to a fractional value).
+        //      `.ready` state back to a scanning value).
         let progressHandler: (Int) -> Void = { [weak self] count in
-            // Once we've already scheduled the terminal 1.0 write, every
-            // subsequent file would still satisfy `isTerminal` and would
-            // bypass the bucket gate. Latch that single-shot event here
-            // so post-estimate files contribute exactly zero scheduled
-            // tasks. (For a 1M-file scan against a 250k estimate that's
-            // 750 000 tasks saved.)
-            if gate.didScheduleTerminal { return }
             let bucket = count / bucketSize
-            // Treat the *first* crossing to the estimate as terminal —
-            // guarantees the bar reaches 1.0 even when the final file
-            // lands mid-bucket — and remember that we did, so later
-            // files don't schedule again.
-            let isTerminal = count >= divisor
-            guard isTerminal || bucket > gate.lastScheduledBucket else { return }
-            if isTerminal {
-                gate.didScheduleTerminal = true
-            }
+            guard bucket > gate.lastScheduledBucket else { return }
             gate.lastScheduledBucket = bucket
-            let fraction = min(1.0, Double(count) / Double(divisor))
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 guard self.scanGeneration == myGeneration else { return }
                 guard case .scanning = self.phase else { return }
-                self.scanProgress = fraction
+                // Drop a hop that landed out of order (the Tasks are
+                // unstructured) so the walked count never ticks backwards.
+                guard count > self.scannedItemCount else { return }
+                self.scannedItemCount = count
             }
         }
 
@@ -321,7 +303,6 @@ final class DiskScannerViewModel {
                 // that resumes after a newer one has started doesn't
                 // clobber the newer scan's `.scanning` / `.ready` state.
                 guard self.scanGeneration == myGeneration else { return }
-                self.scanProgress = 1.0
                 self.phase = .ready(node)
             } catch is CancellationError {
                 // A cancellation is a clean dismissal — the user (or a
@@ -329,12 +310,12 @@ final class DiskScannerViewModel {
                 // Surfacing this as `.error("The operation couldn't be
                 // completed…")` would misrepresent it as a failure.
                 guard self.scanGeneration == myGeneration else { return }
-                self.scanProgress = 0
+                self.scannedItemCount = 0
                 self.phase = .idle
             } catch {
                 guard self.scanGeneration == myGeneration else { return }
                 self.log.error("Disk scan failed: \(String(describing: error), privacy: .private(mask: .hash))")
-                self.scanProgress = 0
+                self.scannedItemCount = 0
                 self.phase = .error(error.localizedDescription)
             }
         }

--- a/VaderCleaner/ScanProgressFormatting.swift
+++ b/VaderCleaner/ScanProgressFormatting.swift
@@ -46,12 +46,4 @@ enum ScanProgressFormatting {
             )
         return String.localizedStringWithFormat(template, formatted)
     }
-
-    /// "47%" — the determinate variant for Space Lens, whose scan reports a real
-    /// completion fraction. `ratio` is clamped to `[0, 1]` so a transient
-    /// out-of-range value can't render "−3%" or "120%".
-    static func percent(_ ratio: Double) -> String {
-        let clamped = max(0.0, min(1.0, ratio))
-        return clamped.formatted(.percent.precision(.fractionLength(0)))
-    }
 }

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -96,21 +96,22 @@ struct SpaceLensView: View {
         .padding()
     }
 
+    // The disk total is unknowable mid-walk, so Space Lens shows the same
+    // open-ended spinner + live walked-count the other scans use (Large &
+    // Old Files, System Junk) rather than a percentage bar that would
+    // misreport completion on a volume larger than the estimate.
     private var scanningState: some View {
         VStack(spacing: 16) {
-            ProgressView(value: viewModel.scanProgress)
-                .progressViewStyle(.linear)
-                .frame(maxWidth: 360)
-            // Space Lens reports a real completion fraction, so show the live
-            // percentage — proof to the user the scan is moving toward done.
-            Text(ScanProgressFormatting.percent(viewModel.scanProgress))
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.secondary)
-                .contentTransition(.numericText())
-                .accessibilityIdentifier("space-lens.scanning.percent")
+            ProgressView()
+                .controlSize(.large)
             Text("Scanning…")
                 .font(.callout)
                 .foregroundStyle(.secondary)
+            Text(ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .contentTransition(.numericText())
+                .accessibilityIdentifier("space-lens.scanning.count")
         }
         .padding()
         .accessibilityElement(children: .contain)

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -1,5 +1,5 @@
 // DiskScannerViewModelTests.swift
-// Verifies DiskScannerViewModel's state machine (.idle → .scanning → .ready / .error) and that injected progress callbacks update scanProgress on the main actor.
+// Verifies DiskScannerViewModel's state machine (.idle → .scanning → .ready / .error) and that injected progress callbacks update scannedItemCount on the main actor.
 
 import XCTest
 import Combine
@@ -8,15 +8,14 @@ import Combine
 /// Drives `DiskScannerViewModel` against an injected scanner closure so the
 /// transitions can be exercised without touching the real filesystem. The
 /// closure also lets us drive the progress callback at controlled points
-/// to lock the threading contract on `scanProgress`.
+/// to lock the threading contract on `scannedItemCount`.
 @MainActor
 final class DiskScannerViewModelTests: XCTestCase {
 
     // MARK: - Happy path
 
     /// A successful scan must transition `.idle → .scanning → .ready(node)`
-    /// and surface the produced root via `phase`. `scanProgress` lands at
-    /// 1.0 once the scan is finished.
+    /// and surface the produced root via `phase`.
     func test_startScan_transitionsToReadyOnSuccess() async {
         let synthetic = DiskNode(
             url: URL(fileURLWithPath: "/tmp/root"),
@@ -36,15 +35,14 @@ final class DiskScannerViewModelTests: XCTestCase {
         await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 100)
 
         XCTAssertEqual(vm.phase, .ready(synthetic))
-        XCTAssertEqual(vm.scanProgress, 1.0)
     }
 
     // MARK: - Failure path
 
     /// An error thrown by the injected scanner must surface as `.error`
     /// carrying the localized description so the view can render it. The
-    /// `scanProgress` value is reset back to 0 — leaving the bar
-    /// half-full would lie about state.
+    /// walked count is reset back to 0 — a leftover count would read as
+    /// progress against a scan that isn't running.
     func test_startScan_transitionsToErrorOnThrow() async {
         struct ScanFailure: LocalizedError {
             var errorDescription: String? { "boom" }
@@ -56,15 +54,13 @@ final class DiskScannerViewModelTests: XCTestCase {
         await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
 
         XCTAssertEqual(vm.phase, .error("boom"))
-        XCTAssertEqual(vm.scanProgress, 0.0)
+        XCTAssertEqual(vm.scannedItemCount, 0)
     }
 
     // MARK: - Progress
 
-    /// The injected progress callback must drive `scanProgress` toward 1.0
-    /// as the count climbs. Locks the divisor (estimated file count), the
-    /// clamp at 1.0 (counts above the estimate must not push past full),
-    /// and the throttle bypass for the terminal value.
+    /// The progress callback must drive `scannedItemCount` upward as the
+    /// walk advances, ending on the last reported count.
     ///
     /// `await Task.yield()` between progress calls is deliberate: the VM
     /// hops every published update through `Task { @MainActor … }` so
@@ -73,8 +69,8 @@ final class DiskScannerViewModelTests: XCTestCase {
     /// test mirrors that pacing so each queued main-actor write applies
     /// while the phase is still `.scanning`. Without yields the writes
     /// would all queue, then bail on the post-scan phase guard, and the
-    /// test would only see the explicit final 1.0.
-    func test_startScan_updatesScanProgressFromCallback() async {
+    /// test would only see the final value.
+    func test_startScan_updatesScannedItemCountFromCallback() async {
         let synthetic = DiskNode(
             url: URL(fileURLWithPath: "/tmp"),
             name: "tmp",
@@ -83,28 +79,52 @@ final class DiskScannerViewModelTests: XCTestCase {
             children: []
         )
         let vm = DiskScannerViewModel(scanner: { _, progress in
-            progress(10)   // 10% of 100
+            progress(10)
             await Task.yield()
-            progress(50)   // 50% of 100
-            await Task.yield()
-            progress(150)  // > 100 → clamped to 1.0
+            progress(50)
             await Task.yield()
             return synthetic
         })
 
-        // Snapshot scanProgress every time the observed value changes.
-        let observed = await recordTransitions(of: \.scanProgress, on: vm) {
+        // Snapshot scannedItemCount every time the observed value changes.
+        let observed = await recordTransitions(of: \.scannedItemCount, on: vm) {
             await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 100)
         }
 
-        // Progress callback must have produced at least one value strictly
-        // between 0 and 1 during the scan, never exceeding 1.0.
-        XCTAssertTrue(observed.contains { $0 > 0 && $0 < 1 },
-                      "scanProgress should report intermediate values during a scan")
-        XCTAssertTrue(observed.allSatisfy { $0 <= 1.0 },
-                      "scanProgress must never exceed 1.0")
-        // Final value (post-scan) is 1.0.
-        XCTAssertEqual(vm.scanProgress, 1.0)
+        // The count must only ever climb — a backwards tick would read as the
+        // scan losing ground.
+        XCTAssertEqual(observed, observed.sorted(),
+                       "scannedItemCount must be monotonically non-decreasing")
+        // Ends on the last count the scanner reported.
+        XCTAssertEqual(vm.scannedItemCount, 50)
+    }
+
+    /// Regression guard for the pinned-progress bug: a real volume holds far
+    /// more files than the default estimate. The walked count must keep
+    /// climbing past the estimate rather than being capped or latched there —
+    /// the old fixed-divisor bar pinned at 100% once the count hit the
+    /// estimate, which read as "done" while a minute of scanning was still
+    /// ahead.
+    func test_startScan_countClimbsPastEstimate() async {
+        let synthetic = DiskNode(
+            url: URL(fileURLWithPath: "/tmp"),
+            name: "tmp",
+            size: 0,
+            isDirectory: true,
+            children: []
+        )
+        let vm = DiskScannerViewModel(scanner: { _, progress in
+            progress(50)    // within the 100-file estimate
+            await Task.yield()
+            progress(500)   // well past the estimate — must not be capped
+            await Task.yield()
+            return synthetic
+        })
+
+        await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 100)
+
+        XCTAssertEqual(vm.scannedItemCount, 500,
+                       "the walked count must continue past the estimate, not cap at it")
     }
 
     // MARK: - Cancellation
@@ -122,7 +142,7 @@ final class DiskScannerViewModelTests: XCTestCase {
         await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
 
         XCTAssertEqual(vm.phase, .idle, "Cancellation should land back in .idle, not .error")
-        XCTAssertEqual(vm.scanProgress, 0.0)
+        XCTAssertEqual(vm.scannedItemCount, 0)
     }
 
     /// App-scoped Space Lens state can outlive the main window when the
@@ -160,7 +180,7 @@ final class DiskScannerViewModelTests: XCTestCase {
         await fulfillment(of: [scanCancelled], timeout: 1)
         await scanTask.value
         XCTAssertEqual(vm.phase, .idle)
-        XCTAssertEqual(vm.scanProgress, 0.0)
+        XCTAssertEqual(vm.scannedItemCount, 0)
     }
 
     // MARK: - Navigation (Prompt 17)


### PR DESCRIPTION
## Problem

The Space Lens progress bar reached 100% and then sat frozen for ~a minute before the visualization appeared.

**Root cause:** the bar's divisor was a hardcoded `250_000` files, but a real home folder holds far more (~3,367,782 on my machine). The bar filled to 100% at roughly **7%** of the actual walk, then a terminal latch pinned it at full while the scan ground through the remaining ~93%. The treemap/sunburst only renders when the walk finishes and `phase` flips to `.ready` — that gap read as "done, but nothing's happening."

The disk total is genuinely **unknowable mid-walk** (an upfront count would roughly double the scan's wall-clock cost — a tradeoff the scanner deliberately rejects), so no fixed divisor can ever be correct. Raising the number just relocates the stall.

## Fix

Match how the other open-ended scans already work (Large & Old Files, System Junk): a circular **indeterminate spinner** + a live **"Scanned N items…"** count, with no percentage to misreport completion.

- **`DiskScannerViewModel`** — publish a monotonic `scannedItemCount: Int` (mirrors `LargeOldFilesViewModel.scannedItemCount`) instead of a `0–1` fraction. Dropped the terminal-write / clamp / `didScheduleTerminal` latch. Kept the per-bucket update throttle so a multi-million-file walk doesn't flood the main actor with UI updates (~one update per 1,250 files).
- **`SpaceLensView`** — scanning state now uses the shared `ProgressView().controlSize(.large)` + label + count idiom.
- **`ScanProgressFormatting`** — removed the now-unused `percent(_:)` helper (it existed solely for the old determinate bar; no callers or tests remain).

## Tests

TDD throughout. **All 974 unit tests pass.** Updated `DiskScannerViewModelTests` to the count-based contract:
- `scannedItemCount` climbs monotonically and ends on the last reported count.
- Regression guard `test_startScan_countClimbsPastEstimate`: the count keeps climbing **past** the estimate rather than capping at it (the old bug pinned the bar at 100% there).

## Reviewer notes

- This changes how the wait **looks**, not how long it takes — scanning 3.4M files is still ~a minute, but the user now sees a spinner and a climbing file count the whole time instead of a stuck 100%. Shortening the wait itself (streaming partial results / off-main rendering) would be a separate, larger change.
- UI tests weren't run (the XCUITest runner gets signal-killed before XPC connect in this environment). The only Space Lens UI-test touchpoint, the `space-lens.scanning` container identifier, is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk scan progress display to show a live count of scanned items with an indeterminate spinner instead of a percentage-based progress bar, providing more accurate feedback as scans progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->