### PR TITLE
Redesign Health Monitor dashboard and align verdict with CleanMyMac

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -138,12 +138,14 @@
 		6E46F49E0A26E456B1666B3D /* ActivationPolicyDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */; };
 		6EF22E5516F91C461FBBB850 /* SmartScanApplicationsReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215EFDDDC81E5E7C6DBD72AB /* SmartScanApplicationsReview.swift */; };
 		6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */; };
+		6FEEC4B62B2D99B25975B8DE /* ConnectedDevicesMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1071E99E2EFBE2C48C528D41 /* ConnectedDevicesMonitorTests.swift */; };
 		70D8E3251176A02F51CB78FD /* MalwareThreatRemoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */; };
 		710F2D2D1D68AEDE1A9462CD /* MalwareViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A9C2E47C91B66B79030BE7 /* MalwareViewModelTests.swift */; };
 		725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */; };
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		7402B73FF79A2F6838E71784 /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C751F5671E4A4657944A7DFC /* PrivacyView.swift */; };
 		7482CE5200C0E7C18DED2C63 /* SpaceLensPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3950DBE6E02BD50A6833C60E /* SpaceLensPalette.swift */; };
+		753D0372717545D89CC0A6C6 /* ConnectedDevicesMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218E411D3045401D9A955CE7 /* ConnectedDevicesMonitor.swift */; };
 		75D6F67D3F8C742940CD9CD8 /* SpaceLensPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D7BEEA4BEA21693232C5B1 /* SpaceLensPaletteTests.swift */; };
 		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		7B4A89F26C67D0A6372E2A78 /* OptimizationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22622AEBD53221D89CB1439D /* OptimizationUITests.swift */; };
@@ -346,6 +348,7 @@
 		0D83104C36AA0A0E85DB7698 /* MaintenanceTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTask.swift; sourceTree = "<group>"; };
 		0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensUITests.swift; sourceTree = "<group>"; };
 		0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModel.swift; sourceTree = "<group>"; };
+		1071E99E2EFBE2C48C528D41 /* ConnectedDevicesMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedDevicesMonitorTests.swift; sourceTree = "<group>"; };
 		1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewSubviews.swift; sourceTree = "<group>"; };
 		133467A06193C406B027D97C /* NavigationSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSectionTests.swift; sourceTree = "<group>"; };
 		13A5713F5928025F9FE34A43 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -361,6 +364,7 @@
 		1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFileLocatorTests.swift; sourceTree = "<group>"; };
 		1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemManagerTests.swift; sourceTree = "<group>"; };
 		215EFDDDC81E5E7C6DBD72AB /* SmartScanApplicationsReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanApplicationsReview.swift; sourceTree = "<group>"; };
+		218E411D3045401D9A955CE7 /* ConnectedDevicesMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedDevicesMonitor.swift; sourceTree = "<group>"; };
 		22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperRegistration.swift; sourceTree = "<group>"; };
 		22622AEBD53221D89CB1439D /* OptimizationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizationUITests.swift; sourceTree = "<group>"; };
 		22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateCheckerTests.swift; sourceTree = "<group>"; };
@@ -686,6 +690,7 @@
 				4F5BB068BDD86F2C6D2FC966 /* ClamAVDetector.swift */,
 				D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */,
 				4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */,
+				218E411D3045401D9A955CE7 /* ConnectedDevicesMonitor.swift */,
 				C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */,
 				232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */,
 				B39407E2EA6D045893F1BA4B /* DiskNode.swift */,
@@ -888,6 +893,7 @@
 				E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */,
 				CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */,
 				C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */,
+				1071E99E2EFBE2C48C528D41 /* ConnectedDevicesMonitorTests.swift */,
 				3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */,
 				EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */,
 				E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */,
@@ -1187,6 +1193,7 @@
 				8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */,
 				725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */,
 				DC099BEFD567C81EAA36519E /* ClamAVScannerTests.swift in Sources */,
+				6FEEC4B62B2D99B25975B8DE /* ConnectedDevicesMonitorTests.swift in Sources */,
 				ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */,
 				DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */,
 				FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */,
@@ -1324,6 +1331,7 @@
 				80B190269BF951513C453663 /* ClamAVDetector.swift in Sources */,
 				25057052F5E478AD7B692B9F /* ClamAVOutputParser.swift in Sources */,
 				117989F5D9137A7400CE8760 /* ClamAVScanner.swift in Sources */,
+				753D0372717545D89CC0A6C6 /* ConnectedDevicesMonitor.swift in Sources */,
 				3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */,
 				BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */,
 				B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
 		565D536F93383C694A29481C /* AppUpdaterErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E433919E8C7F3BD3490A19D /* AppUpdaterErrorTests.swift */; };
 		567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */; };
+		56E0A50749CEFC070968439D /* SMCReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12A2F1D83447E7306463614 /* SMCReader.swift */; };
 		57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */; };
 		5B5767BC82C24D92B50032FE /* MalwareOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */; };
 		5C240506F97A777E37CA25B2 /* PrivacyViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */; };
@@ -574,6 +575,7 @@
 		DFA53708AC4AEF0BCFABC82D /* NotificationThresholdMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitorTests.swift; sourceTree = "<group>"; };
 		E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalPolishUITests.swift; sourceTree = "<group>"; };
 		E0A3E48892F238EEC77DA6E5 /* PreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStore.swift; sourceTree = "<group>"; };
+		E12A2F1D83447E7306463614 /* SMCReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SMCReader.swift; sourceTree = "<group>"; };
 		E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingViewModel.swift; sourceTree = "<group>"; };
 		E2017911CF02D2B89E8BF865 /* MailReindexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailReindexer.swift; sourceTree = "<group>"; };
 		E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewModel.swift; sourceTree = "<group>"; };
@@ -779,6 +781,7 @@
 				3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */,
 				D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */,
 				DEB9C7A07E62C19FD94824B5 /* SmartScanViewSubviews.swift */,
+				E12A2F1D83447E7306463614 /* SMCReader.swift */,
 				B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */,
 				3950DBE6E02BD50A6833C60E /* SpaceLensPalette.swift */,
 				897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */,
@@ -1394,6 +1397,7 @@
 				196F1CEAC86015854C7772D7 /* ProcessLineStreamer.swift in Sources */,
 				7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */,
 				567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */,
+				56E0A50749CEFC070968439D /* SMCReader.swift in Sources */,
 				45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */,
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,
 				9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */; };
 		56E0A50749CEFC070968439D /* SMCReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12A2F1D83447E7306463614 /* SMCReader.swift */; };
 		57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */; };
+		5B37ECDBF03FBACFBE099816 /* MenuRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7322D2E167E70ED4D0FBFBA2 /* MenuRouter.swift */; };
 		5B5767BC82C24D92B50032FE /* MalwareOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E177C5757BB8E0E39F5A0DE1 /* MalwareOnboardingViewModel.swift */; };
 		5C240506F97A777E37CA25B2 /* PrivacyViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */; };
 		5CA2A4BED5346B2FD4ADE096 /* MachOHeaderReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E49583606C1454E9F0AF2C /* MachOHeaderReaderTests.swift */; };
@@ -464,6 +465,7 @@
 		7220D06D757039BF087D7F50 /* ApplicationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsViewModel.swift; sourceTree = "<group>"; };
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		7315AD5A081B0855C316F00F /* MalwareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareView.swift; sourceTree = "<group>"; };
+		7322D2E167E70ED4D0FBFBA2 /* MenuRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRouter.swift; sourceTree = "<group>"; };
 		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
 		7707C4D6B14FF468458441A6 /* SpaceLensViewModeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensViewModeStoreTests.swift; sourceTree = "<group>"; };
 		785EECE3C6B84ECB7D0A3384 /* spaceLens.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = spaceLens.usdz; sourceTree = "<group>"; };
@@ -741,6 +743,7 @@
 				DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */,
 				D2C2B92863509818189F46CD /* MenuBarContent.swift */,
 				8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */,
+				7322D2E167E70ED4D0FBFBA2 /* MenuRouter.swift */,
 				D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */,
 				2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */,
 				B3CD8C98E8253953444DD99F /* NotificationManager.swift */,
@@ -1383,6 +1386,7 @@
 				390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */,
 				BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */,
 				C2F35144C0139C8829C4BB8A /* MenuBarViewModel.swift in Sources */,
+				5B37ECDBF03FBACFBE099816 /* MenuRouter.swift in Sources */,
 				5325F2401AF35C69086E2056 /* NavigationRailView.swift in Sources */,
 				F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */,
 				65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */,

--- a/VaderCleaner/AppUninstallerViewSubviews.swift
+++ b/VaderCleaner/AppUninstallerViewSubviews.swift
@@ -374,7 +374,7 @@ struct AppUninstallerDetailFooter: View {
             ), action: onUninstall)
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(!canUninstall)
                 .accessibilityIdentifier("appUninstaller.uninstall")
         }
@@ -487,7 +487,7 @@ struct AppUninstallerFailedState: View {
                     ), action: onReinstallHelper)
                         .controlSize(.large)
                         .keyboardShortcut(.defaultAction)
-                        .buttonStyle(.borderedProminent)
+                        .buttonStyle(.vaderProminent)
                         .accessibilityIdentifier("appUninstaller.reinstallHelper")
                     Button(String(
                         localized: "Try Again",

--- a/VaderCleaner/AppUpdaterView.swift
+++ b/VaderCleaner/AppUpdaterView.swift
@@ -146,7 +146,7 @@ private struct AppUpdaterListState: View {
                 ), action: updateAllTapped)
                     .controlSize(.large)
                     .keyboardShortcut(.defaultAction)
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.vaderProminent)
                     .accessibilityIdentifier("appUpdater.updateAll")
             }
             .padding(16)

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -386,7 +386,7 @@ struct ApplicationsCard: View {
             HStack {
                 Spacer()
                 Button(actionLabel, action: action)
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.vaderProminent)
                     .accessibilityIdentifier(identifier)
             }
         }
@@ -476,7 +476,7 @@ struct InstallationFilesReviewView: View {
                 localized: "Move to Trash",
                 comment: "Button that moves the selected installation files to the Trash."
             ), action: onRemove)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(!canRemove)
                 .accessibilityIdentifier("applications.installationFiles.remove")
         }
@@ -665,7 +665,7 @@ struct UnsupportedAppsReviewView: View {
                 localized: "Move to Trash",
                 comment: "Button that moves the selected unsupported apps to the Trash."
             ), action: onRemove)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(!canRemove)
                 .accessibilityIdentifier("applications.unsupported.remove")
         }
@@ -841,7 +841,7 @@ struct UnusedAppsReviewView: View {
                 localized: "Move to Trash",
                 comment: "Button that moves the selected unused apps to the Trash."
             ), action: onRemove)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(!canRemove)
                 .accessibilityIdentifier("applications.unused.remove")
         }
@@ -1015,7 +1015,7 @@ struct AppLeftoversReviewView: View {
                 localized: "Move to Trash",
                 comment: "Button that moves the selected leftover files to the Trash."
             ), action: onRemove)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(!canRemove)
                 .accessibilityIdentifier("applications.leftovers.remove")
         }

--- a/VaderCleaner/ConnectedDevicesMonitor.swift
+++ b/VaderCleaner/ConnectedDevicesMonitor.swift
@@ -1,0 +1,106 @@
+// ConnectedDevicesMonitor.swift
+// Lists connected Bluetooth devices and ejectable volumes for the menu's Connected Devices tile, and performs volume ejection.
+
+import Foundation
+import AppKit
+import IOBluetooth
+import Observation
+
+/// One entry in the menu's Connected Devices tile — a connected Bluetooth
+/// device or a removable/ejectable volume.
+struct ConnectedDevice: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case bluetooth
+        case volume
+    }
+
+    let id: String
+    let name: String
+    let kind: Kind
+    /// Battery percentage when the device reports it; `nil` otherwise. Bluetooth
+    /// battery has no public API, so this is typically `nil` for now.
+    let batteryPercent: Int?
+    /// For volumes, the mount URL to eject; `nil` for Bluetooth.
+    let volumeURL: URL?
+}
+
+/// Enumerates connected Bluetooth devices and ejectable volumes, and ejects
+/// volumes on request. App-scope and refreshed on demand (devices change
+/// infrequently) so the menu can show them without a dedicated poll timer.
+@MainActor
+@Observable
+final class ConnectedDevicesMonitor {
+
+    private(set) var devices: [ConnectedDevice] = []
+
+    init(autoRefresh: Bool = true) {
+        if autoRefresh { refresh() }
+    }
+
+    /// Re-reads the Bluetooth and volume lists. Cheap enough to call when the
+    /// menu opens.
+    func refresh() {
+        devices = bluetoothDevices() + ejectableVolumes()
+    }
+
+    /// Ejects a volume entry. No-op for Bluetooth entries or if ejection fails
+    /// (the device may be busy); a failure is surfaced by the volume simply
+    /// remaining in the list on the next refresh.
+    func eject(_ device: ConnectedDevice) {
+        guard let url = device.volumeURL else { return }
+        try? NSWorkspace.shared.unmountAndEjectDevice(at: url)
+        refresh()
+    }
+
+    // MARK: - Volumes
+
+    private func ejectableVolumes() -> [ConnectedDevice] {
+        let keys: Set<URLResourceKey> = [
+            .volumeNameKey, .volumeIsRemovableKey, .volumeIsEjectableKey, .volumeIsInternalKey
+        ]
+        guard let urls = FileManager.default.mountedVolumeURLs(
+            includingResourceValuesForKeys: Array(keys),
+            options: [.skipHiddenVolumes]
+        ) else { return [] }
+
+        return urls.compactMap { url in
+            guard let values = try? url.resourceValues(forKeys: keys) else { return nil }
+            guard Self.shouldList(
+                isEjectable: values.volumeIsEjectable ?? false,
+                isRemovable: values.volumeIsRemovable ?? false,
+                isInternal: values.volumeIsInternal ?? false
+            ) else { return nil }
+            return ConnectedDevice(
+                id: "vol:\(url.path)",
+                name: values.volumeName ?? url.lastPathComponent,
+                kind: .volume,
+                batteryPercent: nil,
+                volumeURL: url
+            )
+        }
+    }
+
+    /// A volume belongs in the tile when it's user-ejectable (removable or
+    /// ejectable) and not the internal boot disk. Pure so the rule is testable.
+    static func shouldList(isEjectable: Bool, isRemovable: Bool, isInternal: Bool) -> Bool {
+        (isEjectable || isRemovable) && !isInternal
+    }
+
+    // MARK: - Bluetooth
+
+    private func bluetoothDevices() -> [ConnectedDevice] {
+        guard let paired = IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice] else { return [] }
+        return paired
+            .filter { $0.isConnected() }
+            .map { device in
+                let address = device.addressString ?? UUID().uuidString
+                return ConnectedDevice(
+                    id: "bt:\(address)",
+                    name: device.name ?? device.addressString ?? String(localized: "Bluetooth Device"),
+                    kind: .bluetooth,
+                    batteryPercent: nil,
+                    volumeURL: nil
+                )
+            }
+    }
+}

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @Environment(PermissionOnboardingViewModel.self) private var onboarding
     @Environment(SystemStatsService.self) private var systemStats
     @Environment(NotificationThresholdMonitor.self) private var notificationMonitor
+    @Environment(MenuRouter.self) private var menuRouter
     @Environment(\.scenePhase) private var scenePhase
     private let systemJunkViewModel: SystemJunkViewModel
     private let largeOldFilesViewModel: LargeOldFilesViewModel
@@ -181,6 +182,11 @@ struct ContentView: View {
                 appState.refresh()
             }
         }
+        // Consume any deep-link the menu bar panel recorded. Handled both on
+        // appear (window was just opened/created by the menu) and on change
+        // (window already open when the menu fired the request).
+        .onAppear { applyPendingRoute() }
+        .onChange(of: menuRouter.requestedSection) { _, _ in applyPendingRoute() }
         // Ask for notification permission only after the FDA onboarding has
         // settled — either the user already has Full Disk Access, or they
         // dismissed the sheet via "Continue Without Access". Stacking the
@@ -227,6 +233,24 @@ struct ContentView: View {
                     selectedSection = target
                 }
             }
+        }
+    }
+
+    /// Applies a pending deep-link from the menu bar panel: navigates to the
+    /// requested section and, when asked, begins that section's scan. Clears the
+    /// request so it fires exactly once. No-op when nothing is pending.
+    private func applyPendingRoute() {
+        guard let target = menuRouter.requestedSection else { return }
+        let startScan = menuRouter.requestStartScan
+        menuRouter.requestedSection = nil
+        menuRouter.requestStartScan = false
+
+        selectSection(target)
+
+        // Only Smart Scan auto-starts from the menu's "Run Smart Scan" — the
+        // other deep-links just reveal the section and let the user act.
+        if startScan, target == .smartScan {
+            smartScanViewModel.beginScan()
         }
     }
 
@@ -373,4 +397,5 @@ private extension AnyTransition {
             preferences: prefs,
             dispatcher: notificationManager
         ))
+        .environment(MenuRouter())
 }

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -447,9 +447,11 @@ private struct HealthRing: View {
     }
 }
 
