### PR TITLE
fix(space-lens): place hover card beside item so it clears the cursor

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		3D65654B589EFF2972927ED7 /* ScanAccessPopoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */; };
 		3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */; };
 		406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */; };
+		40BB821EAD9CD6628F9B0069 /* SpaceLensHoverCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B22856A47E87BF9A84172B2 /* SpaceLensHoverCardTests.swift */; };
 		4156DAE09EB7579F22FA6959 /* MalwareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */; };
 		431465517AFBE2AE7342608D /* SpaceLensViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3631D872F6AA2F98BA133922 /* SpaceLensViewMode.swift */; };
 		4453CD1C9BEA6DFD3C62E054 /* FloatingRunOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */; };
@@ -365,6 +366,7 @@
 		2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModel.swift; sourceTree = "<group>"; };
 		2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManager.swift; sourceTree = "<group>"; };
 		2B14F49807367DE2ABB76753 /* FloatingScanButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanButton.swift; sourceTree = "<group>"; };
+		2B22856A47E87BF9A84172B2 /* SpaceLensHoverCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensHoverCardTests.swift; sourceTree = "<group>"; };
 		2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanViewModelTests.swift; sourceTree = "<group>"; };
 		2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperDeletionPolicyTests.swift; sourceTree = "<group>"; };
 		2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanAccessPopover.swift; sourceTree = "<group>"; };
@@ -929,6 +931,7 @@
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
+				2B22856A47E87BF9A84172B2 /* SpaceLensHoverCardTests.swift */,
 				79D7BEEA4BEA21693232C5B1 /* SpaceLensPaletteTests.swift */,
 				7707C4D6B14FF468458441A6 /* SpaceLensViewModeStoreTests.swift */,
 				22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */,
@@ -1225,6 +1228,7 @@
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				2D8DAC3191BC1733AE762C03 /* SectionThemeTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
+				40BB821EAD9CD6628F9B0069 /* SpaceLensHoverCardTests.swift in Sources */,
 				75D6F67D3F8C742940CD9CD8 /* SpaceLensPaletteTests.swift in Sources */,
 				3312F51624418F8A57FFA6C6 /* SpaceLensViewModeStoreTests.swift in Sources */,
 				8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */,

