### PR TITLE
feat: redesign Privacy section as a dashboard grid with a Privacy Manager catalog

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		DC099BEFD567C81EAA36519E /* ClamAVScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */; };
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
 		DD929B8195C7904CB4AC2E62 /* OptimizationViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1077EED505B80270E2E406A /* OptimizationViewSubviews.swift */; };
+		DFEDB8DF51CD2BA1732D3897 /* PrivacyDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867EACDA1946DCE20BAD163A /* PrivacyDashboardSubviews.swift */; };
 		E0420FF267A637AD7F530407 /* ExtensionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */; };
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */; };
@@ -468,6 +469,7 @@
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
 		82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotCounter.swift; sourceTree = "<group>"; };
+		867EACDA1946DCE20BAD163A /* PrivacyDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDashboardSubviews.swift; sourceTree = "<group>"; };
 		869E8D8A460A998AA0E6B854 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
 		88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanOverlay.swift; sourceTree = "<group>"; };
@@ -741,6 +743,7 @@
 				E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */,
 				5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */,
 				0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */,
+				867EACDA1946DCE20BAD163A /* PrivacyDashboardSubviews.swift */,
 				072BF227B87C8D965EAD3204 /* PrivacyPermissionChecker.swift */,
 				C751F5671E4A4657944A7DFC /* PrivacyView.swift */,
 				90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */,
@@ -1375,6 +1378,7 @@
 				FF87A6FAB563AF43345061BB /* PreferencesStore.swift in Sources */,
 				CF68F2891382E3F3D4CA5474 /* PreferencesView.swift in Sources */,
 				3A0AAEEE22026F9D96D875B2 /* PrivacyCategory.swift in Sources */,
