### PR TITLE
Redesign System Junk into a category dashboard

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		382B47D59D79102AC6DFDEC0 /* PrivacyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3913693728FE2B649B6A308F /* PrivacyUITests.swift */; };
 		390C48318F77FFB4378A7CBF /* MalwareViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */; };
 		3953A87FF8EF36CDB485809F /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */; };
+		3953FD2FDE6C5D300EE97BED /* SystemJunkDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2605C9D00F82838A6A9D11A3 /* SystemJunkDashboardSubviews.swift */; };
 		3A0AAEEE22026F9D96D875B2 /* PrivacyCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3BF28B70DA58E43E441AFF /* PrivacyCategory.swift */; };
 		3A3C0E7B444AE96C4C2D1C8F /* HealthMonitorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF079C62CE2E7C5C9B2B7C2C /* HealthMonitorViewModel.swift */; };
 		3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */; };
@@ -376,6 +377,7 @@
 		22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateCheckerTests.swift; sourceTree = "<group>"; };
 		232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdater.swift; sourceTree = "<group>"; };
 		25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecisionTests.swift; sourceTree = "<group>"; };
+		2605C9D00F82838A6A9D11A3 /* SystemJunkDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDashboardSubviews.swift; sourceTree = "<group>"; };
 		2617BC26104D5196DEDB3589 /* UpdateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfo.swift; sourceTree = "<group>"; };
 		27F1DC062C52C51730548216 /* LoginItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItem.swift; sourceTree = "<group>"; };
 		2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModelTests.swift; sourceTree = "<group>"; };
@@ -804,6 +806,7 @@
 				CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */,
 				44D42C1D0E2A41D26EF168F1 /* SunburstLayout.swift */,
 				7E22C1BDB2BEFB0F5CF93927 /* SunburstView.swift */,
+				2605C9D00F82838A6A9D11A3 /* SystemJunkDashboardSubviews.swift */,
 				16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */,
 				9D7CECF29BA2A62749F36062 /* SystemJunkScanner.swift */,
 				A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */,
@@ -1452,6 +1455,7 @@
 				B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */,
 				948B522FF71E5F5417EC78E6 /* SunburstLayout.swift in Sources */,
 				486889584CC330C197D3641C /* SunburstView.swift in Sources */,
+				3953FD2FDE6C5D300EE97BED /* SystemJunkDashboardSubviews.swift in Sources */,
 				1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */,
 				DAFC4468D2644AE325EB44C7 /* SystemJunkScanner.swift in Sources */,
 				B2DD51B5035C90CF963595C5 /* SystemJunkView.swift in Sources */,

