### PR TITLE
Use the Smart Scan hero image in the Mac Health ring

### DIFF
--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -285,7 +285,7 @@ private struct MacHealthHero: View {
 
                 HealthRing(color: accent, isMeasuring: status == nil)
                     .frame(width: 140, height: 140)
-                    .overlay { laptop }
+                    .overlay { heroArt }
                     .accessibilityIdentifier("health.hero.ring")
             }
 
@@ -358,17 +358,13 @@ private struct MacHealthHero: View {
         }
     }
 
-    /// Laptop glyph centered inside the ring.
-    private var laptop: some View {
-        Image(systemName: "laptopcomputer")
-            .font(.system(size: 44, weight: .light))
-            .foregroundStyle(
-                LinearGradient(
-                    colors: [.white.opacity(0.95), sectionAccent.opacity(0.9)],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
+    /// The Smart Scan section's hero art centered inside the ring.
+    private var heroArt: some View {
+        Image("smartScan")
+            .resizable()
+            .interpolation(.high)
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 96, height: 96)
             .accessibilityHidden(true)
     }
 


### PR DESCRIPTION
## What changed

Replaced the `laptopcomputer` SF Symbol at the center of the Health Monitor hero ring with the Smart Scan section's main image — the `"smartScan"` asset (its `heroAssetName` in `SectionPresentation.swift`).

- Renamed the `laptop` computed property to `heroArt` and updated the `.overlay { heroArt }` call site in `HealthMonitorView.swift`.
- The image renders resizable + high-interpolation, aspect-fit at 96×96 inside the 140×140 ring (replacing the 44pt symbol and its gradient tint).

## Why

Ties the dashboard's focal health verdict to the app's primary scan section, giving the hero a richer, on-brand visual instead of a generic system glyph.

## Notes for reviewers

- Verified the change builds (`xcodebuild ... BUILD SUCCEEDED`). The rendered hero hasn't been screenshotted (no Screen Recording permission in this environment), so a quick visual check of the ring sizing (96×96) is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the health ring's center icon to display a "smart scan" image, replacing the previous laptop glyph for improved visual coherence with the health monitoring feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->