-private extension MacHealthStatus {
+extension MacHealthStatus {
     /// Signature color per tier, matching the reference design's ramp from a
-    /// warm critical red through amber and teal to a confident blue.
+    /// warm critical red through amber and teal to a confident blue. Shared by
+    /// the Health Monitor hero and the menu bar panel so the verdict reads in
+    /// the same colour in both places.
     var accentColor: Color {
         switch self {
         case .critical:          return Color(red: 1.00, green: 0.45, blue: 0.38)

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -1,16 +1,18 @@
 // HealthMonitorView.swift
-// Health Monitor detail view — 5 stat cards (Battery, Disk SMART, RAM, CPU, Disk Space) plus a FileVault footer, bound to SystemStatsService via HealthMonitorViewModel.
+// Health Monitor dashboard — a tall Mac Health hero and a Disk Encryption card in the left column, with a grid of live metric cards (Battery, Disk Health, RAM, CPU, Disk Space) on the right, bound to SystemStatsService via HealthMonitorViewModel.
 
 import SwiftUI
 
-/// Card-style grid showing live system health. Each card is a small fixed-shape
-/// `HealthCard` with an SF Symbol, label, primary value, optional secondary
-/// value, and a status dot driven by `HealthMonitorViewModel`'s `StatusColor`.
+/// Two-column dashboard of live system health. The left column leads with the
+/// `MacHealthHero` — one overall verdict, a glowing ring, and the boot volume's
+/// fill — and carries the Disk Encryption card beneath it. The right column is a
+/// reflowing grid of `HealthCard` tiles, each with a prominent icon, an info
+/// affordance, a primary value, and a status dot driven by the view-model's
+/// `StatusColor`.
 ///
-/// The grid uses `LazyVGrid` with `.adaptive(minimum: 260)` so the card shelf
-/// re-flows on window resize without explicit breakpoints. FileVault — being
-/// a binary security toggle rather than a continuously varying reading — sits
-/// below the grid as a single info row, matching the spec.
+/// The right grid uses `LazyVGrid` with `.adaptive(minimum: 240)` so it drops
+/// from two columns to one as the window narrows, while the left column keeps a
+/// fixed width so the hero never collapses.
 struct HealthMonitorView: View {
 
     @State private var viewModel: HealthMonitorViewModel
@@ -19,37 +21,58 @@ struct HealthMonitorView: View {
         _viewModel = State(initialValue: HealthMonitorViewModel(service: service))
     }
 
-    private let columns = [GridItem(.adaptive(minimum: 260), spacing: 16)]
+    /// Fixed width of the left hero column, so the hero and its disk bar keep a
+    /// stable shape while the right tiles absorb the remaining width.
+    private let leftColumnWidth: CGFloat = 340
+
+    /// The overall Mac Health verdict's signature color (gray while measuring),
+    /// shared by every metric tile so the whole section reads in one accent that
+    /// tracks the hero — the same ramp the hero ring and title use.
+    private var verdictAccent: Color {
+        viewModel.macHealth?.accentColor ?? Color(white: 0.55)
+    }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                // The hero card leads with one overall verdict and the boot
-                // volume's fill, mirroring the dashboard "Mac Health" panel.
-                // The per-metric cards below remain the detailed breakdown.
+        // The whole dashboard fills the detail pane without a scroll view: the
+        // left hero stretches to the column height and the right tiles divide
+        // the available height into equal rows, so the screen fits any window
+        // tall enough for the navigation rail.
+        HStack(alignment: .top, spacing: 20) {
+            // Left column: the focal hero plus the binary security toggle,
+            // mirroring the reference dashboard's hero-and-card stack.
+            VStack(spacing: 16) {
                 MacHealthHero(
                     status: viewModel.macHealth,
                     volumeName: viewModel.diskVolumeName,
                     diskUsageDetail: viewModel.diskUsageDetail,
                     diskRatio: viewModel.diskRatio
                 )
-                // Group the tiles in one container so adjacent glass cards
-                // sample each other and refract consistently as the grid
-                // reflows on resize.
-                GlassEffectContainer(spacing: 16) {
-                    LazyVGrid(columns: columns, spacing: 16) {
+                .frame(maxHeight: .infinity)
+                fileVaultCard
+            }
+            .frame(width: leftColumnWidth)
+
+            // Right column: the per-metric tiles in two rows of two with the
+            // full-width Disk Space tile beneath. Grouped in one container so
+            // adjacent glass cards sample each other and refract consistently.
+            // Every tile takes an equal share of the column height so the grid
+            // never overflows the pane.
+            GlassEffectContainer(spacing: 16) {
+                VStack(spacing: 16) {
+                    HStack(spacing: 16) {
                         batteryCard
                         smartCard
+                    }
+                    HStack(spacing: 16) {
                         ramCard
                         cpuCard
-                        diskCard
                     }
+                    diskCard
                 }
-                Divider()
-                fileVaultRow
             }
-            .padding(20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle(NavigationSection.healthMonitor.title)
     }
@@ -60,24 +83,25 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "battery.100",
             title: "Battery Health",
-            statusColor: viewModel.batteryColor
+            accent: verdictAccent,
+            info: "Battery condition and capacity relative to when it was new, plus lifetime charge cycles."
         ) {
             switch viewModel.batteryAvailability {
             case .unknown:
                 Text("—")
-                    .font(.title2.weight(.semibold))
+                    .font(.title.weight(.semibold))
                 Text("Checking battery")
                     .font(.callout)
                     .foregroundStyle(.secondary)
             case .absent:
                 Text("—")
-                    .font(.title2.weight(.semibold))
+                    .font(.title.weight(.semibold))
                 Text("No internal battery")
                     .font(.callout)
                     .foregroundStyle(.secondary)
             case .present(let stats):
                 Text(HealthMonitorViewModel.batteryCapacityString(stats))
-                    .font(.title2.weight(.semibold))
+                    .font(.title.weight(.semibold))
                     .accessibilityIdentifier("health.battery.capacity")
                 Text(stats.condition)
                     .font(.callout)
@@ -94,10 +118,11 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "internaldrive",
             title: "Disk Health",
-            statusColor: viewModel.smartColor
+            accent: verdictAccent,
+            info: "The drive's SMART self-assessment. \"Good\" means the disk reports no predicted failures."
         ) {
             Text(viewModel.smartLabel)
-                .font(.title2.weight(.semibold))
+                .font(.title.weight(.semibold))
                 .accessibilityIdentifier("health.smart.label")
             Text("SMART status")
                 .font(.callout)
@@ -110,13 +135,14 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "memorychip",
             title: "RAM Pressure",
-            statusColor: viewModel.ramPressureColor
+            accent: verdictAccent,
+            info: "Memory in use versus total, with the system's current memory-pressure level."
         ) {
             Text(viewModel.ramUsage)
-                .font(.title2.weight(.semibold))
+                .font(.title.weight(.semibold))
                 .accessibilityIdentifier("health.ram.usage")
             HStack(spacing: 8) {
-                PressureBadge(level: viewModel.ramPressureLevel, label: viewModel.ramPressureLabel)
+                PressureBadge(label: viewModel.ramPressureLabel, accent: verdictAccent)
                 Spacer()
             }
         }
@@ -127,14 +153,15 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "cpu",
             title: "CPU Load",
-            statusColor: viewModel.cpuColor
+            accent: verdictAccent,
+            info: "Share of processor capacity currently in use across all cores."
         ) {
             Text(viewModel.cpuPercent)
-                .font(.title2.weight(.semibold))
+                .font(.title.weight(.semibold))
                 .accessibilityIdentifier("health.cpu.percent")
             ProgressView(value: viewModel.cpuRatio)
                 .progressViewStyle(.linear)
-                .tint(viewModel.cpuColor.color)
+                .tint(verdictAccent)
         }
         .accessibilityIdentifier("health.card.cpu")
     }
@@ -143,31 +170,48 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "externaldrive",
             title: "Disk Space",
-            statusColor: viewModel.diskColor
+            accent: verdictAccent,
+            info: "How full the boot volume is. Reclaiming space keeps your Mac responsive."
         ) {
             Text(viewModel.diskUsage)
-                .font(.title2.weight(.semibold))
+                .font(.title.weight(.semibold))
                 .accessibilityIdentifier("health.disk.usage")
             ProgressView(value: viewModel.diskRatio)
                 .progressViewStyle(.linear)
-                .tint(viewModel.diskColor.color)
+                .tint(verdictAccent)
         }
         .accessibilityIdentifier("health.card.disk")
     }
 
-    // MARK: - FileVault footer
+    // MARK: - Disk Encryption card
 
-    private var fileVaultRow: some View {
-        HStack(spacing: 10) {
+    /// FileVault — a binary security toggle rather than a continuously varying
+    /// reading — gets a horizontal card beneath the hero, echoing the reference
+    /// dashboard's secondary left-column card.
+    private var fileVaultCard: some View {
+        HStack(spacing: 14) {
             Image(systemName: viewModel.fileVaultIconName)
-                .font(.title3)
-                .foregroundStyle(viewModel.fileVaultColor.color)
-            Text(viewModel.fileVaultLabel)
-                .font(.callout)
-            StatusDot(color: viewModel.fileVaultColor)
-            Spacer()
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(verdictAccent)
+                .frame(width: 46, height: 46)
+                .background(
+                    RoundedRectangle(cornerRadius: 13, style: .continuous)
+                        .fill(verdictAccent.opacity(0.18))
+                )
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Disk Encryption")
+                    .font(.subheadline.weight(.semibold))
+                Text(viewModel.fileVaultLabel)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            StatusDot(color: verdictAccent)
         }
-        .padding(.horizontal, 4)
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassEffect(.regular, in: .rect(cornerRadius: 18))
+        .accessibilityElement(children: .combine)
         .accessibilityIdentifier("health.filevault")
     }
 
@@ -176,9 +220,10 @@ struct HealthMonitorView: View {
 // MARK: - Mac Health hero
 
 /// The dashboard-style hero card: a glowing ring around a laptop, the single
-/// overall verdict, and the boot volume's fill. Always rendered dark (like the
-/// reference design) so it reads as the focal element regardless of system
-/// appearance; text colors are therefore pinned light rather than semantic.
+/// overall verdict, the boot volume's fill, and an info affordance. Always
+/// rendered dark (like the reference design) so it reads as the focal element
+/// regardless of system appearance; text colors are therefore pinned light
+/// rather than semantic.
 private struct MacHealthHero: View {
     /// `nil` means the boot volume hasn't been measured yet — the card shows a
     /// neutral "Measuring…" state instead of a confident verdict.
@@ -187,9 +232,18 @@ private struct MacHealthHero: View {
     let diskUsageDetail: String
     let diskRatio: Double
 
-    /// The status's signature color (gray while measuring). Drives the ring,
-    /// the title, the laptop tint, the disk bar, and the background glow.
+    @State private var showingInfo = false
+
+    /// The status's signature color (gray while measuring). Drives the verdict
+    /// ring, the title, the laptop tint, and the disk bar so the health signal
+    /// reads clearly.
     private var accent: Color { status?.accentColor ?? Color(white: 0.55) }
+
+    /// The section's signature green, pulled from the single source of truth in
+    /// `SectionTheme`. Drives the hero's base gradient, glow, border, and lift so
+    /// the tile's overall vibe stays locked to the Health Monitor section no
+    /// matter which verdict tint the ring is showing.
+    private let sectionAccent = NavigationSection.healthMonitor.theme.accent
 
     private var titleText: String {
         status?.title ?? String(localized: "Measuring…")
@@ -200,44 +254,80 @@ private struct MacHealthHero: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 24) {
-            VStack(alignment: .leading, spacing: 0) {
-                Text("Mac Health:")
-                    .font(.title3.weight(.semibold))
-                    .foregroundStyle(.white.opacity(0.7))
-                Text(titleText)
-                    .font(.system(size: 34, weight: .bold))
-                    .foregroundStyle(accent)
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Mac Health:")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.7))
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(titleText)
+                            .font(.system(size: 30, weight: .bold))
+                            .foregroundStyle(accent)
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.7)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("health.hero.status")
+                        infoButton
+                    }
                     .padding(.top, 2)
-                    .accessibilityIdentifier("health.hero.status")
-                Text(summaryText)
-                    .font(.callout)
-                    .foregroundStyle(.white.opacity(0.6))
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.top, 8)
-
-                Spacer(minLength: 24)
-
-                // While measuring (status == nil) the disk reads zero bytes, so
-                // hide the block rather than show "Zero KB of Zero KB used".
-                if status != nil {
-                    diskBlock
                 }
+
+                Spacer(minLength: 0)
+
+                HealthRing(color: accent, isMeasuring: status == nil)
+                    .frame(width: 140, height: 140)
+                    .overlay { laptop }
+                    .accessibilityIdentifier("health.hero.ring")
             }
 
-            Spacer(minLength: 0)
+            Text(summaryText)
+                .font(.callout)
+                .foregroundStyle(.white.opacity(0.6))
+                .fixedSize(horizontal: false, vertical: true)
 
-            HealthRing(color: accent, isMeasuring: status == nil)
-                .frame(width: 190, height: 190)
-                .overlay { laptop }
-                .accessibilityIdentifier("health.hero.ring")
+            Spacer(minLength: 8)
+
+            // While measuring (status == nil) the disk reads zero bytes, so
+            // hide the block rather than show "Zero KB of Zero KB used".
+            if status != nil {
+                diskBlock
+            }
         }
-        .padding(28)
-        .frame(maxWidth: .infinity, minHeight: 250, alignment: .topLeading)
+        .padding(24)
+        .frame(maxWidth: .infinity, minHeight: 300, alignment: .topLeading)
         .background(heroBackground)
         .clipShape(.rect(cornerRadius: 20))
+        // A hairline accent border and a soft green lift set the hero apart
+        // from the flat glass tiles without leaving the section's palette.
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .strokeBorder(sectionAccent.opacity(0.30), lineWidth: 1)
+        )
+        .shadow(color: sectionAccent.opacity(0.20), radius: 20, y: 8)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("health.hero")
+    }
+
+    /// Small "i" affordance beside the verdict that explains how the overall
+    /// health score is derived.
+    private var infoButton: some View {
+        Button {
+            showingInfo.toggle()
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(0.55))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showingInfo, arrowEdge: .bottom) {
+            Text("Your Mac's overall health, derived from how full the disk is and the individual hardware and security checks.")
+                .font(.callout)
+                .padding(14)
+                .frame(maxWidth: 260)
+        }
+        .help("How the health score is calculated")
+        .accessibilityHidden(true)
     }
 
     /// Boot-volume name with its "used of total" fill below a slim bar.
@@ -263,7 +353,7 @@ private struct MacHealthHero: View {
     /// Laptop glyph centered inside the ring.
     private var laptop: some View {
         Image(systemName: "laptopcomputer")
-            .font(.system(size: 56, weight: .light))
+            .font(.system(size: 44, weight: .light))
             .foregroundStyle(
                 LinearGradient(
                     colors: [.white.opacity(0.95), accent.opacity(0.85)],
@@ -274,23 +364,31 @@ private struct MacHealthHero: View {
             .accessibilityHidden(true)
     }
 
-    /// Fixed dark gradient with the accent glow concentrated behind the ring,
-    /// matching the reference design's always-dark hero panel.
+    /// Rich emerald panel that keeps the hero in the section's green family while
+    /// reading as an elevated, special surface. A deeper, more saturated base
+    /// than the window backdrop, a section-green bloom behind the ring, and a
+    /// soft top sheen for a premium, glassy lift.
     private var heroBackground: some View {
         ZStack {
             LinearGradient(
                 colors: [
-                    Color(red: 0.10, green: 0.09, blue: 0.16),
-                    Color(red: 0.17, green: 0.13, blue: 0.27)
+                    Color(red: 0.02, green: 0.14, blue: 0.11),
+                    Color(red: 0.05, green: 0.24, blue: 0.18)
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
             RadialGradient(
-                colors: [accent.opacity(0.30), .clear],
-                center: UnitPoint(x: 0.82, y: 0.42),
+                colors: [sectionAccent.opacity(0.28), .clear],
+                center: UnitPoint(x: 0.82, y: 0.30),
                 startRadius: 8,
-                endRadius: 300
+                endRadius: 280
+            )
+            RadialGradient(
+                colors: [Color.white.opacity(0.06), .clear],
+                center: UnitPoint(x: 0.2, y: 0.0),
+                startRadius: 0,
+                endRadius: 320
             )
         }
     }
@@ -365,53 +463,93 @@ private extension MacHealthStatus {
 
 // MARK: - Subviews
 
-/// Reusable card wrapper. Keeps card geometry consistent across the grid so
-/// the user's eye doesn't have to retrain on each tile.
+/// Reusable metric tile. Keeps card geometry consistent across the grid so the
+/// user's eye doesn't have to retrain on each tile: a prominent accent icon and
+/// info affordance up top, the metric title, and the live value below.
 private struct HealthCard<Content: View>: View {
     let icon: String
     let title: String
-    let statusColor: StatusColor
+    /// Shared section accent — the overall Mac Health verdict color — used for
+    /// the icon tile and the status dot so every tile reads in one hue.
+    let accent: Color
+    /// Plain-language explanation shown in the card's info popover.
+    let info: String
     @ViewBuilder var content: Content
 
+    @State private var showingInfo = false
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
-                Image(systemName: icon)
-                    .font(.title2)
-                    .foregroundStyle(.tint)
+                iconTile
                 Spacer()
-                StatusDot(color: statusColor)
+                StatusDot(color: accent)
+                infoButton
             }
             Text(title)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
                 .textCase(.uppercase)
             content
+            Spacer(minLength: 0)
         }
-        .padding(16)
-        .frame(maxWidth: .infinity, minHeight: 140, alignment: .topLeading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .padding(18)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .glassEffect(.regular, in: .rect(cornerRadius: 18))
+    }
+
+    /// Prominent rounded icon tile in the shared verdict accent, echoing the
+    /// reference dashboard's large card icons.
+    private var iconTile: some View {
+        Image(systemName: icon)
+            .font(.system(size: 22, weight: .semibold))
+            .foregroundStyle(accent)
+            .frame(width: 46, height: 46)
+            .background(
+                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                    .fill(accent.opacity(0.16))
+            )
+    }
+
+    private var infoButton: some View {
+        Button {
+            showingInfo.toggle()
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showingInfo, arrowEdge: .top) {
+            Text(info)
+                .font(.callout)
+                .padding(14)
+                .frame(maxWidth: 240)
+        }
+        .help(info)
+        .accessibilityHidden(true)
     }
 }
 
-/// 8pt traffic-light dot used for the per-card status indicator and the
-/// FileVault footer.
+/// 8pt accent dot used for the per-card indicator and the Disk Encryption card.
+/// Tinted with the shared verdict accent so every tile reads in one hue.
 private struct StatusDot: View {
-    let color: StatusColor
+    let color: Color
 
     var body: some View {
         Circle()
-            .fill(color.color)
+            .fill(color)
             .frame(width: 10, height: 10)
             .accessibilityHidden(true)
     }
 }
 
 /// Compact pill rendering of the memory pressure level, sitting next to the
-/// raw "used / total" string on the RAM card.
+/// raw "used / total" string on the RAM card. Tinted with the shared verdict
+/// accent so it stays in step with the rest of the section.
 private struct PressureBadge: View {
-    let level: MemoryPressureLevel
     let label: String
+    let accent: Color
 
     var body: some View {
         Text(label)
@@ -419,9 +557,9 @@ private struct PressureBadge: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
             .background(
-                Capsule().fill(HealthMonitorViewModel.pressureColor(for: level).color.opacity(0.15))
+                Capsule().fill(accent.opacity(0.15))
             )
-            .foregroundStyle(HealthMonitorViewModel.pressureColor(for: level).color)
+            .foregroundStyle(accent)
     }
 }
 
@@ -456,7 +594,8 @@ extension StatusColor {
             MacHealthHero(status: .requiresAttention, volumeName: "Macintosh HD", diskUsageDetail: "430 GB of 494 GB used", diskRatio: 0.87)
             MacHealthHero(status: .critical, volumeName: "Macintosh HD", diskUsageDetail: "479 GB of 494 GB used", diskRatio: 0.97)
         }
+        .frame(width: 360)
         .padding(20)
     }
-    .frame(width: 740, height: 720)
+    .frame(width: 420, height: 720)
 }

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -25,12 +25,10 @@ struct HealthMonitorView: View {
     /// stable shape while the right tiles absorb the remaining width.
     private let leftColumnWidth: CGFloat = 340
 
-    /// The overall Mac Health verdict's signature color (gray while measuring),
-    /// shared by every metric tile so the whole section reads in one accent that
-    /// tracks the hero — the same ramp the hero ring and title use.
-    private var verdictAccent: Color {
-        viewModel.macHealth?.accentColor ?? Color(white: 0.55)
-    }
+    /// The section's crimson accent, shared by every metric tile so the whole
+    /// section reads in one Vader-identity accent. The overall health signal is
+    /// carried by the hero's verdict ring and title, which stay semantic.
+    private let sectionAccent = NavigationSection.healthMonitor.theme.accent
 
     var body: some View {
         // The whole dashboard fills the detail pane without a scroll view: the
@@ -83,7 +81,7 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "battery.100",
             title: "Battery Health",
-            accent: verdictAccent,
+            accent: sectionAccent,
             info: "Battery condition and capacity relative to when it was new, plus lifetime charge cycles."
         ) {
             switch viewModel.batteryAvailability {
@@ -118,7 +116,7 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "internaldrive",
             title: "Disk Health",
-            accent: verdictAccent,
+            accent: sectionAccent,
             info: "The drive's SMART self-assessment. \"Good\" means the disk reports no predicted failures."
         ) {
             Text(viewModel.smartLabel)
@@ -135,14 +133,14 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "memorychip",
             title: "RAM Pressure",
-            accent: verdictAccent,
+            accent: sectionAccent,
             info: "Memory in use versus total, with the system's current memory-pressure level."
         ) {
             Text(viewModel.ramUsage)
                 .font(.title.weight(.semibold))
                 .accessibilityIdentifier("health.ram.usage")
             HStack(spacing: 8) {
-                PressureBadge(label: viewModel.ramPressureLabel, accent: verdictAccent)
+                PressureBadge(label: viewModel.ramPressureLabel, accent: sectionAccent)
                 Spacer()
             }
         }
@@ -153,7 +151,7 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "cpu",
             title: "CPU Load",
-            accent: verdictAccent,
+            accent: sectionAccent,
             info: "Share of processor capacity currently in use across all cores."
         ) {
             Text(viewModel.cpuPercent)
@@ -161,7 +159,7 @@ struct HealthMonitorView: View {
                 .accessibilityIdentifier("health.cpu.percent")
             ProgressView(value: viewModel.cpuRatio)
                 .progressViewStyle(.linear)
-                .tint(verdictAccent)
+                .tint(sectionAccent)
         }
         .accessibilityIdentifier("health.card.cpu")
     }
@@ -170,7 +168,7 @@ struct HealthMonitorView: View {
         HealthCard(
             icon: "externaldrive",
             title: "Disk Space",
-            accent: verdictAccent,
+            accent: sectionAccent,
             info: "How full the boot volume is. Reclaiming space keeps your Mac responsive."
         ) {
             Text(viewModel.diskUsage)
@@ -178,7 +176,7 @@ struct HealthMonitorView: View {
                 .accessibilityIdentifier("health.disk.usage")
             ProgressView(value: viewModel.diskRatio)
                 .progressViewStyle(.linear)
-                .tint(verdictAccent)
+                .tint(sectionAccent)
         }
         .accessibilityIdentifier("health.card.disk")
     }
@@ -192,11 +190,11 @@ struct HealthMonitorView: View {
         HStack(spacing: 14) {
             Image(systemName: viewModel.fileVaultIconName)
                 .font(.system(size: 22, weight: .semibold))
-                .foregroundStyle(verdictAccent)
+                .foregroundStyle(sectionAccent)
                 .frame(width: 46, height: 46)
                 .background(
                     RoundedRectangle(cornerRadius: 13, style: .continuous)
-                        .fill(verdictAccent.opacity(0.18))
+                        .fill(sectionAccent.opacity(0.18))
                 )
             VStack(alignment: .leading, spacing: 3) {
                 Text("Disk Encryption")
@@ -206,7 +204,7 @@ struct HealthMonitorView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)
-            StatusDot(color: verdictAccent)
+            StatusDot(color: sectionAccent)
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -345,7 +343,7 @@ private struct MacHealthHero: View {
             }
             ProgressView(value: diskRatio)
                 .progressViewStyle(.linear)
-                .tint(accent)
+                .tint(sectionAccent)
                 .accessibilityIdentifier("health.hero.diskbar")
         }
     }
@@ -356,7 +354,7 @@ private struct MacHealthHero: View {
             .font(.system(size: 44, weight: .light))
             .foregroundStyle(
                 LinearGradient(
-                    colors: [.white.opacity(0.95), accent.opacity(0.85)],
+                    colors: [.white.opacity(0.95), sectionAccent.opacity(0.9)],
                     startPoint: .top,
                     endPoint: .bottom
                 )
@@ -364,16 +362,15 @@ private struct MacHealthHero: View {
             .accessibilityHidden(true)
     }
 
-    /// Rich emerald panel that keeps the hero in the section's green family while
-    /// reading as an elevated, special surface. A deeper, more saturated base
-    /// than the window backdrop, a section-green bloom behind the ring, and a
-    /// soft top sheen for a premium, glassy lift.
+    /// Near-black panel in the Vader identity that reads as an elevated, special
+    /// surface: a deep crimson-black base, a crimson bloom behind the ring, and
+    /// a soft top sheen for a premium, glassy lift.
     private var heroBackground: some View {
         ZStack {
             LinearGradient(
                 colors: [
-                    Color(red: 0.02, green: 0.14, blue: 0.11),
-                    Color(red: 0.05, green: 0.24, blue: 0.18)
+                    Color(red: 0.11, green: 0.03, blue: 0.04),
+                    Color(red: 0.05, green: 0.02, blue: 0.03)
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -25,10 +25,15 @@ struct HealthMonitorView: View {
     /// stable shape while the right tiles absorb the remaining width.
     private let leftColumnWidth: CGFloat = 340
 
-    /// The section's crimson accent, shared by every metric tile so the whole
-    /// section reads in one Vader-identity accent. The overall health signal is
-    /// carried by the hero's verdict ring and title, which stay semantic.
+    /// The section's crimson accent — the Vader-identity chrome color used for
+    /// the prominent tile icons.
     private let sectionAccent = NavigationSection.healthMonitor.theme.accent
+
+    /// The overall Mac Health verdict color (gray while measuring). Drives the
+    /// status dots and progress bars so they track the Mac's health at a glance.
+    private var verdictAccent: Color {
+        viewModel.macHealth?.accentColor ?? Color(white: 0.55)
+    }
 
     var body: some View {
         // The whole dashboard fills the detail pane without a scroll view: the
@@ -82,6 +87,7 @@ struct HealthMonitorView: View {
             icon: "battery.100",
             title: "Battery Health",
             accent: sectionAccent,
+            statusColor: verdictAccent,
             info: "Battery condition and capacity relative to when it was new, plus lifetime charge cycles."
         ) {
             switch viewModel.batteryAvailability {
@@ -117,6 +123,7 @@ struct HealthMonitorView: View {
             icon: "internaldrive",
             title: "Disk Health",
             accent: sectionAccent,
+            statusColor: verdictAccent,
             info: "The drive's SMART self-assessment. \"Good\" means the disk reports no predicted failures."
         ) {
             Text(viewModel.smartLabel)
@@ -134,6 +141,7 @@ struct HealthMonitorView: View {
             icon: "memorychip",
             title: "RAM Pressure",
             accent: sectionAccent,
+            statusColor: verdictAccent,
             info: "Memory in use versus total, with the system's current memory-pressure level."
         ) {
             Text(viewModel.ramUsage)
@@ -152,6 +160,7 @@ struct HealthMonitorView: View {
             icon: "cpu",
             title: "CPU Load",
             accent: sectionAccent,
+            statusColor: verdictAccent,
             info: "Share of processor capacity currently in use across all cores."
         ) {
             Text(viewModel.cpuPercent)
@@ -159,7 +168,7 @@ struct HealthMonitorView: View {
                 .accessibilityIdentifier("health.cpu.percent")
             ProgressView(value: viewModel.cpuRatio)
                 .progressViewStyle(.linear)
-                .tint(sectionAccent)
+                .tint(verdictAccent)
         }
         .accessibilityIdentifier("health.card.cpu")
     }
@@ -169,6 +178,7 @@ struct HealthMonitorView: View {
             icon: "externaldrive",
             title: "Disk Space",
             accent: sectionAccent,
+            statusColor: verdictAccent,
             info: "How full the boot volume is. Reclaiming space keeps your Mac responsive."
         ) {
             Text(viewModel.diskUsage)
@@ -176,7 +186,7 @@ struct HealthMonitorView: View {
                 .accessibilityIdentifier("health.disk.usage")
             ProgressView(value: viewModel.diskRatio)
                 .progressViewStyle(.linear)
-                .tint(sectionAccent)
+                .tint(verdictAccent)
         }
         .accessibilityIdentifier("health.card.disk")
     }
@@ -204,7 +214,7 @@ struct HealthMonitorView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)
-            StatusDot(color: sectionAccent)
+            StatusDot(color: verdictAccent)
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -343,7 +353,7 @@ private struct MacHealthHero: View {
             }
             ProgressView(value: diskRatio)
                 .progressViewStyle(.linear)
-                .tint(sectionAccent)
+                .tint(accent)
                 .accessibilityIdentifier("health.hero.diskbar")
         }
     }
@@ -468,9 +478,11 @@ extension MacHealthStatus {
 private struct HealthCard<Content: View>: View {
     let icon: String
     let title: String
-    /// Shared section accent — the overall Mac Health verdict color — used for
-    /// the icon tile and the status dot so every tile reads in one hue.
+    /// Section accent (crimson) for the prominent icon tile.
     let accent: Color
+    /// Status dot color — the overall Mac Health verdict color, so the dot
+    /// tracks the Mac's health at a glance.
+    let statusColor: Color
     /// Plain-language explanation shown in the card's info popover.
     let info: String
     @ViewBuilder var content: Content
@@ -482,7 +494,7 @@ private struct HealthCard<Content: View>: View {
             HStack(alignment: .top) {
                 iconTile
                 Spacer()
-                StatusDot(color: accent)
+                StatusDot(color: statusColor)
                 infoButton
             }
             Text(title)

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -71,14 +71,7 @@ final class HealthMonitorViewModel {
     /// volume is still unmeasured (so the hero shows "Measuring…" instead of
     /// a confident verdict off zero data on the first tick).
     var macHealth: MacHealthStatus? {
-        Self.macHealthStatus(disk: service.diskSpace, signals: nudgeSignals)
-    }
-
-    /// The non-disk signals that can nudge the disk-driven base verdict down.
-    /// Disk fullness is excluded here because it already sets the base tier —
-    /// folding it in again would double-count it.
-    private var nudgeSignals: [StatusColor] {
-        [batteryColor, smartColor, ramPressureColor, cpuColor, fileVaultColor]
+        Self.macHealthStatus(disk: service.diskSpace, smart: smartStatus, battery: batteryAvailability)
     }
 
     /// "121 GB of 494 GB used" line shown beneath the volume name in the hero.
@@ -86,45 +79,74 @@ final class HealthMonitorViewModel {
 
     // MARK: - Pure formatters / color rules
 
-    /// Derives the overall Mac Health verdict.
-    ///
-    /// Disk fullness sets the base tier (this is a disk-cleaning app, so
-    /// reclaimable space is the headline concern). The other health signals
-    /// then *nudge* that base down: each `.red` signal (failing SMART, battery
-    /// service, critical RAM/CPU) drops two tiers, and the presence of any
-    /// `.yellow` drops one more. `.gray` ("no opinion", the startup state) and
-    /// `.green` never penalize. The result clamps to `.critical` so a near-full
-    /// disk plus a failing component can't underflow.
-    ///
-    /// Reds are allowed to override the disk base on purpose: a failing drive
-    /// *should* be able to force "Critical" even on a near-empty disk.
+    /// Derives the overall Mac Health verdict with a problem-based model that
+    /// mirrors CleanMyMac: the Mac is Excellent until a concrete problem is
+    /// detected, and the verdict is the worst tier any tracked factor produces
+    /// (no compounding, no double-counting). Only the factors CleanMyMac counts
+    /// that we can observe drive it — disk hardware health (SMART), battery
+    /// health, and low disk space. Transient readings (RAM pressure, CPU load)
+    /// and the FileVault toggle keep their own cards but never drag the overall
+    /// verdict, so a momentary CPU spike or a half-full disk no longer reads as
+    /// "Fair".
     ///
     /// Returns `nil` when the volume is unmeasured (`totalBytes == 0`) so the
-    /// hero can show a neutral measuring state rather than defaulting to
-    /// "Excellent" off a zero reading.
-    static func macHealthStatus(disk: DiskStats, signals: [StatusColor]) -> MacHealthStatus? {
+    /// hero can show a neutral measuring state rather than a confident verdict
+    /// off a zero reading.
+    static func macHealthStatus(
+        disk: DiskStats,
+        smart: SMARTStatus,
+        battery: BatteryAvailability
+    ) -> MacHealthStatus? {
         guard disk.totalBytes > 0 else { return nil }
 
-        let base = diskHealthTier(for: disk)
-        let redCount = signals.filter { $0 == .red }.count
-        let anyYellow = signals.contains(.yellow)
-        let penalty = redCount * 2 + (anyYellow ? 1 : 0)
-
-        let index = max(MacHealthStatus.critical.rawValue, base.rawValue - penalty)
-        return MacHealthStatus(rawValue: index) ?? .critical
+        let tiers = [
+            diskSpaceTier(for: disk),
+            smartTier(for: smart),
+            batteryTier(for: battery)
+        ]
+        // `MacHealthStatus` orders worst-to-best, so the minimum tier is the
+        // worst problem found. With every factor healthy the minimum is the
+        // best tier — Excellent.
+        return tiers.min() ?? .excellent
     }
 
-    /// Maps disk fullness to a base verdict tier. Boundaries are inclusive at
-    /// the lower bound. The 0.80 / 0.95 edges line up with
-    /// `diskWarningThreshold` / `diskCriticalThreshold` so the hero verdict and
-    /// the Disk Space card's status dot never tell contradictory stories.
-    static func diskHealthTier(for stats: DiskStats) -> MacHealthStatus {
+    /// Low-disk-space contribution to the verdict. A disk under the card's
+    /// warning threshold is not a problem at all (Excellent); only a genuinely
+    /// full disk escalates. The 0.80 / 0.95 edges line up with
+    /// `diskWarningThreshold` / `diskCriticalThreshold` so the verdict and the
+    /// Disk Space card's status dot never tell contradictory stories.
+    static func diskSpaceTier(for stats: DiskStats) -> MacHealthStatus {
         let ratio = diskUsageRatio(stats)
-        if ratio >= diskCriticalThreshold { return .critical }
-        if ratio >= diskWarningThreshold { return .requiresAttention }
-        if ratio >= 0.70 { return .fair }
-        if ratio >= 0.55 { return .good }
+        if ratio >= 0.98 { return .critical }
+        if ratio >= diskCriticalThreshold { return .requiresAttention }
+        if ratio >= 0.90 { return .fair }
+        if ratio >= diskWarningThreshold { return .good }
         return .excellent
+    }
+
+    /// Disk hardware-health contribution. A failing SMART self-assessment is the
+    /// most serious problem — the user needs to back up immediately — so it
+    /// forces `.critical`. `.good` and `.unknown` are not problems.
+    static func smartTier(for status: SMARTStatus) -> MacHealthStatus {
+        switch status {
+        case .failing: return .critical
+        case .good, .unknown: return .excellent
+        }
+    }
+
+    /// Battery-health contribution. Only the conditions that mean the battery
+    /// needs service count as a problem, matching CleanMyMac's "critical battery
+    /// health" factor. A healthy, absent, unknown, or merely-unreadable
+    /// condition is never penalized — capacity fade alone does not lower the
+    /// overall verdict.
+    static func batteryTier(for availability: BatteryAvailability) -> MacHealthStatus {
+        guard case .present(let stats) = availability else { return .excellent }
+        switch stats.condition {
+        case "Service Battery", "Service Recommended", "Replace Soon", "Replace Now", "Permanent Failure":
+            return .requiresAttention
+        default:
+            return .excellent
+        }
     }
 
     /// "121 GB of 494 GB used" — the hero's disk line. Phrased as

--- a/VaderCleaner/Info.plist
+++ b/VaderCleaner/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>VaderCleaner reads connected Bluetooth devices to show them in the menu bar Connected Devices monitor.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSLocationUsageDescription</key>

--- a/VaderCleaner/Info.plist
+++ b/VaderCleaner/Info.plist
@@ -26,6 +26,10 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
+	<key>NSLocationUsageDescription</key>
+	<string>VaderCleaner uses your location only to read the current Wi-Fi network name for the menu bar network monitor.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>VaderCleaner uses your location only to read the current Wi-Fi network name for the menu bar network monitor.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticTermination</key>

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -267,7 +267,7 @@ struct LargeOldFilesFooter: View {
             Button("Delete Selected", action: onDeleteSelected)
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(!canDelete)
                 .accessibilityIdentifier("large-old.delete")
         }

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -303,7 +303,7 @@ struct MalwareCleanState: View {
                 localized: "Scan Again",
                 comment: "Button that starts another malware scan after a clean result."
             ), action: onScanAgain)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .controlSize(.regular)
                 .accessibilityIdentifier("malware.scanAgain")
         }
@@ -356,7 +356,7 @@ struct MalwareCleanState: View {
                     localized: "Open System Settings",
                     comment: "Button that deep-links to the Full Disk Access pane in System Settings."
                 ), action: openSettings)
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.vaderProminent)
                     .controlSize(.regular)
                     .tint(.white)
                     .foregroundStyle(Color.vaderCrimson)
@@ -429,7 +429,7 @@ struct MalwareResultsState: View {
                     comment: "Button that deletes every detected malware file."
                 ))
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.vaderProminent)
             .controlSize(.regular)
             .tint(.white)
             .foregroundStyle(Color.vaderCrimson)
@@ -521,7 +521,7 @@ struct MalwareDoneState: View {
                 localized: "Done",
                 comment: "Button that returns to the idle Malware Removal screen after removal."
             ), action: onDone)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .controlSize(.regular)
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("malware.doneButton")

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -12,6 +12,7 @@ import AppKit
 struct MenuBarContent: View {
 
     @Environment(MenuBarViewModel.self) private var menuBar
+    @Environment(ConnectedDevicesMonitor.self) private var connectedDevices
     @Environment(\.openWindow) private var openWindow
 
     private let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
@@ -26,6 +27,7 @@ struct MenuBarContent: View {
                     batteryTile
                     cpuTile
                     networkTile
+                    connectedDevicesTile
                 }
                 recommendationCard
             }
@@ -35,6 +37,9 @@ struct MenuBarContent: View {
         }
         .frame(width: 380)
         .background(panelBackground)
+        // Refresh the device list each time the panel opens — devices change
+        // infrequently, so an on-open read beats a dedicated poll timer.
+        .task { connectedDevices.refresh() }
     }
 
     // MARK: - Header
@@ -218,6 +223,63 @@ struct MenuBarContent: View {
         .padding(10)
         .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
         .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+    }
+
+    // MARK: - Connected devices tile
+
+    private var connectedDevicesTile: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: "cable.connector")
+                    .font(.callout)
+                    .foregroundStyle(.tint)
+                Text("Connected Devices")
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            if connectedDevices.devices.isEmpty {
+                Text("None connected")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(connectedDevices.devices.prefix(3)) { device in
+                    deviceRow(device)
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+    }
+
+    private func deviceRow(_ device: ConnectedDevice) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: device.kind == .bluetooth ? "dot.radiowaves.left.and.right" : "externaldrive")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(device.name)
+                .font(.caption)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 0)
+            if let battery = device.batteryPercent {
+                Text("\(battery)%")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            if device.kind == .volume {
+                Button {
+                    connectedDevices.eject(device)
+                } label: {
+                    Image(systemName: "eject.fill")
+                        .font(.caption2)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
+                .help("Eject \(device.name)")
+            }
+        }
     }
 
     @ViewBuilder

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -40,6 +40,10 @@ struct MenuBarContent: View {
         }
         .frame(width: 380)
         .background(panelBackground)
+        // Vader identity: crimson drives every tinted accent (icons, links,
+        // buttons, progress). Semantic status colors (health verdict, memory
+        // pressure, protection) stay as-is so they keep conveying meaning.
+        .tint(.vaderCrimson)
         // Refresh the device list each time the panel opens — devices change
         // infrequently, so an on-open read beats a dedicated poll timer.
         .task { connectedDevices.refresh() }
@@ -74,7 +78,7 @@ struct MenuBarContent: View {
                 .font(.system(size: 34, weight: .light))
                 .foregroundStyle(
                     LinearGradient(
-                        colors: [.white.opacity(0.95), verdictColor.opacity(0.85)],
+                        colors: [.white.opacity(0.95), Color.vaderCrimson.opacity(0.9)],
                         startPoint: .top,
                         endPoint: .bottom
                     )
@@ -91,14 +95,14 @@ struct MenuBarContent: View {
         ZStack {
             LinearGradient(
                 colors: [
-                    Color(red: 0.12, green: 0.07, blue: 0.22),
-                    Color(red: 0.20, green: 0.10, blue: 0.34)
+                    Color(red: 0.14, green: 0.04, blue: 0.06),
+                    Color(red: 0.07, green: 0.02, blue: 0.03)
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
             RadialGradient(
-                colors: [verdictColor.opacity(0.28), .clear],
+                colors: [Color.vaderCrimson.opacity(0.32), .clear],
                 center: UnitPoint(x: 0.85, y: 0.3),
                 startRadius: 4,
                 endRadius: 180
@@ -432,8 +436,8 @@ struct MenuBarContent: View {
     private var panelBackground: some View {
         LinearGradient(
             colors: [
-                Color(red: 0.09, green: 0.06, blue: 0.16),
-                Color(red: 0.06, green: 0.04, blue: 0.10)
+                Color(red: 0.09, green: 0.04, blue: 0.05),
+                Color.vaderSpaceBlack
             ],
             startPoint: .top,
             endPoint: .bottom

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -178,8 +178,10 @@ struct MenuBarContent: View {
                 Image(systemName: "wifi")
                     .font(.callout)
                     .foregroundStyle(.tint)
-                Text("Network")
+                Text(menuBar.wifiNetworkName)
                     .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 Spacer(minLength: 0)
             }
             HStack(spacing: 4) {

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -13,6 +13,7 @@ struct MenuBarContent: View {
 
     @Environment(MenuBarViewModel.self) private var menuBar
     @Environment(ConnectedDevicesMonitor.self) private var connectedDevices
+    @Environment(MalwareViewModel.self) private var malware
     @Environment(\.openWindow) private var openWindow
 
     private let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
@@ -21,6 +22,7 @@ struct MenuBarContent: View {
         VStack(spacing: 0) {
             header
             VStack(spacing: 10) {
+                protectionCard
                 LazyVGrid(columns: columns, spacing: 10) {
                     storageTile
                     memoryTile
@@ -99,6 +101,58 @@ struct MenuBarContent: View {
                 endRadius: 180
             )
         }
+    }
+
+    // MARK: - Protection card
+
+    /// Whether the last scan surfaced unresolved threats.
+    private var hasThreats: Bool {
+        if case .results(let threats) = malware.phase { return !threats.isEmpty }
+        return false
+    }
+
+    private var protectionStatus: MenuBarViewModel.ProtectionStatus {
+        MenuBarViewModel.protectionStatus(hasThreats: hasThreats, hasScanned: malware.lastScanDate != nil)
+    }
+
+    private var protectionColor: Color {
+        switch protectionStatus {
+        case .protected: return .green
+        case .threatsFound: return .red
+        case .notScanned: return .secondary
+        }
+    }
+
+    private var protectionIcon: String {
+        switch protectionStatus {
+        case .protected: return "checkmark.shield.fill"
+        case .threatsFound: return "exclamationmark.shield.fill"
+        case .notScanned: return "shield"
+        }
+    }
+
+    private var protectionCard: some View {
+        HStack(spacing: 12) {
+            Image(systemName: protectionIcon)
+                .font(.title2)
+                .foregroundStyle(protectionColor)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text("Protection")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text(MenuBarViewModel.protectionStatusLabel(protectionStatus))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(protectionColor)
+                }
+                Text(MenuBarViewModel.lastScanString(malware.lastScanDate))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
     }
 
     // MARK: - Tiles
@@ -450,6 +504,9 @@ private struct MenuTile: View {
 }
 
 #Preview {
-    MenuBarContent()
+    let prefs = PreferencesStore(defaults: UserDefaults(suiteName: "menu-preview")!)
+    return MenuBarContent()
         .environment(MenuBarViewModel(service: SystemStatsService(autostart: false)))
+        .environment(ConnectedDevicesMonitor(autoRefresh: false))
+        .environment(MalwareViewModel.live(dispatcher: NotificationManager(), preferences: prefs))
 }

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -25,6 +25,7 @@ struct MenuBarContent: View {
                     memoryTile
                     batteryTile
                     cpuTile
+                    networkTile
                 }
                 recommendationCard
             }
@@ -167,6 +168,67 @@ struct MenuBarContent: View {
             comment: "CPU tile line; %@ is processor load percent, e.g. Load: 20%"
         )
         return String(format: format, menuBar.formattedCPU)
+    }
+
+    // MARK: - Network tile
+
+    private var networkTile: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: "wifi")
+                    .font(.callout)
+                    .foregroundStyle(.tint)
+                Text("Network")
+                    .font(.subheadline.weight(.semibold))
+                Spacer(minLength: 0)
+            }
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.down")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(menuBar.networkDownString)
+                    .font(.caption)
+                    .monospacedDigit()
+            }
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.up")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(menuBar.networkUpString)
+                    .font(.caption)
+                    .monospacedDigit()
+            }
+            HStack {
+                Spacer()
+                speedTestControl
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private var speedTestControl: some View {
+        switch menuBar.speedTestState {
+        case .idle:
+            Button(String(localized: "Test Speed")) { Task { await menuBar.runSpeedTest() } }
+                .buttonStyle(.plain)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tint)
+        case .running:
+            ProgressView().controlSize(.small)
+        case .result(let mbps):
+            Button(MenuBarViewModel.speedTestResultString(mbps)) { Task { await menuBar.runSpeedTest() } }
+                .buttonStyle(.plain)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tint)
+        case .failed:
+            Button(String(localized: "Retry")) { Task { await menuBar.runSpeedTest() } }
+                .buttonStyle(.plain)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.orange)
+        }
     }
 
     // MARK: - Recommendation

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -1,91 +1,249 @@
 // MenuBarContent.swift
-// SwiftUI view rendering the menu bar extra popover — RAM/Disk/CPU/Battery rows + Open and Quit actions.
+// The menu bar panel — a Mac Health header, a grid of live system tiles (Storage, Memory, Battery, CPU), a recommendation card, and a footer, driven by MenuBarViewModel / SystemStatsService.
 
 import SwiftUI
 import AppKit
 
-/// Popover content presented when the user clicks the menu bar icon. Rows are
-/// driven by `MenuBarViewModel` which is in turn fed by `SystemStatsService`,
-/// so values refresh on the same 2-second cadence as the Health Monitor.
-///
-/// The Battery row is conditional — desktops report no internal battery and
-/// startup begins with unknown battery state, so rendering an empty row would
-/// just look like a UI bug.
+/// Wide panel presented when the user clicks the menu bar icon. Mirrors the
+/// CleanMyMac menu's shape — a Mac Health verdict header, a 2-column grid of
+/// monitor tiles, a "Today's Recommendation" card, and a footer — while showing
+/// only VaderCleaner's real telemetry. Values refresh on the same 2-second
+/// cadence as the Health Monitor.
 struct MenuBarContent: View {
 
     @Environment(MenuBarViewModel.self) private var menuBar
     @Environment(\.openWindow) private var openWindow
 
+    private let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            ramRow
-            statRow(label: "Disk", value: menuBar.formattedDiskSpace)
-            statRow(label: "CPU", value: menuBar.formattedCPU)
-            if let battery = menuBar.formattedBatteryHealth {
-                statRow(label: "Battery", value: battery)
+        VStack(spacing: 0) {
+            header
+            VStack(spacing: 10) {
+                LazyVGrid(columns: columns, spacing: 10) {
+                    storageTile
+                    memoryTile
+                    batteryTile
+                    cpuTile
+                }
+                recommendationCard
             }
-
+            .padding(14)
             Divider()
-
-            Button("Open VaderCleaner") {
-                openMainWindow()
-            }
-            .keyboardShortcut("o")
-
-            Button("Quit VaderCleaner") {
-                NSApp.terminate(nil)
-            }
-            .keyboardShortcut("q")
+            footer
         }
-        .padding(12)
-        .frame(width: 240)
+        .frame(width: 380)
+        .background(panelBackground)
     }
 
-    /// RAM row carries an extra pressure-level badge so the user can see at a
-    /// glance whether the system is under memory pressure without having to
-    /// open the Health Monitor. The badge mirrors the Health Monitor card's
-    /// color via the shared `StatusColor` mapping.
-    private var ramRow: some View {
-        HStack {
-            Text("RAM")
-                .foregroundStyle(.secondary)
+    // MARK: - Header
+
+    /// The verdict's signature colour (gray while still measuring).
+    private var verdictColor: Color { menuBar.macHealth?.accentColor ?? Color(white: 0.6) }
+
+    private var verdictTitle: String {
+        menuBar.macHealth?.title ?? String(localized: "Measuring…")
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text("Mac Health:")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.85))
+                    Text(verdictTitle)
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(verdictColor)
+                }
+                Text(menuBar.deviceName)
+                    .font(.subheadline)
+                    .foregroundStyle(.white.opacity(0.55))
+            }
             Spacer()
-            Text(menuBar.formattedRAMUsage)
-                .monospacedDigit()
-            pressureBadge(
-                label: menuBar.ramPressureLabel,
-                color: menuBar.ramPressureColor
+            Image(systemName: "laptopcomputer")
+                .font(.system(size: 34, weight: .light))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [.white.opacity(0.95), verdictColor.opacity(0.85)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(headerBackground)
+    }
+
+    private var headerBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.12, green: 0.07, blue: 0.22),
+                    Color(red: 0.20, green: 0.10, blue: 0.34)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            RadialGradient(
+                colors: [verdictColor.opacity(0.28), .clear],
+                center: UnitPoint(x: 0.85, y: 0.3),
+                startRadius: 4,
+                endRadius: 180
             )
         }
     }
 
-    private func statRow(label: String, value: String) -> some View {
+    // MARK: - Tiles
+
+    private var storageTile: some View {
+        MenuTile(
+            icon: "internaldrive",
+            title: menuBar.bootVolumeName,
+            primary: availableLine,
+            action: (String(localized: "Free Up"), openMainWindow)
+        )
+    }
+
+    private var availableLine: String {
+        let format = String(
+            localized: "Available: %@",
+            comment: "Storage tile line; %@ is free space, e.g. Available: 434.3 GB"
+        )
+        return String(format: format, menuBar.availableDiskSpace)
+    }
+
+    private var memoryTile: some View {
+        MenuTile(
+            icon: "memorychip",
+            title: String(localized: "Memory"),
+            primary: memoryLine,
+            statusColor: swiftUIColor(for: menuBar.ramPressureColor),
+            action: (String(localized: "Free Up"), openMainWindow)
+        )
+    }
+
+    private var memoryLine: String {
+        let format = String(
+            localized: "Pressure: %@",
+            comment: "Memory tile line; %@ is the memory-pressure level, e.g. Pressure: Nominal"
+        )
+        return String(format: format, menuBar.ramPressureLabel)
+    }
+
+    private var batteryTile: some View {
+        MenuTile(
+            icon: "battery.100",
+            title: String(localized: "Battery"),
+            primary: batteryPrimary,
+            secondary: batterySecondary
+        )
+    }
+
+    private var batteryPrimary: String {
+        guard let charge = menuBar.batteryCharge else {
+            return String(localized: "No battery")
+        }
+        return "\(MenuBarViewModel.batteryChargeString(charge)) · \(MenuBarViewModel.batteryStateString(charge))"
+    }
+
+    private var batterySecondary: String? {
+        guard let temp = menuBar.batteryCharge?.temperatureCelsius else { return nil }
+        return MenuBarViewModel.batteryTemperatureString(temp)
+    }
+
+    private var cpuTile: some View {
+        MenuTile(
+            icon: "cpu",
+            title: String(localized: "CPU"),
+            primary: cpuLine
+        )
+    }
+
+    private var cpuLine: String {
+        let format = String(
+            localized: "Load: %@",
+            comment: "CPU tile line; %@ is processor load percent, e.g. Load: 20%"
+        )
+        return String(format: format, menuBar.formattedCPU)
+    }
+
+    // MARK: - Recommendation
+
+    private var recommendationCard: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "sparkles")
+                .font(.title2)
+                .foregroundStyle(.tint)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Today's Recommendation")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                Text("It's time to care for your Mac!")
+                    .font(.subheadline.weight(.semibold))
+                Text("Run Smart Scan to find junk, large files, and threats in one pass.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack {
+                    Spacer()
+                    Button(String(localized: "Run Smart Scan"), action: openMainWindow)
+                        .controlSize(.small)
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
         HStack {
-            Text(label)
-                .foregroundStyle(.secondary)
+            Button(action: openMainWindow) {
+                Text("Open VaderCleaner")
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("o")
+
             Spacer()
-            Text(value)
-                .monospacedDigit()
+
+            SettingsLink {
+                Image(systemName: "gearshape")
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                NSApp.terminate(nil)
+            } label: {
+                Image(systemName: "power")
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("q")
+            .help("Quit VaderCleaner")
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
     }
 
-    /// Compact pill: a colored dot + status label. Sized small so it tucks
-    /// into the trailing edge of the row without competing with the value.
-    private func pressureBadge(label: String, color: StatusColor) -> some View {
-        HStack(spacing: 4) {
-            Circle()
-                .fill(swiftUIColor(for: color))
-                .frame(width: 8, height: 8)
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
+    // MARK: - Background + helpers
+
+    private var panelBackground: some View {
+        LinearGradient(
+            colors: [
+                Color(red: 0.09, green: 0.06, blue: 0.16),
+                Color(red: 0.06, green: 0.04, blue: 0.10)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 
-    /// Maps the view-model's `StatusColor` (deliberately UI-framework-free
-    /// for testability) to a SwiftUI `Color` at the leaf. Same mapping the
-    /// Health Monitor card uses; kept local to the view rather than on the
-    /// enum so the view-model layer stays SwiftUI-import-free.
+    /// Maps the view-model's framework-free `StatusColor` to a SwiftUI `Color`.
     private func swiftUIColor(for status: StatusColor) -> Color {
         switch status {
         case .green: return .green
@@ -96,12 +254,62 @@ struct MenuBarContent: View {
     }
 
     private func openMainWindow() {
-        // `openWindow(id:)` brings the existing main window to front, or opens
-        // a new one if the user previously closed it. Following with
-        // `NSApp.activate()` moves focus to the process so the window comes to
-        // the foreground over other apps.
+        // Brings the existing main window forward, or opens one if it was
+        // closed, then activates the process so it surfaces over other apps.
         openWindow(id: VaderCleanerApp.mainWindowID)
         NSApp.activate()
+    }
+}
+
+/// One monitor tile: an icon + title row, a primary metric line, an optional
+/// secondary line, an optional status dot, and an optional trailing action link.
+private struct MenuTile: View {
+    let icon: String
+    let title: String
+    let primary: String
+    var secondary: String?
+    var statusColor: Color?
+    /// Optional trailing link, e.g. ("Free Up", action).
+    var action: (label: String, run: () -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.callout)
+                    .foregroundStyle(.tint)
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 0)
+                if let statusColor {
+                    Circle().fill(statusColor).frame(width: 7, height: 7)
+                }
+            }
+            Text(primary)
+                .font(.callout)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            if let secondary {
+                Text(secondary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let action {
+                HStack {
+                    Spacer()
+                    Button(action.label, action: action.run)
+                        .buttonStyle(.plain)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tint)
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
     }
 }
 

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -14,6 +14,7 @@ struct MenuBarContent: View {
     @Environment(MenuBarViewModel.self) private var menuBar
     @Environment(ConnectedDevicesMonitor.self) private var connectedDevices
     @Environment(MalwareViewModel.self) private var malware
+    @Environment(MenuRouter.self) private var menuRouter
     @Environment(\.openWindow) private var openWindow
 
     private let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
@@ -82,6 +83,8 @@ struct MenuBarContent: View {
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(headerBackground)
+        .contentShape(Rectangle())
+        .onTapGesture { openSection(.healthMonitor) }
     }
 
     private var headerBackground: some View {
@@ -153,6 +156,8 @@ struct MenuBarContent: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+        .contentShape(Rectangle())
+        .onTapGesture { openSection(.malwareRemoval) }
     }
 
     // MARK: - Tiles
@@ -162,7 +167,7 @@ struct MenuBarContent: View {
             icon: "internaldrive",
             title: menuBar.bootVolumeName,
             primary: availableLine,
-            action: (String(localized: "Free Up"), openMainWindow)
+            action: (String(localized: "Free Up"), { openSection(.systemJunk) })
         )
     }
 
@@ -180,7 +185,7 @@ struct MenuBarContent: View {
             title: String(localized: "Memory"),
             primary: memoryLine,
             statusColor: swiftUIColor(for: menuBar.ramPressureColor),
-            action: (String(localized: "Free Up"), openMainWindow)
+            action: (String(localized: "Free Up"), { openSection(.optimization) })
         )
     }
 
@@ -379,9 +384,11 @@ struct MenuBarContent: View {
                     .fixedSize(horizontal: false, vertical: true)
                 HStack {
                     Spacer()
-                    Button(String(localized: "Run Smart Scan"), action: openMainWindow)
-                        .controlSize(.small)
-                        .buttonStyle(.borderedProminent)
+                    Button(String(localized: "Run Smart Scan")) {
+                        openSection(.smartScan, startScan: true)
+                    }
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
                 }
             }
         }
@@ -449,6 +456,13 @@ struct MenuBarContent: View {
         openWindow(id: VaderCleanerApp.mainWindowID)
         NSApp.activate()
     }
+
+    /// Deep-links into a main-window section: records the request on the router,
+    /// then opens and activates the window so ContentView navigates there.
+    private func openSection(_ section: NavigationSection, startScan: Bool = false) {
+        menuRouter.request(section, startScan: startScan)
+        openMainWindow()
+    }
 }
 
 /// One monitor tile: an icon + title row, a primary metric line, an optional
@@ -509,4 +523,5 @@ private struct MenuTile: View {
         .environment(MenuBarViewModel(service: SystemStatsService(autostart: false)))
         .environment(ConnectedDevicesMonitor(autoRefresh: false))
         .environment(MalwareViewModel.live(dispatcher: NotificationManager(), preferences: prefs))
+        .environment(MenuRouter())
 }

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -157,9 +157,19 @@ struct MenuBarContent: View {
     private var cpuTile: some View {
         MenuTile(
             icon: "cpu",
-            title: String(localized: "CPU"),
-            primary: cpuLine
+            title: cpuTitle,
+            primary: cpuLine,
+            secondary: menuBar.systemUptimeString
         )
+    }
+
+    /// Title carries the temperature when the SMC reports one, e.g. "CPU · 50°C";
+    /// otherwise just "CPU".
+    private var cpuTitle: String {
+        if let temp = menuBar.cpuTemperature {
+            return "\(String(localized: "CPU")) · \(temp)"
+        }
+        return String(localized: "CPU")
     }
 
     private var cpuLine: String {

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -137,6 +137,11 @@ final class MenuBarViewModel {
         Self.menuBarLabel(ram: service.ramUsage, disk: service.diskSpace)
     }
 
+    /// A short reading shown beside the menu bar icon when the user opts in —
+    /// free disk space, the most glanceable single number, kept narrow so it is
+    /// far less prone to being hidden behind the notch than the full label.
+    var menuBarCompactReading: String { Self.availableDiskString(service.diskSpace) }
+
     // MARK: - Pure formatters
 
     /// Formats `MemoryStats` to `"used / total"` in GB. We force the GB unit

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -242,6 +242,47 @@ final class MenuBarViewModel {
         "\(Int(celsius.rounded()))°C"
     }
 
+    // MARK: - Protection
+
+    /// Malware-protection status for the menu's Protection card.
+    enum ProtectionStatus: Equatable {
+        case protected
+        case threatsFound
+        case notScanned
+    }
+
+    /// Derives protection status from the malware scan state: threats outrank
+    /// everything; otherwise a Mac that has been scarred at least once reads as
+    /// protected, and one that never has reads as not-yet-scanned.
+    static func protectionStatus(hasThreats: Bool, hasScanned: Bool) -> ProtectionStatus {
+        if hasThreats { return .threatsFound }
+        return hasScanned ? .protected : .notScanned
+    }
+
+    /// Short status label for the Protection card.
+    static func protectionStatusLabel(_ status: ProtectionStatus) -> String {
+        switch status {
+        case .protected:
+            return String(localized: "Protected", comment: "Protection card status when the last scan was clean.")
+        case .threatsFound:
+            return String(localized: "Threats found", comment: "Protection card status when threats are present.")
+        case .notScanned:
+            return String(localized: "Not scanned", comment: "Protection card status when no scan has run yet.")
+        }
+    }
+
+    /// "Last scan 3 days ago" / "No scans yet" detail for the Protection card.
+    static func lastScanString(_ date: Date?) -> String {
+        guard let date else {
+            return String(localized: "No scans yet", comment: "Protection card detail when no scan has run.")
+        }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        let relative = formatter.localizedString(for: date, relativeTo: Date())
+        let format = String(localized: "Last scan %@", comment: "Protection card detail; %@ is a relative date.")
+        return String(format: format, relative)
+    }
+
     /// Compact uptime, e.g. "up 3d 4h", "up 4h 12m", or "up 8m". Drops to the
     /// two most significant units so the CPU tile stays one short line.
     static func uptimeString(_ interval: TimeInterval) -> String {

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -30,6 +30,11 @@ final class MenuBarViewModel {
         self.service = service
     }
 
+    /// Boot-volume display name ("Macintosh HD"), resolved once — it never
+    /// changes for the life of the view-model and the storage tile shows it on
+    /// every render.
+    let bootVolumeName: String = HealthMonitorViewModel.rootVolumeName()
+
     // MARK: - Live-bound display values
 
     var formattedRAMUsage: String { Self.formattedRAMUsage(service.ramUsage) }
@@ -39,6 +44,33 @@ final class MenuBarViewModel {
     var ramPressureLevel: MemoryPressureLevel { service.ramUsage.pressureLevel }
     var ramPressureLabel: String { Self.pressureLabel(for: ramPressureLevel) }
     var ramPressureColor: StatusColor { Self.pressureColor(for: ramPressureLevel) }
+
+    // MARK: - Menu panel values
+
+    /// The Mac's name (e.g. "Jayvic's MacBook Pro"), shown under the Mac Health
+    /// verdict in the panel header. Falls back to "Mac" if the name is unset.
+    var deviceName: String { Host.current().localizedName ?? "Mac" }
+
+    /// Overall Mac Health verdict for the panel header, reusing the Health
+    /// Monitor's problem-based derivation so the menu and the main window never
+    /// disagree. `nil` while the boot volume is still being measured.
+    var macHealth: MacHealthStatus? {
+        HealthMonitorViewModel.macHealthStatus(
+            disk: service.diskSpace,
+            smart: service.diskSMARTStatus,
+            battery: service.batteryAvailability
+        )
+    }
+
+    /// Free space on the boot volume — the storage tile's headline number.
+    var availableDiskSpace: String { Self.availableDiskString(service.diskSpace) }
+
+    /// Memory in use as a whole percentage — the memory tile's headline number.
+    var memoryUsedPercent: String { Self.memoryUsedPercentString(service.ramUsage) }
+
+    /// Live charge snapshot for the battery tile, or `nil` when there is no
+    /// internal battery.
+    var batteryCharge: BatteryCharge? { service.batteryCharge }
 
     /// Single string the `MenuBarExtra` label renders. The format lives on the
     /// view-model (rather than as a `Text("RAM: \(...) | Disk: \(...)")`
@@ -87,6 +119,45 @@ final class MenuBarViewModel {
     static func formattedBatteryHealth(_ availability: BatteryAvailability) -> String? {
         guard case .present(let stats) = availability else { return nil }
         return SystemStatsFormatters.batteryCapacityString(stats)
+    }
+
+    /// Free space on the boot volume, e.g. "434.3 GB" — the number the storage
+    /// tile leads with ("how much room is left?").
+    static func availableDiskString(_ stats: DiskStats) -> String {
+        let free = stats.totalBytes > stats.usedBytes ? stats.totalBytes - stats.usedBytes : 0
+        return SystemStatsFormatters.byteString(free)
+    }
+
+    /// Memory in use as a whole percentage, clamped to 0…100. `0%` for the
+    /// zero-total pre-first-refresh state rather than NaN.
+    static func memoryUsedPercentString(_ stats: MemoryStats) -> String {
+        guard stats.totalBytes > 0 else { return "0%" }
+        let ratio = Double(stats.usedBytes) / Double(stats.totalBytes)
+        return "\(Int((max(0.0, min(1.0, ratio)) * 100).rounded()))%"
+    }
+
+    /// Current charge as a whole percentage, e.g. "100%".
+    static func batteryChargeString(_ charge: BatteryCharge) -> String {
+        "\(charge.percent)%"
+    }
+
+    /// Plain-language power state for the battery tile's subtitle.
+    static func batteryStateString(_ charge: BatteryCharge) -> String {
+        if charge.isCharging {
+            return String(localized: "Charging", comment: "Battery tile subtitle while charging.")
+        }
+        if charge.percent >= 100 && charge.isPluggedIn {
+            return String(localized: "Fully Charged", comment: "Battery tile subtitle when full and on AC.")
+        }
+        if charge.isPluggedIn {
+            return String(localized: "Plugged In", comment: "Battery tile subtitle on AC but not charging.")
+        }
+        return String(localized: "On Battery", comment: "Battery tile subtitle while discharging.")
+    }
+
+    /// Battery temperature rounded to a whole degree, e.g. "30°C".
+    static func batteryTemperatureString(_ celsius: Double) -> String {
+        "\(Int(celsius.rounded()))°C"
     }
 
     /// Human-readable label for a memory-pressure bucket. Matches the

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -72,6 +72,49 @@ final class MenuBarViewModel {
     /// internal battery.
     var batteryCharge: BatteryCharge? { service.batteryCharge }
 
+    /// Download throughput for the network tile, e.g. "513 bytes/s".
+    var networkDownString: String { Self.speedString(service.networkThroughput.bytesInPerSec) }
+
+    /// Upload throughput for the network tile.
+    var networkUpString: String { Self.speedString(service.networkThroughput.bytesOutPerSec) }
+
+    // MARK: - Speed test
+
+    /// State of the on-demand connection speed test the network tile triggers.
+    enum SpeedTestState: Equatable {
+        case idle
+        case running
+        case result(downloadMbps: Double)
+        case failed
+    }
+
+    private(set) var speedTestState: SpeedTestState = .idle
+
+    /// Cloudflare's public download endpoint, used to measure real throughput.
+    private static let speedTestURL = URL(string: "https://speed.cloudflare.com/__down?bytes=10000000")!
+
+    /// Runs a real download speed test and publishes the result. Idempotent
+    /// while a test is in flight. Any failure (offline, non-2xx) resolves to
+    /// `.failed` so the tile can offer a retry rather than hang.
+    func runSpeedTest() async {
+        guard speedTestState != .running else { return }
+        speedTestState = .running
+        let start = Date()
+        do {
+            var request = URLRequest(url: Self.speedTestURL)
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                speedTestState = .failed
+                return
+            }
+            let seconds = Date().timeIntervalSince(start)
+            speedTestState = .result(downloadMbps: Self.megabitsPerSecond(bytes: data.count, seconds: seconds))
+        } catch {
+            speedTestState = .failed
+        }
+    }
+
     /// Single string the `MenuBarExtra` label renders. The format lives on the
     /// view-model (rather than as a `Text("RAM: \(...) | Disk: \(...)")`
     /// interpolation in the App scene) so the truncation rules in
@@ -158,6 +201,27 @@ final class MenuBarViewModel {
     /// Battery temperature rounded to a whole degree, e.g. "30°C".
     static func batteryTemperatureString(_ celsius: Double) -> String {
         "\(Int(celsius.rounded()))°C"
+    }
+
+    /// Formats a bytes-per-second rate for the network tile, e.g. "2 KB/s".
+    /// Zero traffic renders "0 KB/s" rather than `ByteCountFormatter`'s
+    /// locale-specific "Zero KB".
+    static func speedString(_ bytesPerSec: Double) -> String {
+        let bytes = max(0, bytesPerSec)
+        guard bytes >= 1 else { return "0 KB/s" }
+        let formatted = ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+        return "\(formatted)/s"
+    }
+
+    /// Download megabits-per-second from a payload size and elapsed seconds.
+    static func megabitsPerSecond(bytes: Int, seconds: Double) -> Double {
+        guard seconds > 0, bytes > 0 else { return 0 }
+        return (Double(bytes) * 8.0 / 1_000_000.0) / seconds
+    }
+
+    /// Formats a speed-test result, e.g. "82 Mbps".
+    static func speedTestResultString(_ mbps: Double) -> String {
+        String(format: "%.0f Mbps", mbps)
     }
 
     /// Human-readable label for a memory-pressure bucket. Matches the

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -78,6 +78,10 @@ final class MenuBarViewModel {
     /// Upload throughput for the network tile.
     var networkUpString: String { Self.speedString(service.networkThroughput.bytesOutPerSec) }
 
+    /// Wi-Fi network name for the network tile title, or a generic "Wi-Fi" when
+    /// the SSID is unavailable (not on Wi-Fi, or Location not yet authorized).
+    var wifiNetworkName: String { service.wifiSSID ?? String(localized: "Wi-Fi") }
+
     // MARK: - Speed test
 
     /// State of the on-demand connection speed test the network tile triggers.

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -82,6 +82,15 @@ final class MenuBarViewModel {
     /// the SSID is unavailable (not on Wi-Fi, or Location not yet authorized).
     var wifiNetworkName: String { service.wifiSSID ?? String(localized: "Wi-Fi") }
 
+    /// CPU temperature for the CPU tile, or `nil` when the SMC reports none on
+    /// this hardware (the tile hides the value rather than showing a guess).
+    var cpuTemperature: String? {
+        service.cpuTemperatureCelsius.map(Self.cpuTemperatureString)
+    }
+
+    /// System uptime for the CPU tile, e.g. "up 3d 4h".
+    var systemUptimeString: String { Self.uptimeString(service.systemUptime) }
+
     // MARK: - Speed test
 
     /// State of the on-demand connection speed test the network tile triggers.
@@ -226,6 +235,30 @@ final class MenuBarViewModel {
     /// Formats a speed-test result, e.g. "82 Mbps".
     static func speedTestResultString(_ mbps: Double) -> String {
         String(format: "%.0f Mbps", mbps)
+    }
+
+    /// CPU temperature rounded to a whole degree, e.g. "50°C".
+    static func cpuTemperatureString(_ celsius: Double) -> String {
+        "\(Int(celsius.rounded()))°C"
+    }
+
+    /// Compact uptime, e.g. "up 3d 4h", "up 4h 12m", or "up 8m". Drops to the
+    /// two most significant units so the CPU tile stays one short line.
+    static func uptimeString(_ interval: TimeInterval) -> String {
+        let total = max(0, Int(interval))
+        let days = total / 86_400
+        let hours = (total % 86_400) / 3_600
+        let minutes = (total % 3_600) / 60
+        let value: String
+        if days > 0 {
+            value = "\(days)d \(hours)h"
+        } else if hours > 0 {
+            value = "\(hours)h \(minutes)m"
+        } else {
+            value = "\(minutes)m"
+        }
+        let format = String(localized: "up %@", comment: "CPU tile uptime line; %@ is a duration like 3d 4h")
+        return String(format: format, value)
     }
 
     /// Human-readable label for a memory-pressure bucket. Matches the

--- a/VaderCleaner/MenuRouter.swift
+++ b/VaderCleaner/MenuRouter.swift
@@ -1,0 +1,29 @@
+// MenuRouter.swift
+// App-scope router that lets the menu bar panel deep-link into a main-window section (and optionally start that section's scan).
+
+import Foundation
+import Observation
+
+/// Bridges the menu bar scene to the main window scene. The menu can't reach
+/// `ContentView`'s navigation state directly, so it records a request here and
+/// opens the window; `ContentView` observes the request, navigates, and clears
+/// it.
+@MainActor
+@Observable
+final class MenuRouter {
+
+    /// Section the menu has asked the main window to show, or `nil` when there
+    /// is no pending request. `ContentView` consumes it and resets it to `nil`.
+    var requestedSection: NavigationSection?
+
+    /// When `true`, the requested section should begin its scan once shown.
+    /// Only meaningful for scannable sections.
+    var requestStartScan = false
+
+    /// Records a deep-link request. Callers also open/activate the main window;
+    /// `ContentView` applies the request when it appears or when it changes.
+    func request(_ section: NavigationSection, startScan: Bool = false) {
+        requestStartScan = startScan
+        requestedSection = section
+    }
+}

--- a/VaderCleaner/NavigationRailView.swift
+++ b/VaderCleaner/NavigationRailView.swift
@@ -189,7 +189,7 @@ struct NavigationRailView: View {
             }
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(RailButtonStyle())
         // Suppress the macOS keyboard focus ring. Without this the first
         // focusable row wears the system's blue halo on launch; the rail's
         // selection pill is its own state indicator.
@@ -208,5 +208,17 @@ struct NavigationRailView: View {
         .accessibilityIdentifier(section.accessibilityIdentifier)
         .accessibilityLabel(section.title)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+/// Button style for the rail rows that renders the label with no pressed-state
+/// treatment. The system `.plain` style dims the whole label — including the
+/// selection pill, which lives inside it — on press; re-clicking the already
+/// active row (a no-op for selection) then shows only that dim-and-restore,
+/// reading as a flicker. The lit pill and the hover highlight are the row's
+/// feedback instead, so suppressing the press dim is purely a visual win.
+private struct RailButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
     }
 }

--- a/VaderCleaner/OptimizationDashboardSubviews.swift
+++ b/VaderCleaner/OptimizationDashboardSubviews.swift
@@ -149,7 +149,7 @@ struct PerformanceRecommendationCard: View {
                         Text(recommendation.actionLabel)
                     }
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .tint(isCompleted ? .green : nil)
                 .accessibilityIdentifier("optimization.recommendation.\(recommendation.kind.rawValue)")
             }
@@ -382,7 +382,7 @@ struct OptimizationTaskCatalogView: View {
                 Button(String(localized: "Run", comment: "Runs the selected maintenance tasks.")) {
                     onRunSelected(tasks.filter { selectedTaskIDs.contains($0.id) })
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(selectedTaskIDs.isEmpty)
                 .accessibilityIdentifier("optimization.runSelected")
             }
@@ -490,7 +490,7 @@ struct TaskIconBadge: View {
     var body: some View {
         Image(systemName: symbol)
             .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(.white)
+            .foregroundStyle(tint.legibleForeground)
             .frame(width: 38, height: 38)
             .background(
                 LinearGradient(

--- a/VaderCleaner/PreferencesStore.swift
+++ b/VaderCleaner/PreferencesStore.swift
@@ -44,6 +44,7 @@ final class PreferencesStore {
         static let diskSpaceThresholdPercent = "preferences.diskSpaceThresholdPercent"
         static let launchAtLogin = "preferences.launchAtLogin"
         static let showMenuBar = "preferences.showMenuBar"
+        static let menuBarShowsReading = "preferences.menuBarShowsReading"
     }
 
     // MARK: - Defaults
@@ -57,6 +58,10 @@ final class PreferencesStore {
     static let defaultDiskSpaceThresholdPercent = 10.0
     static let defaultLaunchAtLogin = true
     static let defaultShowMenuBar = true
+    /// Off by default: the menu bar shows just the icon. A wide live reading is
+    /// prone to being hidden behind the notch on a crowded menu bar, so showing
+    /// it is opt-in.
+    static let defaultMenuBarShowsReading = false
 
     /// Reads the current `showMenuBar` value out of an arbitrary `UserDefaults`
     /// suite without instantiating the full store. Used by `VaderCleanerAppDelegate`
@@ -112,6 +117,11 @@ final class PreferencesStore {
         didSet { defaults.set(showMenuBar, forKey: Key.showMenuBar) }
     }
 
+    /// When on, the menu bar shows a compact free-disk reading next to the icon.
+    var menuBarShowsReading: Bool {
+        didSet { defaults.set(menuBarShowsReading, forKey: Key.menuBarShowsReading) }
+    }
+
     // MARK: - Init
 
     @ObservationIgnored private let defaults: UserDefaults
@@ -155,6 +165,8 @@ final class PreferencesStore {
             ?? Self.defaultLaunchAtLogin
         self.showMenuBar = (defaults.object(forKey: Key.showMenuBar) as? Bool)
             ?? Self.defaultShowMenuBar
+        self.menuBarShowsReading = (defaults.object(forKey: Key.menuBarShowsReading) as? Bool)
+            ?? Self.defaultMenuBarShowsReading
 
         // Reconcile the persisted preference with launchd's actual state once
         // the tracked properties are populated. The handler's presence is the

--- a/VaderCleaner/PreferencesView.swift
+++ b/VaderCleaner/PreferencesView.swift
@@ -174,8 +174,11 @@ private struct MenuBarTab: View {
             Section {
                 Toggle("Show VaderCleaner in the menu bar", isOn: $preferences.showMenuBar)
                     .accessibilityIdentifier("preferences.showMenuBar")
+                Toggle("Show free space next to the icon", isOn: $preferences.menuBarShowsReading)
+                    .accessibilityIdentifier("preferences.menuBarShowsReading")
+                    .disabled(!preferences.showMenuBar)
             } footer: {
-                Text("When disabled, the VaderCleaner icon and live stats are hidden from the menu bar.")
+                Text("When disabled, the VaderCleaner icon and live stats are hidden from the menu bar. The free-space reading sits next to the icon — note a wide menu bar can hide it behind the notch.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/VaderCleaner/PrivacyDashboardSubviews.swift
+++ b/VaderCleaner/PrivacyDashboardSubviews.swift
@@ -535,7 +535,7 @@ struct PrivacyDataCatalogView: View {
             ), action: onClear)
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.vaderProminent)
                 .disabled(!canClear)
                 .accessibilityIdentifier("privacy.clear")
         }

--- a/VaderCleaner/SMCReader.swift
+++ b/VaderCleaner/SMCReader.swift
@@ -1,0 +1,232 @@
+// SMCReader.swift
+// Best-effort AppleSMC reader for CPU temperature. SMC keys are undocumented and chip-specific, so every read is defensive and returns nil rather than a guess.
+
+import Foundation
+import IOKit
+
+/// Reads temperature sensors from the Apple System Management Controller.
+///
+/// SMC keys, data types, and which sensors map to "the CPU" are all
+/// undocumented and vary by chip generation, so this is deliberately
+/// conservative: it enumerates the available keys, averages the per-core die
+/// sensors on Apple Silicon (`Tp…`), falls back to the classic Intel CPU keys,
+/// and returns `nil` whenever nothing plausible is found. Callers must treat a
+/// `nil` (or a hidden tile) as the normal "unavailable" case.
+final class SMCReader {
+
+    private var connection: io_connect_t = 0
+
+    /// Opens a user client to `AppleSMC`. Fails (returns `nil`) when the
+    /// service is missing or the connection can't be opened.
+    init?() {
+        let service = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleSMC"))
+        guard service != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(service) }
+        guard IOServiceOpen(service, mach_task_self_, 0, &connection) == kIOReturnSuccess else {
+            return nil
+        }
+    }
+
+    deinit {
+        if connection != 0 { IOServiceClose(connection) }
+    }
+
+    /// Best-effort current CPU temperature in degrees Celsius, or `nil` when no
+    /// plausible sensor is readable on this hardware.
+    func cpuTemperatureCelsius() -> Double? {
+        // Apple Silicon exposes many per-core die sensors keyed `Tp…`; average
+        // the plausible ones for a representative figure.
+        let dieTemps = appleSiliconDieTemperatures()
+        if !dieTemps.isEmpty {
+            return dieTemps.reduce(0, +) / Double(dieTemps.count)
+        }
+        // Intel fallback: CPU die / proximity.
+        for key in ["TC0D", "TC0P", "TC0E", "TC0F"] {
+            if let value = temperature(forKey: key) { return value }
+        }
+        return nil
+    }
+
+    /// Reads every `Tp…`-prefixed sensor (Apple Silicon performance/efficiency
+    /// core die temps) that returns a plausible value.
+    private func appleSiliconDieTemperatures() -> [Double] {
+        guard let count = keyCount() else { return [] }
+        var temps: [Double] = []
+        for index in 0..<count {
+            guard let key = key(atIndex: index) else { continue }
+            // Core die sensors start with "Tp" (perf) or "Te"/"Tg" on some
+            // chips; restrict to "Tp" which is the most consistent CPU proxy.
+            guard key.hasPrefix("Tp") else { continue }
+            if let value = temperature(forKey: key) { temps.append(value) }
+        }
+        return temps
+    }
+
+    /// Reads a single temperature key, decoding its SMC data type. Returns
+    /// `nil` when the key is absent, the type is unsupported, or the value is
+    /// outside a plausible range.
+    private func temperature(forKey key: String) -> Double? {
+        guard let (info, bytes) = readKey(key) else { return nil }
+        guard let celsius = Self.decodeTemperature(dataType: info.dataType, bytes: bytes) else { return nil }
+        guard celsius > 0, celsius < 120 else { return nil }
+        return celsius
+    }
+
+    // MARK: - Pure decoding
+
+    /// Decodes a temperature value from raw SMC bytes by data type. Supports
+    /// `sp78` (Intel signed 7.8 fixed point) and `flt ` (Apple Silicon IEEE
+    /// float, little-endian). Returns `nil` for unsupported types or short
+    /// buffers.
+    static func decodeTemperature(dataType: UInt32, bytes: [UInt8]) -> Double? {
+        switch dataType {
+        case fourCharCode("sp78"):
+            guard bytes.count >= 2 else { return nil }
+            let raw = Int16(bitPattern: UInt16(bytes[0]) << 8 | UInt16(bytes[1]))
+            return Double(raw) / 256.0
+        case fourCharCode("flt "):
+            guard bytes.count >= 4 else { return nil }
+            let bits = UInt32(bytes[0]) | UInt32(bytes[1]) << 8 | UInt32(bytes[2]) << 16 | UInt32(bytes[3]) << 24
+            return Double(Float(bitPattern: bits))
+        default:
+            return nil
+        }
+    }
+
+    /// Packs a 4-character SMC key/type into its big-endian `UInt32` code.
+    static func fourCharCode(_ string: String) -> UInt32 {
+        let chars = Array(string.utf8)
+        guard chars.count == 4 else { return 0 }
+        return UInt32(chars[0]) << 24 | UInt32(chars[1]) << 16 | UInt32(chars[2]) << 8 | UInt32(chars[3])
+    }
+
+    // MARK: - IOKit plumbing
+
+    private func keyCount() -> UInt32? {
+        guard let (info, bytes) = readKey("#KEY"), info.dataSize >= 4, bytes.count >= 4 else { return nil }
+        return UInt32(bytes[0]) << 24 | UInt32(bytes[1]) << 16 | UInt32(bytes[2]) << 8 | UInt32(bytes[3])
+    }
+
+    private func key(atIndex index: UInt32) -> String? {
+        var input = SMCKeyData()
+        input.data8 = SMCSelector.readIndex
+        input.data32 = index
+        guard let output = call(input), output.result == 0 else { return nil }
+        return Self.string(fromKeyCode: output.key)
+    }
+
+    /// Reads a key's info (data type/size) then its raw value bytes.
+    private func readKey(_ key: String) -> (info: SMCKeyDataKeyInfo, bytes: [UInt8])? {
+        let keyCode = Self.fourCharCode(key)
+
+        var infoInput = SMCKeyData()
+        infoInput.key = keyCode
+        infoInput.data8 = SMCSelector.readKeyInfo
+        guard let infoOutput = call(infoInput), infoOutput.result == 0 else { return nil }
+        let info = infoOutput.keyInfo
+
+        var readInput = SMCKeyData()
+        readInput.key = keyCode
+        readInput.keyInfo = info
+        readInput.data8 = SMCSelector.readBytes
+        guard let readOutput = call(readInput), readOutput.result == 0 else { return nil }
+
+        let size = Int(min(info.dataSize, 32))
+        let bytes = Self.bytesArray(readOutput.bytes, count: size)
+        return (info, bytes)
+    }
+
+    private func call(_ input: SMCKeyData) -> SMCKeyData? {
+        var input = input
+        var output = SMCKeyData()
+        var outputSize = MemoryLayout<SMCKeyData>.stride
+        let result = IOConnectCallStructMethod(
+            connection,
+            SMCSelector.kernelIndex,
+            &input,
+            MemoryLayout<SMCKeyData>.stride,
+            &output,
+            &outputSize
+        )
+        return result == kIOReturnSuccess ? output : nil
+    }
+
+    /// Decodes a 4-byte SMC key code back into its string form.
+    private static func string(fromKeyCode code: UInt32) -> String {
+        let chars = [
+            UInt8((code >> 24) & 0xff),
+            UInt8((code >> 16) & 0xff),
+            UInt8((code >> 8) & 0xff),
+            UInt8(code & 0xff)
+        ]
+        return String(decoding: chars, as: UTF8.self)
+    }
+
+    /// Copies the fixed 32-byte SMC tuple into a `[UInt8]` of `count` bytes.
+    private static func bytesArray(_ tuple: SMCBytes32, count: Int) -> [UInt8] {
+        var values = tuple
+        return withUnsafeBytes(of: &values) { raw in
+            Array(raw.prefix(count)).map { $0 }
+        }
+    }
+}
+
+// MARK: - SMC C-compatible structures
+
+/// SMC user-client call selectors and read commands.
+private enum SMCSelector {
+    static let kernelIndex: UInt32 = 2
+    static let readBytes: UInt8 = 5
+    static let readIndex: UInt8 = 8
+    static let readKeyInfo: UInt8 = 9
+}
+
+/// The 32-byte value buffer the SMC returns, as a fixed-size tuple matching the
+/// kernel struct's array.
+typealias SMCBytes32 = (
+    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+)
+
+struct SMCKeyDataVersion {
+    var major: UInt8 = 0
+    var minor: UInt8 = 0
+    var build: UInt8 = 0
+    var reserved: UInt8 = 0
+    var release: UInt16 = 0
+}
+
+struct SMCKeyDataPLimit {
+    var version: UInt16 = 0
+    var length: UInt16 = 0
+    var cpuPLimit: UInt32 = 0
+    var gpuPLimit: UInt32 = 0
+    var memPLimit: UInt32 = 0
+}
+
+struct SMCKeyDataKeyInfo {
+    var dataSize: UInt32 = 0
+    var dataType: UInt32 = 0
+    var dataAttributes: UInt8 = 0
+}
+
+/// Mirror of the kernel's `SMCKeyData_t`. Field order and types must match the
+/// SMC user client exactly.
+struct SMCKeyData {
+    var key: UInt32 = 0
+    var vers = SMCKeyDataVersion()
+    var pLimitData = SMCKeyDataPLimit()
+    var keyInfo = SMCKeyDataKeyInfo()
+    var result: UInt8 = 0
+    var status: UInt8 = 0
+    var data8: UInt8 = 0
+    var data32: UInt32 = 0
+    var bytes: SMCBytes32 = (
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0
+    )
+}

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -286,7 +286,7 @@ struct SectionIntroView: View {
                 .overlay {
                     Image(systemName: feature.symbol)
                         .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(presentation.accent.legibleForeground)
                 }
                 .shadow(color: presentation.accent.opacity(0.4), radius: 7, y: 3)
             Text(feature.title)

--- a/VaderCleaner/SectionTheme.swift
+++ b/VaderCleaner/SectionTheme.swift
@@ -46,11 +46,14 @@ extension NavigationSection {
                 backdropBottom: Color(red: 0.06, green: 0.29, blue: 0.28)
             )
         case .spaceLens:
-            // Keyed to the indigo-violet Space Lens asset.
+            // Keyed to the indigo-violet Space Lens asset, brightened into a
+            // periwinkle: the accent doubles as the control tint (e.g. the
+            // active view-mode label), and the raw indigo was too dark to read
+            // on the backdrop. The gradient is lifted off near-black to match.
             return SectionTheme(
-                accent: Color(red: 0.38, green: 0.33, blue: 0.90),
-                backdropTop: Color(red: 0.04, green: 0.03, blue: 0.12),
-                backdropBottom: Color(red: 0.08, green: 0.06, blue: 0.29)
+                accent: Color(red: 0.52, green: 0.44, blue: 1.00),
+                backdropTop: Color(red: 0.05, green: 0.04, blue: 0.15),
+                backdropBottom: Color(red: 0.10, green: 0.08, blue: 0.34)
             )
         case .malwareRemoval:
             // Keyed to the magenta Protection octagon asset.

--- a/VaderCleaner/SectionTheme.swift
+++ b/VaderCleaner/SectionTheme.swift
@@ -88,10 +88,12 @@ extension NavigationSection {
                 backdropBottom: Color(red: 0.09, green: 0.13, blue: 0.37)
             )
         case .healthMonitor:
+            // Vader identity: lightsaber crimson on a near-black, crimson-deep
+            // backdrop.
             return SectionTheme(
-                accent: Color(red: 0.30, green: 0.86, blue: 0.64),
-                backdropTop: Color(red: 0.03, green: 0.11, blue: 0.09),
-                backdropBottom: Color(red: 0.06, green: 0.27, blue: 0.20)
+                accent: .vaderCrimson,
+                backdropTop: Color(red: 0.10, green: 0.02, blue: 0.03),
+                backdropBottom: Color(red: 0.24, green: 0.04, blue: 0.07)
             )
         }
     }

--- a/VaderCleaner/SectionTheme.swift
+++ b/VaderCleaner/SectionTheme.swift
@@ -74,11 +74,15 @@ extension NavigationSection {
                 backdropBottom: Color(red: 0.06, green: 0.17, blue: 0.29)
             )
         case .applications:
-            // Keyed to the blue Applications hexagon asset.
+            // Keyed to the blue Applications hexagon asset, but a brighter,
+            // less-saturated blue: the accent doubles as the control tint, so it
+            // must read as legible icon and metric text on the dark backdrop —
+            // the raw asset blue was too dark to see. The gradient is lifted off
+            // near-black so the section no longer reads as a heavy navy.
             return SectionTheme(
-                accent: Color(red: 0.05, green: 0.13, blue: 0.90),
-                backdropTop: Color(red: 0.03, green: 0.04, blue: 0.12),
-                backdropBottom: Color(red: 0.06, green: 0.08, blue: 0.29)
+                accent: Color(red: 0.30, green: 0.46, blue: 1.00),
+                backdropTop: Color(red: 0.04, green: 0.06, blue: 0.17),
+                backdropBottom: Color(red: 0.09, green: 0.13, blue: 0.37)
             )
         case .healthMonitor:
             return SectionTheme(

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -138,7 +138,7 @@ private struct SmartScanMetricCard: View {
                         localized: "Review",
                         comment: "Per-card button on the Smart Scan dashboard that opens that tile's manager screen."
                     ), action: onReview)
-                        .buttonStyle(.borderedProminent)
+                        .buttonStyle(.vaderProminent)
                         .accessibilityIdentifier(reviewIdentifier)
                         .opacity(isDeselected ? 0 : 1)
                         .allowsHitTesting(!isDeselected)

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -134,7 +134,7 @@ struct SystemJunkView: View {
             }
             .controlSize(.large)
             .keyboardShortcut(.defaultAction)
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.vaderProminent)
             .disabled(viewModel.totalSelectedSize == 0)
             .accessibilityIdentifier("system-junk.clean")
         }

--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -102,6 +102,24 @@ enum BatteryAvailability: Equatable {
     case present(BatteryStats)
 }
 
+/// Live battery charge snapshot — the moment-to-moment state the menu bar
+/// shows ("100% · Charging"), distinct from `BatteryStats`' long-term health.
+/// `nil` (an absent published value) means there is no internal battery or the
+/// power source could not be read.
+struct BatteryCharge: Equatable {
+    /// Current charge as a whole percentage, 0…100.
+    let percent: Int
+    /// Whether the battery is actively charging.
+    let isCharging: Bool
+    /// Whether the Mac is running on external (AC) power.
+    let isPluggedIn: Bool
+    /// Estimated minutes until full (when charging) or empty (when
+    /// discharging), or `nil` while the estimate is still being calculated.
+    let timeRemainingMinutes: Int?
+    /// Battery temperature in degrees Celsius, or `nil` when unavailable.
+    let temperatureCelsius: Double?
+}
+
 /// SMART status of the boot disk. `.good` corresponds to diskutil's
 /// `"Verified"`, `.failing` to `"Failing"`. `.unknown` covers everything
 /// else — most relevantly, the case where `diskutil info -plist /` fails or
@@ -163,6 +181,9 @@ final class SystemStatsService {
     private(set) var ramUsage: MemoryStats = .empty
     private(set) var diskSpace: DiskStats = .empty
     private(set) var batteryAvailability: BatteryAvailability = .unknown
+    /// Live charge snapshot (percent, charging, time remaining, temperature).
+    /// `nil` until the first refresh, or on a Mac with no internal battery.
+    private(set) var batteryCharge: BatteryCharge?
     private(set) var diskSMARTStatus: SMARTStatus = .unknown
     private(set) var fileVaultState: FileVaultState = .unknown
 
@@ -278,6 +299,7 @@ final class SystemStatsService {
         ramUsage = readMemoryStats()
         diskSpace = readDiskStats()
         batteryAvailability = readBatteryAvailability()
+        batteryCharge = readBatteryCharge()
     }
 
     // MARK: CPU
@@ -473,6 +495,98 @@ final class SystemStatsService {
                 condition: condition.isEmpty ? "Unknown" : condition
             )
         )
+    }
+
+    /// IOPowerSources description keys (the `kIOPS…` string constants from
+    /// `IOKit/ps/IOPSKeys.h`). Spelled out as literals so the pure parser and
+    /// its tests don't depend on the framework constants' import shape.
+    private enum PowerSourceKey {
+        static let currentCapacity = "Current Capacity"
+        static let maxCapacity = "Max Capacity"
+        static let isCharging = "Is Charging"
+        static let powerSourceState = "Power Source State"
+        static let timeToEmpty = "Time to Empty"
+        static let timeToFull = "Time to Full Charge"
+        static let acPowerValue = "AC Power"
+    }
+
+    /// Reads the live battery charge via the public `IOPowerSources` API
+    /// (charge / charging / time remaining) and `AppleSmartBattery` (temperature,
+    /// which IOPowerSources does not report). Returns `nil` when there is no
+    /// internal battery power source.
+    private func readBatteryCharge() -> BatteryCharge? {
+        guard
+            let blob = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+            let sources = IOPSCopyPowerSourcesList(blob)?.takeRetainedValue() as? [CFTypeRef]
+        else { return nil }
+
+        let temperature = readBatteryTemperatureCelsius()
+        for source in sources {
+            guard
+                let description = IOPSGetPowerSourceDescription(blob, source)?
+                    .takeUnretainedValue() as? [String: Any],
+                let charge = Self.parseBatteryCharge(from: description, temperatureCelsius: temperature)
+            else { continue }
+            return charge
+        }
+        return nil
+    }
+
+    /// Reads the battery's current temperature from `AppleSmartBattery`'s
+    /// `Temperature` key. `nil` when no battery or the reading is implausible.
+    private func readBatteryTemperatureCelsius() -> Double? {
+        let matching = IOServiceMatching("AppleSmartBattery")
+        let service = IOServiceGetMatchingService(kIOMainPortDefault, matching)
+        guard service != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(service) }
+        guard let raw = (copyProperty(service: service, key: "Temperature") as? NSNumber)?.intValue else {
+            return nil
+        }
+        return Self.batteryTemperatureCelsius(fromRaw: raw)
+    }
+
+    /// Builds a `BatteryCharge` from an `IOPSGetPowerSourceDescription`
+    /// dictionary. Returns `nil` when the capacity keys are missing or invalid
+    /// (a non-battery source or a malformed entry). Temperature is injected
+    /// separately because IOPowerSources does not report it.
+    static func parseBatteryCharge(
+        from description: [String: Any],
+        temperatureCelsius: Double?
+    ) -> BatteryCharge? {
+        guard
+            let current = (description[PowerSourceKey.currentCapacity] as? NSNumber)?.intValue,
+            let maximum = (description[PowerSourceKey.maxCapacity] as? NSNumber)?.intValue,
+            maximum > 0
+        else { return nil }
+
+        let ratio = Double(current) / Double(maximum)
+        let percent = min(100, max(0, Int((ratio * 100).rounded())))
+        let isCharging = (description[PowerSourceKey.isCharging] as? Bool) ?? false
+        let isPluggedIn = (description[PowerSourceKey.powerSourceState] as? String) == PowerSourceKey.acPowerValue
+
+        // IOPowerSources reports the relevant estimate under different keys for
+        // charging vs discharging, and uses a negative sentinel while it is
+        // still calculating — surface that as `nil` rather than a bogus time.
+        let timeKey = isCharging ? PowerSourceKey.timeToFull : PowerSourceKey.timeToEmpty
+        let rawTime = (description[timeKey] as? NSNumber)?.intValue ?? -1
+        let timeRemaining = rawTime >= 0 ? rawTime : nil
+
+        return BatteryCharge(
+            percent: percent,
+            isCharging: isCharging,
+            isPluggedIn: isPluggedIn,
+            timeRemainingMinutes: timeRemaining,
+            temperatureCelsius: temperatureCelsius
+        )
+    }
+
+    /// Converts `AppleSmartBattery`'s `Temperature` reading (hundredths of a
+    /// degree Celsius) to degrees Celsius. Returns `nil` for implausible values
+    /// so a garbage reading never renders as a confident temperature.
+    static func batteryTemperatureCelsius(fromRaw raw: Int) -> Double? {
+        let celsius = Double(raw) / 100.0
+        guard celsius > -20, celsius < 120 else { return nil }
+        return celsius
     }
 
     /// Thin wrapper around `IORegistryEntryCreateCFProperty` that returns the

--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -210,6 +210,10 @@ final class SystemStatsService {
     /// Current Wi-Fi network name, or `nil` when not on Wi-Fi or Location
     /// Services has not authorized reading it (macOS 14+ gates the SSID).
     private(set) var wifiSSID: String?
+    /// Best-effort CPU temperature in °C from the SMC, or `nil` when no sensor
+    /// is readable on this hardware (SMC keys are chip-specific — `nil` is the
+    /// normal "unavailable" case, not an error).
+    private(set) var cpuTemperatureCelsius: Double?
 
     // MARK: Configuration
 
@@ -251,6 +255,10 @@ final class SystemStatsService {
     /// `nil` until the first sample, which seeds the baseline and reports zero.
     @ObservationIgnored private var previousNetworkCounters: NetworkCounters?
     @ObservationIgnored private var previousNetworkSampleTime: Date?
+
+    /// Best-effort SMC temperature reader. `nil` on hardware where the SMC
+    /// user client can't be opened; reads then simply report no temperature.
+    @ObservationIgnored private lazy var smcReader = SMCReader()
 
     /// Requests Location authorization (required to read the Wi-Fi SSID on
     /// macOS 14+) and re-reads the SSID promptly once it is granted.
@@ -343,7 +351,12 @@ final class SystemStatsService {
         batteryCharge = readBatteryCharge()
         networkThroughput = readNetworkThroughput()
         wifiSSID = readWiFiSSID()
+        cpuTemperatureCelsius = smcReader?.cpuTemperatureCelsius()
     }
+
+    /// Seconds since the system booted. Computed on read (cheap) rather than
+    /// polled — the menu's CPU tile reads it alongside the live stats.
+    var systemUptime: TimeInterval { ProcessInfo.processInfo.systemUptime }
 
     // MARK: CPU
 

--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -5,6 +5,8 @@ import Foundation
 import Darwin
 import IOKit
 import IOKit.ps
+import CoreWLAN
+import CoreLocation
 import Observation
 import os.log
 
@@ -205,6 +207,9 @@ final class SystemStatsService {
     /// Live network throughput (bytes/sec in and out). `.zero` until two
     /// samples exist to diff.
     private(set) var networkThroughput: NetworkThroughput = .zero
+    /// Current Wi-Fi network name, or `nil` when not on Wi-Fi or Location
+    /// Services has not authorized reading it (macOS 14+ gates the SSID).
+    private(set) var wifiSSID: String?
 
     // MARK: Configuration
 
@@ -247,6 +252,15 @@ final class SystemStatsService {
     @ObservationIgnored private var previousNetworkCounters: NetworkCounters?
     @ObservationIgnored private var previousNetworkSampleTime: Date?
 
+    /// Requests Location authorization (required to read the Wi-Fi SSID on
+    /// macOS 14+) and re-reads the SSID promptly once it is granted.
+    @ObservationIgnored private lazy var locationAuthorizer = LocationAuthorizer { [weak self] in
+        Task { @MainActor in
+            guard let self else { return }
+            self.wifiSSID = self.readWiFiSSID()
+        }
+    }
+
     // MARK: Init / lifecycle
 
     init(interval: TimeInterval = 2.0, autostart: Bool = true) {
@@ -275,6 +289,9 @@ final class SystemStatsService {
     func start() {
         stop()
         isStopped = false
+        // Ask for Location once on start — the Wi-Fi SSID is gated behind it on
+        // macOS 14+. Reading throughput and everything else works regardless.
+        locationAuthorizer.requestIfNeeded()
         // Add to `.common` mode so the timer keeps firing while AppKit is in a
         // tracking mode (menu bar popover open, scrollbar drag, etc.). With
         // the default mode the cheap-stats publisher would freeze the moment
@@ -325,6 +342,7 @@ final class SystemStatsService {
         batteryAvailability = readBatteryAvailability()
         batteryCharge = readBatteryCharge()
         networkThroughput = readNetworkThroughput()
+        wifiSSID = readWiFiSSID()
     }
 
     // MARK: CPU
@@ -633,6 +651,13 @@ final class SystemStatsService {
         return Self.throughput(previous: previous, current: current, interval: now.timeIntervalSince(previousTime))
     }
 
+    /// Current Wi-Fi SSID via CoreWLAN. Returns `nil` when not associated to a
+    /// network, or when Location authorization has not been granted — macOS 14+
+    /// returns `nil` from `ssid()` until the app holds Location access.
+    private func readWiFiSSID() -> String? {
+        CWWiFiClient.shared().interface()?.ssid()
+    }
+
     /// Sums `ifi_ibytes` / `ifi_obytes` across all active non-loopback link-layer
     /// interfaces via `getifaddrs`. Cumulative since boot; the caller diffs.
     private func readNetworkCounters() -> NetworkCounters {
@@ -822,6 +847,36 @@ final class SystemStatsService {
             os_log("fdesetup invocation failed: %{public}@",
                    log: log, type: .error, error.localizedDescription)
             return nil
+        }
+    }
+}
+
+/// Minimal CoreLocation authorization shim. Reading the Wi-Fi SSID on macOS 14+
+/// requires the app to hold Location authorization; this requests it once and
+/// notifies when it's granted so the caller can re-read the SSID.
+private final class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    private let onAuthorized: () -> Void
+
+    init(onAuthorized: @escaping () -> Void) {
+        self.onAuthorized = onAuthorized
+        super.init()
+        manager.delegate = self
+    }
+
+    /// Prompts for authorization only when the user hasn't decided yet.
+    func requestIfNeeded() {
+        if manager.authorizationStatus == .notDetermined {
+            manager.requestWhenInUseAuthorization()
+        }
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        switch manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            onAuthorized()
+        default:
+            break
         }
     }
 }

--- a/VaderCleaner/SystemStatsService.swift
+++ b/VaderCleaner/SystemStatsService.swift
@@ -140,6 +140,22 @@ enum FileVaultState: Equatable {
     case on
 }
 
+/// Cumulative interface byte counters (since boot), summed across all active
+/// non-loopback interfaces. Diffed between ticks to derive throughput.
+struct NetworkCounters: Equatable {
+    let bytesIn: UInt64
+    let bytesOut: UInt64
+    static let zero = NetworkCounters(bytesIn: 0, bytesOut: 0)
+}
+
+/// Instantaneous network throughput in bytes per second, for the menu's
+/// network tile.
+struct NetworkThroughput: Equatable {
+    let bytesInPerSec: Double
+    let bytesOutPerSec: Double
+    static let zero = NetworkThroughput(bytesInPerSec: 0, bytesOutPerSec: 0)
+}
+
 // MARK: - SystemStatsService
 
 /// Publishes live system-health readings on a polling timer.
@@ -186,6 +202,9 @@ final class SystemStatsService {
     private(set) var batteryCharge: BatteryCharge?
     private(set) var diskSMARTStatus: SMARTStatus = .unknown
     private(set) var fileVaultState: FileVaultState = .unknown
+    /// Live network throughput (bytes/sec in and out). `.zero` until two
+    /// samples exist to diff.
+    private(set) var networkThroughput: NetworkThroughput = .zero
 
     // MARK: Configuration
 
@@ -222,6 +241,11 @@ final class SystemStatsService {
     /// busy_then) / (total_now - total_then)`. Nil before the first sample;
     /// the first `refresh()` seeds it and publishes `cpuUsage = 0`.
     @ObservationIgnored private var previousCPUTotals: CPUTotals?
+
+    /// Previous network counters + sample time for throughput delta computation.
+    /// `nil` until the first sample, which seeds the baseline and reports zero.
+    @ObservationIgnored private var previousNetworkCounters: NetworkCounters?
+    @ObservationIgnored private var previousNetworkSampleTime: Date?
 
     // MARK: Init / lifecycle
 
@@ -300,6 +324,7 @@ final class SystemStatsService {
         diskSpace = readDiskStats()
         batteryAvailability = readBatteryAvailability()
         batteryCharge = readBatteryCharge()
+        networkThroughput = readNetworkThroughput()
     }
 
     // MARK: CPU
@@ -587,6 +612,69 @@ final class SystemStatsService {
         let celsius = Double(raw) / 100.0
         guard celsius > -20, celsius < 120 else { return nil }
         return celsius
+    }
+
+    // MARK: Network
+
+    /// Samples the interface byte counters and returns the throughput against
+    /// the previous sample. The first call seeds the baseline and returns
+    /// `.zero` because there is nothing to diff against.
+    private func readNetworkThroughput() -> NetworkThroughput {
+        let current = readNetworkCounters()
+        let now = Date()
+        defer {
+            previousNetworkCounters = current
+            previousNetworkSampleTime = now
+        }
+        guard
+            let previous = previousNetworkCounters,
+            let previousTime = previousNetworkSampleTime
+        else { return .zero }
+        return Self.throughput(previous: previous, current: current, interval: now.timeIntervalSince(previousTime))
+    }
+
+    /// Sums `ifi_ibytes` / `ifi_obytes` across all active non-loopback link-layer
+    /// interfaces via `getifaddrs`. Cumulative since boot; the caller diffs.
+    private func readNetworkCounters() -> NetworkCounters {
+        var addrs: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&addrs) == 0, let first = addrs else { return .zero }
+        defer { freeifaddrs(addrs) }
+
+        var totalIn: UInt64 = 0
+        var totalOut: UInt64 = 0
+        var node: UnsafeMutablePointer<ifaddrs>? = first
+        while let current = node {
+            defer { node = current.pointee.ifa_next }
+            guard
+                let addr = current.pointee.ifa_addr,
+                addr.pointee.sa_family == UInt8(AF_LINK)
+            else { continue }
+            // Loopback traffic isn't real network activity — skip it.
+            if String(cString: current.pointee.ifa_name) == "lo0" { continue }
+            guard let data = current.pointee.ifa_data else { continue }
+            let stats = data.assumingMemoryBound(to: if_data.self)
+            totalIn += UInt64(stats.pointee.ifi_ibytes)
+            totalOut += UInt64(stats.pointee.ifi_obytes)
+        }
+        return NetworkCounters(bytesIn: totalIn, bytesOut: totalOut)
+    }
+
+    /// Bytes-per-second throughput from two cumulative counter samples. Guards
+    /// against a non-positive interval and against counter resets / wraps
+    /// (a smaller "current" than "previous" yields zero rather than a huge
+    /// spike).
+    static func throughput(
+        previous: NetworkCounters,
+        current: NetworkCounters,
+        interval: TimeInterval
+    ) -> NetworkThroughput {
+        guard interval > 0 else { return .zero }
+        let inDelta = current.bytesIn >= previous.bytesIn ? current.bytesIn - previous.bytesIn : 0
+        let outDelta = current.bytesOut >= previous.bytesOut ? current.bytesOut - previous.bytesOut : 0
+        return NetworkThroughput(
+            bytesInPerSec: Double(inDelta) / interval,
+            bytesOutPerSec: Double(outDelta) / interval
+        )
     }
 
     /// Thin wrapper around `IORegistryEntryCreateCFProperty` that returns the

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -44,6 +44,9 @@ struct VaderCleanerApp: App {
     // `@EnvironmentObject` — making it a per-view StateObject would
     // double-instantiate the timer.
     @State private var systemStats: SystemStatsService
+    // App-scope list of connected Bluetooth devices and ejectable volumes for
+    // the menu's Connected Devices tile. Refreshed when the menu opens.
+    @State private var connectedDevices = ConnectedDevicesMonitor()
     // App-scope: subscribes to `systemStats` and pushes notifications via
     // `NotificationManager`. Held here so the Combine subscriptions live as
     // long as the app and so the per-kind cooldown table survives across
@@ -274,6 +277,7 @@ struct VaderCleanerApp: App {
                 .environment(preferences)
                 .environment(exclusions)
                 .environment(systemStats)
+                .environment(connectedDevices)
         } label: {
             // Compact label rendered into the system menu bar. The format
             // (prefixes, separator, truncation rules) lives on

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -278,6 +278,7 @@ struct VaderCleanerApp: App {
                 .environment(exclusions)
                 .environment(systemStats)
                 .environment(connectedDevices)
+                .environment(malwareViewModel)
         } label: {
             // Compact label rendered into the system menu bar. The format
             // (prefixes, separator, truncation rules) lives on

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -45,8 +45,11 @@ struct VaderCleanerApp: App {
     // double-instantiate the timer.
     @State private var systemStats: SystemStatsService
     // App-scope list of connected Bluetooth devices and ejectable volumes for
-    // the menu's Connected Devices tile. Refreshed when the menu opens.
-    @State private var connectedDevices = ConnectedDevicesMonitor()
+    // the menu's Connected Devices tile. `autoRefresh: false` so it does NOT
+    // touch Bluetooth (a TCC-gated resource) during App.init — that runs before
+    // the app can present a permission prompt and would crash a menu-bar agent
+    // app at launch. The panel refreshes the list when the menu opens instead.
+    @State private var connectedDevices = ConnectedDevicesMonitor(autoRefresh: false)
     // App-scope: subscribes to `systemStats` and pushes notifications via
     // `NotificationManager`. Held here so the Combine subscriptions live as
     // long as the app and so the per-kind cooldown table survives across

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -283,15 +283,14 @@ struct VaderCleanerApp: App {
                 .environment(connectedDevices)
                 .environment(malwareViewModel)
         } label: {
-            // Compact label rendered into the system menu bar. The format
-            // (prefixes, separator, truncation rules) lives on
-            // `MenuBarViewModel.menuBarLabel(ram:disk:)` so a buggy upstream
-            // reading can't blow up label width — the view-model clamps each
-            // segment before formatting. `.monospacedDigit()` keeps numeric
-            // glyphs fixed-width so neighbouring menu bar items don't jitter
-            // as readings change every two seconds.
-            Text(menuBarViewModel.menuBarLabelText)
-                .monospacedDigit()
+            // A compact icon, not the live RAM/Disk text. A wide text label
+            // gets pushed into the area hidden behind the notch on a crowded
+            // menu bar and becomes invisible; a narrow icon stays reachable and
+            // matches how menu bar apps conventionally present themselves. The
+            // detailed live readings live in the panel; the text is kept as the
+            // accessibility label so VoiceOver still announces them.
+            Image(systemName: "gauge.medium")
+                .accessibilityLabel(menuBarViewModel.menuBarLabelText)
         }
         .menuBarExtraStyle(.window)
     }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -283,14 +283,24 @@ struct VaderCleanerApp: App {
                 .environment(connectedDevices)
                 .environment(malwareViewModel)
         } label: {
-            // A compact icon, not the live RAM/Disk text. A wide text label
-            // gets pushed into the area hidden behind the notch on a crowded
-            // menu bar and becomes invisible; a narrow icon stays reachable and
-            // matches how menu bar apps conventionally present themselves. The
-            // detailed live readings live in the panel; the text is kept as the
-            // accessibility label so VoiceOver still announces them.
-            Image(systemName: "gauge.medium")
+            // A compact health-pulse glyph by default. A wide text label gets
+            // pushed into the area hidden behind the notch on a crowded menu bar
+            // and becomes invisible; the narrow icon stays reachable and matches
+            // how menu bar apps conventionally present themselves. Users who
+            // want a number can opt into a short free-disk reading beside it
+            // (Preferences → "Show free space in the menu bar"). The full
+            // readings live in the panel; the text stays the accessibility label.
+            if preferences.menuBarShowsReading {
+                HStack(spacing: 4) {
+                    Image(systemName: "waveform.path.ecg")
+                    Text(menuBarViewModel.menuBarCompactReading)
+                        .monospacedDigit()
+                }
                 .accessibilityLabel(menuBarViewModel.menuBarLabelText)
+            } else {
+                Image(systemName: "waveform.path.ecg")
+                    .accessibilityLabel(menuBarViewModel.menuBarLabelText)
+            }
         }
         .menuBarExtraStyle(.window)
     }

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -50,6 +50,9 @@ struct VaderCleanerApp: App {
     // the app can present a permission prompt and would crash a menu-bar agent
     // app at launch. The panel refreshes the list when the menu opens instead.
     @State private var connectedDevices = ConnectedDevicesMonitor(autoRefresh: false)
+    // App-scope router so the menu bar panel can deep-link into a main-window
+    // section (and optionally start its scan). Shared by both scenes.
+    @State private var menuRouter = MenuRouter()
     // App-scope: subscribes to `systemStats` and pushes notifications via
     // `NotificationManager`. Held here so the Combine subscriptions live as
     // long as the app and so the per-kind cooldown table survives across
@@ -227,6 +230,7 @@ struct VaderCleanerApp: App {
                 .environment(exclusions)
                 .environment(systemStats)
                 .environment(notificationMonitor)
+                .environment(menuRouter)
         }
         // Hide the title bar so no section title is drawn beside the traffic
         // lights; the controls float over the section's gradient and each
@@ -282,6 +286,7 @@ struct VaderCleanerApp: App {
                 .environment(systemStats)
                 .environment(connectedDevices)
                 .environment(malwareViewModel)
+                .environment(menuRouter)
         } label: {
             // A compact health-pulse glyph by default. A wide text label gets
             // pushed into the area hidden behind the notch on a crowded menu bar

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -2,6 +2,7 @@
 // VaderCleaner's visual identity: the space-black to Sith-red palette and the per-section gradient backdrop that hosts the app's Liquid Glass surfaces.
 
 import SwiftUI
+import AppKit
 
 /// Palette for the Vader identity. Deep near-black base with a vivid crimson
 /// accent — retained as the default control tint for surfaces that have no
@@ -55,6 +56,86 @@ extension View {
     func vaderShell(accent: Color) -> some View {
         self
             .tint(accent)
+            // Mirror the accent into an environment value a `ButtonStyle` can
+            // read — the tint shape style is not introspectable, but the
+            // prominent button style needs the fill colour to pick a legible
+            // label.
+            .environment(\.sectionAccent, accent)
             .preferredColorScheme(.dark)
     }
+}
+
+extension Color {
+    /// A foreground colour guaranteed to read on top of `self` when `self` is
+    /// used as a fill: near-black on light fills, white on dark ones. Chosen by
+    /// the fill's perceived luminance so accent-filled badges and buttons stay
+    /// legible whether the section accent is a bright green or a deep blue.
+    var legibleForeground: Color {
+        Self.perceivedLuminance(of: self) > 0.45 ? Color(white: 0.08) : .white
+    }
+
+    /// WCAG relative luminance (0…1) of a colour in sRGB.
+    fileprivate static func perceivedLuminance(of color: Color) -> Double {
+        let resolved = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(white: 0, alpha: 1)
+        func channel(_ c: CGFloat) -> Double {
+            let value = Double(c)
+            return value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(resolved.redComponent)
+            + 0.7152 * channel(resolved.greenComponent)
+            + 0.0722 * channel(resolved.blueComponent)
+    }
+}
+
+private struct SectionAccentKey: EnvironmentKey {
+    static let defaultValue: Color = .vaderCrimson
+}
+
+extension EnvironmentValues {
+    /// The active section's accent — the same colour as the control tint, but
+    /// readable from a `ButtonStyle` (the tint shape style is not). Drives the
+    /// prominent button fill and its legible label.
+    var sectionAccent: Color {
+        get { self[SectionAccentKey.self] }
+        set { self[SectionAccentKey.self] = newValue }
+    }
+}
+
+/// Prominent action button that fills with the section accent and chooses a
+/// legible label colour by the accent's luminance — so a bright green or cyan
+/// section keeps readable (near-black) button text where the system's fixed
+/// white label would wash out. Used for the section dashboards' and review
+/// screens' primary actions; onboarding/permission flows keep the system style.
+struct VaderProminentButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        ProminentLabel(configuration: configuration)
+    }
+
+    private struct ProminentLabel: View {
+        let configuration: Configuration
+        @Environment(\.sectionAccent) private var accent
+        @Environment(\.isEnabled) private var isEnabled
+        @Environment(\.controlSize) private var controlSize
+
+        /// Large/extra-large controls get a taller capsule so the primary
+        /// action bars keep the heft of a `.controlSize(.large)` button.
+        private var isLarge: Bool { controlSize == .large || controlSize == .extraLarge }
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: isLarge ? 15 : 13, weight: .semibold))
+                .foregroundStyle(accent.legibleForeground)
+                .padding(.horizontal, isLarge ? 20 : 14)
+                .padding(.vertical, isLarge ? 9 : 6)
+                .background(Capsule().fill(accent))
+                .opacity(isEnabled ? (configuration.isPressed ? 0.82 : 1.0) : 0.45)
+                .contentShape(Capsule())
+                .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+        }
+    }
+}
+
+extension ButtonStyle where Self == VaderProminentButtonStyle {
+    /// Section-accent prominent button with a luminance-aware label.
+    static var vaderProminent: VaderProminentButtonStyle { VaderProminentButtonStyle() }
 }

--- a/VaderCleanerTests/ConnectedDevicesMonitorTests.swift
+++ b/VaderCleanerTests/ConnectedDevicesMonitorTests.swift
@@ -1,0 +1,22 @@
+// ConnectedDevicesMonitorTests.swift
+// Pins the rule for which mounted volumes belong in the menu's Connected Devices tile.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class ConnectedDevicesMonitorTests: XCTestCase {
+
+    /// A removable or ejectable external volume is listed; the internal boot
+    /// disk and ordinary internal volumes are not.
+    func test_shouldList_onlyExternalEjectableVolumes() {
+        // External thumb drive: removable + ejectable, not internal.
+        XCTAssertTrue(ConnectedDevicesMonitor.shouldList(isEjectable: true, isRemovable: true, isInternal: false))
+        // External SSD: ejectable, not removable, not internal.
+        XCTAssertTrue(ConnectedDevicesMonitor.shouldList(isEjectable: true, isRemovable: false, isInternal: false))
+        // Internal boot disk: never listed even if flagged ejectable.
+        XCTAssertFalse(ConnectedDevicesMonitor.shouldList(isEjectable: true, isRemovable: true, isInternal: true))
+        // Plain internal volume: not user-ejectable.
+        XCTAssertFalse(ConnectedDevicesMonitor.shouldList(isEjectable: false, isRemovable: false, isInternal: true))
+    }
+}

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -308,61 +308,106 @@ final class HealthMonitorViewModelTests: XCTestCase {
         return DiskStats(usedBytes: UInt64(Double(total) * ratio), totalBytes: total)
     }
 
+    /// A healthy present battery — the common case that must never penalize.
+    private let goodBattery = BatteryAvailability.present(
+        BatteryStats(cycleCount: 100, maxCapacityPercent: 0.95, condition: "Normal")
+    )
+
     /// The very first service tick carries `DiskStats.empty` (zero total).
-    /// The hero must NOT resolve to a confident "Excellent" off zero data —
-    /// it returns `nil` so the view can render a neutral "Measuring…" state.
+    /// The hero must NOT resolve to a confident verdict off zero data — it
+    /// returns `nil` so the view can render a neutral "Measuring…" state.
     func test_macHealthStatus_isNilWhileDiskUnmeasured() {
-        XCTAssertNil(HealthMonitorViewModel.macHealthStatus(disk: .empty, signals: []))
+        XCTAssertNil(
+            HealthMonitorViewModel.macHealthStatus(disk: .empty, smart: .unknown, battery: .unknown)
+        )
     }
 
-    /// Disk fullness drives the base verdict when no other signal is alarming.
-    /// Pins each tier boundary so the ramp can't silently shift.
-    func test_macHealthStatus_diskDrivesBaseTier_whenSignalsHealthy() {
-        let healthy: [StatusColor] = [.green, .green, .green, .green, .green]
-        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: healthy), .excellent)
-        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.60), signals: healthy), .good)
-        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.75), signals: healthy), .fair)
-        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.88), signals: healthy), .requiresAttention)
-        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.97), signals: healthy), .critical)
-    }
-
-    /// Unknown / neutral signals (the startup state) must not penalize the
-    /// verdict — a `.gray` reading is "no opinion", not "bad".
-    func test_macHealthStatus_grayAndGreenSignalsDoNotPenalize() {
-        let neutral: [StatusColor] = [.gray, .gray, .green, .green, .gray]
-        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: neutral), .excellent)
-    }
-
-    /// A single yellow nudge drops the base verdict by one tier.
-    func test_macHealthStatus_yellowSignalNudgesDownOneTier() {
-        // good (disk 0.60) − 1 (one yellow) → fair
-        let signals: [StatusColor] = [.green, .yellow, .green, .green, .green]
-        XCTAssertEqual(HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.60), signals: signals), .fair)
-    }
-
-    /// A red signal (e.g. failing SMART) deliberately overrides the
-    /// disk-driven base: hardware-failure indicators outrank disk fullness.
-    /// One red on an otherwise-excellent (30%-full) disk drops two tiers to
-    /// Fair; two reds drive it to Critical even on an empty disk.
-    func test_macHealthStatus_redSignalsOverrideDiskBase() {
+    /// CleanMyMac-style optimism: with no problem on any tracked factor the
+    /// verdict is Excellent — including the common real-world case of a
+    /// partly-full disk and an unreadable battery condition (the exact inputs
+    /// that previously dragged the verdict down to "Fair").
+    func test_macHealthStatus_isExcellentWhenNoProblems() {
         XCTAssertEqual(
-            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: [.red]),
-            .fair
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.64), smart: .good, battery: goodBattery),
+            .excellent
+        )
+        let unknownBattery = BatteryAvailability.present(
+            BatteryStats(cycleCount: 222, maxCapacityPercent: 0.89, condition: "Unknown")
         )
         XCTAssertEqual(
-            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), signals: [.red, .red]),
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.64), smart: .unknown, battery: unknownBattery),
+            .excellent
+        )
+    }
+
+    /// Absent / unknown battery and unknown SMART are "no opinion", never a
+    /// problem.
+    func test_macHealthStatus_neutralSignalsDoNotPenalize() {
+        XCTAssertEqual(
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), smart: .unknown, battery: .absent),
+            .excellent
+        )
+    }
+
+    /// A failing drive is the most serious problem and forces Critical even on
+    /// a near-empty disk with a healthy battery.
+    func test_macHealthStatus_failingSmartIsCritical() {
+        XCTAssertEqual(
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.10), smart: .failing, battery: goodBattery),
             .critical
         )
     }
 
-    /// Nudges clamp at the worst tier — a near-full disk plus a red signal
-    /// can't underflow past `.critical`.
-    func test_macHealthStatus_nudgeClampsAtCritical() {
-        // requiresAttention (disk 0.88) − 2 (one red) → clamps to critical
+    /// A battery reporting a service condition demotes the verdict to Requires
+    /// Attention — CleanMyMac's "critical battery health" factor. Capacity fade
+    /// alone (a low percentage with a non-service condition) must not.
+    func test_macHealthStatus_serviceBatteryRequiresAttention() {
+        let service = BatteryAvailability.present(
+            BatteryStats(cycleCount: 1500, maxCapacityPercent: 0.60, condition: "Service Recommended")
+        )
         XCTAssertEqual(
-            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.88), signals: [.red]),
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.30), smart: .good, battery: service),
+            .requiresAttention
+        )
+    }
+
+    /// The verdict is the worst tier any factor produces — no compounding, no
+    /// double-counting.
+    func test_macHealthStatus_worstFactorWins() {
+        // Near-full disk (Fair) under a failing drive (Critical) → Critical.
+        XCTAssertEqual(
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.92), smart: .failing, battery: goodBattery),
             .critical
         )
+        // Disk getting full (Good) plus a service battery (Requires Attention)
+        // → the battery problem dominates.
+        let service = BatteryAvailability.present(
+            BatteryStats(cycleCount: 1500, maxCapacityPercent: 0.60, condition: "Service Battery")
+        )
+        XCTAssertEqual(
+            HealthMonitorViewModel.macHealthStatus(disk: disk(ratio: 0.82), smart: .good, battery: service),
+            .requiresAttention
+        )
+    }
+
+    /// Low-disk-space ramp. Only a genuinely full disk is a problem; a
+    /// half-full disk is Excellent. Pins each bucket interior so the ramp can't
+    /// silently shift.
+    func test_diskSpaceTier_escalatesNearFull() {
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.64)), .excellent)
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.85)), .good)
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.92)), .fair)
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.96)), .requiresAttention)
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.99)), .critical)
+    }
+
+    /// Pin the inclusive-lower-bound semantics at each disk tier edge so a
+    /// future `<`/`<=` flip is caught.
+    func test_diskSpaceTier_atExactThresholds() {
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.80)), .good)
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.90)), .fair)
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.95)), .requiresAttention)
+        XCTAssertEqual(HealthMonitorViewModel.diskSpaceTier(for: disk(ratio: 0.98)), .critical)
     }
 
     /// The hero title and summary are user-facing strings; pin one tier so a

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -214,4 +214,57 @@ final class MenuBarViewModelTests: XCTestCase {
             MenuBarViewModel.menuBarLabel(ram: service.ramUsage, disk: service.diskSpace)
         )
     }