--- a/VaderCleaner/SystemJunkDashboardSubviews.swift
+++ b/VaderCleaner/SystemJunkDashboardSubviews.swift
@@ -1,0 +1,515 @@
+// SystemJunkDashboardSubviews.swift
+// Category dashboard, tiles, and per-file review screens for the System Junk section — mirrors the Large & Old Files dashboard so the two sections share one look.
+
+import SwiftUI
+import AppKit
+
+// MARK: - Formatting
+
+enum SystemJunkFormatting {
+    /// Shared file-size formatter for the dashboard tiles, review header, rows,
+    /// and footer. Constructed once because `ByteCountFormatter` allocates
+    /// measurable internal state per instance.
+    static let byteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
+
+    /// Accessibility label for a review row's selection checkbox.
+    static func selectionLabel(for file: ScannedFile) -> String {
+        let format = String(
+            localized: "Select %@",
+            comment: "Accessibility label for selecting a file in the System Junk review list."
+        )
+        return String.localizedStringWithFormat(format, file.url.lastPathComponent)
+    }
+}
+
+// MARK: - Tile presentation
+
+/// View-layer presentation metadata for the junk categories — the SF Symbol and
+/// one-line descriptor each tile shows. Kept here rather than on the persisted
+/// `ScanCategory` domain enum so the stable codable cases stay free of UI copy.
+/// `largeFile` / `oldFile` never appear in a System Junk scan (they belong to
+/// the Large & Old Files section), so they get a neutral fallback.
+extension ScanCategory {
+    var systemJunkIcon: String {
+        switch self {
+        case .systemCache:     return "internaldrive"
+        case .userCache:       return "person.crop.circle"
+        case .systemLogs:      return "doc.text.magnifyingglass"
+        case .userLogs:        return "doc.text"
+        case .languageFiles:   return "globe"
+        case .mailAttachments: return "paperclip"
+        case .iosBackups:      return "iphone"
+        case .trash:           return "trash"
+        case .largeFile, .oldFile: return "doc"
+        }
+    }
+
+    var systemJunkBlurb: String {
+        switch self {
+        case .systemCache:
+            return String(localized: "Rebuildable caches written by macOS.",
+                          comment: "System Junk System Caches tile detail line.")
+        case .userCache:
+            return String(localized: "Temporary files your apps can recreate.",
+                          comment: "System Junk User Caches tile detail line.")
+        case .systemLogs:
+            return String(localized: "Diagnostic logs written by the system.",
+                          comment: "System Junk System Logs tile detail line.")
+        case .userLogs:
+            return String(localized: "Diagnostic logs written by your apps.",
+                          comment: "System Junk User Logs tile detail line.")
+        case .languageFiles:
+            return String(localized: "Unused localizations bundled with apps.",
+                          comment: "System Junk Language Files tile detail line.")
+        case .mailAttachments:
+            return String(localized: "Downloaded copies of Mail attachments.",
+                          comment: "System Junk Mail Attachments tile detail line.")
+        case .iosBackups:
+            return String(localized: "Old iPhone and iPad backups.",
+                          comment: "System Junk iOS Backups tile detail line.")
+        case .trash:
+            return String(localized: "Items already in the Trash.",
+                          comment: "System Junk Trash tile detail line.")
+        case .largeFile, .oldFile:
+            return String(localized: "Removable files found on disk.",
+                          comment: "System Junk fallback tile detail line.")
+        }
+    }
+}
+
+/// One dashboard tile: a category and the files that fall under it. The size is
+/// taken from the scan result's precomputed `sizeByCategory` so the tile never
+/// re-sums the files on construction.
+struct SystemJunkTile: Identifiable, Equatable {
+    let category: ScanCategory
+    let files: [ScannedFile]
+    let count: Int
+    let totalBytes: Int64
+
+    var id: String { category.rawValue }
+
+    init(category: ScanCategory, files: [ScannedFile], totalBytes: Int64) {
+        self.category = category
+        self.files = files
+        self.count = files.count
+        self.totalBytes = totalBytes
+    }
+
+    /// One tile per category present in `result`, heaviest first so the caller
+    /// can promote the first to a hero card. Categories with no findings are
+    /// absent from `itemsByCategory`, so they never produce a tile.
+    static func tiles(from result: ScanResult) -> [SystemJunkTile] {
+        ScanCategory.allCases
+            .compactMap { category in
+                guard let files = result.itemsByCategory[category] else { return nil }
+                return SystemJunkTile(
+                    category: category,
+                    files: files,
+                    totalBytes: result.sizeByCategory[category] ?? 0
+                )
+            }
+            .sorted { $0.totalBytes > $1.totalBytes }
+    }
+}
+
+// MARK: - Dashboard
+
+/// Post-scan landing surface for System Junk: a summary header and a grid of
+/// category tiles. Modelled on `LargeOldFilesDashboardView` — the whole surface
+/// fills the detail pane without a scroll view: the heaviest category is a tall
+/// hero in a fixed-width left column, and the remaining tiles divide the right
+/// column's height into equal rows. Each tile's Review button drills into that
+/// category's file list.
+struct SystemJunkDashboardView: View {
+    let totalBytes: Int64
+    let itemCount: Int
+    let tiles: [SystemJunkTile]
+    let onReview: (ScanCategory) -> Void
+    /// Opens the complete, unfiltered file list — the analog of the Large & Old
+    /// Files section's "View All Files".
+    let onViewAll: () -> Void
+    let onRescan: () -> Void
+
+    /// Fixed width of the hero column so it keeps a stable shape while the right
+    /// tiles absorb the remaining width — mirrors `LargeOldFilesDashboardView`.
+    private let leftColumnWidth: CGFloat = 340
+
+    var body: some View {
+        VStack(spacing: 16) {
+            header
+            cardLayout
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("system-junk.dashboard")
+    }
+
+    /// Centred size headline with the two primary actions beneath it, echoing
+    /// the Large & Old Files dashboard header.
+    private var header: some View {
+        VStack(spacing: 12) {
+            Text(headline)
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("system-junk.summary")
+            Text(detail)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            HStack(spacing: 12) {
+                Button(String(
+                    localized: "View All Files",
+                    comment: "Button that opens the complete, unfiltered System Junk file list."
+                )) {
+                    onViewAll()
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("system-junk.viewAll")
+
+                Button(String(
+                    localized: "Re-scan",
+                    comment: "Button that re-runs the System Junk scan from the dashboard."
+                )) {
+                    onRescan()
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("system-junk.rescan")
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var headline: String {
+        let size = SystemJunkFormatting.byteFormatter.string(fromByteCount: totalBytes)
+        let format = String(
+            localized: "We've found %@ of removable junk on your Mac.",
+            comment: "System Junk dashboard headline; %@ is the total reclaimable size."
+        )
+        return String.localizedStringWithFormat(format, size)
+    }
+
+    private var detail: String {
+        let format = String(
+            localized: "%1$lld items across %2$lld categories.",
+            comment: "System Junk dashboard detail; %1$lld is the item count, %2$lld the category count."
+        )
+        return String.localizedStringWithFormat(format, Int64(itemCount), Int64(tiles.count))
+    }
+
+    /// The Large & Old Files layout: a tall hero in the left column with a
+    /// shorter secondary card tucked beneath it, and the remaining tiles
+    /// dividing the right column into equal-height rows of two. Lower tile
+    /// counts degrade gracefully so the pane never shows an orphaned hero beside
+    /// empty space.
+    @ViewBuilder
+    private var cardLayout: some View {
+        switch tiles.count {
+        case 0:
+            EmptyView()
+        case 1:
+            card(tiles[0], isHero: true)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case 2:
+            HStack(alignment: .top, spacing: 16) {
+                card(tiles[0], isHero: true)
+                    .frame(width: leftColumnWidth)
+                    .frame(maxHeight: .infinity)
+                card(tiles[1], isHero: false)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        default:
+            HStack(alignment: .top, spacing: 16) {
+                leftColumn
+                rightGrid(gridTiles)
+            }
+        }
+    }
+
+    /// The hero plus the compact secondary card. The hero stretches to fill the
+    /// column height while the secondary keeps its natural (shorter) height, so
+    /// the two read as clearly different sizes.
+    private var leftColumn: some View {
+        VStack(spacing: 16) {
+            card(tiles[0], isHero: true)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            if let secondaryTile {
+                card(secondaryTile, isHero: false)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(width: leftColumnWidth)
+    }
+
+    /// The non-hero tiles, excluding the one promoted to the compact left card.
+    private var nonHeroTiles: [SystemJunkTile] { Array(tiles.dropFirst()) }
+
+    /// The smallest non-hero category by reclaimable size becomes the compact
+    /// card under the hero — a small tile for a small bucket.
+    private var secondaryTile: SystemJunkTile? {
+        nonHeroTiles.min { $0.totalBytes < $1.totalBytes }
+    }
+
+    /// What flows through the right grid: every non-hero tile except the one
+    /// shown as the compact left card.
+    private var gridTiles: [SystemJunkTile] {
+        nonHeroTiles.filter { $0.id != secondaryTile?.id }
+    }
+
+    /// The non-hero tiles in equal-height rows of two. Grouped in a
+    /// `GlassEffectContainer` so adjacent glass cards sample each other and
+    /// refract consistently, exactly as the Large & Old Files grid does.
+    private func rightGrid(_ gridTiles: [SystemJunkTile]) -> some View {
+        GlassEffectContainer(spacing: 16) {
+            VStack(spacing: 16) {
+                ForEach(Array(rows(of: gridTiles).enumerated()), id: \.offset) { _, row in
+                    HStack(spacing: 16) {
+                        ForEach(row) { tile in
+                            card(tile, isHero: false)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Chunks the grid tiles into rows of at most two so the right column reads
+    /// as a two-up grid that fills the height.
+    private func rows(of gridTiles: [SystemJunkTile]) -> [[SystemJunkTile]] {
+        stride(from: 0, to: gridTiles.count, by: 2).map {
+            Array(gridTiles[$0..<min($0 + 2, gridTiles.count)])
+        }
+    }
+
+    private func card(_ tile: SystemJunkTile, isHero: Bool) -> some View {
+        ApplicationsCard(
+            title: tile.category.displayName,
+            metric: SystemJunkFormatting.byteFormatter.string(fromByteCount: tile.totalBytes),
+            detail: cardDetail(for: tile),
+            icon: tile.category.systemJunkIcon,
+            actionLabel: String(
+                localized: "Review",
+                comment: "System Junk tile action that opens the category's file list."
+            ),
+            identifier: "system-junk.card.\(tile.category.rawValue)",
+            isHero: isHero,
+            action: { onReview(tile.category) }
+        )
+    }
+
+    private func cardDetail(for tile: SystemJunkTile) -> String {
+        let count = "\(tile.count) item\(tile.count == 1 ? "" : "s")"
+        return "\(count) · \(tile.category.systemJunkBlurb)"
+    }
+}
+
+// MARK: - Review
+
+/// A drill-down's file list: a count header, the per-file selectable list, and a
+/// footer with Re-scan and Clean. Mirrors `LargeOldFilesResultsContent` — the
+/// rendered rows are capped so a category with very many files doesn't freeze the
+/// drill-down building identity for the whole collection up front.
+struct SystemJunkReviewContent: View {
+    let files: [ScannedFile]
+    /// Summed size of every file in this drill-down, for the header.
+    let totalBytes: Int64
+    let totalSelectedSize: Int64
+    let canClean: Bool
+    var fileIconCache: FileIconCache
+    let isSelected: (ScannedFile) -> Bool
+    let onToggleSelection: (ScannedFile) -> Void
+    let onRescan: () -> Void
+    let onClean: () -> Void
+
+    /// Most rows we render at once. The selection set still spans the full file
+    /// list; only the rendered rows are bounded.
+    static let displayRowLimit = 1_000
+
+    var body: some View {
+        let shown = files.count > Self.displayRowLimit
+            ? Array(files.prefix(Self.displayRowLimit))
+            : files
+
+        VStack(spacing: 0) {
+            SystemJunkReviewHeader(fileCount: files.count, totalBytes: totalBytes)
+            Divider()
+            if files.count > shown.count {
+                truncationNote(showing: shown.count, total: files.count)
+                Divider()
+            }
+            SystemJunkReviewList(
+                files: shown,
+                fileIconCache: fileIconCache,
+                isSelected: isSelected,
+                onToggleSelection: onToggleSelection
+            )
+            Divider()
+            SystemJunkReviewFooter(
+                totalSelectedSize: totalSelectedSize,
+                canClean: canClean,
+                onRescan: onRescan,
+                onClean: onClean
+            )
+        }
+        // Key the preload on the bounded slice so it stays cheap.
+        .task(id: shown) {
+            await fileIconCache.preloadIcons(for: shown.map(\.url))
+        }
+    }
+
+    /// Inline note explaining the list is showing only the top slice of a very
+    /// large result set.
+    private func truncationNote(showing: Int, total: Int) -> some View {
+        let format = String(
+            localized: "Showing the top %1$lld of %2$lld files. Clean these and re-scan to see more.",
+            comment: "Note shown when the System Junk review list is capped; %1$lld is the shown count, %2$lld the total."
+        )
+        return HStack(spacing: 6) {
+            Image(systemName: "info.circle")
+            Text(String.localizedStringWithFormat(format, Int64(showing), Int64(total)))
+            Spacer(minLength: 0)
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+}
+
+/// Header bar above the review list: a file-count headline with the reclaimable
+/// total beneath it.
+struct SystemJunkReviewHeader: View {
+    let fileCount: Int
+    let totalBytes: Int64
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(fileCount) file\(fileCount == 1 ? "" : "s")")
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("system-junk.reviewSummary")
+                Text(SystemJunkFormatting.byteFormatter.string(fromByteCount: totalBytes) + " total")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}
+
+/// The review files as a `List` of glass rows — the same pattern every other
+/// section uses. `scrollContentBackground` is hidden so the branded gradient
+/// shows through.
+struct SystemJunkReviewList: View {
+    let files: [ScannedFile]
+    var fileIconCache: FileIconCache
+    let isSelected: (ScannedFile) -> Bool
+    let onToggleSelection: (ScannedFile) -> Void
+
+    var body: some View {
+        List {
+            ForEach(files) { file in
+                SystemJunkReviewRow(
+                    file: file,
+                    fileIconCache: fileIconCache,
+                    isSelected: isSelected(file),
+                    onToggleSelection: { onToggleSelection(file) }
+                )
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .accessibilityIdentifier("system-junk.table")
+    }
+}
+
+/// One file in the review list: selection checkbox, type icon, name, the
+/// containing folder, and the size as a bold trailing metric.
+struct SystemJunkReviewRow: View {
+    let file: ScannedFile
+    var fileIconCache: FileIconCache
+    let isSelected: Bool
+    let onToggleSelection: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(
+                get: { isSelected },
+                set: { _ in onToggleSelection() }
+            ))
+            .toggleStyle(.checkbox)
+            .labelsHidden()
+            .accessibilityLabel(Text(SystemJunkFormatting.selectionLabel(for: file)))
+            .accessibilityIdentifier("system-junk.row.\(file.url.path).checkbox")
+
+            Image(nsImage: fileIconCache.cachedIcon(for: file.url))
+                .resizable()
+                .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(file.url.lastPathComponent)
+                    .font(.body.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(file.url.deletingLastPathComponent().path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .help(file.url.path)
+            }
+
+            Spacer()
+
+            Text(SystemJunkFormatting.byteFormatter.string(fromByteCount: file.size))
+                .font(.callout.monospacedDigit().weight(.semibold))
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .accessibilityIdentifier("system-junk.row.\(file.url.path)")
+    }
+}
+
+/// Pinned footer with the running selection total, a Re-scan, and the prominent
+/// Clean action. Clean removes the whole current selection (which may span
+/// categories), mirroring the Large & Old Files "Delete Selected" footer.
+struct SystemJunkReviewFooter: View {
+    let totalSelectedSize: Int64
+    let canClean: Bool
+    let onRescan: () -> Void
+    let onClean: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Total selected")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(SystemJunkFormatting.byteFormatter.string(fromByteCount: totalSelectedSize))
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("system-junk.totalSelected")
+            }
+            Spacer()
+            Button("Re-scan", action: onRescan)
+                .accessibilityIdentifier("system-junk.rescan")
+            Button("Clean", action: onClean)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.vaderProminent)
+                .disabled(!canClean)
+                .accessibilityIdentifier("system-junk.clean")
+        }
+        .padding(16)
+    }
+}

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -19,6 +19,36 @@ struct SystemJunkView: View {
     private var viewModel: SystemJunkViewModel
     @Environment(AppState.self) private var appState
 
+    /// Shared icon cache so the review rows show each file's real type icon
+    /// instead of a generic glyph. Pre-loaded off the main thread by the review
+    /// content when it appears.
+    @State private var fileIconCache = FileIconCache()
+
+    /// What the user drilled into from the dashboard, or `nil` for the grid.
+    /// Held on the view (not the VM) because it is pure navigation state — the
+    /// same place `LargeOldFilesView` keeps its drill-down selection. Reset to
+    /// the dashboard at the start of every scan.
+    @State private var reviewing: ReviewTarget?
+
+    /// A drill-down destination: the complete list, or one category's slice.
+    private enum ReviewTarget: Equatable {
+        case all
+        case category(ScanCategory)
+
+        /// Title shown in the review screen's Back bar.
+        var title: String {
+            switch self {
+            case .all:
+                return String(
+                    localized: "All Junk Files",
+                    comment: "Back-bar title for the complete, unfiltered System Junk list."
+                )
+            case .category(let category):
+                return category.displayName
+            }
+        }
+    }
+
     init(viewModel: SystemJunkViewModel) {
         self.viewModel = viewModel
     }
@@ -50,6 +80,11 @@ struct SystemJunkView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle(NavigationSection.systemJunk.title)
+        .onChange(of: viewModel.phase) { _, newPhase in
+            // A fresh scan always lands back on the dashboard grid, never a
+            // stale drill-down from the previous run.
+            if case .scanning = newPhase { reviewing = nil }
+        }
     }
 
     // MARK: - States
@@ -77,68 +112,105 @@ struct SystemJunkView: View {
     private func previewState(result: ScanResult) -> some View {
         if result.items.isEmpty {
             // A scan that found nothing collapses to the dedicated empty
-            // subview — the regular preview list + disabled Clean footer
-            // reads as "you did something wrong" when the truth is "nothing
-            // qualified." The empty subview also carries the FDA reminder
-            // for the silent-failure case.
+            // subview — the dashboard + disabled Clean footer reads as "you
+            // did something wrong" when the truth is "nothing qualified." The
+            // empty subview also carries the FDA reminder for the
+            // silent-failure case.
             SystemJunkEmptyPreviewState(
                 onScanAgain: viewModel.scanAgain,
                 hasFullDiskAccess: appState.hasFullDiskAccess,
                 onRefreshAccess: { appState.refresh() }
             )
         } else {
-            VStack(spacing: 0) {
-                previewList(result: result)
-                Divider()
-                previewFooter
-            }
+            resultsContent(result: result)
         }
     }
 
-    private func previewList(result: ScanResult) -> some View {
-        let categories = ScanCategory.allCases.filter { result.itemsByCategory[$0] != nil }
-        return List {
-            ForEach(categories, id: \.self) { category in
-                CategoryRow(
-                    category: category,
-                    itemCount: result.itemsByCategory[category]?.count ?? 0,
-                    sizeBytes: result.sizeByCategory[category] ?? 0,
-                    isChecked: Binding(
-                        get: { viewModel.isChecked(category) },
-                        set: { _ in viewModel.toggle(category) }
-                    )
-                )
-                .accessibilityIdentifier("system-junk.row.\(category.rawValue)")
-            }
+    /// The results surface: the category dashboard, or one drill-down's file
+    /// list behind a Back bar. A drill-down whose files were all cleaned falls
+    /// back to the dashboard so the user is never stranded on an empty review.
+    @ViewBuilder
+    private func resultsContent(result: ScanResult) -> some View {
+        if let target = reviewing, !files(for: target, in: result).isEmpty {
+            reviewScreen(for: target, in: result)
+        } else {
+            // No scroll view: the dashboard fills the detail pane and divides
+            // the available height between the header and the tile grid, like
+            // the Large & Old Files section.
+            SystemJunkDashboardView(
+                totalBytes: result.totalSize,
+                itemCount: result.items.count,
+                tiles: SystemJunkTile.tiles(from: result),
+                onReview: { reviewing = .category($0) },
+                onViewAll: { reviewing = .all },
+                onRescan: viewModel.scanAgain
+            )
         }
-        .scrollContentBackground(.hidden)
     }
 
-    private var previewFooter: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Total selected")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(viewModel.formattedTotalSelectedSize)
-                    .font(.title3.weight(.semibold))
-                    .accessibilityIdentifier("system-junk.totalSelected")
+    /// A drill-down's file list, wrapped in a Back bar that returns to the
+    /// dashboard. Mirrors `LargeOldFilesView.reviewScreen`.
+    private func reviewScreen(for target: ReviewTarget, in result: ScanResult) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button {
+                    reviewing = nil
+                } label: {
+                    // HStack(Image, Text) rather than Label so the control
+                    // surfaces reliably in XCUITest.
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text(String(
+                            localized: "Back",
+                            comment: "Back button returning from a System Junk drill-down to the dashboard."
+                        ))
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("system-junk.backToDashboard")
+                Spacer()
+                Text(target.title)
+                    .font(.headline)
+                Spacer()
+                // Balances the leading Back button so the title stays centred.
+                Color.clear.frame(width: 44, height: 1)
             }
-            Spacer()
-            Button("Re-scan") {
-                viewModel.scanAgain()
-            }
-            .accessibilityIdentifier("system-junk.rescan")
-            Button("Clean") {
-                Task { await viewModel.clean() }
-            }
-            .controlSize(.large)
-            .keyboardShortcut(.defaultAction)
-            .buttonStyle(.vaderProminent)
-            .disabled(viewModel.totalSelectedSize == 0)
-            .accessibilityIdentifier("system-junk.clean")
+            .padding(16)
+            Divider()
+            SystemJunkReviewContent(
+                files: files(for: target, in: result),
+                totalBytes: totalBytes(for: target, in: result),
+                totalSelectedSize: viewModel.totalSelectedSize,
+                canClean: !viewModel.selectedURLs.isEmpty,
+                fileIconCache: fileIconCache,
+                isSelected: viewModel.isSelected,
+                onToggleSelection: viewModel.toggleSelection,
+                onRescan: viewModel.scanAgain,
+                onClean: { Task { await viewModel.clean() } }
+            )
         }
-        .padding(16)
+    }
+
+    /// The files for a drill-down. `.all` is the full result set; a category is
+    /// served straight from the result's per-category grouping.
+    private func files(for target: ReviewTarget, in result: ScanResult) -> [ScannedFile] {
+        switch target {
+        case .all:
+            return result.items
+        case .category(let category):
+            return result.itemsByCategory[category] ?? []
+        }
+    }
+
+    /// Summed size for a drill-down, read from the result's precomputed totals
+    /// so the header never re-sums the files on render.
+    private func totalBytes(for target: ReviewTarget, in result: ScanResult) -> Int64 {
+        switch target {
+        case .all:
+            return result.totalSize
+        case .category(let category):
+            return result.sizeByCategory[category] ?? 0
+        }
     }
 
     private func completeState(bytesFreed: Int64) -> some View {
@@ -185,11 +257,9 @@ struct SystemJunkView: View {
     // MARK: - Formatter
 
     /// Shared `ByteCountFormatter` for the "freed" summary on the complete
-    /// state and every per-category row. `fileprivate` (not `private`) so
-    /// the `CategoryRow` subview below can reuse the same instance instead
-    /// of allocating its own. Kept as a static so the allocation does not
-    /// happen inside the view body's expression evaluator on every redraw.
-    fileprivate static let byteFormatter: ByteCountFormatter = {
+    /// state. Kept as a static so the allocation does not happen inside the
+    /// view body's expression evaluator on every redraw.
+    private static let byteFormatter: ByteCountFormatter = {
         let f = ByteCountFormatter()
         f.allowedUnits = .useAll
         f.countStyle = .file
@@ -198,35 +268,6 @@ struct SystemJunkView: View {
 }
 
 // MARK: - Subviews
-
-/// Single row in the preview list. Bound to a checkbox `Toggle` whose
-/// `Binding` drives `SystemJunkViewModel.toggle(_:)` on changes.
-private struct CategoryRow: View {
-    let category: ScanCategory
-    let itemCount: Int
-    let sizeBytes: Int64
-    @Binding var isChecked: Bool
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Toggle("", isOn: $isChecked)
-                .toggleStyle(.checkbox)
-                .labelsHidden()
-            VStack(alignment: .leading, spacing: 2) {
-                Text(category.displayName)
-                    .font(.body.weight(.medium))
-                Text("\(itemCount) item\(itemCount == 1 ? "" : "s")")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-            Text(SystemJunkView.byteFormatter.string(fromByteCount: sizeBytes))
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 4)
-    }
-}
 
 /// Empty-result variant of the preview state. Surfaces when a scan returns
 /// zero items — without it, the user would land on the regular preview list

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -10,12 +10,13 @@ import os.log
 /// The view-model owns four pieces of state:
 ///   - `phase`: the current step in the state machine, bound to the view's
 ///     switch on rendered content.
-///   - `checkedCategories`: the user's per-category opt-in/out. Defaults to
-///     every category present in the latest scan result on each successful
-///     `scan()`, so users never have to "select all" before cleaning.
+///   - `selectedURLs`: the user's per-file opt-in/out. Defaults to every file
+///     present in the latest scan result on each successful `scan()`, so users
+///     never have to "select all" before cleaning — junk is safe to remove, so
+///     selection is opt-out, not opt-in.
 ///   - `result`: the most recent `ScanResult`. Held alongside `phase` so
-///     toggling a checkbox can recompute `totalSelectedSize` without re-
-///     scanning, and so `clean()` can pick the right items to delete.
+///     toggling a row can recompute `totalSelectedSize` without re-scanning,
+///     and so `clean()` can pick the right items to delete.
 ///   - `errorMessage`: the surfaced description for the `.failed` phase.
 ///
 /// All collaborators are injected as closures so unit tests can drive every
@@ -61,7 +62,17 @@ final class SystemJunkViewModel {
     typealias Deleter = ([ScannedFile]) async throws -> Int64
 
     private(set) var phase: Phase = .idle
-    private(set) var checkedCategories: Set<ScanCategory> = []
+
+    /// URLs of the files the user has selected for cleaning. Defaults to every
+    /// file in the latest scan on success (opt-out), and is cleared on
+    /// `scanAgain()`. The view binds each review row's checkbox to
+    /// `isSelected` + `toggleSelection`.
+    private(set) var selectedURLs: Set<URL> = []
+
+    /// Running total of bytes for files in `selectedURLs`. Maintained
+    /// incrementally on every `toggleSelection` so the footer label updates in
+    /// O(1) rather than walking the (potentially large) result on every read.
+    private(set) var totalSelectedSize: Int64 = 0
 
     /// Running count of filesystem items the in-flight scan has walked. Reset
     /// to 0 at the start of each scan and fed by the scanner's progress
@@ -91,32 +102,34 @@ final class SystemJunkViewModel {
 
     // MARK: - Public surface
 
-    /// Sum of bytes for every file in a currently-checked category. Computed
-    /// from `latestResult.sizeByCategory` (built once when the result lands)
-    /// rather than walking `items` per query, so a hot toggle doesn't burn
-    /// CPU on hundreds of thousands of file records.
-    var totalSelectedSize: Int64 {
-        guard let sizes = latestResult?.sizeByCategory else { return 0 }
-        return checkedCategories.reduce(into: Int64(0)) { acc, category in
-            acc += sizes[category] ?? 0
-        }
-    }
-
     /// Convenience for the view layer — formatting once on the VM keeps the
     /// "human-readable size" rule in one place across cards and totals.
     var formattedTotalSelectedSize: String {
         Self.byteFormatter.string(fromByteCount: totalSelectedSize)
     }
 
-    /// Whether `category` is currently checked. The view binds each row's
-    /// `Toggle` to `Binding(get:set:)` over `isChecked` + `toggle`.
-    func isChecked(_ category: ScanCategory) -> Bool {
-        checkedCategories.contains(category)
+    /// Whether `file` is currently selected. The view binds each review row's
+    /// `Toggle` to `Binding(get:set:)` over `isSelected` + `toggleSelection`.
+    func isSelected(_ file: ScannedFile) -> Bool {
+        selectedURLs.contains(file.url)
+    }
+
+    /// Flip the selection state for `file` and adjust `totalSelectedSize` in
+    /// lockstep. Idempotent in the sense that two calls in a row return the VM
+    /// to its prior selection.
+    func toggleSelection(_ file: ScannedFile) {
+        if selectedURLs.contains(file.url) {
+            selectedURLs.remove(file.url)
+            totalSelectedSize -= file.size
+        } else {
+            selectedURLs.insert(file.url)
+            totalSelectedSize += file.size
+        }
     }
 
     /// Run the injected scanner and land in `.preview` (or `.failed`).
-    /// Marks every category present in the result as checked so the user is
-    /// at "select all" by default.
+    /// Selects every file present in the result so the user is at "select all"
+    /// by default.
     func scan() async {
         scanGeneration &+= 1
         let generation = scanGeneration
@@ -140,21 +153,23 @@ final class SystemJunkViewModel {
                 }
             }
             self.latestResult = result
-            self.checkedCategories = Set(result.itemsByCategory.keys)
+            self.selectedURLs = Set(result.items.map(\.url))
+            self.totalSelectedSize = result.totalSize
             self.phase = .preview(result)
         } catch {
             log.error("System Junk scan failed: \(String(describing: error), privacy: .public)")
             self.latestResult = nil
-            self.checkedCategories = []
+            self.selectedURLs = []
+            self.totalSelectedSize = 0
             self.phase = .failed(stage: .scanning, message: error.localizedDescription)
         }
     }
 
-    /// Hand the injected deleter every file in a checked category and land
-    /// in `.complete(bytesFreed:)`. A no-op when no category is checked.
+    /// Hand the injected deleter every currently-selected file and land in
+    /// `.complete(bytesFreed:)`. A no-op when nothing is selected.
     func clean() async {
-        guard let result = latestResult, !checkedCategories.isEmpty else { return }
-        let toDelete = result.items.filter { checkedCategories.contains($0.category) }
+        guard let result = latestResult, !selectedURLs.isEmpty else { return }
+        let toDelete = result.items.filter { selectedURLs.contains($0.url) }
         guard !toDelete.isEmpty else { return }
 
         phase = .cleaning
@@ -167,22 +182,13 @@ final class SystemJunkViewModel {
         }
     }
 
-    /// Flip the checkbox state for `category`. Idempotent in the sense that
-    /// two calls in a row return the VM to its prior selection, by design.
-    func toggle(_ category: ScanCategory) {
-        if checkedCategories.contains(category) {
-            checkedCategories.remove(category)
-        } else {
-            checkedCategories.insert(category)
-        }
-    }
-
     /// Reset the VM to `.idle`, dropping the cached result and selection so
     /// the next scan starts from a clean slate. Called from the "Scan Again"
-    /// button on the complete state and the "Re-scan" button on preview.
+    /// button on the complete state and the "Re-scan" button on the dashboard.
     func scanAgain() {
         latestResult = nil
-        checkedCategories = []
+        selectedURLs = []
+        totalSelectedSize = 0
         scannedItemCount = 0
         phase = .idle
     }
@@ -254,8 +260,8 @@ extension SystemJunkViewModel: ScanCoordinating {
     func beginScan() {
         // `scan()` has no internal re-entrancy guard, so a double-tapped
         // unified Scan button could race two concurrent disk walks whose
-        // `latestResult` / `checkedCategories` writes interleave. Gate on
-        // the in-flight phases, mirroring `SmartScanViewModel.scan()`.
+        // `latestResult` / `selectedURLs` writes interleave. Gate on the
+        // in-flight phases, mirroring `SmartScanViewModel.scan()`.
         guard phase != .scanning, phase != .cleaning else { return }
         Task { await scan() }
     }

--- a/VaderCleanerTests/SystemJunkViewModelTests.swift
+++ b/VaderCleanerTests/SystemJunkViewModelTests.swift
@@ -16,7 +16,7 @@ final class SystemJunkViewModelTests: XCTestCase {
     func test_init_phaseIsIdle() {
         let vm = makeViewModel()
         XCTAssertEqual(vm.phase, .idle)
-        XCTAssertTrue(vm.checkedCategories.isEmpty)
+        XCTAssertTrue(vm.selectedURLs.isEmpty)
         XCTAssertEqual(vm.totalSelectedSize, 0)
     }
 
@@ -89,20 +89,24 @@ final class SystemJunkViewModelTests: XCTestCase {
         XCTFail("Timed out waiting for: \(message)", file: file, line: line)
     }
 
-    /// All categories present in the scan result must be checked by default —
-    /// the user opts out of categories rather than opting in, matching the
-    /// expectation set in the plan and how cleaner UIs typically work.
-    func test_scan_marksEveryCategoryCheckedByDefault() async {
+    /// Every file in the scan result must be selected by default — the user
+    /// opts out of files rather than opting in, matching how cleaner UIs treat
+    /// safe-to-remove junk (and the section's prior "all categories checked"
+    /// behaviour, now expressed per file).
+    func test_scan_selectsEveryFileByDefault() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 200, category: .systemLogs)
+        let c = makeFile(name: "c", size: 300, category: .trash)
         let result = makeResult(
-            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)]),
-            (.systemLogs, [makeFile(name: "b", size: 200, category: .systemLogs)]),
-            (.trash, [makeFile(name: "c", size: 300, category: .trash)])
+            (.userCache, [a]),
+            (.systemLogs, [b]),
+            (.trash, [c])
         )
         let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
 
         await vm.scan()
 
-        XCTAssertEqual(vm.checkedCategories, [.userCache, .systemLogs, .trash])
+        XCTAssertEqual(vm.selectedURLs, [a.url, b.url, c.url])
         XCTAssertEqual(vm.totalSelectedSize, 600)
     }
 
@@ -127,35 +131,36 @@ final class SystemJunkViewModelTests: XCTestCase {
 
     // MARK: - Selection
 
-    /// Toggling a category off must drop both the membership and its bytes
-    /// from `totalSelectedSize`. Toggling it back on must restore the total —
-    /// the selection state is purely additive, with no side-effects on the
+    /// Toggling a file off must drop both its URL and its bytes from
+    /// `totalSelectedSize`. Toggling it back on must restore the total — the
+    /// selection state is purely additive, with no side-effects on the
     /// underlying scan result.
-    func test_toggle_updatesCheckedCategoriesAndTotalSelectedSize() async {
+    func test_toggleSelection_updatesSelectedURLsAndTotalSelectedSize() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 250, category: .userLogs)
         let result = makeResult(
-            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)]),
-            (.userLogs,  [makeFile(name: "b", size: 250, category: .userLogs)])
+            (.userCache, [a]),
+            (.userLogs,  [b])
         )
         let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
         await vm.scan()
         XCTAssertEqual(vm.totalSelectedSize, 350)
 
-        vm.toggle(.userCache)
-        XCTAssertFalse(vm.checkedCategories.contains(.userCache))
+        vm.toggleSelection(a)
+        XCTAssertFalse(vm.selectedURLs.contains(a.url))
         XCTAssertEqual(vm.totalSelectedSize, 250)
 
-        vm.toggle(.userCache)
-        XCTAssertTrue(vm.checkedCategories.contains(.userCache))
+        vm.toggleSelection(a)
+        XCTAssertTrue(vm.selectedURLs.contains(a.url))
         XCTAssertEqual(vm.totalSelectedSize, 350)
     }
 
     // MARK: - Clean
 
-    /// `clean()` must hand the deleter only the files whose category is
-    /// currently checked. An unchecked category's files must not be passed
-    /// through — we cannot rely on the deleter to filter, the view-model owns
-    /// the contract.
-    func test_clean_invokesDeleterOnlyForCheckedCategories() async {
+    /// `clean()` must hand the deleter only the files that are currently
+    /// selected. A deselected file must not be passed through — we cannot rely
+    /// on the deleter to filter, the view-model owns the contract.
+    func test_clean_invokesDeleterOnlyForSelectedFiles() async {
         let userFile = makeFile(name: "a", size: 100, category: .userCache)
         let logFile  = makeFile(name: "b", size: 250, category: .userLogs)
         let result = makeResult(
@@ -172,11 +177,11 @@ final class SystemJunkViewModelTests: XCTestCase {
         )
 
         await vm.scan()
-        vm.toggle(.userLogs)  // uncheck user logs
+        vm.toggleSelection(logFile)  // deselect the log file
         await vm.clean()
 
         let received = await recorded.value
-        XCTAssertEqual(received, [userFile], "Deleter must receive only files in checked categories")
+        XCTAssertEqual(received, [userFile], "Deleter must receive only selected files")
     }
 
     /// After a successful clean, the phase becomes `.complete(bytesFreed)` so
@@ -222,13 +227,12 @@ final class SystemJunkViewModelTests: XCTestCase {
         }
     }
 
-    /// `clean()` is a no-op when nothing is checked — the View disables the
+    /// `clean()` is a no-op when nothing is selected — the View disables the
     /// button in this state, but the VM contract must hold even if a hot-key
     /// path or future caller bypasses the disabled state.
     func test_clean_withNoSelectionDoesNotInvokeDeleter() async {
-        let result = makeResult(
-            (.userCache, [makeFile(name: "a", size: 100, category: .userCache)])
-        )
+        let file = makeFile(name: "a", size: 100, category: .userCache)
+        let result = makeResult((.userCache, [file]))
         let invoked = ActorBox(false)
         let vm = makeViewModel(
             scanner: { result },
@@ -239,11 +243,11 @@ final class SystemJunkViewModelTests: XCTestCase {
         )
 
         await vm.scan()
-        vm.toggle(.userCache)  // now nothing is checked
+        vm.toggleSelection(file)  // now nothing is selected
         await vm.clean()
 
         let didInvoke = await invoked.value
-        XCTAssertFalse(didInvoke, "Deleter must not be called when no category is checked")
+        XCTAssertFalse(didInvoke, "Deleter must not be called when no file is selected")
     }
 
     // MARK: - Scan again
@@ -266,7 +270,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         vm.scanAgain()
 
         XCTAssertEqual(vm.phase, .idle)
-        XCTAssertTrue(vm.checkedCategories.isEmpty)
+        XCTAssertTrue(vm.selectedURLs.isEmpty)
     }
 
     // MARK: - Scan progress count

--- a/VaderCleanerUITests/SystemJunkUITests.swift
+++ b/VaderCleanerUITests/SystemJunkUITests.swift
@@ -23,11 +23,11 @@ final class SystemJunkUITests: XCTestCase {
         app = nil
     }
 
-    /// Sidebar → System Junk → Scan must reveal the preview UI. We accept any
-    /// of the preview-state identifiers (the totalSelected label, the Clean
-    /// button, or the Re-scan button) as evidence that the preview rendered,
-    /// so the test does not depend on the scan returning at least one result —
-    /// an empty Caches directory on a freshly imaged CI host must not flake.
+    /// Sidebar → System Junk → Scan must reveal the post-scan UI. We accept any
+    /// of the landing identifiers (the dashboard container, its Re-scan button,
+    /// or the empty-state Scan Again) as evidence that results rendered, so the
+    /// test does not depend on the scan returning at least one result — an empty
+    /// Caches directory on a freshly imaged CI host must not flake.
     func test_navigateToSystemJunk_andScan_revealsPreview() throws {
         // The Full Disk Access onboarding sheet may be in the way. Dismiss it
         // through "Continue Without Access" if present so the sidebar is
@@ -58,25 +58,24 @@ final class SystemJunkUITests: XCTestCase {
         scanButton.click()
         proceedPastScanAccessPopoverIfNeeded()
 
-        // The scan completes once we land on the preview footer (Total
-        // selected label / Clean button), or — if no junk files were found —
-        // the empty preview list still rendered. The System Junk scan walks
-        // the entire home directory and there is no mock mode (project
-        // policy forbids one), so on a large real home folder the terminal
-        // state may not arrive within a tight UI-test window; the in-progress
-        // `system-junk.scanning` indicator is then accepted as proof the
-        // sidebar → view-model → view wiring is alive, matching the rationale
-        // `FinalPolishUITests` (Large & Old Files) and `SpaceLensUITests`
-        // already use for the same unbounded walk. Scan correctness itself is
-        // covered exhaustively by `SystemJunkScannerTests` /
-        // `SystemJunkViewModelTests`.
-        // Match every identifier the preview footer always renders — the
-        // total-selected label, the Clean button, and the Re-scan button —
-        // so an empty scan (which still lands on `.preview` with that footer)
-        // is recognised as terminal, not a false failure.
+        // The scan completes once we land on the dashboard (its container or
+        // header Re-scan), or — if no junk files were found — the empty state
+        // rendered. The System Junk scan walks the entire home directory and
+        // there is no mock mode (project policy forbids one), so on a large real
+        // home folder the terminal state may not arrive within a tight UI-test
+        // window; the in-progress `system-junk.scanning` indicator is then
+        // accepted as proof the sidebar → view-model → view wiring is alive,
+        // matching the rationale `FinalPolishUITests` (Large & Old Files) and
+        // `SpaceLensUITests` already use for the same unbounded walk. Scan
+        // correctness itself is covered exhaustively by `SystemJunkScannerTests`
+        // / `SystemJunkViewModelTests`.
+        // Match the identifiers the post-scan surface always renders — the
+        // dashboard container, its Re-scan button, or the empty-state Scan Again
+        // — so an empty scan (which lands on the empty state) is recognised as
+        // terminal, not a false failure.
         let terminal = app.descendants(matching: .any)
             .matching(NSPredicate(
-                format: "identifier IN {'system-junk.totalSelected', 'system-junk.clean', 'system-junk.rescan'}"
+                format: "identifier IN {'system-junk.dashboard', 'system-junk.rescan', 'system-junk.emptyScanAgain'}"
             ))
             .firstMatch
         if terminal.waitForExistence(timeout: 120) {
@@ -119,12 +118,11 @@ final class SystemJunkUITests: XCTestCase {
         proceedPastScanAccessPopoverIfNeeded()
 
         // The section has left `.intro` once it shows any non-intro state:
-        // the in-progress scanning indicator, or the preview footer (which
-        // always renders the total-selected label, Clean, and Re-scan, even
-        // for an empty scan).
+        // the in-progress scanning indicator, the dashboard (container or its
+        // Re-scan button), or the empty-state Scan Again.
         let nonIntroPredicate = NSPredicate(format:
-            "identifier IN {'system-junk.scanning', 'system-junk.totalSelected', "
-            + "'system-junk.clean', 'system-junk.rescan'}")
+            "identifier IN {'system-junk.scanning', 'system-junk.dashboard', "
+            + "'system-junk.rescan', 'system-junk.emptyScanAgain'}")
         let nonIntroState = app.descendants(matching: .any)
             .matching(nonIntroPredicate).firstMatch
         XCTAssertTrue(


### PR DESCRIPTION
## What & why

System Junk was the last scan section still using the old flat layout — a `List` of category rows with checkboxes and a single Clean footer. Every other section (Applications, Large & Old Files) now lands on a **category dashboard**: a summary header with primary actions, a grid of category tiles each with a **Review** button, and per-item review drill-downs with selection + a clean/delete footer. This brings System Junk in line so the app reads consistently.

This mirrors the just-merged Large & Old Files redesign (#139).

## Changes

- **`SystemJunkView`** — post-scan surface is now a category dashboard (hero + tile grid) with **View All Files** / **Re-scan** in the header, and per-category **Review** drill-downs behind a **Back** bar. Removed the old `CategoryRow`, flat `previewList`, and `previewFooter`.
- **`SystemJunkDashboardSubviews.swift`** (new) — `SystemJunkTile` + builder, per-category icon/blurb presentation, `SystemJunkDashboardView` (reuses the shared `ApplicationsCard` and the hero/grid `GlassEffectContainer` layout), and the per-file `SystemJunkReviewContent` / list / row / footer.
- **`SystemJunkViewModel`** — swapped whole-category checkboxes for **per-file selection** (`selectedURLs`, `isSelected`, `toggleSelection`, incremental `totalSelectedSize`). Files are selected by default (opt-out — junk is safe to remove). The existing `.complete(bytesFreed:)` success flow and the privileged-helper `SystemJunkDeleter` are unchanged.

## Behavior notes for reviewers

- Cleaning granularity moved from **per-category** to **per-file**: the review lists let you deselect individual files, and **Clean** removes the current selection (which can span categories, mirroring Large & Old Files' "Delete Selected"). The old "deselect a whole category in one click" gesture is replaced by finer-grained control.
- Selection defaults to *everything selected* on each scan, preserving the prior opt-out semantics.
- Review lists cap rendered rows at 1,000 (selection still spans the full set), matching the Large & Old Files pattern.

## Testing

- `xcodegen generate` (new file registered via XcodeGen; no pbxproj hand-editing).
- Full unit suite: **1058 tests, 0 failures** (clean build, `CODE_SIGNING_ALLOWED=NO`). `SystemJunkViewModelTests` were retargeted to the per-file API (TDD).
- `build-for-testing` succeeds for the whole scheme incl. the UI test target. `SystemJunkUITests` terminal/non-intro anchors updated to the dashboard identifiers; the XCUITest runner can't be driven headlessly here, so please run those from Xcode and give the section a quick visual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added System Junk dashboard displaying junk categories with summary tiles.
  * Implemented file-level review interface allowing users to view and select individual files before cleaning.
  * Changed selection model from category-level to per-file selection with checkboxes.
  * Integrated Re-scan and View All Files actions into the dashboard.

* **Tests**
  * Updated unit and UI tests to reflect per-file selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->