### PR TITLE
refactor: extract shared UpdateProbe from the three update-check copies

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		D04A64F83480761DF5F12344 /* OptimizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669493D60C3958979B97FA04 /* OptimizationViewModelTests.swift */; };
 		D25319BADD929D75CA704136 /* MailReindexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2017911CF02D2B89E8BF865 /* MailReindexer.swift */; };
 		D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */; };
+		D911FAA1B6067442C5D36F11 /* UpdateProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE71FA16E4B413D837F097E2 /* UpdateProbeTests.swift */; };
 		D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */; };
 		DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */; };
 		DC01035B8409197605E03C76 /* PerformanceRecommendationEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD3CFDAD89263D0CAE10471 /* PerformanceRecommendationEngineTests.swift */; };
@@ -264,6 +265,7 @@
 		F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */; };
 		F4BF8822B044CE3445A144E7 /* UnsupportedAppScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */; };
 		F55BC38F95450A1FE40124B0 /* AppUpdaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E8635D102B895AF349A13D /* AppUpdaterView.swift */; };
+		F6161C632AB8AA90DD7B9A36 /* UpdateProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3508580ADD1F5DD0DB60EE01 /* UpdateProbe.swift */; };
 		F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */; };
 		F7CA4D7A9B843507613DEEBE /* BundledClamAVRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282664DFAA58CB5A5C87FFE /* BundledClamAVRuntime.swift */; };
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
@@ -377,6 +379,7 @@
 		31C569D24F96C56C9F198BCC /* AppUninstallerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelTests.swift; sourceTree = "<group>"; };
 		32BF07D3C75C31A0EA7E9037 /* MacHealthStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacHealthStatus.swift; sourceTree = "<group>"; };
 		33EC67B639248BC5EA1F5473 /* ScanCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategory.swift; sourceTree = "<group>"; };
+		3508580ADD1F5DD0DB60EE01 /* UpdateProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProbe.swift; sourceTree = "<group>"; };
 		3631D872F6AA2F98BA133922 /* SpaceLensViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewMode.swift; sourceTree = "<group>"; };
 		3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscHostView.swift; sourceTree = "<group>"; };
 		36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = com.personal.VaderCleaner.helper.plist; sourceTree = "<group>"; };
@@ -539,6 +542,7 @@
 		CAC2037BDF5D632418393BD9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		CC13455C35AFED113F2D85DE /* MaintenanceTaskRunners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTaskRunners.swift; sourceTree = "<group>"; };
 		CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVOutputParserTests.swift; sourceTree = "<group>"; };
+		CE71FA16E4B413D837F097E2 /* UpdateProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProbeTests.swift; sourceTree = "<group>"; };
 		CEAF96E747AD4C1378B4043D /* VersionComparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparator.swift; sourceTree = "<group>"; };
 		CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateChecker.swift; sourceTree = "<group>"; };
 		CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModelTests.swift; sourceTree = "<group>"; };
@@ -788,6 +792,7 @@
 				EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */,
 				9C1D85C87621345FBF7CDC41 /* UnusedAppScanner.swift */,
 				2617BC26104D5196DEDB3589 /* UpdateInfo.swift */,
+				3508580ADD1F5DD0DB60EE01 /* UpdateProbe.swift */,
 				9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */,
 				FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */,
 				A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */,
@@ -945,6 +950,7 @@
 				1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */,
 				382745ACB652CA50CA393BD5 /* UnusedAppScannerTests.swift */,
 				B46943B264F72B3753075A8C /* UpdateInfoTests.swift */,
+				CE71FA16E4B413D837F097E2 /* UpdateProbeTests.swift */,
 				1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */,
 				E149BD1FE4E65D6589292B84 /* Helpers */,
 			);
@@ -1243,6 +1249,7 @@
 				F4BF8822B044CE3445A144E7 /* UnsupportedAppScannerTests.swift in Sources */,
 				48EF0257049EE6954E00E936 /* UnusedAppScannerTests.swift in Sources */,
 				218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */,
+				D911FAA1B6067442C5D36F11 /* UpdateProbeTests.swift in Sources */,
 				3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1419,6 +1426,7 @@
 				6D2476F58F6EDCF6C12C844D /* UnusedApp.swift in Sources */,
 				EF0D76FCD2FBEB20D8C9E7FA /* UnusedAppScanner.swift in Sources */,
 				7CE637E8DEECA40F849AF39F /* UpdateInfo.swift in Sources */,
+				F6161C632AB8AA90DD7B9A36 /* UpdateProbe.swift in Sources */,
 				6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */,
 				BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */,
 				A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */,

--- a/VaderCleaner/AppUpdaterViewModel.swift
+++ b/VaderCleaner/AppUpdaterViewModel.swift
@@ -6,28 +6,6 @@ import Foundation
 import Observation
 import os.log
 
-/// Outcome of a single update-feed lookup. `.unreachable` is the
-/// signal Prompt 20's swallow contract was missing: it lets the
-/// view-model tell "this feed was down" apart from "this app has no
-/// update", so a genuinely offline check can surface the network copy
-/// while a single dead feed still never blanks the whole list. Generic
-/// over the payload so the App Store and Sparkle channels share one
-/// shape instead of near-identical enums.
-///
-/// `.noResult` means a network round-trip completed but carried nothing
-/// actionable (no MAS entry, nothing newer, or a swallowed non-network
-/// failure) — proof the network is up. `.skipped` means no request was
-/// ever made (e.g. the app carries no `SUFeedURL`), so it must stay
-/// neutral in the offline decision: counting a skipped app as "reached"
-/// would mask a genuinely offline machine the moment one non-updatable
-/// app is installed — which is essentially always.
-enum CheckResult<Payload: Sendable>: Sendable {
-    case found(Payload)
-    case noResult
-    case unreachable
-    case skipped
-}
-
 /// Drives the App Updater feature view (check → ready → update).
 ///
 /// All collaborators are injected as closures so unit tests can drive