+
+    // MARK: - Menu panel formatters
+
+    /// Available disk space is the free portion (total − used), formatted.
+    func test_availableDiskString_isFreePortion() {
+        let stats = DiskStats(usedBytes: 600_000_000_000, totalBytes: 1_000_000_000_000)
+        let formatted = MenuBarViewModel.availableDiskString(stats)
+        XCTAssertTrue(formatted.contains("400"), "Expected ~400 GB free, got \(formatted)")
+    }
+
+    /// Memory used percent is used/total, rounded and clamped.
+    func test_memoryUsedPercentString_isUsedOverTotal() {
+        let stats = MemoryStats(usedBytes: 8_000_000_000, totalBytes: 16_000_000_000)
+        XCTAssertEqual(MenuBarViewModel.memoryUsedPercentString(stats), "50%")
+    }
+
+    /// Zero-total memory (pre-first-refresh) renders 0%, not NaN.
+    func test_memoryUsedPercentString_handlesZeroTotal() {
+        XCTAssertEqual(MenuBarViewModel.memoryUsedPercentString(.empty), "0%")
+    }
+
+    /// Charge percent renders straight through.
+    func test_batteryChargeString_rendersPercent() {
+        let charge = BatteryCharge(percent: 100, isCharging: true, isPluggedIn: true,
+                                   timeRemainingMinutes: nil, temperatureCelsius: nil)
+        XCTAssertEqual(MenuBarViewModel.batteryChargeString(charge), "100%")
+    }
+
+    /// Power state copy covers charging, full-on-AC, plugged-not-charging, and
+    /// discharging.
+    func test_batteryStateString_coversPowerStates() {
+        let charging = BatteryCharge(percent: 80, isCharging: true, isPluggedIn: true,
+                                     timeRemainingMinutes: 30, temperatureCelsius: nil)
+        XCTAssertEqual(MenuBarViewModel.batteryStateString(charging), "Charging")
+
+        let full = BatteryCharge(percent: 100, isCharging: false, isPluggedIn: true,
+                                 timeRemainingMinutes: nil, temperatureCelsius: nil)
+        XCTAssertEqual(MenuBarViewModel.batteryStateString(full), "Fully Charged")
+
+        let plugged = BatteryCharge(percent: 90, isCharging: false, isPluggedIn: true,
+                                    timeRemainingMinutes: nil, temperatureCelsius: nil)
+        XCTAssertEqual(MenuBarViewModel.batteryStateString(plugged), "Plugged In")
+
+        let onBattery = BatteryCharge(percent: 64, isCharging: false, isPluggedIn: false,
+                                      timeRemainingMinutes: 120, temperatureCelsius: nil)
+        XCTAssertEqual(MenuBarViewModel.batteryStateString(onBattery), "On Battery")
+    }
+
+    /// Temperature rounds to a whole degree.
+    func test_batteryTemperatureString_roundsToWholeDegree() {
+        XCTAssertEqual(MenuBarViewModel.batteryTemperatureString(30.4), "30°C")
+        XCTAssertEqual(MenuBarViewModel.batteryTemperatureString(30.6), "31°C")
+    }
 }

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -313,6 +313,13 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(MenuBarViewModel.uptimeString(8 * 60 + 30), "up 8m")
     }
 
