### PR TITLE
Redesign Large & Old Files into a category dashboard

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46943B264F72B3753075A8C /* UpdateInfoTests.swift */; };
 		2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */; };
 		25057052F5E478AD7B692B9F /* ClamAVOutputParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */; };
+		250889E632F3F3F6E0C37E2B /* LargeOldFilesSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691F38EF10E826B31149A787 /* LargeOldFilesSummaryTests.swift */; };
 		26841554E89CE98867F07C45 /* AppUninstallerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FBB55B07C193DE6185E12B /* AppUninstallerView.swift */; };
 		26F0CFE53A3BAD72AFF2BB30 /* SpaceLensUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */; };
 		27009AF3896291F9B80D01CA /* privacy.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 3BEAD4C3A7D9B274C73AE97A /* privacy.usdz */; };
@@ -130,6 +131,7 @@
 		652B6EC5C57CE9B03E4C85AE /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7220D06D757039BF087D7F50 /* ApplicationsViewModel.swift */; };
 		65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */; };
+		6746D69BC05985EAFC558C3B /* LargeOldFilesCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193E73E38CE67CB12A25C70D /* LargeOldFilesCategoryTests.swift */; };
 		67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */; };
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
 		6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */; };
@@ -275,6 +277,7 @@
 		F6161C632AB8AA90DD7B9A36 /* UpdateProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3508580ADD1F5DD0DB60EE01 /* UpdateProbe.swift */; };
 		F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */; };
 		F7CA4D7A9B843507613DEEBE /* BundledClamAVRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282664DFAA58CB5A5C87FFE /* BundledClamAVRuntime.swift */; };
+		F8F35236079EECA6BB24FA71 /* LargeOldFilesCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11029188312048FFBE677A17 /* LargeOldFilesCategory.swift */; };
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
 		FE156E2CD69BA8F894E9078D /* FloatingScanButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A35775D85A4E890A04EE26 /* FloatingScanButtonTests.swift */; };
 		FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */; };
@@ -350,6 +353,7 @@
 		0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensUITests.swift; sourceTree = "<group>"; };
 		0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModel.swift; sourceTree = "<group>"; };
 		1071E99E2EFBE2C48C528D41 /* ConnectedDevicesMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedDevicesMonitorTests.swift; sourceTree = "<group>"; };
+		11029188312048FFBE677A17 /* LargeOldFilesCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesCategory.swift; sourceTree = "<group>"; };
 		1118EEB70EAD2A87D42A6605 /* LargeOldFilesViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesViewSubviews.swift; sourceTree = "<group>"; };
 		133467A06193C406B027D97C /* NavigationSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSectionTests.swift; sourceTree = "<group>"; };
 		13A5713F5928025F9FE34A43 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -359,6 +363,7 @@
 		168266DA7B9E9A25E0B56A8C /* systemJunk.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = systemJunk.usdz; sourceTree = "<group>"; };
 		1683C13B4837D58AD519341C /* largeOldFiles.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = largeOldFiles.usdz; sourceTree = "<group>"; };
 		16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleter.swift; sourceTree = "<group>"; };
+		193E73E38CE67CB12A25C70D /* LargeOldFilesCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesCategoryTests.swift; sourceTree = "<group>"; };
 		1A06928276134E79D8ADFBF5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparatorTests.swift; sourceTree = "<group>"; };
 		1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedAppScannerTests.swift; sourceTree = "<group>"; };
@@ -450,6 +455,7 @@
 		67388E0F949FBDE5ECC7A8E6 /* PrivacyViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewSubviews.swift; sourceTree = "<group>"; };
 		673CA7922445475111927C0B /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModel.swift; sourceTree = "<group>"; };
+		691F38EF10E826B31149A787 /* LargeOldFilesSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesSummaryTests.swift; sourceTree = "<group>"; };
 		6970B875C4CDF95000BB116C /* PreferencesStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoreTests.swift; sourceTree = "<group>"; };
 		6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroViewTests.swift; sourceTree = "<group>"; };
 		6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsServiceTests.swift; sourceTree = "<group>"; };
@@ -720,6 +726,7 @@
 				F2C612F641A894AE10ADDA8F /* InstallationFile.swift */,
 				574D2DD309CA4FA07640FAA0 /* InstallationFileScanner.swift */,
 				06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */,
+				11029188312048FFBE677A17 /* LargeOldFilesCategory.swift */,
 				8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */,
 				93E602D46A51164E50C879C2 /* LargeOldFilesView.swift */,
 				E356F94AA9A841A2BF4FA016 /* LargeOldFilesViewModel.swift */,
@@ -916,7 +923,9 @@
 				811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */,
 				CFF1BAC0B12BDB540F250299 /* InstallationFileScannerTests.swift */,
 				1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */,
+				193E73E38CE67CB12A25C70D /* LargeOldFilesCategoryTests.swift */,
 				603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */,
+				691F38EF10E826B31149A787 /* LargeOldFilesSummaryTests.swift */,
 				BF4DD2F83D34617375FD592F /* LargeOldFilesViewModelTests.swift */,
 				FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */,
 				C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */,
@@ -1216,7 +1225,9 @@
 				17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */,
 				B86DA7DFDECF401C5BCCAC24 /* InstallationFileScannerTests.swift in Sources */,
 				57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */,
+				6746D69BC05985EAFC558C3B /* LargeOldFilesCategoryTests.swift in Sources */,
 				50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */,
+				250889E632F3F3F6E0C37E2B /* LargeOldFilesSummaryTests.swift in Sources */,
 				2381C954E27D18AF11428927 /* LargeOldFilesViewModelTests.swift in Sources */,
 				04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */,
 				C848FD080F1DED2282ADC12E /* LocalSnapshotCounterTests.swift in Sources */,
@@ -1363,6 +1374,7 @@
 				03E56C4EFC8903CA9291A959 /* InstallationFile.swift in Sources */,
 				55B6AD3998807918EE9FD2AF /* InstallationFileScanner.swift in Sources */,
 				D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */,
+				F8F35236079EECA6BB24FA71 /* LargeOldFilesCategory.swift in Sources */,
 				1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */,
 				E2BD46A6EEA03215B79433F7 /* LargeOldFilesView.swift in Sources */,
 				91D078AE5A4F061021D4A0FE /* LargeOldFilesViewModel.swift in Sources */,

