### PR TITLE
perf(space-lens): cap sunburst depth to cut section-switch lag

### DIFF
--- a/VaderCleaner/SunburstView.swift
+++ b/VaderCleaner/SunburstView.swift
@@ -29,9 +29,15 @@ struct SunburstView: View {
     /// details card.
     @State private var hoveredID: DiskNode.ID?
 
-    /// Deepest ring to draw. Past this the arcs grow too thin to read or click;
-    /// the user drills in to see deeper. Matches the layout's depth cap.
-    private static let maxDepth = 5
+    /// Deepest ring to draw. Past this the arcs grow too thin to read or
+    /// click, and the count of rendered `AnnularSector` segments climbs steeply
+    /// — each ring subdivides its parents, so deeper rings hold the bulk of the
+    /// arcs. That arc count is the dominant cost when the detail pane fades
+    /// between sections: every segment is re-rendered through the transition,
+    /// so a deep tree drops frames on a section switch. Three rings keeps the
+    /// visualization readable while bounding that per-transition cost; the user
+    /// drills in to see deeper. Matches the layout's depth cap.
+    private static let maxDepth = 3
     /// Inset from the shorter edge so the outermost ring doesn't touch the
     /// view bounds.
     private static let edgePadding: CGFloat = 12


### PR DESCRIPTION
## What

Caps the Space Lens sunburst at **3 rings** (was 5) by lowering `SunburstView.maxDepth`.

## Why

Switching away from Space Lens to another section stuttered noticeably — but only when **Sunburst** was the active view mode, which is the default. The treemap never lagged.

The detail pane fades between sections with an `.opacity` transition ([ContentView.swift](../blob/main/VaderCleaner/ContentView.swift)). The sunburst rendered the disk tree to five rings, which — because each ring subdivides its parents — can be **several hundred `AnnularSector` segments**. Every one of those custom-`Shape` segments is re-rendered through the transition, so the total arc count drove a steep per-frame cost that dropped frames on each switch. The treemap renders only a node's direct children (a few dozen tiles), so it stayed smooth under the identical transition.

## How it was diagnosed

Narrowed by experiment rather than guesswork:

1. **Treemap vs. sunburst** — switching tabs from the treemap was clean; from the sunburst it stuttered. → Sunburst-specific.
2. **`.compositingGroup()`** (flatten for the opacity pass) — no improvement. → Ruled out the GPU group-opacity offscreen pass.
3. **Hard arc-count cut** (depth 2) — switched cleanly. → Confirmed **arc-count-bound**: the cost scales with the number of rendered segments.

Three rings is the richest setting that keeps the switch smooth while staying readable; users drill in to see deeper.

## Scope / safety

- One-line behavioral change (`maxDepth` 5 → 3) plus an evergreen comment explaining the depth cap.
- **No change** to drill-down, hover, tooltips, or accessibility — only how many rings draw.
- `SunburstLayoutTests` (12 tests) pass.

## Note for reviewers

Depth 3 vs 4 is a detail/performance trade-off — depth 2 is the only value empirically confirmed smooth, and 3 leaves a comfortable margin. Easy to bump to 4 if the extra ring is wanted and still feels smooth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
- Sunburst visualization now displays up to 3 ring levels (previously 5) for enhanced readability and improved rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->