+    /// The compact menu bar reading forwards to the available-disk formatter.
+    func test_menuBarCompactReading_isAvailableDisk() {
+        let service = SystemStatsService(interval: 2.0, autostart: false)
+        let sut = MenuBarViewModel(service: service)
+        XCTAssertEqual(sut.menuBarCompactReading, MenuBarViewModel.availableDiskString(service.diskSpace))
+    }
+
     // MARK: - Protection status
 
     /// Threats outrank a clean history; a scanned-once Mac reads protected; a

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -267,4 +267,36 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(MenuBarViewModel.batteryTemperatureString(30.4), "30°C")
         XCTAssertEqual(MenuBarViewModel.batteryTemperatureString(30.6), "31°C")
     }
+
+    // MARK: - Network formatters
+
+    /// Zero traffic renders a clean "0 KB/s", not "Zero KB/s".
+    func test_speedString_zeroIsCleanedUp() {
+        XCTAssertEqual(MenuBarViewModel.speedString(0), "0 KB/s")
+    }
+
+    /// Non-zero rates carry a unit and a per-second suffix.
+    func test_speedString_formatsRateWithSuffix() {
+        let kilobytes = MenuBarViewModel.speedString(2_048)
+        XCTAssertTrue(kilobytes.contains("KB"), "Expected KB unit, got \(kilobytes)")
+        XCTAssertTrue(kilobytes.hasSuffix("/s"), "Expected /s suffix, got \(kilobytes)")
+
+        let megabytes = MenuBarViewModel.speedString(5_000_000)
+        XCTAssertTrue(megabytes.contains("MB"), "Expected MB unit, got \(megabytes)")
+    }
+
+    /// Mbps math: 10 MB downloaded in 8 s is 10 Mbps (10e6 bytes × 8 ÷ 1e6 ÷ 8).
+    func test_megabitsPerSecond_computesRate() {
+        XCTAssertEqual(MenuBarViewModel.megabitsPerSecond(bytes: 10_000_000, seconds: 8), 10, accuracy: 0.001)
+    }
+
+    /// Guard against divide-by-zero and empty payloads.
+    func test_megabitsPerSecond_guardsZeroes() {
+        XCTAssertEqual(MenuBarViewModel.megabitsPerSecond(bytes: 0, seconds: 5), 0)
+        XCTAssertEqual(MenuBarViewModel.megabitsPerSecond(bytes: 1_000, seconds: 0), 0)
+    }
+
+    func test_speedTestResultString_formatsMbps() {
+        XCTAssertEqual(MenuBarViewModel.speedTestResultString(82.4), "82 Mbps")
+    }
 }

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -299,4 +299,17 @@ final class MenuBarViewModelTests: XCTestCase {
     func test_speedTestResultString_formatsMbps() {
         XCTAssertEqual(MenuBarViewModel.speedTestResultString(82.4), "82 Mbps")
     }
+
+    // MARK: - CPU temperature + uptime formatters
+
+    func test_cpuTemperatureString_roundsToWholeDegree() {
+        XCTAssertEqual(MenuBarViewModel.cpuTemperatureString(49.6), "50°C")
+    }
+
+    /// Uptime collapses to the two most significant units, by magnitude.
+    func test_uptimeString_picksTwoMostSignificantUnits() {
+        XCTAssertEqual(MenuBarViewModel.uptimeString(3 * 86_400 + 4 * 3_600 + 30 * 60), "up 3d 4h")
+        XCTAssertEqual(MenuBarViewModel.uptimeString(4 * 3_600 + 12 * 60), "up 4h 12m")
+        XCTAssertEqual(MenuBarViewModel.uptimeString(8 * 60 + 30), "up 8m")
+    }
 }

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -312,4 +312,30 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(MenuBarViewModel.uptimeString(4 * 3_600 + 12 * 60), "up 4h 12m")
         XCTAssertEqual(MenuBarViewModel.uptimeString(8 * 60 + 30), "up 8m")
     }