+				DFEDB8DF51CD2BA1732D3897 /* PrivacyDashboardSubviews.swift in Sources */,
 				F0838C9B10FFB6AD75523D0A /* PrivacyPermissionChecker.swift in Sources */,
 				7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */,
 				63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */,

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -347,7 +347,8 @@ struct ApplicationsDashboardView: View {
 
 /// A single Applications summary card. Uses the same glass surface and corner
 /// radius as the Optimization / Smart Scan dashboards so the app's card
-/// surfaces stay consistent.
+/// surfaces stay consistent. Also reused by the Privacy dashboard's category
+/// cards for the same reason.
 struct ApplicationsCard: View {
     let title: String
     /// Short, emphasized magnitude (reclaimable size or item count) shown as the

--- a/VaderCleaner/PrivacyDashboardSubviews.swift
+++ b/VaderCleaner/PrivacyDashboardSubviews.swift
@@ -1,0 +1,587 @@
+// PrivacyDashboardSubviews.swift
+// Post-scan dashboard for the Privacy section — the "We found X" header, the per-category summary card grid, and the Privacy Manager catalog with its pinned Clear bar.
+
+import AppKit
+import SwiftUI
+
+// MARK: - Dashboard
+
+/// The Privacy landing surface after a scan: a headline total, a "View All
+/// Data" affordance, and up to four recommendation cards (per-category
+/// findings plus a System card for Recent Items) — mirroring the Applications
+/// dashboard's hero + adaptive grid so the app's card surfaces stay
+/// consistent. The full per-browser breakdown lives in the catalog behind
+/// "View All Data".
+struct PrivacyDashboardView: View {
+    let browserCount: Int
+    let totalFoundSize: Int64
+    /// Categories with findings, largest first — the first entry renders as
+    /// the tall hero card. Supplied by `PrivacyViewModel.dashboardCategories()`.
+    let categories: [PrivacyCategory]
+    let categorySize: (PrivacyCategory) -> Int64
+    let onReviewCategory: (PrivacyCategory) -> Void
+    let onReviewSystem: () -> Void
+    let onViewAllData: () -> Void
+    let onRescan: () -> Void
+
+    /// At most this many cards render on the dashboard — the rest of the
+    /// findings stay reachable through the "View All Data" catalog. Matches
+    /// the Optimization dashboard's curated-recommendations feel.
+    private static let maxCards = 4
+
+    var body: some View {
+        VStack(spacing: 28) {
+            header
+            cardLayout
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        .accessibilityIdentifier("privacy.dashboard")
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Text(headlineText)
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("privacy.foundTotal")
+
+            HStack(spacing: 12) {
+                Button(action: onViewAllData) {
+                    Text(String(
+                        localized: "View All Data",
+                        comment: "Button that opens the full browsing-data catalog."
+                    ))
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("privacy.viewAllData")
+
+                Button(action: onRescan) {
+                    Text(String(
+                        localized: "Re-scan",
+                        comment: "Button that re-runs the Privacy scan."
+                    ))
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("privacy.rescan")
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// One dashboard card's content. Built as data so the layout can promote
+    /// the first one to a tall hero and flow the rest through an adaptive
+    /// grid, mirroring the Applications dashboard.
+    private struct CardSpec: Identifiable {
+        let id: String
+        let title: String
+        let metric: String
+        let detail: String
+        let icon: String
+        let actionLabel: String
+        let action: () -> Void
+    }
+
+    /// One card per category with findings, plus the System card last —
+    /// Recent Items has no byte size, so it never competes for the hero slot.
+    /// Capped at `maxCards`; the System card is the first one dropped, since
+    /// Recent Items stays reachable through the catalog's System pane.
+    private var cardSpecs: [CardSpec] {
+        Array((categories.map(spec(for:)) + [systemSpec]).prefix(Self.maxCards))
+    }
+
+    private func spec(for category: PrivacyCategory) -> CardSpec {
+        CardSpec(
+            id: "privacy.card.\(category.rawValue)",
+            title: category.displayName,
+            metric: PrivacyViewFormatting.byteFormatter.string(fromByteCount: categorySize(category)),
+            detail: detailText(for: category),
+            icon: icon(for: category),
+            actionLabel: reviewLabel,
+            action: { onReviewCategory(category) }
+        )
+    }
+
+    private var systemSpec: CardSpec {
+        CardSpec(
+            id: "privacy.card.system",
+            title: String(
+                localized: "System Traces",
+                comment: "Privacy dashboard card title for system-level cleanup (Recent Items)."
+            ),
+            metric: String(
+                localized: "Recent Items",
+                comment: "Privacy System Traces card metric naming what it clears."
+            ),
+            detail: String(
+                localized: "The Apple-menu Recent Items list and this app's recent documents.",
+                comment: "Privacy System Traces card detail."
+            ),
+            icon: "clock",
+            actionLabel: reviewLabel,
+            action: onReviewSystem
+        )
+    }
+
+    /// The card layout, mirroring the Applications dashboard exactly so the
+    /// two share one look: the first card is a tall hero capped at 320pt on
+    /// the left, the rest flow through an adaptive grid.
+    private var cardLayout: some View {
+        HStack(alignment: .top, spacing: 16) {
+            if let hero = cardSpecs.first {
+                card(hero, isHero: true)
+                    .frame(maxWidth: 320)
+            }
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 260), spacing: 16)],
+                alignment: .leading,
+                spacing: 16
+            ) {
+                ForEach(cardSpecs.dropFirst()) { spec in
+                    card(spec, isHero: false)
+                }
+            }
+        }
+    }
+
+    private func card(_ spec: CardSpec, isHero: Bool) -> some View {
+        ApplicationsCard(
+            title: spec.title,
+            metric: spec.metric,
+            detail: spec.detail,
+            icon: spec.icon,
+            actionLabel: spec.actionLabel,
+            identifier: spec.id,
+            isHero: isHero,
+            action: spec.action
+        )
+    }
+
+    // MARK: Copy
+
+    private var headlineText: String {
+        if browserCount == 0 {
+            return String(
+                localized: "No browsers were detected on your Mac.",
+                comment: "Privacy dashboard headline when the scan found no installed browsers."
+            )
+        }
+        let format = String(
+            localized: "We've found %1$@ of browsing data across %2$lld browsers.",
+            comment: "Privacy dashboard headline; %1$@ is the total size, %2$lld the browser count."
+        )
+        return String.localizedStringWithFormat(
+            format,
+            PrivacyViewFormatting.byteFormatter.string(fromByteCount: totalFoundSize),
+            Int64(browserCount)
+        )
+    }
+
+    private var reviewLabel: String {
+        String(localized: "Review", comment: "Privacy card action that opens a review screen.")
+    }
+
+    private func icon(for category: PrivacyCategory) -> String {
+        switch category {
+        case .history:    return "clock.arrow.circlepath"
+        case .downloads:  return "arrow.down.circle"
+        case .cookies:    return "lock.shield"
+        case .cache:      return "internaldrive"
+        case .savedForms: return "rectangle.and.pencil.and.ellipsis"
+        }
+    }
+
+    private func detailText(for category: PrivacyCategory) -> String {
+        privacyCategoryDetailText(category)
+    }
+}
+
+/// What each category contains and the consequence of clearing it. Shared by
+/// the dashboard cards and the catalog's pane descriptions so the two
+/// surfaces never drift apart.
+private func privacyCategoryDetailText(_ category: PrivacyCategory) -> String {
+    switch category {
+    case .history:
+        return String(
+            localized: "A record of the pages you've visited. On most browsers this also includes download history.",
+            comment: "Privacy Browsing History card detail."
+        )
+    case .downloads:
+        return String(
+            localized: "The list of files you've downloaded from the web.",
+            comment: "Privacy Download History card detail."
+        )
+    case .cookies:
+        return String(
+            localized: "Site logins, preferences, and trackers. Clearing signs you out of most websites.",
+            comment: "Privacy Cookies card detail, warning about the sign-out consequence."
+        )
+    case .cache:
+        return String(
+            localized: "Temporary files browsers keep to load sites faster. Safe to clear — pages just load slower the first time.",
+            comment: "Privacy Cached Data card detail."
+        )
+    case .savedForms:
+        return String(
+            localized: "Autofill entries like names, addresses, and search terms.",
+            comment: "Privacy Saved Form Data card detail."
+        )
+    }
+}
+
+/// A browser's real app icon, read through the shared `AppIconCache`. Falls
+/// back to a generic globe when the bundle URL couldn't be resolved (the
+/// cache's own placeholder only kicks in for un-preloaded URLs).
+struct PrivacyBrowserIcon: View {
+    let browser: Browser
+    var iconCache: AppIconCache
+    let bundleURL: URL?
+    let side: CGFloat
+
+    var body: some View {
+        Group {
+            if let bundleURL {
+                Image(nsImage: iconCache.icon(for: bundleURL))
+                    .resizable()
+            } else {
+                Image(systemName: "globe")
+                    .resizable()
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: side, height: side)
+        .accessibilityLabel(Text(browser.displayName))
+    }
+}
+
+/// One selectable data row: a checkbox, the browser's icon and name, and the
+/// cell's size.
+struct PrivacyCheckRow: View {
+    let browser: Browser
+    var iconCache: AppIconCache
+    let bundleURL: URL?
+    let sizeBytes: Int64
+    @Binding var isChecked: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: $isChecked)
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+                .accessibilityLabel(Text(browser.displayName))
+            PrivacyBrowserIcon(browser: browser, iconCache: iconCache, bundleURL: bundleURL, side: 28)
+            Text(browser.displayName)
+                .font(.body)
+            Spacer()
+            Text(PrivacyViewFormatting.byteFormatter.string(fromByteCount: sizeBytes))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// Row rendered for cells whose data is coupled to Browsing History at the
+/// file level and therefore can't be cleared independently.
+struct PrivacyCoupledRow: View {
+    let browser: Browser
+    var iconCache: AppIconCache
+    let bundleURL: URL?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Spacer().frame(width: 16)
+            PrivacyBrowserIcon(browser: browser, iconCache: iconCache, bundleURL: bundleURL, side: 28)
+            Text(browser.displayName)
+                .font(.body)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(String(
+                localized: "Included with Browsing History",
+                comment: "Explanation for why a privacy data cell cannot be cleared independently."
+            ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - Data catalog
+
+/// The catalog reached from "View All Data" and from every card's Review
+/// button, modelled on Optimization's Performance Manager: a back affordance,
+/// a left sub-navigation (one item per data category, plus System), a detail
+/// pane listing each detected browser's data for that category as a
+/// multi-select checklist, and a pinned Clear bar with the running selection
+/// total. A Review click opens it on the matching category pane.
+struct PrivacyDataCatalogView: View {
+
+    /// The catalog panes the sub-navigation switches between.
+    enum Pane: Hashable {
+        case category(PrivacyCategory)
+        case system
+    }
+
+    /// Which pane is shown. Bound to the owning view so a dashboard card or
+    /// the View All Data button can open the catalog on a specific pane.
+    @Binding var pane: Pane
+    let browsers: [Browser]
+    /// Icon cache + per-browser bundle-URL resolver for the row icons,
+    /// shared with the dashboard so each icon loads once.
+    var iconCache: AppIconCache
+    let bundleURL: (Browser) -> URL?
+    let categorySize: (Browser, PrivacyCategory) -> Int64
+    let isCategoryActionable: (Browser, PrivacyCategory) -> Bool
+    let isCategoryChecked: (Browser, PrivacyCategory) -> Bool
+    let onToggleCategory: (Browser, PrivacyCategory) -> Void
+    let isClearRecentsChecked: Bool
+    let onToggleClearRecents: () -> Void
+    let totalSelectedSize: Int64
+    let canClear: Bool
+    let onClear: () -> Void
+    let onBack: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            HStack(spacing: 0) {
+                subNavigation
+                    .frame(width: 220)
+                    .padding(16)
+                Divider()
+                VStack(spacing: 0) {
+                    detailPane
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    Divider()
+                    clearBar
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("privacy.catalog")
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack {
+            Button(action: onBack) {
+                // HStack(Image, Text) rather than Label so the control surfaces
+                // reliably in XCUITest.
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text(String(
+                        localized: "Back",
+                        comment: "Back button returning from the Privacy data catalog to the dashboard."
+                    ))
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("privacy.backToDashboard")
+            Spacer()
+            Text(String(
+                localized: "Privacy Manager",
+                comment: "Title of the View All Data catalog."
+            ))
+            .font(.headline)
+            Spacer()
+            // Balances the leading Back button so the title stays centred.
+            Color.clear.frame(width: 44, height: 1)
+        }
+        .padding(16)
+    }
+
+    // MARK: Sub-navigation
+
+    private var subNavigation: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(PrivacyCategory.allCases) { category in
+                navItem(.category(category), category.displayName,
+                        "privacy.catalog.nav.\(category.rawValue)")
+            }
+            navItem(.system,
+                    String(localized: "System", comment: "Privacy catalog sub-nav item for system traces."),
+                    "privacy.catalog.nav.system")
+            Spacer()
+        }
+    }
+
+    private func navItem(_ target: Pane, _ title: String, _ identifier: String) -> some View {
+        Button {
+            pane = target
+        } label: {
+            Text(title)
+                .font(.body.weight(pane == target ? .semibold : .regular))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    pane == target ? Color.primary.opacity(0.10) : .clear,
+                    in: .rect(cornerRadius: 8)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+
+    // MARK: Detail pane
+
+    @ViewBuilder
+    private var detailPane: some View {
+        switch pane {
+        case .category(let category):
+            categoryPane(category)
+        case .system:
+            systemPane
+        }
+    }
+
+    private func categoryPane(_ category: PrivacyCategory) -> some View {
+        paneScroll(
+            heading: category.displayName,
+            description: privacyCategoryDetailText(category)
+        ) {
+            ForEach(browsers) { browser in
+                if isCategoryActionable(browser, category) {
+                    PrivacyCheckRow(
+                        browser: browser,
+                        iconCache: iconCache,
+                        bundleURL: bundleURL(browser),
+                        sizeBytes: categorySize(browser, category),
+                        isChecked: Binding(
+                            get: { isCategoryChecked(browser, category) },
+                            set: { _ in onToggleCategory(browser, category) }
+                        )
+                    )
+                    .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue)")
+                } else {
+                    PrivacyCoupledRow(
+                        browser: browser,
+                        iconCache: iconCache,
+                        bundleURL: bundleURL(browser)
+                    )
+                    .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue).coupled")
+                }
+            }
+        }
+    }
+
+    private var systemPane: some View {
+        paneScroll(
+            heading: String(
+                localized: "System Traces",
+                comment: "Privacy catalog system-pane heading."
+            ),
+            description: String(
+                localized: "Traces macOS keeps outside your browsers.",
+                comment: "Privacy catalog system-pane description."
+            )
+        ) {
+            PrivacyRecentItemsRow(
+                isChecked: isClearRecentsChecked,
+                onToggle: onToggleClearRecents
+            )
+        }
+    }
+
+    private func paneScroll<Content: View>(
+        heading: String,
+        description: String,
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(heading)
+                    .font(.title3.weight(.semibold))
+                Text(description)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                VStack(spacing: 10) {
+                    content()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(24)
+        }
+    }
+
+    // MARK: Clear bar
+
+    /// Pinned under the detail pane on every catalog pane — the selection is
+    /// global across panes, so the total and the destructive Clear travel
+    /// with the catalog rather than living on one pane. Mirrors the
+    /// Optimization catalog's Run bar.
+    private var clearBar: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(
+                    localized: "Total selected",
+                    comment: "Label above the selected-size total on the Privacy catalog's Clear bar."
+                ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(PrivacyViewFormatting.byteFormatter.string(fromByteCount: totalSelectedSize))
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("privacy.totalSelected")
+            }
+            Spacer()
+            Button(String(
+                localized: "Clear",
+                comment: "Button on the Privacy catalog that clears the selected data."
+            ), action: onClear)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canClear)
+                .accessibilityIdentifier("privacy.clear")
+        }
+        .padding(16)
+    }
+}
+
+#Preview("Privacy Dashboard") {
+    ScrollView {
+        PrivacyDashboardView(
+            browserCount: 3,
+            totalFoundSize: 1_200_000_000,
+            categories: [.cache, .history, .cookies],
+            categorySize: { category in
+                switch category {
+                case .cache:   return 1_100_000_000
+                case .history: return 96_000_000
+                default:       return 4_000_000
+                }
+            },
+            onReviewCategory: { _ in },
+            onReviewSystem: { },
+            onViewAllData: { },
+            onRescan: { }
+        )
+        .padding(24)
+    }
+    .frame(width: 900, height: 600)
+}
+
+#Preview("Privacy Catalog") {
+    PrivacyDataCatalogView(
+        pane: .constant(.category(.cookies)),
+        browsers: [.safari, .chrome],
+        iconCache: AppIconCache(),
+        bundleURL: { _ in nil },
+        categorySize: { browser, _ in browser == .safari ? 420_000 : 1_300_000 },
+        isCategoryActionable: { _, category in category != .downloads },
+        isCategoryChecked: { _, _ in true },
+        onToggleCategory: { _, _ in },
+        isClearRecentsChecked: true,
+        onToggleClearRecents: { },
+        totalSelectedSize: 1_720_000,
+        canClear: true,
+        onClear: { },
+        onBack: { }
+    )
+    .frame(width: 900, height: 600)
+}

--- a/VaderCleaner/PrivacyView.swift
+++ b/VaderCleaner/PrivacyView.swift
@@ -1,6 +1,7 @@
 // PrivacyView.swift
 // Privacy feature view — orchestrates privacy scan phases, destructive confirmation, and clear / re-scan actions.
 
+import AppKit
 import SwiftUI
 
 /// Detail view shown when the user selects "Privacy" in the sidebar.
@@ -15,6 +16,31 @@ struct PrivacyView: View {
     private var viewModel: PrivacyViewModel
     @State private var showClearConfirmation = false
 
+    /// Which screen the preview surface is showing — the dashboard grid or
+    /// the Privacy Manager catalog. Owned here (mirroring
+    /// `ApplicationsView.detail`) and reset whenever the phase leaves
+    /// `.preview` so a fresh scan always lands on the dashboard.
+    @State private var previewDetail: PreviewDetail = .dashboard
+
+    /// Which catalog pane to show. Owned here (mirroring
+    /// `OptimizationView.catalogPane`) so a card's Review button can open the
+    /// catalog on its matching category pane.
+    @State private var catalogPane: PrivacyDataCatalogView.Pane = .category(.history)
+
+    private enum PreviewDetail: Equatable {
+        case dashboard
+        case catalog
+    }
+
+    /// Shared icon cache so the dashboard's browser strip and the catalog's
+    /// rows show each browser's real app icon. Pre-loaded off the main
+    /// thread once the detected browsers land.
+    @State private var iconCache = AppIconCache()
+
+    /// Resolved `.app` bundle URL per detected browser, looked up once per
+    /// scan via Launch Services rather than per-row inside SwiftUI `body`.
+    @State private var browserBundleURLs: [Browser: URL] = [:]
+
     init(viewModel: PrivacyViewModel) {
         self.viewModel = viewModel
     }
@@ -23,6 +49,24 @@ struct PrivacyView: View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle(NavigationSection.privacy.title)
+            .onChange(of: viewModel.phase) { _, newPhase in
+                if newPhase != .preview {
+                    previewDetail = .dashboard
+                }
+            }
+            .task(id: viewModel.detectedBrowsers) {
+                // Resolve each detected browser's bundle URL once per scan
+                // (Launch Services lookup), then warm the icon cache off the
+                // main thread so rows render real icons without synchronous
+                // NSWorkspace calls in `body`.
+                var urls: [Browser: URL] = [:]
+                for browser in viewModel.detectedBrowsers {
+                    urls[browser] = NSWorkspace.shared
+                        .urlForApplication(withBundleIdentifier: browser.bundleIdentifier)
+                }
+                browserBundleURLs = urls
+                await iconCache.preloadIcons(for: Array(urls.values))
+            }
             .alert(clearConfirmationTitle, isPresented: $showClearConfirmation) {
                 Button("Cancel", role: .cancel) { }
                 Button("Clear", role: .destructive) {
@@ -49,20 +93,7 @@ struct PrivacyView: View {
                 detail: ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount)
             )
         case .preview:
-            PrivacyPreviewContent(
-                browsers: viewModel.detectedBrowsers,
-                totalSelectedSize: viewModel.totalSelectedSize,
-                isClearRecentsChecked: viewModel.isClearRecentsChecked,
-                canClear: viewModel.totalSelectedSize != 0 || viewModel.isClearRecentsChecked,
-                sizeOnDisk: { viewModel.sizeOnDisk(for: $0) },
-                categorySize: { viewModel.size(for: $0, category: $1) },
-                isCategoryActionable: { viewModel.isCategoryActionable(browser: $0, category: $1) },
-                isCategoryChecked: { viewModel.isChecked(browser: $0, category: $1) },
-                onToggleCategory: { viewModel.toggle(browser: $0, category: $1) },
-                onToggleClearRecents: { viewModel.toggleClearRecents() },
-                onRescan: viewModel.scanAgain,
-                onClear: { showClearConfirmation = true }
-            )
+            previewContent
         case .clearing:
             PrivacyProgressState(label: "Clearing…", identifier: "privacy.clearing")
         case .complete(let bytes):
@@ -70,6 +101,58 @@ struct PrivacyView: View {
         case .failed(let stage, let message):
             PrivacyFailedState(stage: stage, message: message, onTryAgain: viewModel.scanAgain)
         }
+    }
+
+    /// The `.preview` surface: the dashboard grid, or the Privacy Manager
+    /// catalog that both "View All Data" and every card's Review button open.
+    /// The catalog carries the pinned Clear bar, so the destructive action
+    /// only appears once the user is looking at the selection it acts on.
+    @ViewBuilder
+    private var previewContent: some View {
+        switch previewDetail {
+        case .dashboard:
+            // Mirrors the Applications dashboard host: a scrolling hero +
+            // adaptive card grid, so the two share one look.
+            ScrollView {
+                PrivacyDashboardView(
+                    browserCount: viewModel.detectedBrowsers.count,
+                    totalFoundSize: viewModel.totalFoundSize,
+                    categories: viewModel.dashboardCategories(),
+                    categorySize: { viewModel.size(forCategory: $0) },
+                    onReviewCategory: { openCatalog(on: .category($0)) },
+                    onReviewSystem: { openCatalog(on: .system) },
+                    onViewAllData: { openCatalog(on: .category(.history)) },
+                    onRescan: viewModel.scanAgain
+                )
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .catalog:
+            PrivacyDataCatalogView(
+                pane: $catalogPane,
+                browsers: viewModel.detectedBrowsers,
+                iconCache: iconCache,
+                bundleURL: { browserBundleURLs[$0] },
+                categorySize: { viewModel.size(for: $0, category: $1) },
+                isCategoryActionable: { viewModel.isCategoryActionable(browser: $0, category: $1) },
+                isCategoryChecked: { viewModel.isChecked(browser: $0, category: $1) },
+                onToggleCategory: { viewModel.toggle(browser: $0, category: $1) },
+                isClearRecentsChecked: viewModel.isClearRecentsChecked,
+                onToggleClearRecents: { viewModel.toggleClearRecents() },
+                totalSelectedSize: viewModel.totalSelectedSize,
+                canClear: viewModel.totalSelectedSize != 0 || viewModel.isClearRecentsChecked,
+                onClear: { showClearConfirmation = true },
+                onBack: { previewDetail = .dashboard }
+            )
+        }
+    }
+
+    /// Open the Privacy Manager catalog on `pane` — the shared destination
+    /// for View All Data and every card's Review button, which differ only
+    /// in which pane they land on.
+    private func openCatalog(on pane: PrivacyDataCatalogView.Pane) {
+        catalogPane = pane
+        previewDetail = .catalog
     }
 
     private var clearConfirmationTitle: String {

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -122,6 +122,60 @@ final class PrivacyViewModel {
         sumOfSizes(over: checkedSelections)
     }
 
+    /// Path-deduped total across every `(browser, category)` cell of the
+    /// detected browsers, regardless of selection — feeds the dashboard
+    /// headline ("We found X across N browsers"). Selection-independent so
+    /// unchecking rows in a review screen doesn't shrink the headline.
+    var totalFoundSize: Int64 {
+        sumOfSizes(over: allDetectedSelections())
+    }
+
+    /// Sum of bytes for `category` across every detected browser, regardless
+    /// of selection — feeds the per-category dashboard card metric. Cells
+    /// with no paths contribute 0 (coupled cells like Chromium `.downloads`),
+    /// so a card never claims bytes only another card can clear.
+    func size(forCategory category: PrivacyCategory) -> Int64 {
+        let selections = detectedBrowsers.map {
+            Selection(browser: $0, category: category)
+        }
+        return sumOfSizes(over: Set(selections))
+    }
+
+    /// Categories with any found bytes, largest first — the dashboard
+    /// renders one card per entry and promotes the first to the hero slot.
+    /// Ties keep `PrivacyCategory.allCases` order so the card layout doesn't
+    /// shuffle between two otherwise identical scans.
+    func dashboardCategories() -> [PrivacyCategory] {
+        struct Entry {
+            let index: Int
+            let category: PrivacyCategory
+            let size: Int64
+        }
+        var entries: [Entry] = []
+        for (index, category) in PrivacyCategory.allCases.enumerated() {
+            let size = size(forCategory: category)
+            if size > 0 {
+                entries.append(Entry(index: index, category: category, size: size))
+            }
+        }
+        entries.sort { lhs, rhs in
+            lhs.size != rhs.size ? lhs.size > rhs.size : lhs.index < rhs.index
+        }
+        return entries.map(\.category)
+    }
+
+    /// Every `(browser, category)` cell of the detected browsers — the
+    /// universe the dashboard metrics aggregate over.
+    private func allDetectedSelections() -> Set<Selection> {
+        var selections: Set<Selection> = []
+        for browser in detectedBrowsers {
+            for category in PrivacyCategory.allCases {
+                selections.insert(Selection(browser: browser, category: category))
+            }
+        }
+        return selections
+    }
+
     /// Whether `(browser, category)` is currently checked. The view
     /// binds each row's `Toggle` to this getter + `toggle(browser:category:)`.
     func isChecked(browser: Browser, category: PrivacyCategory) -> Bool {

--- a/VaderCleaner/PrivacyViewSubviews.swift
+++ b/VaderCleaner/PrivacyViewSubviews.swift
@@ -1,5 +1,5 @@
 // PrivacyViewSubviews.swift
-// Dedicated subviews for PrivacyView state screens, preview sections, rows, and footer.
+// Dedicated subviews for PrivacyView state screens and the Recent Items row.
 
 import SwiftUI
 
@@ -36,152 +36,6 @@ struct PrivacyProgressState: View {
         }
         .padding()
         .accessibilityIdentifier(identifier)
-    }
-}
-
-struct PrivacyPreviewContent: View {
-    let browsers: [Browser]
-    let totalSelectedSize: Int64
-    let isClearRecentsChecked: Bool
-    let canClear: Bool
-    let sizeOnDisk: (Browser) -> Int64
-    let categorySize: (Browser, PrivacyCategory) -> Int64
-    let isCategoryActionable: (Browser, PrivacyCategory) -> Bool
-    let isCategoryChecked: (Browser, PrivacyCategory) -> Bool
-    let onToggleCategory: (Browser, PrivacyCategory) -> Void
-    let onToggleClearRecents: () -> Void
-    let onRescan: () -> Void
-    let onClear: () -> Void
-
-    var body: some View {
-        VStack(spacing: 0) {
-            List {
-                ForEach(browsers) { browser in
-                    PrivacyBrowserSection(
-                        browser: browser,
-                        totalBytes: sizeOnDisk(browser),
-                        categorySize: { categorySize(browser, $0) },
-                        isCategoryActionable: { isCategoryActionable(browser, $0) },
-                        isCategoryChecked: { isCategoryChecked(browser, $0) },
-                        onToggleCategory: { onToggleCategory(browser, $0) }
-                    )
-                }
-
-                Section {
-                    PrivacyRecentItemsRow(
-                        isChecked: isClearRecentsChecked,
-                        onToggle: onToggleClearRecents
-                    )
-                } header: {
-                    Text(String(
-                        localized: "System",
-                        comment: "Section title for system privacy cleanup options."
-                    ))
-                        .font(.callout.weight(.semibold))
-                }
-            }
-            .scrollContentBackground(.hidden)
-            Divider()
-            PrivacyPreviewFooter(
-                totalSelectedSize: totalSelectedSize,
-                canClear: canClear,
-                onRescan: onRescan,
-                onClear: onClear
-            )
-        }
-    }
-}
-
-struct PrivacyBrowserSection: View {
-    let browser: Browser
-    let totalBytes: Int64
-    let categorySize: (PrivacyCategory) -> Int64
-    let isCategoryActionable: (PrivacyCategory) -> Bool
-    let isCategoryChecked: (PrivacyCategory) -> Bool
-    let onToggleCategory: (PrivacyCategory) -> Void
-
-    var body: some View {
-        Section {
-            ForEach(PrivacyCategory.allCases) { category in
-                if isCategoryActionable(category) {
-                    PrivacyCategoryRow(
-                        category: category,
-                        sizeBytes: categorySize(category),
-                        isChecked: Binding(
-                            get: { isCategoryChecked(category) },
-                            set: { _ in onToggleCategory(category) }
-                        )
-                    )
-                    .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue)")
-                } else {
-                    PrivacyCoupledCategoryRow(category: category)
-                        .accessibilityIdentifier("privacy.row.\(browser.rawValue).\(category.rawValue).coupled")
-                }
-            }
-        } header: {
-            PrivacyBrowserHeader(browser: browser, totalBytes: totalBytes)
-        }
-    }
-}
-
-struct PrivacyBrowserHeader: View {
-    let browser: Browser
-    let totalBytes: Int64
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Text(browser.displayName)
-                .font(.callout.weight(.semibold))
-            Spacer()
-            Text(PrivacyViewFormatting.byteFormatter.string(fromByteCount: totalBytes))
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
-        }
-    }
-}
-
-/// Row rendered for categories whose data is coupled to another browser
-/// category at the file level.
-struct PrivacyCoupledCategoryRow: View {
-    let category: PrivacyCategory
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Spacer().frame(width: 16)
-            Text(category.displayName)
-                .font(.body)
-                .foregroundStyle(.secondary)
-            Spacer()
-            Text(String(
-                localized: "Included with Browsing History",
-                comment: "Explanation for why a privacy category cannot be cleared independently."
-            ))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 2)
-    }
-}
-
-struct PrivacyCategoryRow: View {
-    let category: PrivacyCategory
-    let sizeBytes: Int64
-    @Binding var isChecked: Bool
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Toggle("", isOn: $isChecked)
-                .toggleStyle(.checkbox)
-                .labelsHidden()
-                .accessibilityLabel(Text(category.displayName))
-            Text(category.displayName)
-                .font(.body)
-            Spacer()
-            Text(PrivacyViewFormatting.byteFormatter.string(fromByteCount: sizeBytes))
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 2)
     }
 }
 
