### PR TITLE
Add right pane title and description headers to Applications and My Clutter managers

### DIFF
--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -403,6 +403,71 @@ struct ApplicationsManagerView: View {
 
     // MARK: - Right pane
 
+    private var uninstallerRightPaneTitle: String {
+        switch uninstallerFacet {
+        case .all:              return String(localized: "All Applications", comment: "Uninstaller right pane title.")
+        case .unused:           return String(localized: "Unused", comment: "Uninstaller right pane title.")
+        case .suspicious:       return String(localized: "Suspicious", comment: "Uninstaller right pane title.")
+        case .selected:         return String(localized: "Selected", comment: "Uninstaller right pane title.")
+        case .store(true):      return String(localized: "App Store", comment: "Uninstaller right pane title.")
+        case .store(false):     return String(localized: "Other", comment: "Uninstaller right pane title.")
+        case .vendor(let v):    return v.title
+        }
+    }
+
+    private var uninstallerRightPaneDescription: String {
+        switch uninstallerFacet {
+        case .all:              return String(localized: "Every app installed on this Mac.", comment: "Uninstaller right pane description.")
+        case .unused:           return String(localized: "Apps you haven't opened recently.", comment: "Uninstaller right pane description.")
+        case .suspicious:       return String(localized: "Apps flagged as potentially unwanted.", comment: "Uninstaller right pane description.")
+        case .selected:         return String(localized: "Apps you've marked for removal.", comment: "Uninstaller right pane description.")
+        case .store(true):      return String(localized: "Apps installed from the Mac App Store.", comment: "Uninstaller right pane description.")
+        case .store(false):     return String(localized: "Apps installed outside the Mac App Store.", comment: "Uninstaller right pane description.")
+        case .vendor(let v):    return String(localized: "Apps from \(v.title).", comment: "Uninstaller right pane description for a vendor.")
+        }
+    }
+
+    private var updaterRightPaneTitle: String {
+        switch updaterFacet {
+        case .all:              return String(localized: "All Updates", comment: "Updater right pane title.")
+        case .selected:         return String(localized: "Selected", comment: "Updater right pane title.")
+        case .store(true):      return String(localized: "App Store", comment: "Updater right pane title.")
+        case .store(false):     return String(localized: "Other", comment: "Updater right pane title.")
+        }
+    }
+
+    private var updaterRightPaneDescription: String {
+        switch updaterFacet {
+        case .all:              return String(localized: "Apps with new versions available.", comment: "Updater right pane description.")
+        case .selected:         return String(localized: "Updates you've chosen to install.", comment: "Updater right pane description.")
+        case .store(true):      return String(localized: "Updates available through the Mac App Store.", comment: "Updater right pane description.")
+        case .store(false):     return String(localized: "Updates available from developer websites.", comment: "Updater right pane description.")
+        }
+    }
+
+    private var extensionsRightPaneTitle: String {
+        switch extensionsFacet {
+        case .all:              return String(localized: "All Extensions", comment: "Extensions right pane title.")
+        case .selected:         return String(localized: "Selected", comment: "Extensions right pane title.")
+        case .type(let t):      return localizedExtensionType(t)
+        }
+    }
+
+    private var extensionsRightPaneDescription: String {
+        switch extensionsFacet {
+        case .all:              return String(localized: "Every extension and plug-in installed on this Mac.", comment: "Extensions right pane description.")
+        case .selected:         return String(localized: "Extensions you've chosen to remove.", comment: "Extensions right pane description.")
+        case .type(let t):
+            switch t {
+            case .safariExtension:  return String(localized: "Extensions installed in Safari.", comment: "Safari extensions right pane description.")
+            case .chromeExtension:  return String(localized: "Extensions installed in Google Chrome.", comment: "Chrome extensions right pane description.")
+            case .firefoxExtension: return String(localized: "Extensions installed in Firefox.", comment: "Firefox extensions right pane description.")
+            case .mailPlugin:       return String(localized: "Plug-ins installed in the Mail app.", comment: "Mail plugins right pane description.")
+            case .internetPlugin:   return String(localized: "Legacy plug-ins used by web browsers.", comment: "Browser plug-ins right pane description.")
+            }
+        }
+    }
+
     @ViewBuilder
     private var rightPane: some View {
         switch pane {
@@ -412,12 +477,21 @@ struct ApplicationsManagerView: View {
             } else if uninstallerViewModel.apps.isEmpty, uninstallerViewModel.phase == .loading {
                 loadingPane
             } else {
-                uninstallerList
+                VStack(alignment: .leading, spacing: 0) {
+                    paneHeader(title: uninstallerRightPaneTitle, description: uninstallerRightPaneDescription)
+                    uninstallerList
+                }
             }
         case .updater:
-            updaterPane
+            VStack(alignment: .leading, spacing: 0) {
+                paneHeader(title: updaterRightPaneTitle, description: updaterRightPaneDescription)
+                updaterPane
+            }
         case .extensions:
-            extensionsPane
+            VStack(alignment: .leading, spacing: 0) {
+                paneHeader(title: extensionsRightPaneTitle, description: extensionsRightPaneDescription)
+                extensionsPane
+            }
         case .leftovers:
             leftoverList
         }

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -281,8 +281,72 @@ struct MyClutterManagerView: View {
 
     // MARK: - Right pane
 
+    private var rightPaneHeader: (title: String, description: String)? {
+        switch category {
+        case .largeOld:
+            switch largeOldFacet {
+            case .all:
+                return (
+                    String(localized: "All Files", comment: "Large & Old right pane title."),
+                    String(localized: "All large and old files detected on your Mac.", comment: "Large & Old right pane description.")
+                )
+            case .selected:
+                return (
+                    String(localized: "Selected", comment: "Large & Old right pane title."),
+                    String(localized: "Files you have marked for removal.", comment: "Large & Old right pane description.")
+                )
+            case .kind(let kind):
+                let desc: String
+                switch kind {
+                case .archives:
+                    desc = String(localized: "Compressed archives, disk images, and packages.", comment: "Archives right pane description.")
+                case .videos:
+                    desc = String(localized: "Video files taking up space on your Mac.", comment: "Videos right pane description.")
+                case .other:
+                    desc = String(localized: "Large or old files that are not videos or archives.", comment: "Other right pane description.")
+                }
+                return (kind.title, desc)
+            case .size(let bucket):
+                let desc: String
+                switch bucket {
+                case .huge:
+                    desc = String(localized: "Files larger than 5 GB.", comment: "Huge right pane description.")
+                case .average:
+                    desc = String(localized: "Files between 1 GB and 5 GB.", comment: "Average right pane description.")
+                case .small:
+                    desc = String(localized: "Files under 1 GB.", comment: "Small right pane description.")
+                }
+                return (bucket.title, desc)
+            }
+        case .duplicates:
+            let id = selectedGroupID ?? viewModel.duplicateGroups.first?.id
+            let title = viewModel.duplicateGroups.first(where: { $0.id == id })?.original.url.lastPathComponent
+                ?? String(localized: "Duplicates", comment: "Duplicates right pane fallback title.")
+            return (title, String(localized: "Identical copies stored in different places.", comment: "Duplicates right pane description."))
+        case .similar:
+            let id = selectedGroupID ?? viewModel.similarGroups.first?.id
+            let title = viewModel.similarGroups.first(where: { $0.id == id })?.original.url.lastPathComponent
+                ?? String(localized: "Similar Images", comment: "Similar right pane fallback title.")
+            return (title, String(localized: "Similar images you can compare — keep the best, remove the rest.", comment: "Similar right pane description."))
+        case .downloads:
+            let source = selectedBrowser ?? downloadCache.first?.source
+            let title = source ?? String(localized: "Downloads", comment: "Downloads right pane fallback title.")
+            return (title, String(localized: "Files downloaded from the web. Remove one-time downloads to save space.", comment: "Downloads right pane description."))
+        }
+    }
+
     @ViewBuilder
     private var rightPane: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let h = rightPaneHeader {
+                paneHeader(title: h.title, description: h.description)
+            }
+            rightPaneContent
+        }
+    }
+
+    @ViewBuilder
+    private var rightPaneContent: some View {
         switch category {
         case .largeOld:
             if isLoadingCache { loadingPane } else { fileList(display(largeOldBase)) }


### PR DESCRIPTION
## Summary

- **Applications Manager**: The right pane for the Uninstaller, Updater, and Extensions panes now shows a contextual title + description header that reflects the active facet selection (e.g. "All Applications", "App Store", "Safari Extensions"). The Leftovers pane already had its own header via `leftoverFileList` and was left unchanged.
- **My Clutter Manager**: The right pane now shows a title + description header for all four categories — Large & Old (per-facet: All Files, a kind, or a size bucket), Duplicates (selected group's original filename), Similar Images (selected group's original filename), and Downloads (selected browser name).

## What changed and why

The Cleanup Manager and Protection Manager already followed a consistent three-pane pattern where both the middle and right panes open with a title + one-line description of the currently selected item. The Applications and My Clutter managers were missing the right-pane half of that pattern. This brings all four managers into alignment with the reference design shown in the attached screenshot.

## Reviewer notes

- `rightPane` in `MyClutterManagerView` was split into `rightPane` (prepends the header) and `rightPaneContent` (unchanged item content) to keep the view builder switch readable.
- For the Applications Manager, right pane headers are computed via dedicated `*RightPaneTitle` / `*RightPaneDescription` properties — one set per pane — so each switches over its own facet type cleanly.
- No changes to models, data flow, or existing header logic.

## Test plan

- [ ] Open My Clutter Manager → verify right pane shows title/description for each category and changes as you select different facets/groups/browsers
- [ ] Open Applications Manager → Uninstaller, Updater, Extensions panes each show a right-pane header that updates when a different facet is selected
- [ ] Leftovers pane header is unchanged
- [ ] Cleanup and Protection managers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual headers above right-side panes in the app, showing titles and descriptions that match the current view.
  * Improved the right pane in the clutter manager with category-aware header text for more consistent navigation.

* **Bug Fixes**
  * Restored consistent header presentation across Uninstaller, Updater, and Extensions views.
  * Right-pane content now updates more accurately based on the selected category, facet, group, or source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->