+
+    // MARK: - Protection status
+
+    /// Threats outrank a clean history; a scanned-once Mac reads protected; a
+    /// never-scanned Mac reads not-scanned.
+    func test_protectionStatus_derivation() {
+        XCTAssertEqual(MenuBarViewModel.protectionStatus(hasThreats: true, hasScanned: true), .threatsFound)
+        XCTAssertEqual(MenuBarViewModel.protectionStatus(hasThreats: true, hasScanned: false), .threatsFound)
+        XCTAssertEqual(MenuBarViewModel.protectionStatus(hasThreats: false, hasScanned: true), .protected)
+        XCTAssertEqual(MenuBarViewModel.protectionStatus(hasThreats: false, hasScanned: false), .notScanned)
+    }
+
+    func test_protectionStatusLabel_copy() {
+        XCTAssertEqual(MenuBarViewModel.protectionStatusLabel(.protected), "Protected")
+        XCTAssertEqual(MenuBarViewModel.protectionStatusLabel(.threatsFound), "Threats found")
+        XCTAssertEqual(MenuBarViewModel.protectionStatusLabel(.notScanned), "Not scanned")
+    }
+
+    /// No scan date reads as "No scans yet"; a real date produces a non-empty
+    /// relative phrase.
+    func test_lastScanString_handlesNilAndDate() {
+        XCTAssertEqual(MenuBarViewModel.lastScanString(nil), "No scans yet")
+        let recent = MenuBarViewModel.lastScanString(Date(timeIntervalSinceNow: -3_600))
+        XCTAssertFalse(recent.isEmpty)
+        XCTAssertNotEqual(recent, "No scans yet")
+    }
 }