@@ -223,36 +77,6 @@ struct PrivacyRecentItemsRow: View {
             localized: "Clears the Apple-menu Recent Items list and this app's recent documents.",
             comment: "Description for the option that clears system recent items."
         )
-    }
-}
-
-struct PrivacyPreviewFooter: View {
-    let totalSelectedSize: Int64
-    let canClear: Bool
-    let onRescan: () -> Void
-    let onClear: () -> Void
-
-    var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Total selected")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(PrivacyViewFormatting.byteFormatter.string(fromByteCount: totalSelectedSize))
-                    .font(.title3.weight(.semibold))
-                    .accessibilityIdentifier("privacy.totalSelected")
-            }
-            Spacer()
-            Button("Re-scan", action: onRescan)
-                .accessibilityIdentifier("privacy.rescan")
-            Button("Clear", action: onClear)
-                .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
-                .disabled(!canClear)
-                .accessibilityIdentifier("privacy.clear")
-        }
-        .padding(16)
     }
 }
 
@@ -320,18 +144,3 @@ struct PrivacyFailedState: View {
     }
 }
 
-#Preview("Privacy Row") {
-    PrivacyCategoryRow(category: .history, sizeBytes: 12_000_000, isChecked: .constant(true))
-        .padding()
-        .frame(width: 460)
-}
-
-#Preview("Privacy Footer") {
-    PrivacyPreviewFooter(
-        totalSelectedSize: 42_000_000,
-        canClear: true,
-        onRescan: {},
-        onClear: {}
-    )
-    .frame(width: 700)
-}