--- a/VaderCleaner/SpaceLensHoverCard.swift
+++ b/VaderCleaner/SpaceLensHoverCard.swift
@@ -20,10 +20,14 @@ struct SpaceLensHoverCard: View {
     /// Fixed width the visualizations frame the card to, so the anchor-clamping
     /// math has a known size to keep the card on-canvas.
     static let preferredWidth: CGFloat = 260
-    /// Half the card's assumed height, used only to clamp its center within the
-    /// canvas. A slight overestimate is harmless — it just keeps a tall card
-    /// from being clipped at the bottom edge.
-    private static let halfHeight: CGFloat = 48
+    /// Half the card's assumed height, used to clamp its center within the
+    /// canvas and to push the card clear of the hovered item. A slight
+    /// overestimate is harmless — it just keeps a tall card from being clipped
+    /// at the bottom edge.
+    static let halfHeight: CGFloat = 48
+    /// Breathing room left between the hovered item and the nearest card edge
+    /// when the card is placed beside the item.
+    static let anchorGap: CGFloat = 8
 
     /// Clamp the card's center so a card of `preferredWidth` stays fully inside
     /// `bounds`. Anchored to the hovered item, an arc near the edge would
@@ -38,6 +42,41 @@ struct SpaceLensHoverCard: View {
             x: min(max(anchor.x, minX), maxX),
             y: min(max(anchor.y, minY), maxY)
         )
+    }
+
+    /// Center for the card describing a treemap tile, placed just above or
+    /// below the tile — outside its bounds — so it never covers the pointer,
+    /// which sits somewhere inside the tile. Prefers below the tile; flips
+    /// above when the card wouldn't fit beneath. The result is clamped on-canvas
+    /// (a tile taller than the canvas minus the card can still force overlap, an
+    /// accepted edge case).
+    static func anchor(forTile rect: CGRect, in bounds: CGSize) -> CGPoint {
+        let belowY = rect.maxY + anchorGap + halfHeight
+        let aboveY = rect.minY - anchorGap - halfHeight
+        let y = belowY + halfHeight <= bounds.height ? belowY : aboveY
+        return clampedCenter(anchor: CGPoint(x: rect.midX, y: y), in: bounds)
+    }
+
+    /// Center for the card describing a sunburst segment, pushed radially past
+    /// the segment's outer edge along its mid-angle. The push includes the
+    /// card's support distance in that direction (`|cos|·halfWidth +
+    /// |sin|·halfHeight`) so the rectangle clears the arc whatever the angle —
+    /// a wide card needs far more clearance toward 3/9 o'clock than 12/6. The
+    /// result is clamped on-canvas; on a canvas too small to fit the card beside
+    /// the ring the clamp can still pull it back over a side segment, an
+    /// accepted edge case.
+    static func anchor(
+        forSegmentMidAngle midAngle: Double,
+        outerRadius: CGFloat,
+        center: CGPoint,
+        in bounds: CGSize
+    ) -> CGPoint {
+        let dx = CGFloat(cos(midAngle))
+        let dy = CGFloat(sin(midAngle))
+        let support = abs(dx) * (preferredWidth / 2) + abs(dy) * halfHeight
+        let reach = outerRadius + anchorGap + support
+        let anchor = CGPoint(x: center.x + dx * reach, y: center.y + dy * reach)
+        return clampedCenter(anchor: anchor, in: bounds)
     }
 
     var body: some View {

--- a/VaderCleaner/SunburstView.swift
+++ b/VaderCleaner/SunburstView.swift
@@ -134,11 +134,12 @@ struct SunburstView: View {
         .accessibilityIdentifier("space-lens.sunburst")
     }
 
-    /// Details card for the hovered segment, positioned next to the segment it
-    /// describes (not the cursor — anchoring to the item keeps re-renders to
-    /// hover *transitions*, so the squarified/angular layout isn't recomputed
-    /// on every pointer move). Clamped to stay fully on-canvas. Renders nothing
-    /// when no segment is hovered.
+    /// Details card for the hovered segment, pushed radially just past the
+    /// segment's outer edge so it sits beside the arc, never over it, and
+    /// doesn't cover the pointer. Anchored to the segment rather than the cursor
+    /// so re-renders stay tied to hover *transitions*, not every pointer move
+    /// (which would recompute the angular layout). Clamped to stay fully
+    /// on-canvas. Renders nothing when no segment is hovered.
     @ViewBuilder
     private func hoverCard(
         nodesByID: [DiskNode.ID: DiskNode],
@@ -152,11 +153,7 @@ struct SunburstView: View {
            let diskNode = nodesByID[hoveredID],
            let segment = segments.first(where: { $0.id == hoveredID }) {
             let midAngle = (segment.startAngle + segment.endAngle) / 2
-            let midRadius = hole + (CGFloat(segment.depth) - 0.5) * ringThickness
-            let anchor = CGPoint(
-                x: center.x + CGFloat(cos(midAngle)) * midRadius,
-                y: center.y + CGFloat(sin(midAngle)) * midRadius
-            )
+            let outerRadius = hole + CGFloat(segment.depth) * ringThickness
             SpaceLensHoverCard(
                 name: diskNode.name,
                 formattedSize: diskNode.formattedSize,
@@ -165,7 +162,14 @@ struct SunburstView: View {
             )
             .frame(width: SpaceLensHoverCard.preferredWidth)
             .fixedSize(horizontal: false, vertical: true)
-            .position(SpaceLensHoverCard.clampedCenter(anchor: anchor, in: bounds))
+            .position(
+                SpaceLensHoverCard.anchor(
+                    forSegmentMidAngle: midAngle,
+                    outerRadius: outerRadius,
+                    center: center,
+                    in: bounds
+                )
+            )
             .allowsHitTesting(false)
         }
     }

--- a/VaderCleaner/TreemapView.swift
+++ b/VaderCleaner/TreemapView.swift
@@ -86,16 +86,16 @@ struct TreemapView: View {
         .accessibilityIdentifier("space-lens.treemap")
     }
 
-    /// Details card for the hovered tile, positioned over the tile it
-    /// describes (not the cursor — anchoring to the item keeps re-renders to
-    /// hover *transitions*, so the squarified layout isn't recomputed on every
-    /// pointer move). Clamped to stay fully on-canvas. Renders nothing when no
-    /// tile is hovered.
+    /// Details card for the hovered tile, placed just beside the tile it
+    /// describes — above or below it, never over it, so the card doesn't cover
+    /// the pointer. Anchored to the tile rather than the cursor so re-renders
+    /// stay tied to hover *transitions*, not every pointer move (which would
+    /// recompute the squarified layout). Clamped to stay fully on-canvas.
+    /// Renders nothing when no tile is hovered.
     @ViewBuilder
     private func hoverCard(tiles: [PlacedTile], bounds: CGSize) -> some View {
         if let hoveredID, let placed = tiles.first(where: { $0.id == hoveredID }) {
             let model = placed.model
-            let anchor = CGPoint(x: placed.rect.midX, y: placed.rect.midY)
             SpaceLensHoverCard(
                 name: model.node.name,
                 formattedSize: model.formattedSize,
@@ -104,7 +104,7 @@ struct TreemapView: View {
             )
             .frame(width: SpaceLensHoverCard.preferredWidth)
             .fixedSize(horizontal: false, vertical: true)
-            .position(SpaceLensHoverCard.clampedCenter(anchor: anchor, in: bounds))
+            .position(SpaceLensHoverCard.anchor(forTile: placed.rect, in: bounds))
             .allowsHitTesting(false)
         }
     }

--- a/VaderCleanerTests/SpaceLensHoverCardTests.swift
+++ b/VaderCleanerTests/SpaceLensHoverCardTests.swift
@@ -1,0 +1,125 @@
+// SpaceLensHoverCardTests.swift
+// Locks the hover card's anchor math: the card is placed beside the hovered item (outside a treemap tile, past a sunburst arc) so it never covers the pointer, while staying clamped on-canvas.
+
+import XCTest
+import CoreGraphics
+@testable import VaderCleaner
+
+/// Unit tests for `SpaceLensHoverCard`'s positioning helpers. These are pure
+/// static functions, so the tests reconstruct the card's rectangle from its
+/// returned center and assert it clears the hovered item — the property that
+/// keeps the tooltip off the cursor.
+final class SpaceLensHoverCardTests: XCTestCase {
+
+    private let halfWidth = SpaceLensHoverCard.preferredWidth / 2
+    private let halfHeight = SpaceLensHoverCard.halfHeight
+
+    /// The card rectangle implied by a returned center.
+    private func cardRect(at center: CGPoint) -> CGRect {
+        CGRect(
+            x: center.x - halfWidth,
+            y: center.y - halfHeight,
+            width: SpaceLensHoverCard.preferredWidth,
+            height: halfHeight * 2
+        )
+    }
+
+    // MARK: - Treemap tiles
+
+    /// A tile with room beneath it gets a card placed entirely below it, so the
+    /// card never overlaps the tile the pointer is inside.
+    func test_tileAnchor_placesCardBelowWhenRoomBelow() {
+        let bounds = CGSize(width: 400, height: 300)
+        let tile = CGRect(x: 150, y: 120, width: 100, height: 60)
+
+        let center = SpaceLensHoverCard.anchor(forTile: tile, in: bounds)
+        let card = cardRect(at: center)
+
+        XCTAssertFalse(card.intersects(tile), "Card overlaps the tile it describes")
+        XCTAssertGreaterThanOrEqual(card.minY, tile.maxY, "Card should sit below the tile")
+    }
+
+    /// A tile hugging the bottom edge — no room below — flips the card above it.
+    func test_tileAnchor_flipsAboveWhenNoRoomBelow() {
+        let bounds = CGSize(width: 400, height: 300)
+        let tile = CGRect(x: 150, y: 240, width: 100, height: 50)
+
+        let center = SpaceLensHoverCard.anchor(forTile: tile, in: bounds)
+        let card = cardRect(at: center)
+
+        XCTAssertFalse(card.intersects(tile), "Card overlaps the tile it describes")
+        XCTAssertLessThanOrEqual(card.maxY, tile.minY, "Card should sit above the tile")
+    }
+
+    /// The card stays fully on-canvas regardless of where the tile sits.
+    func test_tileAnchor_keepsCardOnCanvas() {
+        let bounds = CGSize(width: 400, height: 300)
+        let tile = CGRect(x: 0, y: 0, width: 60, height: 40)
+
+        let center = SpaceLensHoverCard.anchor(forTile: tile, in: bounds)
+
+        XCTAssertGreaterThanOrEqual(center.x, halfWidth)
+        XCTAssertLessThanOrEqual(center.x, bounds.width - halfWidth)
+        XCTAssertGreaterThanOrEqual(center.y, halfHeight)
+        XCTAssertLessThanOrEqual(center.y, bounds.height - halfHeight)
+    }
+
+    // MARK: - Sunburst segments
+
+    /// Closest distance from `point` to the edge of axis-aligned `rect`
+    /// (0 when the point is inside).
+    private func distance(from point: CGPoint, to rect: CGRect) -> CGFloat {
+        let dx = max(rect.minX - point.x, 0, point.x - rect.maxX)
+        let dy = max(rect.minY - point.y, 0, point.y - rect.maxY)
+        return (dx * dx + dy * dy).squareRoot()
+    }
+
+    /// On a canvas large enough to fit the card beside the ring, the card clears
+    /// the segment's arc at every angle — including 3/9 o'clock, where the card's
+    /// width (not its height) is the clearance that matters.
+    func test_segmentAnchor_clearsArcInAllDirections() {
+        let bounds = CGSize(width: 800, height: 800)
+        let center = CGPoint(x: 400, y: 400)
+        let outerRadius: CGFloat = 140
+
+        let angles: [Double] = [
+            0, .pi / 2, .pi, 3 * .pi / 2,        // cardinal
+            .pi / 4, 3 * .pi / 4, 5 * .pi / 4    // diagonal
+        ]
+
+        for angle in angles {
+            let anchor = SpaceLensHoverCard.anchor(
+                forSegmentMidAngle: angle,
+                outerRadius: outerRadius,
+                center: center,
+                in: bounds
+            )
+            let card = cardRect(at: anchor)
+            // The arc lives within `outerRadius` of center; the card must not
+            // intrude into that disc.
+            XCTAssertGreaterThanOrEqual(
+                distance(from: center, to: card), outerRadius,
+                "Card intrudes on the arc at angle \(angle)"
+            )
+        }
+    }
+
+    /// The card stays fully on-canvas even when the radial push would otherwise
+    /// run it off the edge.
+    func test_segmentAnchor_keepsCardOnCanvas() {
+        let bounds = CGSize(width: 360, height: 360)
+        let center = CGPoint(x: 180, y: 180)
+
+        let anchor = SpaceLensHoverCard.anchor(
+            forSegmentMidAngle: 0,
+            outerRadius: 120,
+            center: center,
+            in: bounds
+        )
+
+        XCTAssertGreaterThanOrEqual(anchor.x, halfWidth)
+        XCTAssertLessThanOrEqual(anchor.x, bounds.width - halfWidth)
+        XCTAssertGreaterThanOrEqual(anchor.y, halfHeight)
+        XCTAssertLessThanOrEqual(anchor.y, bounds.height - halfHeight)
+    }
+}


### PR DESCRIPTION
## What

The Space Lens hover card no longer covers the pointer. It's now placed *beside* the hovered item instead of centered on it.

## Why

The card was anchored at the hovered item's geometric center (treemap tile center / sunburst arc mid-radius). On a large tile or a thick segment, that center coincides with where you're pointing, so the card sat on top of the cursor.

The fix preserves the deliberate **item-anchored** design — anchoring to the live cursor would re-run the view body and recompute the chart layout on every pointer move, which the recent Space Lens perf work specifically avoids. Instead, the card is positioned *outside* the item's region:

- **Treemap** — card sits just above or below the tile (whichever side has room), fully outside the tile's bounds.
- **Sunburst** — card is pushed radially past the segment's outer edge. The push includes the card's *width* (`|cos|·halfWidth + |sin|·halfHeight`) so 3-o'clock / 9-o'clock segments clear too, not just top/bottom ones.

Both placements stay clamped on-canvas. Shared math lives in two pure static helpers on `SpaceLensHoverCard`.

## Tests

New `SpaceLensHoverCardTests` lock the "card never overlaps the item" property in both modes (including all four cardinal sunburst directions) plus the on-canvas clamp. Full unit suite green: **979 tests, 0 failures**.

## Reviewer notes

- The math is unit-verified; the **visual** result wasn't confirmed in-app from the build environment (UITests can't bootstrap here, screenshot needs Screen Recording permission). Worth a quick hover-check of large tiles and a wide ring segment.
- Two geometric edge cases survive by design, both clamped rather than perfect: a tile *taller* than canvas-minus-card can still overlap, and on a *very small* sunburst canvas the clamp can pull a left/right card back over the ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced hover card positioning logic for both treemap tiles and sunburst segments with improved placement calculations and boundary clamping to ensure cards remain on-screen.

* **Tests**
  * Added comprehensive unit tests to validate hover card anchor positioning behavior, including placement verification for tiles, segment clearance validation, and on-canvas boundary checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->