--- a/VaderCleanerTests/PreferencesStoreTests.swift
+++ b/VaderCleanerTests/PreferencesStoreTests.swift
@@ -38,6 +38,7 @@ final class PreferencesStoreTests: XCTestCase {
         XCTAssertEqual(sut.diskSpaceThresholdPercent, 10.0, accuracy: 0.001)
         XCTAssertTrue(sut.launchAtLogin)
         XCTAssertTrue(sut.showMenuBar)
+        XCTAssertFalse(sut.menuBarShowsReading)
     }
 
     // MARK: - Persistence
@@ -80,6 +81,14 @@ final class PreferencesStoreTests: XCTestCase {
         let reader = PreferencesStore(defaults: defaults)
         XCTAssertFalse(reader.launchAtLogin)
         XCTAssertFalse(reader.showMenuBar)
+    }
+
+    func test_persistsMenuBarShowsReading() {
+        let writer = PreferencesStore(defaults: defaults)
+        writer.menuBarShowsReading = true
+
+        let reader = PreferencesStore(defaults: defaults)
+        XCTAssertTrue(reader.menuBarShowsReading)
     }
 
     // MARK: - Launch-at-login wiring

--- a/VaderCleanerTests/SystemStatsServiceTests.swift
+++ b/VaderCleanerTests/SystemStatsServiceTests.swift
@@ -290,8 +290,9 @@ final class SystemStatsServiceTests: XCTestCase {
     }
 
     /// AppleSmartBattery reports temperature in hundredths of a degree Celsius.