--- a/VaderCleaner/LargeOldFilesCategory.swift
+++ b/VaderCleaner/LargeOldFilesCategory.swift
@@ -1,0 +1,182 @@
+// LargeOldFilesCategory.swift
+// Groups a flat Large & Old Files scan into the dashboard's recommendation tiles — type/age lenses, their titles and icons, and the assembly of non-empty tiles with the heaviest one first.
+
+import Foundation
+
+/// One lens over the Large & Old Files scan, surfaced as a dashboard tile.
+/// `.videos` / `.archives` / `.other` partition every file by type; `.old`
+/// (age) and `.largest` (top by size) are cross-cutting lenses that overlap
+/// the type tiles on purpose — each is a different way to slice the same scan.
+enum LargeOldFilesCategory: String, CaseIterable, Identifiable {
+    case largest
+    case old
+    case videos
+    case archives
+    case other
+
+    var id: String { rawValue }
+
+    /// Tile heading and the title of the drill-down review screen.
+    var title: String {
+        switch self {
+        case .largest:
+            return String(localized: "Largest Files",
+                          comment: "Large & Old Files tile: the biggest files by size.")
+        case .old:
+            return String(localized: "Old Files",
+                          comment: "Large & Old Files tile: files untouched for six months or more.")
+        case .videos:
+            return String(localized: "Videos",
+                          comment: "Large & Old Files tile: movie and recording files.")
+        case .archives:
+            return String(localized: "Archives & Disk Images",
+                          comment: "Large & Old Files tile: compressed archives and disk images.")
+        case .other:
+            return String(localized: "Other Large Files",
+                          comment: "Large & Old Files tile: everything that isn't a video or an archive.")
+        }
+    }
+
+    /// SF Symbol shown on the tile.
+    var icon: String {
+        switch self {
+        case .largest: return "arrow.up.right.circle.fill"
+        case .old: return "clock.arrow.circlepath"
+        case .videos: return "film.fill"
+        case .archives: return "archivebox.fill"
+        case .other: return "doc.fill"
+        }
+    }
+
+    /// One-line descriptor shown under the tile's size metric.
+    var blurb: String {
+        switch self {
+        case .largest:
+            return String(localized: "Your biggest space hogs, ranked by size.",
+                          comment: "Large & Old Files Largest tile detail line.")
+        case .old:
+            return String(localized: "Untouched for six months or more.",
+                          comment: "Large & Old Files Old tile detail line.")
+        case .videos:
+            return String(localized: "Movies and recordings — usually the biggest win.",
+                          comment: "Large & Old Files Videos tile detail line.")
+        case .archives:
+            return String(localized: "Disk images and compressed archives.",
+                          comment: "Large & Old Files Archives tile detail line.")
+        case .other:
+            return String(localized: "Documents and everything else.",
+                          comment: "Large & Old Files Other tile detail line.")
+        }
+    }
+}
+
+/// One dashboard tile: a category and the files that fall under it. The
+/// aggregates are computed **once** at construction and stored, never derived on
+/// access — the view reads `totalBytes`/`oldCount` many times per render across
+/// several tiles, and a category can hold hundreds of thousands of files, so a
+/// computed `reduce` here would re-scan the whole set on every read and freeze
+/// the UI.
+struct LargeOldFilesTile: Identifiable, Equatable {
+    let category: LargeOldFilesCategory
+    let files: [ScannedFile]
+    /// Number of files in this tile.
+    let count: Int
+    /// Summed size of the tile's files, in bytes.
+    let totalBytes: Int64
+    /// How many of the tile's files are tagged `.oldFile` — feeds the "N older
+    /// than 6 months" line without re-scanning the files.
+    let oldCount: Int
+
+    var id: String { category.rawValue }
+
+    init(category: LargeOldFilesCategory, files: [ScannedFile]) {
+        self.category = category
+        self.files = files
+        var bytes: Int64 = 0
+        var old = 0
+        for file in files {
+            bytes += file.size
+            if file.category == .oldFile { old += 1 }
+        }
+        self.count = files.count
+        self.totalBytes = bytes
+        self.oldCount = old
+    }
+}
+
+/// Pure grouping of a scan into category lenses and dashboard tiles. Free of
+/// any view so the bucketing rules stay unit-testable.
+enum LargeOldFilesCategorizer {
+
+    /// The "Largest Files" lens caps at this many files — enough to surface the
+    /// genuine space hogs without re-listing the whole scan.
+    static let largestTileLimit = 20
+
+    /// Extensions classified as video. Matched case-insensitively against the
+    /// file's path extension.
+    static let videoExtensions: Set<String> = [
+        "mov", "mp4", "m4v", "mkv", "avi", "wmv", "flv", "webm",
+        "mpg", "mpeg", "3gp", "ts", "m2ts"
+    ]
+
+    /// Extensions classified as a compressed archive or installer disk image.
+    /// Excludes the sparse VM/container disk images (`raw`, `sparseimage`,
+    /// `sparsebundle`) — the scanner skips those entirely, and a bare `.raw`
+    /// that does slip through is a camera photo that belongs in "Other".
+    static let archiveExtensions: Set<String> = [
+        "zip", "dmg", "iso", "tar", "gz", "tgz", "bz2", "xz",
+        "7z", "rar", "pkg", "img", "cdr"
+    ]
+
+    /// The files that fall under `category`. For `.largest` this is the top
+    /// `largestTileLimit` by size; for `.old` it is age-driven; the rest match
+    /// by file extension.
+    static func files(
+        in category: LargeOldFilesCategory,
+        from files: [ScannedFile],
+        referenceDate: Date = Date()
+    ) -> [ScannedFile] {
+        switch category {
+        case .largest:
+            return Array(files.sorted { $0.size > $1.size }.prefix(largestTileLimit))
+        case .old:
+            let cutoff = referenceDate.addingTimeInterval(-LargeOldFilesScanner.ageThresholdSeconds)
+            return files.filter { file in
+                guard let accessed = file.lastAccessDate else { return false }
+                return accessed <= cutoff
+            }
+        case .videos:
+            return files.filter { videoExtensions.contains(ext(of: $0)) }
+        case .archives:
+            return files.filter { archiveExtensions.contains(ext(of: $0)) }
+        case .other:
+            return files.filter {
+                let e = ext(of: $0)
+                return !videoExtensions.contains(e) && !archiveExtensions.contains(e)
+            }
+        }
+    }
+
+    /// The dashboard's tiles: one per category that has findings, the primary
+    /// type/age lenses ordered heaviest-first (so the caller can promote the
+    /// first to a hero card), with the cross-cutting "Largest Files" lens
+    /// appended only when there are more files than it caps at — otherwise it
+    /// would just duplicate the whole result set.
+    static func tiles(from files: [ScannedFile], referenceDate: Date = Date()) -> [LargeOldFilesTile] {
+        let primary: [LargeOldFilesCategory] = [.videos, .archives, .old, .other]
+        var tiles = primary
+            .map { LargeOldFilesTile(category: $0, files: self.files(in: $0, from: files, referenceDate: referenceDate)) }
+            .filter { !$0.files.isEmpty }
+            .sorted { $0.totalBytes > $1.totalBytes }
+
+        if files.count > largestTileLimit {
+            tiles.append(LargeOldFilesTile(category: .largest,
+                                           files: self.files(in: .largest, from: files, referenceDate: referenceDate)))
+        }
+        return tiles
+    }
+
+    private static func ext(of file: ScannedFile) -> String {
+        file.url.pathExtension.lowercased()
+    }
+}

