### PR TITLE
Simplify malware scan loader and fix Protection Manager top margin

### DIFF
--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -7,41 +7,14 @@ import SwiftUI
 
 struct MalwareProgressState: View {
     let label: String
-    let detail: String?
     let identifier: String
-    /// Optional live count line (e.g. "3,201 files") shown above the streamed
-    /// path so the user sees the scan advancing even as individual path lines
-    /// flicker past.
-    var countDetail: String? = nil
     /// Rotating personality phrases for the open scan; falls back to `label`.
     var phrases: [String]? = nil
-    var onCancel: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 16) {
             ScanProgressIndicator()
-            ScanningStatusView(
-                phrases: phrases ?? [label],
-                count: countDetail,
-                countIdentifier: "\(identifier).count"
-            )
-            if let detail, !detail.isEmpty {
-                Text(detail)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .frame(maxWidth: 460)
-                    .accessibilityIdentifier("\(identifier).detail")
-            }
-            if let onCancel {
-                Button(String(
-                    localized: "Cancel",
-                    comment: "Button that stops an in-progress malware scan."
-                ), action: onCancel)
-                    .buttonStyle(.bordered)
-                    .accessibilityIdentifier("malware.cancel")
-            }
+            ScanningStatusView(phrases: phrases ?? [label])
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier(identifier)

--- a/VaderCleaner/ProtectionDashboardView.swift
+++ b/VaderCleaner/ProtectionDashboardView.swift
@@ -123,18 +123,9 @@ struct ProtectionDashboardView: View {
         MalwareProgressState(
             label: String(localized: "Looking for threats…",
                           comment: "Protection loading-screen label while scans run."),
-            detail: malwareProgressLine,
             identifier: "protection.loading",
-            countDetail: ScanProgressFormatting.filesScanned(malware.scannedItemCount),
-            phrases: ScanPhrases.scanning(for: .malwareRemoval),
-            onCancel: { viewModel.startOver() }
+            phrases: ScanPhrases.scanning(for: .malwareRemoval)
         )
-    }
-
-    /// The current clamscan progress line, if the malware scan is streaming.
-    private var malwareProgressLine: String? {
-        if case .scanning(let progress) = malware.phase { return progress }
-        return nil
     }
 
     /// Resolves each detected browser's `.app` bundle URL via Launch Services

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -94,6 +94,10 @@ struct ProtectionManagerView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .shadow(color: .black.opacity(0.18), radius: 16, y: 6)
                 .padding(14)
+                // Extend up under the title-bar safe area so the top margin is
+                // as thin as the sides instead of leaving the toolbar's tall
+                // gradient band above the card.
+                .ignoresSafeArea(.container, edges: .top)
                 .tint(accent)
                 .environment(\.sectionAccent, accent)
         }


### PR DESCRIPTION
## What changed

Two unrelated UI refinements to the Protection section.

### 1. Malware scan loading screen
Stripped the malware scan loader down to just the animated `ScanProgressIndicator` and the rotating status phrase. Removed:
- the live item count line (e.g. "2 files")
- the streamed file-path line (e.g. `…/Invoice.pdf: OK`)
- the **Cancel** button

The now-unused parameters on `MalwareProgressState` (`detail`, `countDetail`, `onCancel`) and the corresponding arguments at its single call site in `ProtectionDashboardView` were removed too, so no dead inputs are left behind.

### 2. Protection Manager card top margin
The Protection Manager card had a large gap between its top edge and the window top, while the sides and bottom were a thin 14pt margin. Cause: `ProtectionManagerView` uses its own private `ManagerSurfaceChrome` that was missing the `.ignoresSafeArea(.container, edges: .top)` modifier the shared `ManagerSurfaceModifier` already applies. Without it, the card respected the title-bar safe-area inset, so its top margin was the title-bar height *plus* the 14pt padding. Added the missing modifier so the top margin now matches the sides.

## Why
Cleaner, less noisy scan loader; consistent card margins matching the other manager screens.

## Reviewer notes
- The malware scanner's own `cancel()` method (on the view model) is untouched — only the UI Cancel button was removed. With it gone, there is no longer an in-loader way to abort the scan; flag if a different escape hatch is wanted.
- The Protection Manager fix duplicates logic that already lives in the shared `ManagerSurfaceModifier`. The two copies drifted (which caused this bug). Consolidating onto the shared modifier would prevent future drift but was left out of scope here.
- Verified with `xcodebuild build` (BUILD SUCCEEDED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the malware scan progress view for a cleaner, less cluttered loading experience.
  * Removed extra progress details and the cancel option from the scan screen.
  * Adjusted the dashboard loading layout so the top spacing now appears more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->