-    func test_batteryTemperatureCelsius_dividesByHundred() {
-        XCTAssertEqual(SystemStatsService.batteryTemperatureCelsius(fromRaw: 3010), 30.10, accuracy: 0.001)
+    func test_batteryTemperatureCelsius_dividesByHundred() throws {
+        let celsius = try XCTUnwrap(SystemStatsService.batteryTemperatureCelsius(fromRaw: 3010))
+        XCTAssertEqual(celsius, 30.10, accuracy: 0.001)
     }
 
     /// Out-of-range readings return nil so a garbage value never renders as a

--- a/VaderCleanerTests/SystemStatsServiceTests.swift
+++ b/VaderCleanerTests/SystemStatsServiceTests.swift
@@ -212,6 +212,94 @@ final class SystemStatsServiceTests: XCTestCase {
         wait(for: [settle], timeout: 1.0)
         XCTAssertEqual(counter.count, 0, "Service emitted \(counter.count) updates after stop()")
     }
+
+    // MARK: - Battery charge parsing
+
+    /// A charging battery on AC power: percent is current/max, the charging and
+    /// plugged-in flags are read straight through, and the time-remaining uses
+    /// the time-to-full estimate.
+    func test_parseBatteryCharge_chargingOnACPower() {
+        let description: [String: Any] = [
+            "Current Capacity": 75,
+            "Max Capacity": 100,
+            "Is Charging": true,
+            "Power Source State": "AC Power",
+            "Time to Full Charge": 42,
+            "Time to Empty": -1
+        ]
+        let charge = SystemStatsService.parseBatteryCharge(from: description, temperatureCelsius: 30.5)
+        XCTAssertEqual(charge?.percent, 75)
+        XCTAssertEqual(charge?.isCharging, true)
+        XCTAssertEqual(charge?.isPluggedIn, true)
+        XCTAssertEqual(charge?.timeRemainingMinutes, 42)
+        XCTAssertEqual(charge?.temperatureCelsius, 30.5)
+    }
+
+    /// A discharging battery reads the time-to-empty estimate and reports not
+    /// plugged in.
+    func test_parseBatteryCharge_dischargingUsesTimeToEmpty() {
+        let description: [String: Any] = [
+            "Current Capacity": 48,
+            "Max Capacity": 100,
+            "Is Charging": false,
+            "Power Source State": "Battery Power",
+            "Time to Full Charge": -1,
+            "Time to Empty": 137
+        ]
+        let charge = SystemStatsService.parseBatteryCharge(from: description, temperatureCelsius: nil)
+        XCTAssertEqual(charge?.percent, 48)
+        XCTAssertEqual(charge?.isCharging, false)
+        XCTAssertEqual(charge?.isPluggedIn, false)
+        XCTAssertEqual(charge?.timeRemainingMinutes, 137)
+        XCTAssertNil(charge?.temperatureCelsius)
+    }
+
+    /// A negative time estimate means "still calculating" and must surface as
+    /// nil rather than a bogus negative duration.
+    func test_parseBatteryCharge_calculatingTimeIsNil() {
+        let description: [String: Any] = [
+            "Current Capacity": 90,
+            "Max Capacity": 100,
+            "Is Charging": true,
+            "Power Source State": "AC Power",
+            "Time to Full Charge": -1
+        ]
+        let charge = SystemStatsService.parseBatteryCharge(from: description, temperatureCelsius: nil)
+        XCTAssertNil(charge?.timeRemainingMinutes)
+    }
+
+    /// Percent is computed from current/max (not assumed to be a percentage
+    /// already) and clamps to 0…100.
+    func test_parseBatteryCharge_percentIsCurrentOverMax() {
+        let description: [String: Any] = [
+            "Current Capacity": 2500,
+            "Max Capacity": 5000,
+            "Is Charging": false,
+            "Power Source State": "Battery Power"
+        ]
+        let charge = SystemStatsService.parseBatteryCharge(from: description, temperatureCelsius: nil)
+        XCTAssertEqual(charge?.percent, 50)
+    }
+
+    /// Missing or zero capacity keys (a non-battery power source) yield nil so
+    /// the caller skips to the next source.
+    func test_parseBatteryCharge_returnsNilWithoutCapacity() {
+        XCTAssertNil(SystemStatsService.parseBatteryCharge(from: [:], temperatureCelsius: nil))
+        let zeroMax: [String: Any] = ["Current Capacity": 10, "Max Capacity": 0]
+        XCTAssertNil(SystemStatsService.parseBatteryCharge(from: zeroMax, temperatureCelsius: nil))
+    }
+
+    /// AppleSmartBattery reports temperature in hundredths of a degree Celsius.
+    func test_batteryTemperatureCelsius_dividesByHundred() {
+        XCTAssertEqual(SystemStatsService.batteryTemperatureCelsius(fromRaw: 3010), 30.10, accuracy: 0.001)
+    }
+
+    /// Out-of-range readings return nil so a garbage value never renders as a
+    /// confident temperature.
+    func test_batteryTemperatureCelsius_rejectsImplausibleValues() {
+        XCTAssertNil(SystemStatsService.batteryTemperatureCelsius(fromRaw: -5000))
+        XCTAssertNil(SystemStatsService.batteryTemperatureCelsius(fromRaw: 20000))
+    }
 }
 
 /// Reference-typed counter so the arming closure can mutate a shared count