@@ -88,47 +66,15 @@ final class AppUpdaterViewModel {
         phase = .checking
         do {
             let apps = try await discover(false)
-            // Bind to locals so the captured values in the TaskGroup
-            // don't accidentally reach back into the actor — closures
-            // are already `@Sendable`, but keeping the capture explicit
-            // makes the data flow obvious.
-            let appStoreCheck = self.checkAppStore
-            let sparkleCheck = self.checkSparkle
-            let outcomes = await withTaskGroup(of: AppCheckOutcome.self) { group -> [AppCheckOutcome] in
-                // Bounded concurrency: a machine with hundreds of installed
-                // apps would otherwise fire hundreds of simultaneous HTTPS
-                // requests at the iTunes Search API and assorted Sparkle
-                // feeds, inviting rate limiting. A sliding window keeps the
-                // checks parallel but caps in-flight work.
-                var nextIndex = 0
-                while nextIndex < apps.count, nextIndex < Self.maxConcurrentChecks {
-                    let app = apps[nextIndex]
-                    group.addTask {
-                        await Self.checkUpdate(
-                            app: app,
-                            appStoreCheck: appStoreCheck,
-                            sparkleCheck: sparkleCheck
-                        )
-                    }
-                    nextIndex += 1
-                }
-                var results: [AppCheckOutcome] = []
-                while let outcome = await group.next() {
-                    results.append(outcome)
-                    if nextIndex < apps.count {
-                        let app = apps[nextIndex]
-                        group.addTask {
-                            await Self.checkUpdate(
-                                app: app,
-                                appStoreCheck: appStoreCheck,
-                                sparkleCheck: sparkleCheck
-                            )
-                        }
-                        nextIndex += 1
-                    }
-                }
-                return results
-            }
+            // The bounded-concurrency fan-out and per-app channel routing
+            // live in `UpdateProbe`, shared with the Applications dashboard
+            // and Smart Scan so all three surfaces produce identical update
+            // lists.
+            let probe = UpdateProbe(
+                checkAppStore: checkAppStore,
+                checkSparkle: checkSparkle
+            )
+            let outcomes = await probe.outcomes(for: apps)
             guard self.checkGeneration == generation else { return }
 
             var updates: [UpdateInfo] = []
@@ -197,105 +143,9 @@ final class AppUpdaterViewModel {
 
     // MARK: - Private
 
-    /// Maximum number of update checks (HTTPS requests) in flight at once.
-    /// Sized to keep the scan responsive without stampeding the iTunes
-    /// Search API / Sparkle hosts on machines with many installed apps.
-    private static let maxConcurrentChecks = 6
-
     private func beginCheck() -> Int {
         checkGeneration += 1
         return checkGeneration
-    }
-
-    /// Per-app result after version comparison. `.noUpdate` means the
-    /// feed was reached but there is nothing newer to offer (including a
-    /// swallowed non-network failure — the server answered, so the
-    /// network is fine). `.unreachable` means the feed could not be
-    /// reached at all. `.skipped` means no request was attempted (no
-    /// feed configured). The aggregator in `checkForUpdates()` uses the
-    /// reachable/unreachable split to tell "up to date" from "offline",
-    /// and keeps `.skipped` out of that split entirely.
-    private enum AppCheckOutcome {
-        case update(UpdateInfo)
-        case noUpdate
-        case unreachable
-        case skipped
-    }
-
-    /// Dispatches a single app to the correct update channel. Factored
-    /// out of `checkForUpdates()` so the bounded-concurrency window can
-    /// schedule the same task body in two places without duplication.
-    private static func checkUpdate(
-        app: AppInfo,
-        appStoreCheck: CheckAppStore,
-        sparkleCheck: CheckSparkle
-    ) async -> AppCheckOutcome {
-        if app.isAppStore {
-            return await checkAppStoreUpdate(app: app, check: appStoreCheck)
-        } else {
-            return await checkSparkleUpdate(app: app, check: sparkleCheck)
-        }
-    }
-
-    /// Runs the App Store lookup and folds the result into an
-    /// `UpdateInfo` if (and only if) the remote version is newer than
-    /// the installed one. An unreachable feed reports `.unreachable` so
-    /// the aggregator can distinguish offline from up-to-date; one slow
-    /// checker still must not blank the whole update list.
-    private static func checkAppStoreUpdate(
-        app: AppInfo,
-        check: CheckAppStore
-    ) async -> AppCheckOutcome {
-        switch await check(app.bundleID) {
-        case .unreachable:
-            return .unreachable
-        case .noResult:
-            return .noUpdate
-        case .skipped:
-            return .skipped
-        case .found(let lookup):
-            let installed = app.version ?? "0"
-            guard VersionComparator.isNewer(version: lookup.version, than: installed) else {
-                return .noUpdate
-            }
-            return .update(UpdateInfo(
-                appName: app.name,
-                bundleID: app.bundleID,
-                bundleURL: app.bundleURL,
-                installedVersion: installed,
-                latestVersion: lookup.version,
-                source: .appStore,
-                updateURL: lookup.appStoreURL
-            ))
-        }
-    }
-
-    private static func checkSparkleUpdate(
-        app: AppInfo,
-        check: CheckSparkle
-    ) async -> AppCheckOutcome {
-        switch await check(app) {
-        case .unreachable:
-            return .unreachable
-        case .noResult:
-            return .noUpdate
-        case .skipped:
-            return .skipped
-        case .found(let item):
-            let installed = app.version ?? "0"
-            guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else {
-                return .noUpdate
-            }
-            return .update(UpdateInfo(
-                appName: app.name,
-                bundleID: app.bundleID,
-                bundleURL: app.bundleURL,
-                installedVersion: installed,
-                latestVersion: item.shortVersion,
-                source: .sparkle,
-                updateURL: item.downloadURL
-            ))
-        }
     }
 }
 
@@ -304,43 +154,17 @@ final class AppUpdaterViewModel {
 extension AppUpdaterViewModel {
 
     /// Build a view-model wired to the real `DefaultAppDiscovery`,
-    /// `DefaultAppStoreUpdateChecker`, `DefaultSparkleUpdateChecker`, and
+    /// `UpdateProbe`'s live App Store / Sparkle checkers, and
     /// `NSWorkspace.open`.
     @MainActor
     static func live() -> AppUpdaterViewModel {
         let discovery = DefaultAppDiscovery()
-        let appStore = DefaultAppStoreUpdateChecker()
-        let sparkle = DefaultSparkleUpdateChecker()
         return AppUpdaterViewModel(
             discover: { includingSystemApps in
                 try await discovery.installedApps(includingSystemApps: includingSystemApps)
             },
-            checkAppStore: { bundleID in
-                do {
-                    if let lookup = try await appStore.latestVersion(forBundleID: bundleID) {
-                        return .found(lookup)
-                    }
-                    return .noResult
-                } catch {
-                    // Re-surface only loss of connectivity. Every other
-                    // failure (a decode error, a malformed response)
-                    // stays swallowed as `.noResult` so one bad app can
-                    // never blank the list — Prompt 20's partial-
-                    // degradation contract is preserved, not reversed.
-                    return AppUpdaterError.isNetworkError(error) ? .unreachable : .noResult
-                }
-            },
-            checkSparkle: { app in
-                guard let feedURL = sparkle.feedURL(for: app) else { return .skipped }
-                do {
-                    if let item = try await sparkle.fetchAppcast(feedURL: feedURL) {
-                        return .found(item)
-                    }
-                    return .noResult
-                } catch {
-                    return AppUpdaterError.isNetworkError(error) ? .unreachable : .noResult
-                }
-            },
+            checkAppStore: UpdateProbe.liveAppStoreCheck(),
+            checkSparkle: UpdateProbe.liveSparkleCheck(),
             opener: { url in
                 await MainActor.run {
                     _ = NSWorkspace.shared.open(url)

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -480,15 +480,14 @@ final class ApplicationsViewModel {
 
 extension ApplicationsViewModel {
 
-    /// Builds a view-model wired to the real `DefaultAppDiscovery` and the App
-    /// Store / Sparkle update checkers — the same collaborators
-    /// `AppUpdaterViewModel.live` uses, so the dashboard's update count matches
-    /// the updater list it opens.
+    /// Builds a view-model wired to the real `DefaultAppDiscovery` and
+    /// `UpdateProbe.live()` — the same collaborators `AppUpdaterViewModel.live`
+    /// uses, so the dashboard's update count matches the updater list it
+    /// opens.
     @MainActor
     static func live() -> ApplicationsViewModel {
         let discovery = DefaultAppDiscovery()
-        let appStore = DefaultAppStoreUpdateChecker()
-        let sparkle = DefaultSparkleUpdateChecker()
+        let probe = UpdateProbe.live()
         let installerScanner = DefaultInstallationFileScanner()
         let unsupportedScanner = DefaultUnsupportedAppScanner()
         let unusedScanner = DefaultUnusedAppScanner()
@@ -500,7 +499,7 @@ extension ApplicationsViewModel {
                 try await discovery.installedApps(includingSystemApps: false)
             },
             checkUpdates: { apps in
-                await Self.fetchUpdates(for: apps, appStore: appStore, sparkle: sparkle, log: log)
+                await probe.availableUpdates(for: apps)
             },
             scanInstallationFiles: {
                 await installerScanner.scan()
@@ -538,88 +537,6 @@ extension ApplicationsViewModel {
         }
     }
 
-    /// Bounded-concurrency (≤6 in-flight HTTPS requests) discover-and-probe
-    /// loop over already-discovered apps. Mirrors
-    /// `AppUpdaterViewModel.checkForUpdates`'s sliding window so a heavily-
-    /// installed machine never stampedes the iTunes Search API or assorted
-    /// Sparkle hosts. Marked `nonisolated` so the HTTP fan-out runs off the
-    /// main actor instead of serializing on the UI thread.
-    nonisolated private static func fetchUpdates(
-        for apps: [AppInfo],
-        appStore: DefaultAppStoreUpdateChecker,
-        sparkle: DefaultSparkleUpdateChecker,
-        log: Logger
-    ) async -> [UpdateInfo] {
-        let updates = await withTaskGroup(of: UpdateInfo?.self) { group -> [UpdateInfo] in
-            var nextIndex = 0
-            let maxInFlight = 6
-            while nextIndex < apps.count, nextIndex < maxInFlight {
-                let app = apps[nextIndex]
-                group.addTask {
-                    await Self.checkUpdate(for: app, appStore: appStore, sparkle: sparkle)
-                }
-                nextIndex += 1
-            }
-            var results: [UpdateInfo] = []
-            while let result = await group.next() {
-                if let info = result { results.append(info) }
-                if nextIndex < apps.count {
-                    let app = apps[nextIndex]
-                    group.addTask {
-                        await Self.checkUpdate(for: app, appStore: appStore, sparkle: sparkle)
-                    }
-                    nextIndex += 1
-                }
-            }
-            return results
-        }
-        return updates.sorted {
-            $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
-        }
-    }
-
-    /// Routes a single installed app to its update channel and returns an
-    /// `UpdateInfo` only when the remote version is strictly newer. Every
-    /// failure — network, decode, missing feed — is swallowed to `nil` so one
-    /// bad app can never blank the whole list.
-    nonisolated private static func checkUpdate(
-        for app: AppInfo,
-        appStore: DefaultAppStoreUpdateChecker,
-        sparkle: DefaultSparkleUpdateChecker
-    ) async -> UpdateInfo? {
-        if app.isAppStore {
-            guard let lookup = (try? await appStore.latestVersion(forBundleID: app.bundleID)) ?? nil else {
-                return nil
-            }
-            let installed = app.version ?? "0"
-            guard VersionComparator.isNewer(version: lookup.version, than: installed) else { return nil }
-            return UpdateInfo(
-                appName: app.name,
-                bundleID: app.bundleID,
-                bundleURL: app.bundleURL,
-                installedVersion: installed,
-                latestVersion: lookup.version,
-                source: .appStore,
-                updateURL: lookup.appStoreURL
-            )
-        } else {
-            guard let feedURL = sparkle.feedURL(for: app) else { return nil }
-            guard let item = (try? await sparkle.fetchAppcast(feedURL: feedURL)) ?? nil else {
-                return nil
-            }
-            let installed = app.version ?? "0"
-            guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else { return nil }
-            return UpdateInfo(
-                appName: app.name,
-                bundleID: app.bundleID,
-                bundleURL: app.bundleURL,
-                installedVersion: installed,
-                latestVersion: item.shortVersion,
-                source: .sparkle,
-                updateURL: item.downloadURL
-            )
-        }
-    }
 }
 
 // MARK: - ScanCoordinating

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -722,9 +722,9 @@ extension SmartScanViewModel {
             // App Updater wiring: discover installed apps, then fan out
             // per-app version probes against the App Store and Sparkle
             // channels. The underlying collaborators (`DefaultAppDiscovery`,
-            // `DefaultAppStoreUpdateChecker`, `DefaultSparkleUpdateChecker`)
-            // are the same ones `AppUpdaterViewModel.live` uses, so the
-            // two surfaces produce identical update lists.
+            // `UpdateProbe.live()`) are the same ones
+            // `AppUpdaterViewModel.live` uses, so the two surfaces produce
+            // identical update lists.
             updatesChecker: { await Self.fetchAvailableUpdates(log: log) },
             junkCleaner: { try await SystemJunkDeleter().delete($0) },
             threatRemover: { await remover.remove($0) },
@@ -756,93 +756,22 @@ extension SmartScanViewModel {
         )
     }
 
-    /// Discover-and-probe loop for the Applications tile. Mirrors
-    /// `AppUpdaterViewModel.checkForUpdates`'s bounded-concurrency window
-    /// (≤6 in-flight HTTPS requests) so a heavily-installed machine never
-    /// stampedes the iTunes Search API or assorted Sparkle hosts during
-    /// Smart Scan. Marked `nonisolated` so the HTTP fan-out runs off the
-    /// main actor — without this annotation the static would inherit
-    /// `@MainActor` from the class extension and serialize on the UI
-    /// thread, freezing every per-app hop on the scan's progress label.
+    /// Discover-and-probe loop for the Applications tile. Delegates the
+    /// bounded-concurrency fan-out (≤6 in-flight HTTPS requests) to
+    /// `UpdateProbe` so a heavily-installed machine never stampedes the
+    /// iTunes Search API or assorted Sparkle hosts during Smart Scan.
+    /// Marked `nonisolated` so the HTTP fan-out runs off the main actor —
+    /// without this annotation the static would inherit `@MainActor` from
+    /// the class extension and serialize on the UI thread, freezing every
+    /// per-app hop on the scan's progress label.
     nonisolated private static func fetchAvailableUpdates(log: Logger) async -> [UpdateInfo] {
         let discovery = DefaultAppDiscovery()
-        let appStore = DefaultAppStoreUpdateChecker()
-        let sparkle = DefaultSparkleUpdateChecker()
         do {
             let apps = try await discovery.installedApps(includingSystemApps: false)
-            let updates = await withTaskGroup(of: UpdateInfo?.self) { group -> [UpdateInfo] in
-                var nextIndex = 0
-                let maxInFlight = 6
-                while nextIndex < apps.count, nextIndex < maxInFlight {
-                    let app = apps[nextIndex]
-                    group.addTask {
-                        await Self.checkUpdate(for: app, appStore: appStore, sparkle: sparkle)
-                    }
-                    nextIndex += 1
-                }
-                var results: [UpdateInfo] = []
-                while let result = await group.next() {
-                    if let info = result { results.append(info) }
-                    if nextIndex < apps.count {
-                        let app = apps[nextIndex]
-                        group.addTask {
-                            await Self.checkUpdate(for: app, appStore: appStore, sparkle: sparkle)
-                        }
-                        nextIndex += 1
-                    }
-                }
-                return results
-            }
-            return updates.sorted {
-                $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
-            }
+            return await UpdateProbe.live().availableUpdates(for: apps)
         } catch {
             log.error("Smart Scan updates check failed: \(String(describing: error), privacy: .public)")
             return []
-        }
-    }
-
-    /// Routes a single installed app to its update channel and returns an
-    /// `UpdateInfo` only when the remote version is strictly newer. Every
-    /// failure — network, decode, missing feed — is swallowed to `nil` so
-    /// one bad app can never blank the whole list. Nonisolated for the
-    /// same reason as `fetchAvailableUpdates`.
-    nonisolated private static func checkUpdate(
-        for app: AppInfo,
-        appStore: DefaultAppStoreUpdateChecker,
-        sparkle: DefaultSparkleUpdateChecker
-    ) async -> UpdateInfo? {
-        if app.isAppStore {
-            guard let lookup = (try? await appStore.latestVersion(forBundleID: app.bundleID)) ?? nil else {
-                return nil
-            }
-            let installed = app.version ?? "0"
-            guard VersionComparator.isNewer(version: lookup.version, than: installed) else { return nil }
-            return UpdateInfo(
-                appName: app.name,
-                bundleID: app.bundleID,
-                bundleURL: app.bundleURL,
-                installedVersion: installed,
-                latestVersion: lookup.version,
-                source: .appStore,
-                updateURL: lookup.appStoreURL
-            )
-        } else {
-            guard let feedURL = sparkle.feedURL(for: app) else { return nil }
-            guard let item = (try? await sparkle.fetchAppcast(feedURL: feedURL)) ?? nil else {
-                return nil
-            }
-            let installed = app.version ?? "0"
-            guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else { return nil }
-            return UpdateInfo(
-                appName: app.name,
-                bundleID: app.bundleID,
-                bundleURL: app.bundleURL,
-                installedVersion: installed,
-                latestVersion: item.shortVersion,
-                source: .sparkle,
-                updateURL: item.downloadURL
-            )
         }
     }
 

--- a/VaderCleaner/UpdateProbe.swift
+++ b/VaderCleaner/UpdateProbe.swift
@@ -1,0 +1,264 @@
+// UpdateProbe.swift
+// Shared update-check pipeline — routes each installed app to its App Store or Sparkle channel, compares versions, and fans the per-app probes out with bounded concurrency. Used by the App Updater, the Applications dashboard, and Smart Scan so all three surfaces produce identical update lists.
+
+import Foundation
+
+/// Outcome of a single update-feed lookup. `.unreachable` is the
+/// signal Prompt 20's swallow contract was missing: it lets the
+/// view-model tell "this feed was down" apart from "this app has no
+/// update", so a genuinely offline check can surface the network copy
+/// while a single dead feed still never blanks the whole list. Generic
+/// over the payload so the App Store and Sparkle channels share one
+/// shape instead of near-identical enums.
+///
+/// `.noResult` means a network round-trip completed but carried nothing
+/// actionable (no MAS entry, nothing newer, or a swallowed non-network
+/// failure) — proof the network is up. `.skipped` means no request was
+/// ever made (e.g. the app carries no `SUFeedURL`), so it must stay
+/// neutral in the offline decision: counting a skipped app as "reached"
+/// would mask a genuinely offline machine the moment one non-updatable
+/// app is installed — which is essentially always.
+enum CheckResult<Payload: Sendable>: Sendable {
+    case found(Payload)
+    case noResult
+    case unreachable
+    case skipped
+}
+
+/// Per-app result after version comparison. `.noUpdate` means the
+/// feed was reached but there is nothing newer to offer (including a
+/// swallowed non-network failure — the server answered, so the
+/// network is fine). `.unreachable` means the feed could not be
+/// reached at all. `.skipped` means no request was attempted (no
+/// feed configured). `AppUpdaterViewModel` uses the
+/// reachable/unreachable split to tell "up to date" from "offline",
+/// and keeps `.skipped` out of that split entirely.
+enum UpdateProbeOutcome: Sendable {
+    case update(UpdateInfo)
+    case noUpdate
+    case unreachable
+    case skipped
+}
+
+/// Probes installed apps for available updates. Each app is dispatched
+/// to exactly one channel — the App Store lookup when the bundle carries
+/// a MAS receipt, the Sparkle appcast otherwise — and a remote version is
+/// folded into an `UpdateInfo` only when it is strictly newer than the
+/// installed one.
+///
+/// Checkers are injected as closures so unit tests can drive every
+/// outcome without touching the network. Production wiring lives in
+/// `UpdateProbe.live()`.
+struct UpdateProbe: Sendable {
+
+    typealias CheckAppStore = @Sendable (_ bundleID: String) async -> CheckResult<AppStoreLookup>
+    typealias CheckSparkle  = @Sendable (_ app: AppInfo) async -> CheckResult<SparkleAppcastItem>
+
+    /// Maximum number of update checks (HTTPS requests) in flight at once.
+    /// Sized to keep the scan responsive without stampeding the iTunes
+    /// Search API / Sparkle hosts on machines with many installed apps.
+    static let maxConcurrentChecks = 6
+
+    private let checkAppStore: CheckAppStore
+    private let checkSparkle: CheckSparkle
+
+    init(
+        checkAppStore: @escaping CheckAppStore,
+        checkSparkle: @escaping CheckSparkle
+    ) {
+        self.checkAppStore = checkAppStore
+        self.checkSparkle = checkSparkle
+    }
+
+    /// Probes every app and returns one outcome per app, in completion
+    /// order. Bounded concurrency: a machine with hundreds of installed
+    /// apps would otherwise fire hundreds of simultaneous HTTPS requests
+    /// at the iTunes Search API and assorted Sparkle feeds, inviting rate
+    /// limiting. A sliding window keeps the checks parallel but caps
+    /// in-flight work at `maxConcurrentChecks`.
+    func outcomes(for apps: [AppInfo]) async -> [UpdateProbeOutcome] {
+        let appStoreCheck = checkAppStore
+        let sparkleCheck = checkSparkle
+        return await withTaskGroup(of: UpdateProbeOutcome.self) { group -> [UpdateProbeOutcome] in
+            var nextIndex = 0
+            while nextIndex < apps.count, nextIndex < Self.maxConcurrentChecks {
+                let app = apps[nextIndex]
+                group.addTask {
+                    await Self.checkUpdate(
+                        app: app,
+                        appStoreCheck: appStoreCheck,
+                        sparkleCheck: sparkleCheck
+                    )
+                }
+                nextIndex += 1
+            }
+            var results: [UpdateProbeOutcome] = []
+            while let outcome = await group.next() {
+                results.append(outcome)
+                if nextIndex < apps.count {
+                    let app = apps[nextIndex]
+                    group.addTask {
+                        await Self.checkUpdate(
+                            app: app,
+                            appStoreCheck: appStoreCheck,
+                            sparkleCheck: sparkleCheck
+                        )
+                    }
+                    nextIndex += 1
+                }
+            }
+            return results
+        }
+    }
+
+    /// Convenience for surfaces that only need the update list (the
+    /// Applications dashboard, Smart Scan): probes every app and returns
+    /// just the available updates.
+    func availableUpdates(for apps: [AppInfo]) async -> [UpdateInfo] {
+        Self.updates(in: await outcomes(for: apps))
+    }
+
+    /// Extracts the `.update` payloads, sorted case-insensitively by app
+    /// name so the list order is deterministic between successive checks.
+    static func updates(in outcomes: [UpdateProbeOutcome]) -> [UpdateInfo] {
+        let updates = outcomes.compactMap { outcome -> UpdateInfo? in
+            guard case .update(let info) = outcome else { return nil }
+            return info
+        }
+        return updates.sorted {
+            $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
+        }
+    }
+
+    // MARK: - Per-app channel dispatch
+
+    /// Dispatches a single app to the correct update channel. The two
+    /// channels are independent — a Sparkle-bundled app uploaded later to
+    /// the Mac App Store would appear in `isAppStore`, so the dispatch is
+    /// exclusive.
+    private static func checkUpdate(
+        app: AppInfo,
+        appStoreCheck: CheckAppStore,
+        sparkleCheck: CheckSparkle
+    ) async -> UpdateProbeOutcome {
+        if app.isAppStore {
+            return await checkAppStoreUpdate(app: app, check: appStoreCheck)
+        } else {
+            return await checkSparkleUpdate(app: app, check: sparkleCheck)
+        }
+    }
+
+    /// Runs the App Store lookup and folds the result into an
+    /// `UpdateInfo` if (and only if) the remote version is newer than
+    /// the installed one. An unreachable feed reports `.unreachable` so
+    /// an aggregator can distinguish offline from up-to-date; one slow
+    /// checker still must not blank the whole update list.
+    private static func checkAppStoreUpdate(
+        app: AppInfo,
+        check: CheckAppStore
+    ) async -> UpdateProbeOutcome {
+        switch await check(app.bundleID) {
+        case .unreachable:
+            return .unreachable
+        case .noResult:
+            return .noUpdate
+        case .skipped:
+            return .skipped
+        case .found(let lookup):
+            let installed = app.version ?? "0"
+            guard VersionComparator.isNewer(version: lookup.version, than: installed) else {
+                return .noUpdate
+            }
+            return .update(UpdateInfo(
+                appName: app.name,
+                bundleID: app.bundleID,
+                bundleURL: app.bundleURL,
+                installedVersion: installed,
+                latestVersion: lookup.version,
+                source: .appStore,
+                updateURL: lookup.appStoreURL
+            ))
+        }
+    }
+
+    private static func checkSparkleUpdate(
+        app: AppInfo,
+        check: CheckSparkle
+    ) async -> UpdateProbeOutcome {
+        switch await check(app) {
+        case .unreachable:
+            return .unreachable
+        case .noResult:
+            return .noUpdate
+        case .skipped:
+            return .skipped
+        case .found(let item):
+            let installed = app.version ?? "0"
+            guard VersionComparator.isNewer(version: item.shortVersion, than: installed) else {
+                return .noUpdate
+            }
+            return .update(UpdateInfo(
+                appName: app.name,
+                bundleID: app.bundleID,
+                bundleURL: app.bundleURL,
+                installedVersion: installed,
+                latestVersion: item.shortVersion,
+                source: .sparkle,
+                updateURL: item.downloadURL
+            ))
+        }
+    }
+}
+
+// MARK: - Production wiring
+
+extension UpdateProbe {
+
+    /// Probe wired to the real `DefaultAppStoreUpdateChecker` and
+    /// `DefaultSparkleUpdateChecker`.
+    static func live() -> UpdateProbe {
+        UpdateProbe(
+            checkAppStore: liveAppStoreCheck(),
+            checkSparkle: liveSparkleCheck()
+        )
+    }
+
+    /// Live App Store checker. Re-surfaces only loss of connectivity.
+    /// Every other failure (a decode error, a malformed response) stays
+    /// swallowed as `.noResult` so one bad app can never blank the list —
+    /// Prompt 20's partial-degradation contract is preserved, not
+    /// reversed.
+    static func liveAppStoreCheck(
+        appStore: DefaultAppStoreUpdateChecker = DefaultAppStoreUpdateChecker()
+    ) -> CheckAppStore {
+        { bundleID in
+            do {
+                if let lookup = try await appStore.latestVersion(forBundleID: bundleID) {
+                    return .found(lookup)
+                }
+                return .noResult
+            } catch {
+                return AppUpdaterError.isNetworkError(error) ? .unreachable : .noResult
+            }
+        }
+    }
+
+    /// Live Sparkle checker. Apps without an `SUFeedURL` are `.skipped`
+    /// (no request is made); failures follow the same network/non-network
+    /// split as the App Store checker.
+    static func liveSparkleCheck(
+        sparkle: DefaultSparkleUpdateChecker = DefaultSparkleUpdateChecker()
+    ) -> CheckSparkle {
+        { app in
+            guard let feedURL = sparkle.feedURL(for: app) else { return .skipped }
+            do {
+                if let item = try await sparkle.fetchAppcast(feedURL: feedURL) {
+                    return .found(item)
+                }
+                return .noResult
+            } catch {
+                return AppUpdaterError.isNetworkError(error) ? .unreachable : .noResult
+            }
+        }
+    }
+}

--- a/VaderCleanerTests/UpdateProbeTests.swift
+++ b/VaderCleanerTests/UpdateProbeTests.swift
@@ -1,0 +1,302 @@
+// UpdateProbeTests.swift
+// Exercises the shared UpdateProbe pipeline — per-app channel routing, version comparison, UpdateInfo construction, outcome mapping, sorted update extraction, and the bounded-concurrency fan-out — using injected checker closures so no network is touched.
+
+import XCTest
+@testable import VaderCleaner
+
+final class UpdateProbeTests: XCTestCase {
+
+    // MARK: - Channel routing
+
+    /// App Store apps go to the App Store checker, Sparkle apps to the
+    /// Sparkle checker — the dispatch is exclusive, never both.
+    func test_outcomes_routesEachAppToExactlyOneChannel() async {
+        let masApp = makeApp(name: "Helio", bundleID: "com.acme.helio", isAppStore: true)
+        let sparkleApp = makeApp(name: "Mango", bundleID: "com.acme.mango", isAppStore: false)
+
+        let appStoreIDs = ActorBox<[String]>([])
+        let sparkleIDs = ActorBox<[String]>([])
+        let probe = UpdateProbe(
+            checkAppStore: { bundleID in
+                await appStoreIDs.append(bundleID)
+                return .noResult
+            },
+            checkSparkle: { app in
+                await sparkleIDs.append(app.bundleID)
+                return .noResult
+            }
+        )
+
+        _ = await probe.outcomes(for: [masApp, sparkleApp])
+
+        let masCalls = await appStoreIDs.value
+        let sparkleCalls = await sparkleIDs.value
+        XCTAssertEqual(masCalls, ["com.acme.helio"])
+        XCTAssertEqual(sparkleCalls, ["com.acme.mango"])
+    }
+
+    // MARK: - App Store outcomes
+
+    /// A newer remote version folds into `.update` carrying a fully
+    /// populated `UpdateInfo` for the App Store channel.
+    func test_outcomes_appStoreNewerVersionYieldsUpdate() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio",
+                          version: "1.0.0", isAppStore: true)
+        let storeURL = URL(string: "https://apps.apple.com/app/id123")!
+        let probe = UpdateProbe(
+            checkAppStore: { _ in .found(AppStoreLookup(version: "2.0.0", appStoreURL: storeURL)) },
+            checkSparkle: { _ in .skipped }
+        )
+
+        let outcomes = await probe.outcomes(for: [app])
+
+        guard case .update(let info)? = outcomes.first else {
+            return XCTFail("Expected .update, got \(outcomes)")
+        }
+        XCTAssertEqual(info.appName, "Helio")
+        XCTAssertEqual(info.bundleID, "com.acme.helio")
+        XCTAssertEqual(info.bundleURL, app.bundleURL)
+        XCTAssertEqual(info.installedVersion, "1.0.0")
+        XCTAssertEqual(info.latestVersion, "2.0.0")
+        XCTAssertEqual(info.source, .appStore)
+        XCTAssertEqual(info.updateURL, storeURL)
+    }
+
+    /// Remote version equal to (or older than) the installed one maps to
+    /// `.noUpdate` so up-to-date apps never surface as update rows.
+    func test_outcomes_appStoreEqualOrOlderVersionYieldsNoUpdate() async {
+        for remote in ["1.0.0", "0.9.0"] {
+            let app = makeApp(name: "Helio", bundleID: "com.acme.helio",
+                              version: "1.0.0", isAppStore: true)
+            let probe = UpdateProbe(
+                checkAppStore: { _ in
+                    .found(AppStoreLookup(
+                        version: remote,
+                        appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
+                    ))
+                },
+                checkSparkle: { _ in .skipped }
+            )
+            let outcomes = await probe.outcomes(for: [app])
+            guard case .noUpdate? = outcomes.first else {
+                return XCTFail("Expected .noUpdate for remote \(remote), got \(outcomes)")
+            }
+        }
+    }
+
+    /// A nil installed version is treated as "0" so any real remote
+    /// version counts as newer.
+    func test_outcomes_nilInstalledVersionTreatedAsZero() async {
+        let app = makeApp(name: "Helio", bundleID: "com.acme.helio",
+                          version: nil, isAppStore: true)
+        let probe = UpdateProbe(
+            checkAppStore: { _ in
+                .found(AppStoreLookup(
+                    version: "1.0.0",
+                    appStoreURL: URL(string: "https://apps.apple.com/app/id1")!
+                ))
+            },
+            checkSparkle: { _ in .skipped }
+        )
+        let outcomes = await probe.outcomes(for: [app])
+        guard case .update(let info)? = outcomes.first else {
+            return XCTFail("Expected .update, got \(outcomes)")
+        }
+        XCTAssertEqual(info.installedVersion, "0")
+    }
+
+    /// `CheckResult` cases that carry no usable payload pass through to the
+    /// matching outcome for the App Store channel.
+    func test_outcomes_appStoreNoResultUnreachableSkippedPassThrough() async {
+        let cases: [(CheckResult<AppStoreLookup>, String)] = [
+            (.noResult, "noUpdate"),
+            (.unreachable, "unreachable"),
+            (.skipped, "skipped"),
+        ]
+        for (result, expected) in cases {
+            let app = makeApp(name: "Helio", bundleID: "com.acme.helio", isAppStore: true)
+            let probe = UpdateProbe(
+                checkAppStore: { _ in result },
+                checkSparkle: { _ in .skipped }
+            )
+            let outcomes = await probe.outcomes(for: [app])
+            XCTAssertEqual(outcomes.count, 1)
+            switch (outcomes[0], expected) {
+            case (.noUpdate, "noUpdate"), (.unreachable, "unreachable"), (.skipped, "skipped"):
+                break
+            default:
+                XCTFail("Expected \(expected), got \(outcomes[0])")
+            }
+        }
+    }
+
+    // MARK: - Sparkle outcomes
+
+    /// A newer appcast item folds into `.update` carrying a fully populated
+    /// `UpdateInfo` for the Sparkle channel.
+    func test_outcomes_sparkleNewerVersionYieldsUpdate() async {
+        let app = makeApp(name: "Mango", bundleID: "com.acme.mango",
+                          version: "1.0.0", isAppStore: false)
+        let downloadURL = URL(string: "https://example.com/mango-2.dmg")!
+        let probe = UpdateProbe(
+            checkAppStore: { _ in .skipped },
+            checkSparkle: { _ in
+                .found(SparkleAppcastItem(
+                    shortVersion: "2.0.0",
+                    version: "2000",
+                    downloadURL: downloadURL
+                ))
+            }
+        )
+
+        let outcomes = await probe.outcomes(for: [app])
+
+        guard case .update(let info)? = outcomes.first else {
+            return XCTFail("Expected .update, got \(outcomes)")
+        }
+        XCTAssertEqual(info.appName, "Mango")
+        XCTAssertEqual(info.installedVersion, "1.0.0")
+        XCTAssertEqual(info.latestVersion, "2.0.0")
+        XCTAssertEqual(info.source, .sparkle)
+        XCTAssertEqual(info.updateURL, downloadURL)
+    }
+
+    /// An up-to-date Sparkle app maps to `.noUpdate`, and the no-payload
+    /// `CheckResult` cases pass through for the Sparkle channel too.
+    func test_outcomes_sparkleNoResultUnreachableSkippedPassThrough() async {
+        let cases: [(CheckResult<SparkleAppcastItem>, String)] = [
+            (.noResult, "noUpdate"),
+            (.unreachable, "unreachable"),
+            (.skipped, "skipped"),
+        ]
+        for (result, expected) in cases {
+            let app = makeApp(name: "Mango", bundleID: "com.acme.mango", isAppStore: false)
+            let probe = UpdateProbe(
+                checkAppStore: { _ in .skipped },
+                checkSparkle: { _ in result }
+            )
+            let outcomes = await probe.outcomes(for: [app])
+            XCTAssertEqual(outcomes.count, 1)
+            switch (outcomes[0], expected) {
+            case (.noUpdate, "noUpdate"), (.unreachable, "unreachable"), (.skipped, "skipped"):
+                break
+            default:
+                XCTFail("Expected \(expected), got \(outcomes[0])")
+            }
+        }
+    }
+
+    // MARK: - availableUpdates
+
+    /// `availableUpdates(for:)` keeps only the `.update` payloads, sorted
+    /// case-insensitively by app name so list order is deterministic.
+    func test_availableUpdates_extractsUpdatesSortedByNameCaseInsensitively() async {
+        let apps = [
+            makeApp(name: "zeta", bundleID: "com.acme.zeta", version: "1.0", isAppStore: true),
+            makeApp(name: "Stale", bundleID: "com.acme.stale", version: "9.9", isAppStore: true),
+            makeApp(name: "Alpha", bundleID: "com.acme.alpha", version: "1.0", isAppStore: true),
+        ]
+        let probe = UpdateProbe(
+            checkAppStore: { bundleID in
+                guard bundleID != "com.acme.stale" else { return .noResult }
+                return .found(AppStoreLookup(
+                    version: "2.0",
+                    appStoreURL: URL(string: "https://apps.apple.com/app/\(bundleID)")!
+                ))
+            },
+            checkSparkle: { _ in .skipped }
+        )
+
+        let updates = await probe.availableUpdates(for: apps)
+
+        XCTAssertEqual(updates.map(\.appName), ["Alpha", "zeta"])
+    }
+
+    /// An empty app list yields no updates and never calls a checker.
+    func test_availableUpdates_emptyAppsYieldsEmptyWithoutCheckerCalls() async {
+        let calls = ActorBox(0)
+        let probe = UpdateProbe(
+            checkAppStore: { _ in await calls.increment(); return .noResult },
+            checkSparkle: { _ in await calls.increment(); return .noResult }
+        )
+        let updates = await probe.availableUpdates(for: [])
+        XCTAssertTrue(updates.isEmpty)
+        let count = await calls.value
+        XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - Bounded concurrency
+
+    /// The fan-out never holds more than `maxConcurrentChecks` probes in
+    /// flight, so a machine with hundreds of apps can't stampede the
+    /// iTunes Search API or Sparkle hosts.
+    func test_outcomes_neverExceedsMaxConcurrentChecks() async {
+        let apps = (0..<20).map { index in
+            makeApp(name: "App\(index)", bundleID: "com.acme.app\(index)", isAppStore: true)
+        }
+        let gauge = ConcurrencyGauge()
+        let probe = UpdateProbe(
+            checkAppStore: { _ in
+                await gauge.enter()
+                try? await Task.sleep(nanoseconds: 5_000_000)
+                await gauge.exit()
+                return .noResult
+            },
+            checkSparkle: { _ in .skipped }
+        )
+
+        let outcomes = await probe.outcomes(for: apps)
+
+        XCTAssertEqual(outcomes.count, 20)
+        let peak = await gauge.peak
+        XCTAssertLessThanOrEqual(peak, UpdateProbe.maxConcurrentChecks)
+        XCTAssertGreaterThan(peak, 1, "Probes should actually run concurrently")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeApp(
+        name: String,
+        bundleID: String,
+        version: String? = "1.0.0",
+        isAppStore: Bool
+    ) -> AppInfo {
+        AppInfo(
+            name: name,
+            bundleID: bundleID,
+            version: version,
+            bundleURL: URL(fileURLWithPath: "/Applications/\(name).app"),
+            isAppStore: isAppStore
+        )
+    }
+}
+
+/// Tracks how many probe bodies are inside the checker simultaneously and
+/// records the high-water mark.
+private actor ConcurrencyGauge {
+    private var current = 0
+    private(set) var peak = 0
+
+    func enter() {
+        current += 1
+        peak = max(peak, current)
+    }
+
+    func exit() {
+        current -= 1
+    }
+}
+
+private actor ActorBox<Value: Sendable> {
+    private(set) var value: Value
+    init(_ initial: Value) { self.value = initial }
+    func set(_ newValue: Value) { value = newValue }
+}
+
+private extension ActorBox where Value == Int {
+    func increment() { value += 1 }
+}
+
+private extension ActorBox where Value == [String] {
+    func append(_ element: String) { value.append(element) }
+}


### PR DESCRIPTION
## Summary
The bounded-concurrency fan-out (≤6 in-flight HTTPS requests) and the per-app App Store / Sparkle channel routing existed nearly verbatim in three places — `AppUpdaterViewModel.checkForUpdates`, `ApplicationsViewModel.fetchUpdates`, and `SmartScanViewModel.fetchAvailableUpdates` — with comments requiring the copies to mirror each other so all three surfaces show identical update lists. This PR extracts that pipeline into one shared `UpdateProbe`:

- `outcomes(for:)` keeps the reachability granularity (`update` / `noUpdate` / `unreachable` / `skipped`) the App Updater needs to tell "up to date" apart from "offline".
- `availableUpdates(for:)` is the updates-only convenience the Applications dashboard and Smart Scan use.
- `live()` / `liveAppStoreCheck()` / `liveSparkleCheck()` centralize the production wiring, including the network-vs-other error split that was previously inlined in `AppUpdaterViewModel.live`.
- `CheckResult` moves to `UpdateProbe.swift` unchanged as part of the shared contract.

`AppUpdaterViewModel` keeps its closure-injected init, so its existing test suite runs **unmodified** against the new plumbing. Net: −360 lines of duplicated production code (+ the new shared file and its tests), and the three surfaces can no longer drift apart.

## Behavior notes
- The dashboard/Smart Scan copies previously swallowed *all* checker errors to `nil`; the shared live wiring maps network errors to `.unreachable` and the rest to `.noResult`, both of which are dropped by `availableUpdates(for:)` — observable behavior is identical.
- Sort order (case-insensitive by app name) and the concurrency cap (6) are unchanged.

## Test plan
- TDD: `UpdateProbeTests` written first (10 tests — channel routing, version comparison, `UpdateInfo` construction, outcome mapping, sorted extraction, empty input, concurrency cap via a high-water-mark gauge).
- Full unit suite: `xcodebuild clean test -only-testing:VaderCleanerTests` — **989 tests, 0 failures** (979 pre-existing + 10 new), including the untouched `AppUpdaterViewModelTests`, `ApplicationsViewModelTests`, and `SmartScanViewModelTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)