### PR TITLE
security(helper): anchor the XPC code-signing pin to Apple's CA

### DIFF
--- a/Shared/HelperProtocol.swift
+++ b/Shared/HelperProtocol.swift
@@ -13,10 +13,28 @@ enum HelperCodeSigningRequirements {
     static let helperIdentifier = "com.personal.VaderCleaner.helper"
 
     /// Set to the Developer ID Team ID before distributing signed Release builds.
+    ///
+    /// BEFORE YOU DISTRIBUTE — security checklist (safe to ignore for a
+    /// personal, locally-built, single-user app; each item only matters once
+    /// the app leaves your own machine):
+    ///
+    ///   1. Set `releaseTeamIdentifier` to your Developer ID Team ID. Until
+    ///      then a Release build authorizes the helper by bundle identifier
+    ///      alone, which an ad-hoc binary can forge — local privilege
+    ///      escalation to the root helper. Once set, the requirement becomes
+    ///      `identifier "…" and anchor apple generic and certificate
+    ///      leaf[subject.OU] = "<team>"`, which actually pins the connection.
+    ///   2. Flip `ENABLE_HARDENED_RUNTIME` to YES in project.yml. It's
+    ///      required for notarization, and the app's JIT / unsigned-memory
+    ///      entitlements only take effect under the hardened runtime.
+    ///   3. (Optional, stricter) Prefer the bundled ClamAV over the
+    ///      user-writable Homebrew fallbacks (`/opt/homebrew/bin`,
+    ///      `/usr/local/bin`) in `ClamAVDetector` / `DatabaseUpdater` so a
+    ///      planted binary there can't be run in a Release build.
     private static let releaseTeamIdentifier: String? = nil
 
     #if !DEBUG
-    #warning("Set releaseTeamIdentifier to the Developer ID Team ID before distributing signed Release builds.")
+    #warning("Before distributing: set releaseTeamIdentifier to the Developer ID Team ID and enable the hardened runtime — see the checklist on releaseTeamIdentifier.")
     #endif
 
     static func requirement(identifier: String, teamIdentifier: String?) -> String {
@@ -24,7 +42,14 @@ enum HelperCodeSigningRequirements {
         guard let teamIdentifier = configuredTeamIdentifier(teamIdentifier) else {
             return identifierRequirement
         }
-        return "\(identifierRequirement) and certificate leaf[subject.OU] = \"\(teamIdentifier)\""
+        // `anchor apple generic` is required, not optional: a bare
+        // `certificate leaf[subject.OU] = "<team>"` is satisfied by any
+        // self-signed certificate whose leaf simply sets that OU — and the
+        // Team ID is public, so an attacker can forge it. Anchoring to
+        // Apple's CA means only an Apple-issued (Developer ID / Development)
+        // certificate carrying that team can pass, which is what actually
+        // pins the connection's identity.
+        return "\(identifierRequirement) and anchor apple generic and certificate leaf[subject.OU] = \"\(teamIdentifier)\""
     }
 
     static func releaseRequirement(identifier: String, teamIdentifier: String? = releaseTeamIdentifier) -> String {

--- a/VaderCleanerTests/HelperProtocolTests.swift
+++ b/VaderCleanerTests/HelperProtocolTests.swift
@@ -18,7 +18,7 @@ final class HelperProtocolTests: XCTestCase {
 
         XCTAssertEqual(
             requirement,
-            "identifier \"com.personal.VaderCleaner\" and certificate leaf[subject.OU] = \"ABCDE12345\""
+            "identifier \"com.personal.VaderCleaner\" and anchor apple generic and certificate leaf[subject.OU] = \"ABCDE12345\""
         )
     }
 


### PR DESCRIPTION
## Summary

Hardens the code-signing requirement on the privileged XPC channel between the app and `VaderCleanerHelper` (the root daemon).

The release requirement was:
```
identifier "X" and certificate leaf[subject.OU] = "TEAMID"
```
Without `anchor apple generic`, that check is satisfiable by **any self-signed certificate** that sets its leaf subject OU to the Team ID — and the Team ID is public, so it's forgeable. This applies to both directions: the helper authorizing incoming clients (`kHelperClientCodeSigningRequirement`) and the app authenticating the helper (`kHelperServerCodeSigningRequirement`). A forged-OU binary could reach the root helper or impersonate it.

Now:
```
identifier "X" and anchor apple generic and certificate leaf[subject.OU] = "TEAMID"
```
so only an Apple-issued (Developer ID / Development) certificate carrying that team passes. DEBUG / ad-hoc local dev is unchanged (still identifier-only by design, so the helper-backed actions keep working locally).

## Context

This came out of a full security pass. The helper itself is already well-hardened — allowlist validated in both `/var` and `/private/var` spellings, symlink-safe `openat`/`O_NOFOLLOW` recursive deletion, no shell/command-injection surface, no cleartext networking, no embedded secrets. This was the one substantive gap.

The `#warning` is also expanded into a **pre-distribution checklist** so the release-only follow-ups aren't lost:
1. Set `releaseTeamIdentifier` to the Developer ID Team ID (this PR only takes effect once a Team ID is configured).
2. Enable the hardened runtime.
3. (Optional) Prefer bundled ClamAV over the user-writable Homebrew fallbacks.

These remaining items are theoretical for a personal, locally-built, single-user app and are intentionally left as documented decisions rather than changed here.

## Testing

`HelperProtocolTests` updated to pin the hardened string; runs green:
```
xcodebuild test -only-testing:VaderCleanerTests/HelperProtocolTests ... → TEST SUCCEEDED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced identity verification for internal application communications, strengthening protection against unauthorized access and improving overall security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->