--- a/VaderCleanerTests/SystemStatsServiceTests.swift
+++ b/VaderCleanerTests/SystemStatsServiceTests.swift
@@ -300,6 +300,36 @@ final class SystemStatsServiceTests: XCTestCase {
         XCTAssertNil(SystemStatsService.batteryTemperatureCelsius(fromRaw: -5000))
         XCTAssertNil(SystemStatsService.batteryTemperatureCelsius(fromRaw: 20000))
     }
+
+    // MARK: - Network throughput
+
+    /// Throughput is the per-second delta of the cumulative counters.
+    func test_throughput_isPerSecondDelta() {
+        let previous = NetworkCounters(bytesIn: 1_000, bytesOut: 2_000)
+        let current = NetworkCounters(bytesIn: 3_000, bytesOut: 5_000)
+        let rate = SystemStatsService.throughput(previous: previous, current: current, interval: 2.0)
+        XCTAssertEqual(rate.bytesInPerSec, 1_000, accuracy: 0.001)
+        XCTAssertEqual(rate.bytesOutPerSec, 1_500, accuracy: 0.001)
+    }
+
+    /// A counter reset/wrap (current < previous) reports zero rather than a
+    /// massive spurious spike.
+    func test_throughput_counterResetYieldsZero() {
+        let previous = NetworkCounters(bytesIn: 9_000, bytesOut: 9_000)
+        let current = NetworkCounters(bytesIn: 10, bytesOut: 10)
+        let rate = SystemStatsService.throughput(previous: previous, current: current, interval: 1.0)
+        XCTAssertEqual(rate, .zero)
+    }
+
+    /// A non-positive interval can't produce a rate.
+    func test_throughput_nonPositiveIntervalYieldsZero() {
+        let rate = SystemStatsService.throughput(
+            previous: .zero,
+            current: NetworkCounters(bytesIn: 100, bytesOut: 100),
+            interval: 0
+        )
+        XCTAssertEqual(rate, .zero)
+    }
 }
 
 /// Reference-typed counter so the arming closure can mutate a shared count

--- a/VaderCleanerTests/SystemStatsServiceTests.swift
+++ b/VaderCleanerTests/SystemStatsServiceTests.swift
@@ -331,6 +331,34 @@ final class SystemStatsServiceTests: XCTestCase {
         )
         XCTAssertEqual(rate, .zero)
     }
+
+    // MARK: - SMC temperature decoding
+
+    /// A FourCC packs four ASCII bytes big-endian.
+    func test_fourCharCode_packsBigEndian() {
+        XCTAssertEqual(SMCReader.fourCharCode("TC0P"), 0x54_43_30_50)
+    }
+
+    /// `sp78` is signed 7.8 fixed point: the integer part is the high byte.
+    func test_decodeTemperature_sp78() throws {
+        let bytes: [UInt8] = [0x1E, 0x00] // 30.0
+        let celsius = try XCTUnwrap(SMCReader.decodeTemperature(dataType: SMCReader.fourCharCode("sp78"), bytes: bytes))
+        XCTAssertEqual(celsius, 30.0, accuracy: 0.01)
+    }
+
+    /// `flt ` is a little-endian IEEE float.
+    func test_decodeTemperature_float() throws {
+        var value: Float = 42.5
+        let bytes = withUnsafeBytes(of: &value) { Array($0) } // little-endian on arm64/x86_64
+        let celsius = try XCTUnwrap(SMCReader.decodeTemperature(dataType: SMCReader.fourCharCode("flt "), bytes: bytes))
+        XCTAssertEqual(celsius, 42.5, accuracy: 0.01)
+    }
+
+    /// Unknown data types and short buffers decode to nil rather than garbage.
+    func test_decodeTemperature_rejectsUnknownTypeAndShortBuffer() {
+        XCTAssertNil(SMCReader.decodeTemperature(dataType: SMCReader.fourCharCode("ui32"), bytes: [1, 2, 3, 4]))
+        XCTAssertNil(SMCReader.decodeTemperature(dataType: SMCReader.fourCharCode("sp78"), bytes: [0x1E]))
+    }
 }
 
 /// Reference-typed counter so the arming closure can mutate a shared count

--- a/project.yml
+++ b/project.yml
@@ -85,6 +85,8 @@ targets:
         LSMinimumSystemVersion: "$(MACOSX_DEPLOYMENT_TARGET)"
         LSUIElement: true
         NSHumanReadableCopyright: ""
+        NSLocationUsageDescription: "VaderCleaner uses your location only to read the current Wi-Fi network name for the menu bar network monitor."
+        NSLocationWhenInUseUsageDescription: "VaderCleaner uses your location only to read the current Wi-Fi network name for the menu bar network monitor."
         NSPrincipalClass: NSApplication
         NSSupportsAutomaticTermination: false
         NSSupportsSuddenTermination: false

--- a/project.yml
+++ b/project.yml
@@ -84,6 +84,7 @@ targets:
         CFBundleVersion: "1"
         LSMinimumSystemVersion: "$(MACOSX_DEPLOYMENT_TARGET)"
         LSUIElement: true
+        NSBluetoothAlwaysUsageDescription: "VaderCleaner reads connected Bluetooth devices to show them in the menu bar Connected Devices monitor."
         NSHumanReadableCopyright: ""
         NSLocationUsageDescription: "VaderCleaner uses your location only to read the current Wi-Fi network name for the menu bar network monitor."
         NSLocationWhenInUseUsageDescription: "VaderCleaner uses your location only to read the current Wi-Fi network name for the menu bar network monitor."


### PR DESCRIPTION
## Overview

Total redesign of the **Health Monitor** section into a CleanMyMac-style dashboard, plus a rebuild of the **Mac Health verdict** onto a problem-based model that mirrors CleanMyMac.

## What changed

### Layout & visuals — `HealthMonitorView`
- **Two-column dashboard that fills the pane without scrolling.** Left: a tall Mac Health hero + a Disk Encryption (FileVault) card. Right: metric tiles — Battery / Disk Health, RAM / CPU, and a full-width Disk Space tile — that divide the available height into equal rows so nothing overflows.
- **Prominent icon tiles + info popovers** on each tile, echoing the reference design.
- **Hero re-based into the section's emerald palette** (was purple/indigo, which fought the green section) with a hairline accent border and a soft lift, so it reads as *special* while staying consistent with the rest of the section.
- **One cohesive accent across all tiles.** Every metric tile (icon tile, progress bar, status dot, RAM pressure badge) now shares the **overall Mac Health verdict color** — Excellent = blue, Good = sky blue, Fair = teal, Requires Attention = amber, Critical = red — so the whole grid tracks the hero. `StatusDot`, `PressureBadge`, and `HealthCard` were generalized to take a `Color`.

### Verdict logic — `HealthMonitorViewModel`
- Replaced the old "disk-fullness base tier, then nudge down on any non-green signal" model with a **problem-based model mirroring [CleanMyMac's Mac Health](https://macpaw.com/support/cleanmymac/knowledgebase/mac-health)**: the Mac is **Excellent until a concrete problem is detected**, and the verdict is the **worst tier any tracked factor produces** (no compounding).
- Tracked factors (the CleanMyMac ones we can observe): **disk hardware health (SMART)**, **battery health**, **low disk space**.
- **Transient RAM/CPU and the FileVault toggle no longer drag the overall verdict** — they keep their own tiles. This also stops the headline flickering on momentary CPU/RAM spikes.
- A **partly-full disk** and an **unreadable ("Unknown") battery condition** are no longer penalized, so a healthy Mac now reads **Excellent** (it previously showed "Fair" for a 64%-full disk + an "Unknown" battery — the exact discrepancy vs. CleanMyMac).

## Why

The previous screen was a generic hero + adaptive grid that required scrolling, used an off-theme purple hero, and ran a pessimistic verdict that rarely reached "Excellent." This brings the look and the scoring in line with the CleanMyMac reference the design targets.

## Tests
- Rewrote the verdict section of `HealthMonitorViewModelTests` (TDD) to pin the new model: worst-factor-wins, disk-ramp boundaries, neutral signals don't penalize, failing SMART → Critical, service battery → Requires Attention, and a regression for the **64%-disk + Unknown-battery → Excellent** case.
- Full unit suite green: **1001 tests, 0 failures**.

## Reviewer notes
- **Accessibility identifiers** the UI tests depend on (`health.hero*`, `health.card.*`, `health.filevault`) are all preserved; the section stays non-scannable.
- **UI tests were not run** — XCUITests can't bootstrap from the terminal in this environment. Please run them in Xcode to confirm end-to-end.
- **Trade-off (intentional):** metric tiles no longer show their own per-metric status color — they all adopt the overall verdict accent. The per-metric color logic still lives in the view-model (and stays tested) if we later want a hybrid (e.g. status dots keeping per-metric color as an early-warning flag).
- I couldn't screenshot the running app from here, so a visual pass in Xcode is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the Health Monitor into a two-column dashboard with refreshed hero and metric tiles.
  * Added a Mac Health panel in the menu bar with live tiles, recommendations, connected devices, and a speed test.
  * Added richer telemetry (Wi‑Fi, CPU temperature, and battery status with charging/time estimates) and a menu bar toggle for showing free space next to the icon.
* **Bug Fixes**
  * Improved health verdict logic with worst-factor tiering and correct handling for unmeasured disk data.
  * Reduced navigation rail dim/flicker on reselect.
* **Tests**
  * Expanded unit tests for health verdicts, menu formatting, battery/throughput parsing, and connected-device filtering.
* **Style**
  * Standardized prominent button styling and improved accent-based legibility across sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->