--- a/VaderCleaner/LargeOldFilesScanner.swift
+++ b/VaderCleaner/LargeOldFilesScanner.swift
@@ -22,6 +22,38 @@ struct LargeOldFilesScanner {
     /// the constant is unit-clear at the call site.
     static let ageThresholdSeconds: TimeInterval = 60 * 60 * 24 * 30 * 6
 
+    /// Extensions for app-managed virtual disks and VM/container volumes. The
+    /// scan skips these for two reasons: deleting one destroys the owning app's
+    /// data (Docker images, virtual machines, disk-image backups), so it is not
+    /// "reclaimable junk"; and they are sparse, so their logical size wildly
+    /// overstates what they actually occupy on disk (a 2 TB `Docker.raw` may
+    /// use a fraction of that). `.raw` is handled separately because a bare
+    /// `.raw` can also be a camera photo.
+    static let virtualDiskExtensions: Set<String> = [
+        "utm", "vmdk", "qcow2", "qcow", "vdi", "vhd", "vhdx", "hds",
+        "pvm", "vbox", "vmwarevm", "sparsebundle", "sparseimage"
+    ]
+
+    /// Path fragments that mark a container/VM data store. Used to gate the
+    /// ambiguous `.raw` extension: a Docker VM volume lives at
+    /// `…/com.docker.docker/Data/vms/0/data/Docker.raw`, whereas a camera
+    /// `.raw` photo lives under Pictures and must not be hidden.
+    private static let virtualDiskPathMarkers: [String] = [
+        "/vms/", "com.docker", "/.docker/", "colima", "orbstack", "/lima/", "podman"
+    ]
+
+    /// Whether `url` is an app-managed virtual disk image the scan should skip.
+    /// Unambiguous VM/disk-image extensions always match; the catch-all `.raw`
+    /// matches only inside a known container/VM store so genuine camera RAW
+    /// photos are still surfaced.
+    static func isVirtualDiskImage(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        if virtualDiskExtensions.contains(ext) { return true }
+        guard ext == "raw" else { return false }
+        let path = url.path.lowercased()
+        return virtualDiskPathMarkers.contains { path.contains($0) }
+    }
+
     private let fileScanner: FileScanning
     private let pathProvider: UserFilesPathProviding
     private let now: () -> Date
@@ -112,6 +144,11 @@ struct LargeOldFilesScanner {
     /// threshold. This avoids a stale-volume backup folder showing every
     /// 4-byte file as "ancient" just because its access date is missing.
     private static func classify(_ file: ScannedFile, cutoff: Date) -> ScannedFile? {
+        // Skip app-managed virtual disks (Docker.raw, *.utm, *.sparsebundle, …)
+        // before any size/age check: deleting them is destructive, and their
+        // sparse logical size would otherwise dominate the results with a
+        // phantom multi-terabyte entry.
+        if isVirtualDiskImage(file.url) { return nil }
         let isLarge = file.size > sizeThresholdBytes
         let isOld: Bool = {
             guard let lastAccess = file.lastAccessDate else { return false }

--- a/VaderCleaner/LargeOldFilesView.swift
+++ b/VaderCleaner/LargeOldFilesView.swift
@@ -23,6 +23,31 @@ struct LargeOldFilesView: View {
     /// re-render of the same `.results` phase.
     @State private var notifiedForCurrentScan = false
 
+    /// What the user drilled into from the dashboard, or `nil` for the grid.
+    /// Held on the view (not the VM) because it is pure navigation state for the
+    /// results surface — the same place `ApplicationsView` keeps its `detail`
+    /// selection. Reset to the dashboard at the start of every scan.
+    @State private var reviewing: ReviewTarget?
+
+    /// A drill-down destination: the complete list, or one category's slice.
+    private enum ReviewTarget: Equatable {
+        case all
+        case category(LargeOldFilesCategory)
+
+        /// Title shown in the review screen's Back bar.
+        var title: String {
+            switch self {
+            case .all:
+                return String(
+                    localized: "All Files",
+                    comment: "Back-bar title for the complete, unfiltered Large & Old Files list."
+                )
+            case .category(let category):
+                return category.title
+            }
+        }
+    }
+
     init(viewModel: LargeOldFilesViewModel) {
         self.viewModel = viewModel
     }
@@ -69,8 +94,75 @@ struct LargeOldFilesView: View {
                 detail: ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount)
             )
         case .results:
+            resultsContent
+        case .empty:
+            LargeOldFilesEmptyState(
+                onScanAgain: viewModel.scanAgain,
+                hasFullDiskAccess: appState.hasFullDiskAccess,
+                onRefreshAccess: { appState.refresh() }
+            )
+        case .failed(let stage, let message):
+            LargeOldFilesFailedState(stage: stage, message: message, onTryAgain: viewModel.scanAgain)
+        }
+    }
+
+    /// The results surface: the category dashboard, or one category's filtered
+    /// file list behind a Back bar. A category whose files were all deleted
+    /// falls back to the dashboard so the user is never stranded on an empty
+    /// review.
+    @ViewBuilder
+    private var resultsContent: some View {
+        if let target = reviewing, !files(for: target).isEmpty {
+            reviewScreen(for: target)
+        } else {
+            // No scroll view: the dashboard fills the detail pane and divides
+            // the available height between the hero and the tile grid, like the
+            // Health Monitor section.
+            LargeOldFilesDashboardView(
+                fileCount: viewModel.displayedFiles.count,
+                oldCount: viewModel.displayedOldCount,
+                totalBytes: viewModel.displayedTotalBytes,
+                tiles: viewModel.displayedTiles,
+                onReview: { reviewing = .category($0) },
+                onViewAll: { reviewing = .all },
+                onRescan: startScan
+            )
+        }
+    }
+
+    /// A drill-down's file list, reusing the shared results content (header +
+    /// list + footer) wrapped in a Back bar that returns to the dashboard.
+    private func reviewScreen(for target: ReviewTarget) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button {
+                    reviewing = nil
+                } label: {
+                    // HStack(Image, Text) rather than Label so the control
+                    // surfaces reliably in XCUITest.
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text(String(
+                            localized: "Back",
+                            comment: "Back button returning from a Large & Old Files drill-down to the dashboard."
+                        ))
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("large-old.backToDashboard")
+                Spacer()
+                Text(target.title)
+                    .font(.headline)
+                Spacer()
+                // Balances the leading Back button so the title stays centred.
+                Color.clear.frame(width: 44, height: 1)
+            }
+            .padding(16)
+            Divider()
             LargeOldFilesResultsContent(
-                files: viewModel.displayedFiles,
+                files: files(for: target),
+                oldCount: summary(for: target).oldCount,
+                totalBytes: summary(for: target).totalBytes,
                 sortOrder: $viewModel.sortOrder,
                 totalSelectedSize: viewModel.totalSelectedSize,
                 canDelete: !viewModel.selectedURLs.isEmpty,
@@ -83,14 +175,34 @@ struct LargeOldFilesView: View {
                 onDeleteFile: requestDeletionForSingle,
                 onAddToExclusions: { exclusions.add(path: $0.url.path) }
             )
-        case .empty:
-            LargeOldFilesEmptyState(
-                onScanAgain: viewModel.scanAgain,
-                hasFullDiskAccess: appState.hasFullDiskAccess,
-                onRefreshAccess: { appState.refresh() }
-            )
-        case .failed(let stage, let message):
-            LargeOldFilesFailedState(stage: stage, message: message, onTryAgain: viewModel.scanAgain)
+        }
+    }
+
+    /// The files for a drill-down. `.all` is the full result set; a category is
+    /// served straight from the view-model's precomputed tiles (already in the
+    /// active sort order) so the review never re-runs the grouping on a render
+    /// or selection toggle.
+    private func files(for target: ReviewTarget) -> [ScannedFile] {
+        switch target {
+        case .all:
+            return viewModel.displayedFiles
+        case .category(let category):
+            return viewModel.displayedTiles.first { $0.category == category }?.files ?? []
+        }
+    }
+
+    /// Precomputed header aggregates for a drill-down — the full-set summary for
+    /// `.all`, the tile's stored totals for a category — so the review header
+    /// never re-scans the files on render.
+    private func summary(for target: ReviewTarget) -> (oldCount: Int, totalBytes: Int64) {
+        switch target {
+        case .all:
+            return (viewModel.displayedOldCount, viewModel.displayedTotalBytes)
+        case .category(let category):
+            guard let tile = viewModel.displayedTiles.first(where: { $0.category == category }) else {
+                return (0, 0)
+            }
+            return (tile.oldCount, tile.totalBytes)
         }
     }
 
@@ -135,6 +247,9 @@ struct LargeOldFilesView: View {
         switch newPhase {
         case .scanning, .idle:
             notifiedForCurrentScan = false
+            // A fresh scan always lands back on the dashboard grid, never a
+            // stale drill-down from the previous run.
+            reviewing = nil
         case .results(let files) where !notifiedForCurrentScan && !files.isEmpty:
             notifiedForCurrentScan = true
             let total = files.reduce(Int64(0)) { $0 + $1.size }

--- a/VaderCleaner/LargeOldFilesViewModel.swift
+++ b/VaderCleaner/LargeOldFilesViewModel.swift
@@ -95,6 +95,24 @@ final class LargeOldFilesViewModel {
     /// through a phase-replacement.
     private(set) var displayedFiles: [ScannedFile] = []
 
+    /// The dashboard's category tiles, recomputed only when the file *set*
+    /// changes (scan completes, files deleted) — never on a sort change, since
+    /// tile membership is independent of order. Cached here rather than derived
+    /// in the view because the scan can return a very large set (every file
+    /// untouched for six months qualifies, not just the big ones), and
+    /// re-running the grouping on every SwiftUI body evaluation froze the
+    /// window with a beach ball.
+    private(set) var displayedTiles: [LargeOldFilesTile] = []
+
+    /// Summed size of the whole result set, computed once when the set changes.
+    /// The dashboard and "View All" header read this instead of reducing the
+    /// (potentially hundreds of thousands) `displayedFiles` on every render.
+    private(set) var displayedTotalBytes: Int64 = 0
+
+    /// How many of `displayedFiles` are tagged `.oldFile`, computed once when
+    /// the set changes — feeds the header's "N older than 6 months" line.
+    private(set) var displayedOldCount: Int = 0
+
     @ObservationIgnored private let scanner: Scanner
     @ObservationIgnored private let deleter: Deleter
 
@@ -192,6 +210,8 @@ final class LargeOldFilesViewModel {
         let actuallyDeleted = await deleter(urls)
         let survivors = displayedFiles.filter { !actuallyDeleted.contains($0.url) }
         displayedFiles = survivors
+        displayedTiles = LargeOldFilesCategorizer.tiles(from: survivors)
+        (displayedTotalBytes, displayedOldCount) = Self.summarize(survivors)
         // Drop the deleted URLs from the selection set, then recompute
         // `totalSelectedSize` from scratch. The incremental upkeep in
         // `toggleSelection` only handles user-driven add/remove — deletion
@@ -208,6 +228,9 @@ final class LargeOldFilesViewModel {
     /// "Scan Again" button on the empty / complete states.
     func scanAgain() {
         displayedFiles = []
+        displayedTiles = []
+        displayedTotalBytes = 0
+        displayedOldCount = 0
         selectedURLs = []
         totalSelectedSize = 0
         scannedItemCount = 0
@@ -222,12 +245,29 @@ final class LargeOldFilesViewModel {
     private func applyScanResult(_ files: [ScannedFile]) {
         if files.isEmpty {
             displayedFiles = []
+            displayedTiles = []
+            displayedTotalBytes = 0
+            displayedOldCount = 0
             phase = .empty
             return
         }
         let sorted = Self.sort(files, by: sortOrder)
         displayedFiles = sorted
+        displayedTiles = LargeOldFilesCategorizer.tiles(from: sorted)
+        (displayedTotalBytes, displayedOldCount) = Self.summarize(sorted)
         phase = .results(sorted)
+    }
+
+    /// One pass over a result set producing the aggregates the header needs, so
+    /// the view never reduces the (possibly huge) array on render.
+    private static func summarize(_ files: [ScannedFile]) -> (totalBytes: Int64, oldCount: Int) {
+        var bytes: Int64 = 0
+        var old = 0
+        for file in files {
+            bytes += file.size
+            if file.category == .oldFile { old += 1 }
+        }
+        return (bytes, old)
     }
 
     /// Re-sort the displayed list in place using the current `sortOrder`.
@@ -237,6 +277,13 @@ final class LargeOldFilesViewModel {
     private func recomputeDisplayedFiles() {
         guard !displayedFiles.isEmpty else { return }
         displayedFiles = Self.sort(displayedFiles, by: sortOrder)
+        // Reorder each tile's files to match — membership is unchanged by a
+        // sort, so only the order is refreshed, never the grouping. This keeps
+        // a drilled-in category list honouring the active sort without
+        // re-running the (potentially expensive) categorization.
+        displayedTiles = displayedTiles.map {
+            LargeOldFilesTile(category: $0.category, files: Self.sort($0.files, by: sortOrder))
+        }
         if case .results = phase {
             phase = .results(displayedFiles)
         }

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -39,6 +39,58 @@ enum LargeOldFilesActions {
     }
 }
 
+/// Pure strings for the results header above the file list: a headline file
+/// count and a supporting detail line. Kept free of any view so the phrasing
+/// is unit-testable without rendering.
+enum LargeOldFilesSummary {
+    /// Headline metric — the bare, pluralized file count, e.g. "142 files".
+    static func headline(count: Int) -> String {
+        "\(count) file\(count == 1 ? "" : "s")"
+    }
+
+    /// Full-sentence headline for the dashboard, echoing the Applications
+    /// section's "We've found N apps on your Mac." phrasing.
+    static func foundSentence(count: Int) -> String {
+        let format = String(
+            localized: "We've found %lld large or old files on your Mac.",
+            comment: "Large & Old Files dashboard headline; %lld is the file count."
+        )
+        return String.localizedStringWithFormat(format, Int64(count))
+    }
+
+    /// Supporting detail — the count of age-qualified files and the total
+    /// reclaimable size, separated by a middle dot. The old-file clause is
+    /// dropped when nothing qualified so the line never reads "0 older than
+    /// six months". Takes precomputed aggregates so the header never re-scans a
+    /// huge result set on render.
+    static func detail(oldCount: Int, totalBytes: Int64) -> String {
+        let totalClause = LargeOldFilesFormatting.byteFormatter.string(fromByteCount: totalBytes) + " total"
+        guard oldCount > 0 else { return totalClause }
+        return "\(oldCount) older than 6 months · \(totalClause)"
+    }
+
+    // Convenience overloads that derive the aggregates from a file array — used
+    // by tests and any caller that hasn't already summarized the set.
+
+    static func headline(for files: [ScannedFile]) -> String {
+        headline(count: files.count)
+    }
+
+    static func foundSentence(for files: [ScannedFile]) -> String {
+        foundSentence(count: files.count)
+    }
+
+    static func detail(for files: [ScannedFile]) -> String {
+        var totalBytes: Int64 = 0
+        var oldCount = 0
+        for file in files {
+            totalBytes += file.size
+            if file.category == .oldFile { oldCount += 1 }
+        }
+        return detail(oldCount: oldCount, totalBytes: totalBytes)
+    }
+}
+
 struct LargeOldFilesProgressState: View {
     let label: String
     let identifier: String
@@ -68,6 +120,10 @@ struct LargeOldFilesProgressState: View {
 
 struct LargeOldFilesResultsContent: View {
     let files: [ScannedFile]
+    /// Precomputed aggregates for the header, so it never re-scans `files`
+    /// (which can be hundreds of thousands of entries) on render.
+    let oldCount: Int
+    let totalBytes: Int64
     @Binding var sortOrder: LargeOldFilesViewModel.SortOrder
     let totalSelectedSize: Int64
     let canDelete: Bool
@@ -80,11 +136,35 @@ struct LargeOldFilesResultsContent: View {
     let onDeleteFile: (ScannedFile) -> Void
     let onAddToExclusions: (ScannedFile) -> Void
 
+    /// Most rows we render at once. A category like "Old Files" can hold
+    /// hundreds of thousands of entries, and a SwiftUI `List`/`ForEach` builds
+    /// identity for the whole collection up front — rendering all of them froze
+    /// the drill-down for seconds. The list is already sorted (size-descending
+    /// by default), so the capped slice is the meaningful, actionable top of the
+    /// list; the tail is reached by deleting these and re-scanning.
+    static let displayRowLimit = 1_000
+
     var body: some View {
+        // Cap the rendered rows. `files` stays the full set for the header's
+        // true totals; only the list is bounded.
+        let shown = files.count > Self.displayRowLimit
+            ? Array(files.prefix(Self.displayRowLimit))
+            : files
+
         VStack(spacing: 0) {
-            LargeOldFilesTable(
-                files: files,
-                sortOrder: $sortOrder,
+            LargeOldFilesResultsHeader(
+                fileCount: files.count,
+                oldCount: oldCount,
+                totalBytes: totalBytes,
+                sortOrder: $sortOrder
+            )
+            Divider()
+            if files.count > shown.count {
+                truncationNote(showing: shown.count, total: files.count)
+                Divider()
+            }
+            LargeOldFilesList(
+                files: shown,
                 fileIconCache: fileIconCache,
                 isSelected: isSelected,
                 onToggleSelection: onToggleSelection,
@@ -100,15 +180,280 @@ struct LargeOldFilesResultsContent: View {
                 onDeleteSelected: onDeleteSelected
             )
         }
-        .task(id: files) {
-            await fileIconCache.preloadIcons(for: files.map(\.url))
+        // Key the preload on the bounded slice (≤ `displayRowLimit`) so it stays
+        // cheap and doesn't compare the full hundreds-of-thousands array.
+        .task(id: shown) {
+            await fileIconCache.preloadIcons(for: shown.map(\.url))
         }
+    }
+
+    /// Inline note explaining the list is showing only the top slice of a very
+    /// large result set.
+    private func truncationNote(showing: Int, total: Int) -> some View {
+        let format = String(
+            localized: "Showing the top %lld of %lld files. Clear these and re-scan to see more.",
+            comment: "Note shown when the Large & Old Files list is capped; the first %lld is the shown count, the second the total."
+        )
+        return HStack(spacing: 6) {
+            Image(systemName: "info.circle")
+            Text(String.localizedStringWithFormat(format, Int64(showing), Int64(total)))
+            Spacer(minLength: 0)
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
     }
 }
 
-struct LargeOldFilesTable: View {
-    let files: [ScannedFile]
+/// Post-scan landing surface for Large & Old Files: a summary header and a grid
+/// of category tiles. Modelled on the Health Monitor dashboard — the whole
+/// surface fills the detail pane without a scroll view: the heaviest category is
+/// a tall hero in a fixed-width left column, and the remaining tiles divide the
+/// right column's height into equal rows so the grid never overflows. Each
+/// tile's Review button drills into that category's filtered file list.
+struct LargeOldFilesDashboardView: View {
+    /// All precomputed by the view-model when the file set changes — never
+    /// derived here, so a huge scan doesn't re-scan the files on every render.
+    let fileCount: Int
+    let oldCount: Int
+    let totalBytes: Int64
+    let tiles: [LargeOldFilesTile]
+    let onReview: (LargeOldFilesCategory) -> Void
+    /// Opens the complete, unfiltered file list — the analog of the
+    /// Applications section's "Manage My Applications".
+    let onViewAll: () -> Void
+    let onRescan: () -> Void
+
+    /// Fixed width of the hero column so it keeps a stable shape while the right
+    /// tiles absorb the remaining width — mirrors `HealthMonitorView`.
+    private let leftColumnWidth: CGFloat = 340
+
+    var body: some View {
+        VStack(spacing: 16) {
+            header
+            cardLayout
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("large-old.dashboard")
+    }
+
+    /// Centred count headline with the two primary actions beneath it, echoing
+    /// the Applications dashboard header.
+    private var header: some View {
+        VStack(spacing: 12) {
+            Text(LargeOldFilesSummary.foundSentence(count: fileCount))
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("large-old.summary")
+            Text(LargeOldFilesSummary.detail(oldCount: oldCount, totalBytes: totalBytes))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            HStack(spacing: 12) {
+                Button(String(
+                    localized: "View All Files",
+                    comment: "Button that opens the complete, unfiltered Large & Old Files list."
+                )) {
+                    onViewAll()
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("large-old.viewAll")
+
+                Button(String(
+                    localized: "Re-scan",
+                    comment: "Button that re-runs the Large & Old Files scan from the dashboard."
+                )) {
+                    onRescan()
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("large-old.rescan")
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// The Health Monitor layout: a tall hero in the left column with a shorter
+    /// secondary card tucked beneath it, and the remaining tiles dividing the
+    /// right column into equal-height rows of two. Mixing the tall hero, the
+    /// compact left card, and the right grid keeps the tiles from all sharing
+    /// one size. Lower tile counts degrade gracefully so the pane never shows an
+    /// orphaned hero beside empty space.
+    @ViewBuilder
+    private var cardLayout: some View {
+        switch tiles.count {
+        case 0:
+            EmptyView()
+        case 1:
+            card(tiles[0], isHero: true)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case 2:
+            HStack(alignment: .top, spacing: 16) {
+                card(tiles[0], isHero: true)
+                    .frame(width: leftColumnWidth)
+                    .frame(maxHeight: .infinity)
+                card(tiles[1], isHero: false)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        default:
+            HStack(alignment: .top, spacing: 16) {
+                leftColumn
+                rightGrid(gridTiles)
+            }
+        }
+    }
+
+    /// The hero plus the compact secondary card. The hero stretches to fill the
+    /// column height while the secondary keeps its natural (shorter) height, so
+    /// the two read as clearly different sizes — the Health Monitor hero +
+    /// `fileVaultCard` stack.
+    private var leftColumn: some View {
+        VStack(spacing: 16) {
+            card(tiles[0], isHero: true)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            if let secondaryTile {
+                card(secondaryTile, isHero: false)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(width: leftColumnWidth)
+    }
+
+    /// The non-hero tiles, excluding the one promoted to the compact left card.
+    private var nonHeroTiles: [LargeOldFilesTile] { Array(tiles.dropFirst()) }
+
+    /// The smallest non-hero category by reclaimable size becomes the compact
+    /// card under the hero — a small tile for a small bucket.
+    private var secondaryTile: LargeOldFilesTile? {
+        nonHeroTiles.min { $0.totalBytes < $1.totalBytes }
+    }
+
+    /// What flows through the right grid: every non-hero tile except the one
+    /// shown as the compact left card.
+    private var gridTiles: [LargeOldFilesTile] {
+        nonHeroTiles.filter { $0.id != secondaryTile?.id }
+    }
+
+    /// The non-hero tiles in equal-height rows of two. Grouped in a
+    /// `GlassEffectContainer` so adjacent glass cards sample each other and
+    /// refract consistently, exactly as the Health Monitor metric grid does.
+    private func rightGrid(_ gridTiles: [LargeOldFilesTile]) -> some View {
+        GlassEffectContainer(spacing: 16) {
+            VStack(spacing: 16) {
+                ForEach(Array(rows(of: gridTiles).enumerated()), id: \.offset) { _, row in
+                    HStack(spacing: 16) {
+                        ForEach(row) { tile in
+                            card(tile, isHero: false)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Chunks the grid tiles into rows of at most two so the right column reads
+    /// as a two-up grid that fills the height.
+    private func rows(of gridTiles: [LargeOldFilesTile]) -> [[LargeOldFilesTile]] {
+        stride(from: 0, to: gridTiles.count, by: 2).map {
+            Array(gridTiles[$0..<min($0 + 2, gridTiles.count)])
+        }
+    }
+
+    private func card(_ tile: LargeOldFilesTile, isHero: Bool) -> some View {
+        ApplicationsCard(
+            title: tile.category.title,
+            metric: LargeOldFilesFormatting.byteFormatter.string(fromByteCount: tile.totalBytes),
+            detail: cardDetail(for: tile),
+            icon: tile.category.icon,
+            actionLabel: String(
+                localized: "Review",
+                comment: "Large & Old Files tile action that opens the category's file list."
+            ),
+            identifier: "large-old.card.\(tile.category.rawValue)",
+            isHero: isHero,
+            action: { onReview(tile.category) }
+        )
+    }
+
+    private func cardDetail(for tile: LargeOldFilesTile) -> String {
+        let count = "\(tile.count) file\(tile.count == 1 ? "" : "s")"
+        return "\(count) · \(tile.category.blurb)"
+    }
+}
+
+/// Header bar above the file list: a count headline with a supporting detail
+/// line on the left, and the sort control on the right. Replaces the orphaned
+/// toolbar picker so the sort affordance sits with the content it reorders,
+/// matching the in-content headers the other section dashboards use.
+struct LargeOldFilesResultsHeader: View {
+    let fileCount: Int
+    let oldCount: Int
+    let totalBytes: Int64
     @Binding var sortOrder: LargeOldFilesViewModel.SortOrder
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(LargeOldFilesSummary.headline(count: fileCount))
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("large-old.summary")
+                Text(LargeOldFilesSummary.detail(oldCount: oldCount, totalBytes: totalBytes))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            sortPicker
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var sortPicker: some View {
+        Picker(String(
+            localized: "Sort by",
+            comment: "Label for the Large & Old Files sort menu."
+        ), selection: $sortOrder) {
+            Text(String(
+                localized: "Largest first",
+                comment: "Sort option that orders files from largest to smallest."
+            )).tag(LargeOldFilesViewModel.SortOrder.sizeDescending)
+            Text(String(
+                localized: "Smallest first",
+                comment: "Sort option that orders files from smallest to largest."
+            )).tag(LargeOldFilesViewModel.SortOrder.sizeAscending)
+            Text(String(
+                localized: "Oldest first",
+                comment: "Sort option that orders files by oldest access date first."
+            )).tag(LargeOldFilesViewModel.SortOrder.dateAscending)
+            Text(String(
+                localized: "Newest first",
+                comment: "Sort option that orders files by newest access date first."
+            )).tag(LargeOldFilesViewModel.SortOrder.dateDescending)
+            Text(String(
+                localized: "Name (A–Z)",
+                comment: "Sort option that orders files alphabetically by name."
+            )).tag(LargeOldFilesViewModel.SortOrder.nameAscending)
+        }
+        .pickerStyle(.menu)
+        .labelsHidden()
+        .fixedSize()
+        .accessibilityIdentifier("large-old.sort")
+    }
+}
+
+/// The scan results as a `List` of glass rows — the same pattern every other
+/// section uses (System Junk, Applications, Smart Scan). `scrollContentBackground`
+/// is hidden so the branded gradient shows through instead of the opaque,
+/// accent-tinted row bands a raw `Table` paints over it.
+struct LargeOldFilesList: View {
+    let files: [ScannedFile]
     var fileIconCache: FileIconCache
     let isSelected: (ScannedFile) -> Bool
     let onToggleSelection: (ScannedFile) -> Void
@@ -117,129 +462,90 @@ struct LargeOldFilesTable: View {
     let onAddToExclusions: (ScannedFile) -> Void
 
     var body: some View {
-        Table(files) {
-            TableColumn("") { file in
-                Toggle("", isOn: Binding(
-                    get: { isSelected(file) },
-                    set: { _ in onToggleSelection(file) }
-                ))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
-                .accessibilityLabel(Text(LargeOldFilesFormatting.selectionLabel(for: file)))
-                .accessibilityIdentifier("large-old.row.\(file.url.path).checkbox")
-            }
-            .width(28)
-
-            TableColumn(String(
-                localized: "Name",
-                comment: "Column title for the file name column in the Large & Old Files table."
-            )) { file in
-                LargeOldFilesRowNameCell(
+        List {
+            ForEach(files) { file in
+                LargeOldFilesRow(
                     file: file,
                     fileIconCache: fileIconCache,
-                    onShowInFinder: onShowInFinder,
-                    onDelete: onDeleteFile,
-                    onAddToExclusions: onAddToExclusions
+                    isSelected: isSelected(file),
+                    onToggleSelection: { onToggleSelection(file) },
+                    onShowInFinder: { onShowInFinder(file) },
+                    onDelete: { onDeleteFile(file) },
+                    onAddToExclusions: { onAddToExclusions(file) }
                 )
             }
-
-            TableColumn(String(
-                localized: "Size",
-                comment: "Column title for the file size column in the Large & Old Files table."
-            )) { file in
-                Text(LargeOldFilesFormatting.byteFormatter.string(fromByteCount: file.size))
-                    .font(.callout.monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
-            .width(min: 70, ideal: 90, max: 120)
-
-            TableColumn(String(
-                localized: "Last Accessed",
-                comment: "Column title for the last accessed date column in the Large & Old Files table."
-            )) { file in
-                Text(LargeOldFilesFormatting.accessDate(file.lastAccessDate))
-                    .font(.callout.monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
-            .width(min: 110, ideal: 140, max: 180)
-
-            TableColumn(String(
-                localized: "Path",
-                comment: "Column title for the file path column in the Large & Old Files table."
-            )) { file in
-                Text(file.url.deletingLastPathComponent().path)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.head)
-                    .help(file.url.path)
-            }
         }
-        .accessibilityIdentifier("large-old.table")
         .scrollContentBackground(.hidden)
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Picker(String(
-                    localized: "Sort by",
-                    comment: "Label for the Large & Old Files sort menu."
-                ), selection: $sortOrder) {
-                    Text(String(
-                        localized: "Largest first",
-                        comment: "Sort option that orders files from largest to smallest."
-                    )).tag(LargeOldFilesViewModel.SortOrder.sizeDescending)
-                    Text(String(
-                        localized: "Smallest first",
-                        comment: "Sort option that orders files from smallest to largest."
-                    )).tag(LargeOldFilesViewModel.SortOrder.sizeAscending)
-                    Text(String(
-                        localized: "Oldest first",
-                        comment: "Sort option that orders files by oldest access date first."
-                    )).tag(LargeOldFilesViewModel.SortOrder.dateAscending)
-                    Text(String(
-                        localized: "Newest first",
-                        comment: "Sort option that orders files by newest access date first."
-                    )).tag(LargeOldFilesViewModel.SortOrder.dateDescending)
-                    Text(String(
-                        localized: "Name (A–Z)",
-                        comment: "Sort option that orders files alphabetically by name."
-                    )).tag(LargeOldFilesViewModel.SortOrder.nameAscending)
-                }
-                .pickerStyle(.menu)
-                .accessibilityIdentifier("large-old.sort")
-            }
-        }
+        .accessibilityIdentifier("large-old.table")
     }
 }
 
-struct LargeOldFilesRowNameCell: View {
+/// One file in the results list: selection checkbox, type icon, name, a
+/// secondary "last-accessed · folder" line, and the size as a bold trailing
+/// metric. The full path is tail-truncated so the meaningful end stays visible.
+struct LargeOldFilesRow: View {
     let file: ScannedFile
     var fileIconCache: FileIconCache
-    let onShowInFinder: (ScannedFile) -> Void
-    let onDelete: (ScannedFile) -> Void
-    let onAddToExclusions: (ScannedFile) -> Void
+    let isSelected: Bool
+    let onToggleSelection: () -> Void
+    let onShowInFinder: () -> Void
+    let onDelete: () -> Void
+    let onAddToExclusions: () -> Void
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(
+                get: { isSelected },
+                set: { _ in onToggleSelection() }
+            ))
+            .toggleStyle(.checkbox)
+            .labelsHidden()
+            .accessibilityLabel(Text(LargeOldFilesFormatting.selectionLabel(for: file)))
+            .accessibilityIdentifier("large-old.row.\(file.url.path).checkbox")
+
             Image(nsImage: fileIconCache.cachedIcon(for: file.url))
                 .resizable()
-                .frame(width: 16, height: 16)
-            Text(file.url.lastPathComponent)
-                .lineLimit(1)
-                .truncationMode(.middle)
+                .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(file.url.lastPathComponent)
+                    .font(.body.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                HStack(spacing: 4) {
+                    Text(LargeOldFilesFormatting.accessDate(file.lastAccessDate))
+                        .layoutPriority(1)
+                    Text("·")
+                    Text(file.url.deletingLastPathComponent().path)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                        .help(file.url.path)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(LargeOldFilesFormatting.byteFormatter.string(fromByteCount: file.size))
+                .font(.callout.monospacedDigit().weight(.semibold))
         }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .accessibilityIdentifier("large-old.row.\(file.url.path)")
         .contextMenu {
             Button("Show in Finder") {
-                onShowInFinder(file)
+                onShowInFinder()
             }
             Button(String(
                 localized: "Add to Exclusions",
                 comment: "Context menu item that adds the selected file to the scan-exclusions list."
             )) {
-                onAddToExclusions(file)
+                onAddToExclusions()
             }
             Divider()
             Button("Delete", role: .destructive) {
-                onDelete(file)
+                onDelete()
             }
         }
     }

--- a/VaderCleanerTests/LargeOldFilesCategoryTests.swift
+++ b/VaderCleanerTests/LargeOldFilesCategoryTests.swift
@@ -1,0 +1,141 @@
+// LargeOldFilesCategoryTests.swift
+// Tests the pure grouping that turns a flat scan into the dashboard's category tiles — extension/age classification, the top-by-size "Largest" lens, and tile assembly (non-empty only, hero first, correct totals).
+
+import XCTest
+@testable import VaderCleaner
+
+final class LargeOldFilesCategoryTests: XCTestCase {
+
+    /// A fixed "now" so the age-based classification is deterministic.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Per-category membership
+
+    /// Video extensions land in `.videos`, case-insensitively.
+    func test_files_videosMatchVideoExtensions() {
+        let files = [
+            makeFile(name: "clip.MOV", size: 10),
+            makeFile(name: "movie.mkv", size: 10),
+            makeFile(name: "notes.txt", size: 10)
+        ]
+        let videos = LargeOldFilesCategorizer.files(in: .videos, from: files, referenceDate: now)
+        XCTAssertEqual(Set(videos.map(\.url.lastPathComponent)), ["clip.MOV", "movie.mkv"])
+    }
+
+    /// Installer disk images and compressed archives land in `.archives`. The
+    /// sparse VM/container disk images (`.raw`/`.sparsebundle`) are deliberately
+    /// excluded — the scanner skips them, and a stray camera `.raw` is "Other".
+    func test_files_archivesMatchArchiveExtensions() {
+        let files = [
+            makeFile(name: "Install.dmg", size: 10),
+            makeFile(name: "backup.zip", size: 10),
+            makeFile(name: "image.iso", size: 10),
+            makeFile(name: "photo.raw", size: 10),
+            makeFile(name: "clip.mov", size: 10)
+        ]
+        let archives = LargeOldFilesCategorizer.files(in: .archives, from: files, referenceDate: now)
+        XCTAssertEqual(Set(archives.map(\.url.lastPathComponent)), ["Install.dmg", "backup.zip", "image.iso"])
+
+        // A bare `.raw` is not an archive — it falls through to "Other".
+        let other = LargeOldFilesCategorizer.files(in: .other, from: files, referenceDate: now)
+        XCTAssertTrue(other.contains { $0.url.lastPathComponent == "photo.raw" })
+    }
+
+    /// Anything that is neither a video nor an archive lands in `.other`.
+    func test_files_otherExcludesVideosAndArchives() {
+        let files = [
+            makeFile(name: "clip.mov", size: 10),
+            makeFile(name: "backup.zip", size: 10),
+            makeFile(name: "report.pdf", size: 10),
+            makeFile(name: "README", size: 10)
+        ]
+        let other = LargeOldFilesCategorizer.files(in: .other, from: files, referenceDate: now)
+        XCTAssertEqual(Set(other.map(\.url.lastPathComponent)), ["report.pdf", "README"])
+    }
+
+    /// `.old` is age-driven: files last accessed on or before the six-month
+    /// cutoff qualify; recently-accessed files and files with no access date
+    /// do not.
+    func test_files_oldUsesAccessDateCutoff() {
+        let ancient = makeFile(name: "ancient.bin", size: 10,
+                               accessed: now.addingTimeInterval(-LargeOldFilesScanner.ageThresholdSeconds - 86_400))
+        let recent = makeFile(name: "recent.bin", size: 10,
+                              accessed: now.addingTimeInterval(-86_400))
+        let undated = ScannedFile(url: URL(fileURLWithPath: "/tmp/cat/undated.bin"),
+                                  size: 10, lastAccessDate: nil, lastModifiedDate: nil, category: .largeFile)
+
+        let old = LargeOldFilesCategorizer.files(in: .old, from: [ancient, recent, undated], referenceDate: now)
+        XCTAssertEqual(old.map(\.url.lastPathComponent), ["ancient.bin"])
+    }
+
+    /// `.largest` is a lens, not a partition: it returns the top N files by
+    /// size regardless of type.
+    func test_files_largestReturnsTopBySize() {
+        let files = (1...(LargeOldFilesCategorizer.largestTileLimit + 5)).map {
+            makeFile(name: "f\($0).bin", size: Int64($0))
+        }
+        let largest = LargeOldFilesCategorizer.files(in: .largest, from: files, referenceDate: now)
+        XCTAssertEqual(largest.count, LargeOldFilesCategorizer.largestTileLimit)
+        XCTAssertEqual(largest.first?.size, Int64(LargeOldFilesCategorizer.largestTileLimit + 5),
+                       "Largest must lead with the biggest file")
+    }
+
+    // MARK: - Tile assembly
+
+    /// Categories with no files produce no tile — the grid only shows lenses
+    /// that have findings, like the Applications dashboard.
+    func test_tiles_omitsEmptyCategories() {
+        let files = [makeFile(name: "report.pdf", size: 10)]  // only `.other`
+        let categories = LargeOldFilesCategorizer.tiles(from: files, referenceDate: now).map(\.category)
+        XCTAssertEqual(categories, [.other])
+    }
+
+    /// Among the primary (type/age) tiles, the one with the most reclaimable
+    /// bytes is first so the dashboard can promote it to the hero card.
+    func test_tiles_heroIsLargestByBytes() {
+        let files = [
+            makeFile(name: "small.zip", size: 100),          // archives
+            makeFile(name: "big.mov", size: 10_000),         // videos
+            makeFile(name: "report.pdf", size: 500)          // other
+        ]
+        let tiles = LargeOldFilesCategorizer.tiles(from: files, referenceDate: now)
+        XCTAssertEqual(tiles.first?.category, .videos)
+    }
+
+    /// The "Largest Files" lens only earns a tile when there are more files
+    /// than it caps at — otherwise it just duplicates the whole result set.
+    func test_tiles_largestAppearsOnlyAboveLimit() {
+        let few = (1...3).map { makeFile(name: "f\($0).pdf", size: Int64($0)) }
+        XCTAssertFalse(LargeOldFilesCategorizer.tiles(from: few, referenceDate: now).contains { $0.category == .largest })
+
+        let many = (1...(LargeOldFilesCategorizer.largestTileLimit + 1)).map {
+            makeFile(name: "f\($0).pdf", size: Int64($0))
+        }
+        XCTAssertTrue(LargeOldFilesCategorizer.tiles(from: many, referenceDate: now).contains { $0.category == .largest })
+    }
+
+    /// A tile reports the count, summed size, and old-file count of its files —
+    /// all computed once at construction, not derived on access.
+    func test_tile_countTotalBytesAndOldCount() {
+        let files = [
+            makeFile(name: "a.mov", size: 1_000, category: .largeFile),
+            makeFile(name: "b.mov", size: 2_500, category: .oldFile)
+        ]
+        let videos = LargeOldFilesCategorizer.tiles(from: files, referenceDate: now).first { $0.category == .videos }
+        XCTAssertEqual(videos?.count, 2)
+        XCTAssertEqual(videos?.totalBytes, 3_500)
+        XCTAssertEqual(videos?.oldCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeFile(name: String, size: Int64, accessed: Date? = nil, category: ScanCategory = .largeFile) -> ScannedFile {
+        ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/cat/\(name)"),
+            size: size,
+            lastAccessDate: accessed,
+            lastModifiedDate: accessed,
+            category: category
+        )
+    }
+}

--- a/VaderCleanerTests/LargeOldFilesScannerTests.swift
+++ b/VaderCleanerTests/LargeOldFilesScannerTests.swift
@@ -185,6 +185,48 @@ final class LargeOldFilesScannerTests: XCTestCase {
                        "Tiebreak: a file matching both criteria is reported as .largeFile")
     }
 
+    // MARK: - Virtual disk images
+
+    /// A sparse `Docker.raw` VM volume must be skipped: deleting it destroys
+    /// Docker's data, and its logical size is a phantom that would otherwise
+    /// dominate the whole scan. Gated by its container-store path so a real
+    /// camera `.raw` is unaffected.
+    func test_scan_excludesDockerRawVirtualDisk() async throws {
+        let dockerRaw = bigRecentFile(
+            "/Users/me/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw"
+        )
+        let files = try await scanEmitting([dockerRaw])
+        XCTAssertTrue(files.isEmpty, "A sparse Docker.raw VM disk must be skipped")
+    }
+
+    /// Unambiguous VM/container disk-image extensions are skipped regardless of
+    /// path — deleting them is destructive and their size is sparse.
+    func test_scan_excludesVirtualDiskExtensions() async throws {
+        let emitted = [
+            bigRecentFile("/Users/me/VMs/Ubuntu.utm"),
+            bigRecentFile("/Users/me/Backups/disk.sparsebundle"),
+            bigRecentFile("/Users/me/VMs/win.vmdk")
+        ]
+        let files = try await scanEmitting(emitted)
+        XCTAssertTrue(files.isEmpty, "Every VM/container disk image must be skipped, got \(files)")
+    }
+
+    /// A camera `.raw` photo outside any container/VM store is a legitimate
+    /// large file and must NOT be hidden.
+    func test_scan_keepsCameraRawOutsideVMPaths() async throws {
+        let photo = bigRecentFile("/Users/me/Pictures/Shoot/IMG_2401.raw")
+        let files = try await scanEmitting([photo])
+        XCTAssertEqual(files.count, 1, "A camera .raw outside a VM store must be surfaced")
+    }
+
+    /// Safe installer disk images (`.dmg`/`.iso`) are the legit purpose of the
+    /// Archives tile and stay in the results.
+    func test_scan_keepsInstallerDiskImages() async throws {
+        let dmg = bigRecentFile("/Users/me/Downloads/App.dmg")
+        let files = try await scanEmitting([dmg])
+        XCTAssertEqual(files.count, 1, "Installer .dmg downloads must be kept")
+    }
+
     // MARK: - Unknown access date
 
     /// Files whose `lastAccessDate` is `nil` cannot be classified by age and,
@@ -496,6 +538,30 @@ final class LargeOldFilesScannerTests: XCTestCase {
         values.contentModificationDate = date
         var mutable = url
         try mutable.setResourceValues(values)
+    }
+
+    /// A synthetic above-threshold, recently-accessed `ScannedFile` at `path`.
+    /// Recent + large means the only thing that can drop it is the virtual-disk
+    /// guard, so these fixtures isolate the exclusion from the size/age filter.
+    private func bigRecentFile(_ path: String) -> ScannedFile {
+        ScannedFile(
+            url: URL(fileURLWithPath: path),
+            size: LargeOldFilesScanner.sizeThresholdBytes + 1,
+            lastAccessDate: referenceNow.addingTimeInterval(-3_600),
+            lastModifiedDate: nil,
+            category: .largeFile
+        )
+    }
+
+    /// Runs the scanner over a `FakeFileScanner` emitting `emitted`, returning
+    /// the matched files.
+    private func scanEmitting(_ emitted: [ScannedFile]) async throws -> [ScannedFile] {
+        let scanner = LargeOldFilesScanner(
+            fileScanner: FakeFileScanner(emitted: emitted),
+            pathProvider: StubUserFilesPathProvider(roots: [tempRoot]),
+            now: { self.referenceNow }
+        )
+        return try await scanner.scan(excluding: [])
     }
 
     private func createSparseFile(at url: URL, size: Int64) throws {

--- a/VaderCleanerTests/LargeOldFilesSummaryTests.swift
+++ b/VaderCleanerTests/LargeOldFilesSummaryTests.swift
@@ -1,0 +1,90 @@
+// LargeOldFilesSummaryTests.swift
+// Tests the pure header-summary strings the Large & Old Files results screen shows above its list — file count headline and the "older than 6 months · total" detail.
+
+import XCTest
+@testable import VaderCleaner
+
+final class LargeOldFilesSummaryTests: XCTestCase {
+
+    // MARK: - Headline
+
+    /// The headline is the bare file count, pluralized — the list's primary
+    /// "here's what the scan found" line.
+    func test_headline_pluralizesFileCount() {
+        XCTAssertEqual(LargeOldFilesSummary.headline(for: makeFiles(count: 3)), "3 files")
+    }
+
+    /// A single result must read "1 file", not "1 files".
+    func test_headline_singularForOneFile() {
+        XCTAssertEqual(LargeOldFilesSummary.headline(for: makeFiles(count: 1)), "1 file")
+    }
+
+    // MARK: - Found sentence
+
+    /// The dashboard headline is a full sentence carrying the file count,
+    /// echoing the Applications section's "We've found N apps" phrasing.
+    func test_foundSentence_carriesFileCount() {
+        let sentence = LargeOldFilesSummary.foundSentence(for: makeFiles(count: 51))
+        XCTAssertTrue(sentence.contains("51"), "Expected the file count, got \(sentence)")
+        XCTAssertTrue(sentence.contains("large or old files"),
+                      "Expected the Large & Old phrasing, got \(sentence)")
+    }
+
+    // MARK: - Detail
+
+    /// When some files qualified by age, the detail leads with the old-file
+    /// count and then the total reclaimable size, separated by a middle dot.
+    func test_detail_includesOldCountAndTotalSize() {
+        let files = [
+            makeFile(size: 1_000, category: .largeFile),
+            makeFile(size: 2_000, category: .oldFile),
+            makeFile(size: 3_000, category: .oldFile)
+        ]
+        let detail = LargeOldFilesSummary.detail(for: files)
+        XCTAssertTrue(detail.contains("2 older than 6 months"),
+                      "Expected the old-file count, got \(detail)")
+        XCTAssertTrue(detail.contains("·"),
+                      "Expected a middle-dot separator, got \(detail)")
+        XCTAssertTrue(detail.contains("total"),
+                      "Expected the total-size clause, got \(detail)")
+    }
+
+    /// With no age-qualified files the old-file clause is dropped entirely —
+    /// the detail is just the total size so the line never reads
+    /// "0 older than 6 months".
+    func test_detail_dropsOldClauseWhenNoneQualify() {
+        let files = [
+            makeFile(size: 1_000, category: .largeFile),
+            makeFile(size: 2_000, category: .largeFile)
+        ]
+        let detail = LargeOldFilesSummary.detail(for: files)
+        XCTAssertFalse(detail.contains("older than"),
+                       "Expected no old-file clause, got \(detail)")
+        XCTAssertTrue(detail.contains("total"),
+                      "Expected the total-size clause, got \(detail)")
+    }
+
+    /// A single old file reads "1 older than 6 months", not "1 older…s".
+    func test_detail_singularOldFile() {
+        let files = [makeFile(size: 1_000, category: .oldFile)]
+        let detail = LargeOldFilesSummary.detail(for: files)
+        XCTAssertTrue(detail.contains("1 older than 6 months"),
+                      "Expected singular old-file phrasing, got \(detail)")
+    }
+
+    // MARK: - Helpers
+
+    private func makeFiles(count: Int) -> [ScannedFile] {
+        (0..<count).map { _ in makeFile(size: 1_000, category: .largeFile) }
+    }
+
+    private func makeFile(size: Int64, category: ScanCategory) -> ScannedFile {
+        ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/large-old-summary/\(UUID().uuidString)"),
+            size: size,
+            lastAccessDate: nil,
+            lastModifiedDate: nil,
+            category: category
+        )
+    }
+}

--- a/VaderCleanerTests/LargeOldFilesViewModelTests.swift
+++ b/VaderCleanerTests/LargeOldFilesViewModelTests.swift
@@ -218,6 +218,89 @@ final class LargeOldFilesViewModelTests: XCTestCase {
         XCTAssertEqual(vm.displayedFiles.map(\.url), [b.url])
     }
 
+    // MARK: - Dashboard tiles
+
+    /// A successful scan precomputes the dashboard tiles so the view never has
+    /// to re-run the grouping on a render — the fix for the post-scan beach
+    /// ball on large result sets.
+    func test_scan_populatesDisplayedTiles() async {
+        let files = [
+            makeFile(name: "clip.mov", size: 200, accessDaysAgo: 10, category: .largeFile),
+            makeFile(name: "report.pdf", size: 100, accessDaysAgo: 10, category: .largeFile)
+        ]
+        let vm = makeViewModel(scanner: { files })
+
+        await vm.scan()
+
+        XCTAssertTrue(vm.displayedTiles.contains { $0.category == .videos })
+        XCTAssertTrue(vm.displayedTiles.contains { $0.category == .other })
+    }
+
+    /// Deleting files refreshes the cached tiles so a category that loses all
+    /// its files drops off the dashboard.
+    func test_deleteSelected_refreshesDisplayedTiles() async {
+        let video = makeFile(name: "clip.mov", size: 200, accessDaysAgo: 10, category: .largeFile)
+        let doc = makeFile(name: "report.pdf", size: 100, accessDaysAgo: 10, category: .largeFile)
+        let vm = makeViewModel(scanner: { [video, doc] }, deleter: { Set($0) })
+        await vm.scan()
+        XCTAssertTrue(vm.displayedTiles.contains { $0.category == .videos })
+
+        vm.toggleSelection(video)
+        await vm.deleteSelected()
+
+        XCTAssertFalse(vm.displayedTiles.contains { $0.category == .videos },
+                       "The Videos tile must disappear once its only file is deleted")
+    }
+
+    /// Re-scanning clears the cached tiles so a stale dashboard never flashes
+    /// before the next results land.
+    func test_scanAgain_clearsDisplayedTiles() async {
+        let vm = makeViewModel(scanner: {
+            [self.makeFile(name: "clip.mov", size: 200, accessDaysAgo: 10, category: .largeFile)]
+        })
+        await vm.scan()
+        XCTAssertFalse(vm.displayedTiles.isEmpty)
+
+        vm.scanAgain()
+
+        XCTAssertTrue(vm.displayedTiles.isEmpty)
+    }
+
+    // MARK: - Precomputed summary
+
+    /// The full-set aggregates the dashboard/header read are computed once at
+    /// scan time, not derived from `displayedFiles` on every render — the fix
+    /// for the slow Back navigation.
+    func test_scan_precomputesDisplayedSummary() async {
+        let files = [
+            makeFile(name: "a.bin", size: 100, accessDaysAgo: 10, category: .largeFile),
+            makeFile(name: "b.bin", size: 250, accessDaysAgo: 400, category: .oldFile)
+        ]
+        let vm = makeViewModel(scanner: { files })
+
+        await vm.scan()
+
+        XCTAssertEqual(vm.displayedTotalBytes, 350)
+        XCTAssertEqual(vm.displayedOldCount, 1)
+    }
+
+    /// Deleting files refreshes the precomputed aggregates so the header stays
+    /// truthful without re-scanning the survivors on render.
+    func test_delete_refreshesDisplayedSummary() async {
+        let old = makeFile(name: "old.bin", size: 250, accessDaysAgo: 400, category: .oldFile)
+        let large = makeFile(name: "big.bin", size: 100, accessDaysAgo: 10, category: .largeFile)
+        let vm = makeViewModel(scanner: { [old, large] }, deleter: { Set($0) })
+        await vm.scan()
+        XCTAssertEqual(vm.displayedTotalBytes, 350)
+        XCTAssertEqual(vm.displayedOldCount, 1)
+
+        vm.toggleSelection(old)
+        await vm.deleteSelected()
+
+        XCTAssertEqual(vm.displayedTotalBytes, 100)
+        XCTAssertEqual(vm.displayedOldCount, 0)
+    }
+
     // MARK: - Icon cache
 
     /// Files that share an extension should share one cached NSWorkspace

--- a/VaderCleanerUITests/FinalPolishUITests.swift
+++ b/VaderCleanerUITests/FinalPolishUITests.swift
@@ -224,10 +224,12 @@ final class FinalPolishUITests: XCTestCase {
 
         // Prefer a terminal state; allow a generous window for the walk.
         // One combined query so an early empty/failed state short-circuits
-        // instead of blocking the full timeout waiting only for the table.
+        // instead of blocking the full timeout waiting only for the dashboard.
+        // A successful scan now lands on the category dashboard (`large-old.dashboard`),
+        // which drills into the file list — so the dashboard is the results terminal.
         let terminal = app.descendants(matching: .any)
             .matching(NSPredicate(
-                format: "identifier IN {'large-old.table', 'large-old.emptyTitle', 'large-old.errorMessage'}"
+                format: "identifier IN {'large-old.dashboard', 'large-old.emptyTitle', 'large-old.errorMessage'}"
             ))
             .firstMatch
         if terminal.waitForExistence(timeout: 120) {
@@ -239,7 +241,7 @@ final class FinalPolishUITests: XCTestCase {
         let scanning = app.descendants(matching: .any)["large-old.scanning"]
         XCTAssertTrue(
             scanning.exists,
-            "Expected Large & Old Files to reach the table, empty, failed, or scanning state after a scan"
+            "Expected Large & Old Files to reach the dashboard, empty, failed, or scanning state after a scan"
         )
     }
 


### PR DESCRIPTION
## Overview

Reworks the **Large & Old Files** section from a single raw SwiftUI `Table` into the app's house dashboard pattern, and fixes the data-quality and performance issues that surfaced while doing it. All work is scoped to this section.

## What changed

### UI / UX
- **Drop the raw `Table`** — it was the only one in the app and painted opaque, accent-tinted selection/alternating bands over the branded gradient. Replaced with the **List-of-glass-rows** pattern every other section uses.
- **Category dashboard after a scan** — results now land on a grid of tiles (Videos, Archives & Disk Images, Old Files, Largest Files, Other Large Files), mirroring the Applications/Optimization dashboards. Each tile's **Review** drills into that category's filtered list behind a Back bar.
- **Health Monitor-style layout (no scroll view)** — a tall hero plus a shorter secondary card in the left column, with the remaining tiles dividing the right column into equal-height rows, so the tiles vary in size and fill the pane.
- **Centered header** — "We've found N large or old files on your Mac." with **View All Files** (the complete unfiltered list) and **Re-scan**, echoing the Applications header.

### Correctness
- **Exclude app-managed virtual disk images** (`Docker.raw`, `*.utm`, `*.sparsebundle`, `*.vmdk`, …) from the scan. These are sparse — a `Docker.raw` reported a phantom **2 TB** logical size that dominated the tiles and total — and deleting one destroys the owning app's data. `.raw` is gated by container/VM path so genuine **camera RAW photos are still surfaced**.

### Performance
- **Cache tiles + the full-set summary in the view model**, computed once per scan/delete instead of on every render (was causing a post-scan beach ball).
- **Store each tile's `count`/`totalBytes`/`oldCount` at construction** instead of recomputing `reduce()` on every read — the root cause of the slow **Back** navigation, since the hero tile holds ~565k files and the dashboard reads `totalBytes` many times per render.
- **Cap the drill-down list to the top 1,000 rows** (by the active sort) with a truncation note, so opening Review/View All on a ~635k-file category no longer freezes building a `ForEach` over the whole set.

## Testing
- New unit tests: categorizer grouping, summary strings, virtual-disk exclusion (incl. camera-`.raw` is kept), and the precomputed view-model aggregates.
- Updated the UI test terminal state from `large-old.table` to the new `large-old.dashboard`.
- **Full suite: 1058 tests, 0 failures.**

## Reviewer notes
- **Verified via build + unit tests only** — the on-screen behavior (grid rendering, drill-down speed) was not visually confirmed from this environment; worth a manual pass.
- The drill-down list cap is intentional (1,000 rows by current sort) since a 635k-row `List` isn't usable or performant; the header still shows the true totals.
- VM/disk-image exclusion is scoped to the Large & Old Files scan only; System Junk is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard view with category tiles to organize large and old files (Videos, Archives, Large, Old, Other)
  * Added drill-down navigation to review files by specific category
  * Virtual disk images are now excluded from scan results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->