--- a/VaderCleanerTests/PrivacyViewModelTests.swift
+++ b/VaderCleanerTests/PrivacyViewModelTests.swift
@@ -310,6 +310,129 @@ final class PrivacyViewModelTests: XCTestCase {
         XCTAssertEqual(vm.totalSelectedSize, 200)
     }
 
+    // MARK: - Dashboard metrics
+
+    /// The dashboard's category cards show one total per category summed
+    /// across every detected browser, so the user sees "Cached Data — 600 B"
+    /// rather than seven per-browser rows.
+    func test_sizeForCategory_sumsCategoryAcrossDetectedBrowsers() async {
+        let vm = makeViewModel(
+            detected: [.safari, .chrome],
+            sizer: { _, category in category == .cache ? 300 : 10 },
+            pathsFor: { browser, category in
+                [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+
+        await vm.preview()
+
+        XCTAssertEqual(vm.size(forCategory: .cache), 600)
+        XCTAssertEqual(vm.size(forCategory: .history), 20)
+    }
+
+    /// Card metrics describe what the scan *found*, not what's currently
+    /// checked — unchecking a cell in a review screen must not shrink the
+    /// dashboard card behind it.
+    func test_sizeForCategory_ignoresSelectionState() async {
+        let vm = makeViewModel(
+            detected: [.safari, .chrome],
+            sizer: { _, _ in 100 },
+            pathsFor: { browser, category in
+                [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+        await vm.preview()
+
+        vm.toggle(browser: .safari, category: .cache)
+
+        XCTAssertEqual(vm.size(forCategory: .cache), 200)
+    }
+
+    /// Coupled cells (Chromium / Firefox `.downloads` lives inside the
+    /// History SQLite, so the cell has no paths of its own) must contribute
+    /// 0 — otherwise the Downloads card would claim bytes only the History
+    /// card can actually clear.
+    func test_sizeForCategory_excludesCellsWithoutPaths() async {
+        let vm = makeViewModel(
+            detected: [.chrome],
+            sizer: { _, _ in 100 },
+            pathsFor: { browser, category in
+                category == .downloads
+                    ? []
+                    : [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+        await vm.preview()
+
+        XCTAssertEqual(vm.size(forCategory: .downloads), 0)
+    }
+
+    /// The headline ("We found X across N browsers") reports the path-deduped
+    /// total of everything the scan found, independent of selection state.
+    func test_totalFoundSize_dedupesSharedPathsAndIgnoresSelection() async {
+        let sharedPath = URL(fileURLWithPath: "/tmp/vctests/Chrome/Default/History")
+        let vm = makeViewModel(
+            detected: [.chrome],
+            sizer: { _, _ in 100 },
+            pathsFor: { _, category in
+                switch category {
+                case .history, .downloads: return [sharedPath]
+                case .cookies: return [URL(fileURLWithPath: "/tmp/vctests/Chrome/Default/Cookies")]
+                default: return []
+                }
+            }
+        )
+        await vm.preview()
+
+        // history + downloads share one path (100, counted once) and
+        // cookies adds a unique path (100); the rest have no paths.
+        XCTAssertEqual(vm.totalFoundSize, 200)
+
+        vm.toggle(browser: .chrome, category: .cookies)
+        XCTAssertEqual(vm.totalFoundSize, 200,
+                       "Headline total must not change with selection")
+    }
+
+    /// The dashboard renders one card per category with findings, largest
+    /// first so the dominant category lands in the hero slot. Categories
+    /// with nothing to clear are dropped rather than shown as 0-byte cards.
+    func test_dashboardCategories_ordersBySizeDescendingAndDropsEmpties() async {
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, category in
+                switch category {
+                case .cache:      return 500
+                case .history:    return 200
+                case .cookies:    return 300
+                default:          return 0
+                }
+            },
+            pathsFor: { browser, category in
+                [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+        await vm.preview()
+
+        XCTAssertEqual(vm.dashboardCategories(), [.cache, .cookies, .history])
+    }
+
+    /// Equal-size categories must keep `PrivacyCategory.allCases` order so
+    /// the card layout doesn't shuffle between two otherwise identical scans.
+    func test_dashboardCategories_breaksTiesInDeclarationOrder() async {
+        let vm = makeViewModel(
+            detected: [.safari],
+            sizer: { _, category in
+                category == .cache || category == .history ? 100 : 0
+            },
+            pathsFor: { browser, category in
+                [URL(fileURLWithPath: "/tmp/vctests/\(browser.rawValue)/\(category.rawValue)")]
+            }
+        )
+        await vm.preview()
+
+        XCTAssertEqual(vm.dashboardCategories(), [.history, .cache])
+    }
+
     // MARK: - Clear
 
     /// `clear()` must invoke the clearer for every checked

--- a/VaderCleanerUITests/PrivacyUITests.swift
+++ b/VaderCleanerUITests/PrivacyUITests.swift
@@ -1,0 +1,219 @@
+// PrivacyUITests.swift
+// End-to-end coverage for the Privacy section — intro → Scan → dashboard grid → per-category review screens — exercised against the real app process.
+
+import XCTest
+
+/// These tests never trigger destructive controls. They drive the scan and
+/// open the dashboard's review screens, but stop at display states — the
+/// clear side-effects are covered by the view-model unit tests.
+final class PrivacyUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    /// Scan → the dashboard appears with the headline total, the View All
+    /// Data and Re-scan header buttons, and at most four recommendation
+    /// cards. There is no pinned footer — the selection total and Clear live
+    /// in the catalog.
+    func test_privacy_scanShowsDashboard() throws {
+        dismissOnboardingIfNeeded()
+        openPrivacyAndScan()
+
+        let dashboard = app.descendants(matching: .any)["privacy.dashboard"]
+        XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
+                      "Expected the Privacy dashboard after the scan")
+
+        XCTAssertTrue(app.descendants(matching: .any)["privacy.foundTotal"].waitForExistence(timeout: 5),
+                      "Expected the headline total on the dashboard")
+        XCTAssertTrue(app.buttons["privacy.viewAllData"].waitForExistence(timeout: 5),
+                      "Expected the View All Data button on the dashboard header")
+        XCTAssertTrue(app.buttons["privacy.rescan"].waitForExistence(timeout: 5),
+                      "Expected the Re-scan button next to View All Data")
+        XCTAssertFalse(app.descendants(matching: .any)["privacy.totalSelected"].exists,
+                       "The selection total must not render on the dashboard — it lives in the catalog")
+
+        let cards = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'privacy.card.'")
+        )
+        XCTAssertGreaterThanOrEqual(cards.count, 1,
+                                    "Expected at least one card — the System card renders even with no findings")
+        XCTAssertLessThanOrEqual(cards.count, 4,
+                                 "The dashboard grid is capped at four recommendation cards")
+    }
+
+    /// A category card's Review opens the Privacy Manager catalog — the same
+    /// surface View All Data opens — with its Clear bar, and Back returns to
+    /// the dashboard. Which category cards appear depends on the host's
+    /// browser data, so this exercises whichever card is present; on a host
+    /// with no findings only the System card renders and the test accepts that.
+    func test_privacy_categoryCardOpensCatalogAndBackReturns() throws {
+        dismissOnboardingIfNeeded()
+        openPrivacyAndScan()
+
+        let dashboard = app.descendants(matching: .any)["privacy.dashboard"]
+        XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
+                      "Expected the Privacy dashboard after the scan")
+
+        let card = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier IN {"
+                + "'privacy.card.history','privacy.card.downloads',"
+                + "'privacy.card.cookies','privacy.card.cache',"
+                + "'privacy.card.savedForms'}"))
+            .firstMatch
+
+        guard card.waitForExistence(timeout: 10) else {
+            // No browser findings → only the System card; nothing to open.
+            XCTAssertTrue(app.buttons["privacy.card.system"].exists,
+                          "With no category cards the System card must still render")
+            return
+        }
+
+        card.click()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.catalog"].waitForExistence(timeout: 10),
+            "Expected a category card's Review to open the Privacy Manager catalog"
+        )
+        XCTAssertTrue(app.descendants(matching: .any)["privacy.totalSelected"].waitForExistence(timeout: 5),
+                      "Expected the Clear bar's selection total inside the catalog")
+        XCTAssertTrue(app.buttons["privacy.clear"].exists,
+                      "Expected the Clear button inside the catalog")
+
+        let back = app.buttons["privacy.backToDashboard"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        back.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.dashboard"].waitForExistence(timeout: 5),
+            "Expected Back to return to the dashboard"
+        )
+    }
+
+    /// The System Traces card opens the catalog on its System pane with the
+    /// Recent Items toggle. The System card is the first one dropped by the
+    /// four-card cap, so on a host with four or more category findings it
+    /// isn't on the dashboard and the test accepts that — the catalog test
+    /// covers the System pane host-independently.
+    func test_privacy_systemCardOpensCatalogSystemPane() throws {
+        dismissOnboardingIfNeeded()
+        openPrivacyAndScan()
+
+        let dashboard = app.descendants(matching: .any)["privacy.dashboard"]
+        XCTAssertTrue(dashboard.waitForExistence(timeout: 90),
+                      "Expected the Privacy dashboard after the scan")
+
+        let systemCard = app.buttons["privacy.card.system"]
+        guard systemCard.waitForExistence(timeout: 10) else {
+            // Four or more category cards → the System card is capped out.
+            return
+        }
+        systemCard.click()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.catalog"].waitForExistence(timeout: 10),
+            "Expected the System card to open the Privacy Manager catalog"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.row.recentItems"].waitForExistence(timeout: 5),
+            "Expected the Recent Items toggle row on the catalog's System pane"
+        )
+
+        let back = app.buttons["privacy.backToDashboard"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        back.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.dashboard"].waitForExistence(timeout: 5),
+            "Expected Back to return to the dashboard"
+        )
+    }
+
+    /// View All Data opens the Privacy Manager catalog with its per-category +
+    /// System sub-navigation and the Clear bar; the System pane renders the
+    /// Recent Items toggle and Back returns to the dashboard.
+    func test_privacy_viewAllDataOpensCatalog() throws {
+        dismissOnboardingIfNeeded()
+        openPrivacyAndScan()
+
+        let viewAll = app.buttons["privacy.viewAllData"]
+        XCTAssertTrue(viewAll.waitForExistence(timeout: 90),
+                      "Expected the View All Data button after the scan")
+        viewAll.click()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.catalog"].waitForExistence(timeout: 10),
+            "Expected the Privacy Manager catalog"
+        )
+
+        // The sub-navigation lists every data category plus System.
+        for navID in ["privacy.catalog.nav.history",
+                      "privacy.catalog.nav.downloads",
+                      "privacy.catalog.nav.cookies",
+                      "privacy.catalog.nav.cache",
+                      "privacy.catalog.nav.savedForms",
+                      "privacy.catalog.nav.system"] {
+            XCTAssertTrue(app.buttons[navID].waitForExistence(timeout: 5),
+                          "Expected sub-nav item \(navID)")
+        }
+
+        app.buttons["privacy.catalog.nav.system"].click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.row.recentItems"].waitForExistence(timeout: 5),
+            "Expected the Recent Items toggle row on the catalog's System pane"
+        )
+
+        // The Clear bar (selection total + Clear) is pinned inside the catalog.
+        XCTAssertTrue(app.descendants(matching: .any)["privacy.totalSelected"].exists,
+                      "Expected the Clear bar's selection total inside the catalog")
+        XCTAssertTrue(app.buttons["privacy.clear"].exists,
+                      "Expected the Clear button inside the catalog")
+
+        let back = app.buttons["privacy.backToDashboard"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5), "Expected a Back control")
+        back.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["privacy.dashboard"].waitForExistence(timeout: 5),
+            "Expected Back to return to the dashboard"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Navigate to Privacy and trigger the scan via the floating button.
+    private func openPrivacyAndScan() {
+        let row = app.buttons["sidebar.privacy"].firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 5),
+                      "Expected Privacy row in sidebar")
+        row.click()
+
+        let scan = app.buttons["section.privacy.scan"]
+        XCTAssertTrue(scan.waitForExistence(timeout: 5),
+                      "Expected the floating Scan button on the Privacy intro")
+        scan.click()
+        proceedPastScanAccessPopoverIfNeeded()
+    }
+
+    private func dismissOnboardingIfNeeded() {
+        let continueWithout = app.buttons["Continue Without Access"]
+        if continueWithout.waitForExistence(timeout: 2) {
+            continueWithout.click()
+        }
+    }
+
+    /// Without Full Disk Access the scan button raises the access popover —
+    /// proceed with "Scan Anyway" so the test exercises the dashboard either way.
+    private func proceedPastScanAccessPopoverIfNeeded() {
+        let scanAnyway = app.buttons["fda.popover.scanAnyway"]
+        if scanAnyway.waitForExistence(timeout: 3) {
+            scanAnyway.click()
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Reshapes the post-scan Privacy screen from a flat list of up to 35 per-browser × per-category checkbox rows (everything pre-checked, no summary, inconsistent with the rest of the app) into a curated dashboard plus a single management catalog — reusing the card and "View All Tasks" catalog patterns already established by the Applications and Optimization sections.

## What changed

**Dashboard** (`PrivacyDashboardView`)
- Headline: "We've found X of browsing data across N browsers."
- Curated card grid **capped at 4 cards** — largest categories first as a tall hero + adaptive grid, reusing `ApplicationsCard` so tile widths/surfaces match Applications and Optimization exactly. The System Traces card is the first dropped when 4+ categories have findings (it stays reachable in the catalog).
- Header buttons **"View All Data"** and **"Re-scan"** side by side. No pinned footer.

**Privacy Manager catalog** (`PrivacyDataCatalogView`)
- One shared surface opened by both "View All Data" and every card's **"Review"** — Review deep-links to the matching pane.
- Sub-navigation is **per-category + System**; each pane lists the detected browsers as a multi-select checklist showing each browser's **real app icon** (via the shared `AppIconCache`, resolved once per scan through Launch Services and warmed off the main thread).
- A pinned **Clear bar** carries the running selection total and the destructive Clear action, mirroring Optimization's Run bar. The confirmation alert is unchanged.

**View model** (`PrivacyViewModel`, TDD)
- New `totalFoundSize`, `size(forCategory:)`, and `dashboardCategories()` aggregate the already-cached per-cell sizes using the existing path-dedup. All selection-independent, so they need no new I/O.
- Selection state and the `clear()` path are unchanged.

## Reviewer notes

- This is largely a view-layer reshape; the destructive `clear()` logic, default selection, and path-dedup were not touched.
- Browser icons appear **only when reviewing** (catalog rows), not on the dashboard grid — by design.
- **Tests:** 6 new `PrivacyViewModel` unit tests for the dashboard metrics; full unit suite passes (`CODE_SIGNING_ALLOWED=NO`). New `PrivacyUITests` cover the 4-card cap, Review → catalog deep-link, and the catalog panes / Clear bar — these compile but, per this project's known limitation, the XCUITest runner can't bootstrap from a headless terminal, so they need a run from Xcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Privacy Dashboard displays discovered privacy data in an organized card layout with category metrics and total size information
  * New Privacy Manager catalog enables detailed browsing and multi-select management of privacy data across detected browsers
  * Streamlined clear functionality with a pinned action bar and selection summary for efficient data removal

* **Tests**
  * Comprehensive test coverage added for privacy scanning, dashboard rendering, and data management workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->