### PR TITLE
Rework Space Lens review sheet, intro, and list interactions

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
 		0D07D802660BE818551E4750 /* DocumentVersionsScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4F4BBD5F811CE84BAA223E /* DocumentVersionsScanner.swift */; };
 		0E8642014D5CCD4A995238C9 /* ManagerChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEC791E5358B5C8B2C594E2 /* ManagerChrome.swift */; };
+		1017364677836D697B5087F9 /* SpaceLensProtectionMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CB0FF38AA0C4E58C4ADFF8 /* SpaceLensProtectionMessageTests.swift */; };
 		102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */; };
 		10262DDD8C0BD95D484F5215 /* AppLeftover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D631EBC782CB95D9221AD977 /* AppLeftover.swift */; };
 		1067C5FF648F898628C6C987 /* SystemJunkDeleter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */; };
@@ -287,6 +288,7 @@
 		CFF959AB010953129DB8B8D0 /* SmartScanPerformanceReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952CFA79F6F0E89198DED8E3 /* SmartScanPerformanceReview.swift */; };
 		D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */; };
 		D25319BADD929D75CA704136 /* MailReindexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2017911CF02D2B89E8BF865 /* MailReindexer.swift */; };
+		D478ECC4A65EA341DD21CCB7 /* SpaceLensVolumePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5347E39C28AE8B7F020B233 /* SpaceLensVolumePicker.swift */; };
 		D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */; };
 		D62E869A1721F311F4599726 /* SpaceLensVolumeUsage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C27EE261148D623AC319C6D /* SpaceLensVolumeUsage.swift */; };
 		D6C17A4A7EE7DABEBDE62F94 /* BrowserPrivacyRemoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A4A9DC4B07D250A7F369C1 /* BrowserPrivacyRemoverTests.swift */; };
@@ -566,6 +568,7 @@
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
 		82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotCounter.swift; sourceTree = "<group>"; };
 		869E8D8A460A998AA0E6B854 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
+		86CB0FF38AA0C4E58C4ADFF8 /* SpaceLensProtectionMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensProtectionMessageTests.swift; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
 		88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanOverlay.swift; sourceTree = "<group>"; };
 		897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensView.swift; sourceTree = "<group>"; };
@@ -627,6 +630,7 @@
 		B3CD8C98E8253953444DD99F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		B46943B264F72B3753075A8C /* UpdateInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfoTests.swift; sourceTree = "<group>"; };
 		B51321F0F77F5813E6777822 /* performance.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = performance.usdz; sourceTree = "<group>"; };
+		B5347E39C28AE8B7F020B233 /* SpaceLensVolumePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensVolumePicker.swift; sourceTree = "<group>"; };
 		B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensHoverCard.swift; sourceTree = "<group>"; };
 		B79E0766E335360E04FC6A53 /* AppDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscovery.swift; sourceTree = "<group>"; };
 		B8D99E37C2929F79D0A6DD11 /* SpaceLensSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensSelection.swift; sourceTree = "<group>"; };
@@ -951,6 +955,7 @@
 				42005C1A322A1B5ED65AE376 /* SpaceLensReviewSheet.swift */,
 				B8D99E37C2929F79D0A6DD11 /* SpaceLensSelection.swift */,
 				897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */,
+				B5347E39C28AE8B7F020B233 /* SpaceLensVolumePicker.swift */,
 				6C27EE261148D623AC319C6D /* SpaceLensVolumeUsage.swift */,
 				CEFFAA5C1164E12A4D5CBEA1 /* SparkleUpdateChecker.swift */,
 				2605C9D00F82838A6A9D11A3 /* SystemJunkDashboardSubviews.swift */,
@@ -1136,6 +1141,7 @@
 				2BE4B778A9C7809CCF464005 /* SpaceLensBubbleLayoutTests.swift */,
 				097AE3488CA0478D96306C58 /* SpaceLensChildrenTests.swift */,
 				2B22856A47E87BF9A84172B2 /* SpaceLensHoverCardTests.swift */,
+				86CB0FF38AA0C4E58C4ADFF8 /* SpaceLensProtectionMessageTests.swift */,
 				D2D81614C060D1B03E9922F3 /* SpaceLensProtectionTests.swift */,
 				A75EF6CEA94213CDD0564C48 /* SpaceLensSelectionTests.swift */,
 				44EE14A680D5C81A7BA681DD /* SpaceLensVolumeUsageTests.swift */,
@@ -1459,6 +1465,7 @@
 				90CEF79E082F50E5AB75C886 /* SpaceLensBubbleLayoutTests.swift in Sources */,
 				6E61E59F919063FCB9279BED /* SpaceLensChildrenTests.swift in Sources */,
 				40BB821EAD9CD6628F9B0069 /* SpaceLensHoverCardTests.swift in Sources */,
+				1017364677836D697B5087F9 /* SpaceLensProtectionMessageTests.swift in Sources */,
 				486EBB681D5216ADDC6CC4FD /* SpaceLensProtectionTests.swift in Sources */,
 				8C90B9AC0EA622B41E8E9C10 /* SpaceLensSelectionTests.swift in Sources */,
 				4136425911121661B4C7774F /* SpaceLensVolumeUsageTests.swift in Sources */,
@@ -1675,6 +1682,7 @@
 				04327D324A0E8B4DA1AA55AA /* SpaceLensReviewSheet.swift in Sources */,
 				46E9C9EDAD414CB454C187AA /* SpaceLensSelection.swift in Sources */,
 				024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */,
+				D478ECC4A65EA341DD21CCB7 /* SpaceLensVolumePicker.swift in Sources */,
 				D62E869A1721F311F4599726 /* SpaceLensVolumeUsage.swift in Sources */,
 				B9EF7AA9251121851DDEDB67 /* SparkleUpdateChecker.swift in Sources */,
 				3953FD2FDE6C5D300EE97BED /* SystemJunkDashboardSubviews.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -381,6 +381,8 @@ struct ContentView: View {
             ScannableSectionContent(coordinator: spaceLensViewModel, section: section) {
                 SpaceLensView(viewModel: spaceLensViewModel)
             }
+            // The intro's volume picker reads the scan root from the view model.
+            .environment(spaceLensViewModel)
         case .applications:
             ScannableSectionContent(coordinator: applicationsViewModel, section: section) {
                 ApplicationsView(

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -78,6 +78,18 @@ final class DiskScannerViewModel {
     /// Whether the "Review files before removal" sheet is showing.
     var reviewActive = false
 
+    /// The item the pointer is currently over, shared by the list and the
+    /// bubble chart so hovering a row rings its bubble and vice versa. This is
+    /// the focus highlight — distinct from `selection`, which marks items for
+    /// removal.
+    var highlightedNodeID: DiskNode.ID?
+
+    /// The volume the next scan walks, chosen in the intro's volume picker.
+    /// Defaults to the boot volume so Space Lens opens at "Macintosh HD" the way
+    /// a disk-usage map is expected to read; `beginScan()` reads this as the
+    /// scan root and the footer gauge reports this volume's capacity.
+    var selectedVolumeURL: URL = DiskScannerViewModel.volumeRootURL
+
     var canGoBack: Bool { !navigationPath.isEmpty }
     var canGoForward: Bool { !forwardStack.isEmpty }
 
@@ -219,7 +231,7 @@ final class DiskScannerViewModel {
         selection.deselect(targets.filter { movedIDs.contains($0.id) })
         forwardStack.removeAll()
         phase = .ready(prunedRoot)
-        volumeUsage = volumeUsageProvider()
+        volumeUsage = volumeUsageProvider(selectedVolumeURL)
         reviewActive = false
     }
 
@@ -281,7 +293,7 @@ final class DiskScannerViewModel {
 
     @ObservationIgnored private let scanner: Scanner
     @ObservationIgnored private let trash: TrashSink
-    @ObservationIgnored private let volumeUsageProvider: () -> SpaceLensVolumeUsage
+    @ObservationIgnored private let volumeUsageProvider: (URL) -> SpaceLensVolumeUsage
     @ObservationIgnored private let log = Logger(
         subsystem: "com.personal.VaderCleaner",
         category: "DiskScannerViewModel"
@@ -290,7 +302,7 @@ final class DiskScannerViewModel {
     init(
         scanner: @escaping Scanner,
         trash: @escaping TrashSink = DiskScannerViewModel.recycle,
-        volumeUsageProvider: @escaping () -> SpaceLensVolumeUsage = SpaceLensVolumeUsage.current
+        volumeUsageProvider: @escaping (URL) -> SpaceLensVolumeUsage = SpaceLensVolumeUsage.current
     ) {
         self.scanner = scanner
         self.trash = trash
@@ -425,7 +437,7 @@ final class DiskScannerViewModel {
                 guard self.scanGeneration == myGeneration else { return }
                 self.selection.clear()
                 self.phase = .ready(node)
-                self.volumeUsage = self.volumeUsageProvider()
+                self.volumeUsage = self.volumeUsageProvider(root)
             } catch is CancellationError {
                 // A cancellation is a clean dismissal — the user (or a
                 // fresh scan) chose to stop the in-flight walk.
@@ -522,12 +534,12 @@ extension DiskScannerViewModel: ScanCoordinating {
     }
 
     func beginScan() {
-        // Space Lens scans the whole boot volume so the explorer starts at
-        // "Macintosh HD" and the breadcrumb matches the volume tree, the way
-        // a disk-usage map is expected to read.
-        Task { await startScan(root: Self.volumeRootURL) }
+        // Space Lens scans the volume chosen in the intro picker (the boot
+        // volume by default), so the explorer starts at that volume's root and
+        // the breadcrumb matches its tree, the way a disk-usage map reads.
+        Task { await startScan(root: selectedVolumeURL) }
     }
 
-    /// The boot volume's mount point — the Space Lens scan root.
+    /// The boot volume's mount point — the default Space Lens scan root.
     static let volumeRootURL = URL(fileURLWithPath: "/")
 }

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -269,6 +269,14 @@ struct SectionIntroView: View {
                     .padding(.top, 4)
             }
 
+            // Space Lens scans a whole volume; its intro carries a volume
+            // selector so the user can map any mounted drive, not just the boot
+            // volume.
+            if section == .spaceLens {
+                SpaceLensVolumePicker(accent: presentation.accent)
+                    .padding(.top, 4)
+            }
+
             // Protection exposes its scan options and mode in Settings; the
             // Configure Scan button routes there directly.
             if section == .malwareRemoval {

--- a/VaderCleaner/SectionPresentation.swift
+++ b/VaderCleaner/SectionPresentation.swift
@@ -154,17 +154,21 @@ struct SectionPresentation {
                 accent: section.theme.accent,
                 heroTitle: nil,
                 tagline: String(
-                    localized: "See what's using your storage with an interactive map.",
+                    localized: "Visualize what's taking up the most disk space and clean up your storage quickly.",
                     comment: "Space Lens intro tagline."
                 ),
                 features: [
                     SectionFeature(
-                        symbol: "chart.pie",
-                        title: String(localized: "Disk Usage Map", comment: "Space Lens feature row.")
+                        symbol: "map",
+                        title: String(localized: "Visual Storage Map", comment: "Space Lens feature row.")
+                    ),
+                    SectionFeature(
+                        symbol: "doc.text.magnifyingglass",
+                        title: String(localized: "Hidden Files Uncovered", comment: "Space Lens feature row.")
                     ),
                     SectionFeature(
                         symbol: "folder",
-                        title: String(localized: "Drill Into Folders", comment: "Space Lens feature row.")
+                        title: String(localized: "Large Folders Overview", comment: "Space Lens feature row.")
                     ),
                 ]
             )

--- a/VaderCleaner/SpaceLensBubbleView.swift
+++ b/VaderCleaner/SpaceLensBubbleView.swift
@@ -51,8 +51,13 @@ struct SpaceLensBubbleView: View {
                 case .active(let location):
                     let id = circles.first { hit($0, location) }?.id
                     if hoveredID != id { hoveredID = id }
+                    // Mirror the hover into the shared highlight so the matching
+                    // list row lights up too.
+                    let nodeID = id.flatMap { itemsByID[$0]?.node?.id }
+                    if viewModel.highlightedNodeID != nodeID { viewModel.highlightedNodeID = nodeID }
                 case .ended:
                     if hoveredID != nil { hoveredID = nil }
+                    if viewModel.highlightedNodeID != nil { viewModel.highlightedNodeID = nil }
                 }
             }
             .overlay { hoverCard(circles: circles, itemsByID: itemsByID, bounds: geometry.size) }
@@ -72,6 +77,8 @@ struct SpaceLensBubbleView: View {
     @ViewBuilder
     private func bubble(item: SpaceLensDisplayItem, circle: PackedCircle<AnyHashable>) -> some View {
         let isHovered = hoveredID == circle.id
+        // Focus highlight from either the bubble or its list row.
+        let isHighlighted = item.node.map { viewModel.highlightedNodeID == $0.id } ?? false
         let isSelected = item.node.map { viewModel.selection.isSelected($0) } ?? false
         let isSelectable = item.node.map { !SpaceLensProtection.isProtected(url: $0.url, isDirectory: $0.isDirectory) } ?? false
         // A checkbox appears on hover (or when already selected) for selectable
@@ -88,17 +95,17 @@ struct SpaceLensBubbleView: View {
 
         ZStack {
             Circle()
-                .fill(bubbleFill(isSelected: isSelected, isHovered: isHovered, radius: circle.radius))
+                .fill(bubbleFill(isSelected: isSelected, isHovered: isHighlighted, radius: circle.radius))
                 .overlay(
                     Circle().strokeBorder(
                         isSelected ? Self.accent.opacity(0.85)
-                            : Color.white.opacity(isHovered ? 0.7 : 0.28),
-                        lineWidth: isSelected ? 2 : (isHovered ? 2 : 1)
+                            : (isHighlighted ? Self.accent.opacity(0.9) : Color.white.opacity(0.28)),
+                        lineWidth: (isSelected || isHighlighted) ? 2 : 1
                     )
                 )
                 .shadow(color: isSelected ? Self.accent.opacity(0.5)
-                            : (isHovered ? Color.white.opacity(0.22) : .clear),
-                        radius: isSelected ? 22 : (isHovered ? 14 : 0))
+                            : (isHighlighted ? Self.accent.opacity(0.45) : .clear),
+                        radius: isSelected ? 22 : (isHighlighted ? 16 : 0))
 
             VStack(spacing: 6) {
                 bubbleIcon(item: item, size: iconSize)

--- a/VaderCleaner/SpaceLensListPanel.swift
+++ b/VaderCleaner/SpaceLensListPanel.swift
@@ -19,11 +19,14 @@ struct SpaceLensListPanel: View {
 
     @State private var selectMode: SpaceLensSelectMode = .manually
     @State private var isOtherExpanded = false
-    @State private var hoveredRow: AnyHashable?
+    /// The protected row whose "i" badge is hovered, so its tooltip shows.
+    @State private var hoveredProtectedID: DiskNode.ID?
 
     /// Uniform row metrics so every list row is the same height and gap.
     private static let rowHeight: CGFloat = 40
     private static let rowSpacing: CGFloat = 4
+    /// The removal accent shared with the bubbles and bottom bar.
+    private static let accent = Color(red: 0.96, green: 0.20, blue: 0.78)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -46,6 +49,19 @@ struct SpaceLensListPanel: View {
         .padding(16)
         .frame(maxHeight: .infinity, alignment: .top)
         .background(.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 16))
+        // Draw the protected-item tooltip at the panel level (above the
+        // ScrollView) so it isn't clipped by the scrolling rows.
+        .overlayPreferenceValue(ProtectedTooltipKey.self) { value in
+            GeometryReader { proxy in
+                if let value {
+                    let rect = proxy[value.anchor]
+                    tooltip(text: value.text)
+                        .frame(width: 230)
+                        .offset(x: rect.maxX + 8, y: rect.midY - 26)
+                        .allowsHitTesting(false)
+                }
+            }
+        }
         .accessibilityIdentifier("space-lens.list")
     }
 
@@ -114,35 +130,39 @@ struct SpaceLensListPanel: View {
     @ViewBuilder
     private func row(for child: DiskNode) -> some View {
         let selected = viewModel.selection.isSelected(child)
-        let hovered = hoveredRow == AnyHashable(child.id)
+        // The shared focus highlight: lit whenever the pointer is over this row
+        // or its bubble, so the row and bubble stay in lockstep.
+        let highlighted = viewModel.highlightedNodeID == child.id
         HStack(spacing: 10) {
             leadingControl(for: child, selected: selected)
             Image(nsImage: iconCache.icon(for: child.url))
                 .resizable()
                 .interpolation(.high)
                 .frame(width: 22, height: 22)
-            Button {
-                if child.isDirectory { viewModel.drillDown(into: child) }
-            } label: {
-                Text(child.name)
-                    .font(.callout)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .buttonStyle(.plain)
-            .disabled(!child.isDirectory)
+            Text(child.name)
+                .font(.callout)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
             Text(child.formattedSize)
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(.secondary)
         }
         .padding(.horizontal, 10)
         .frame(height: Self.rowHeight)
-        .background(hovered ? Color.white.opacity(0.08) : .clear,
+        .background(highlighted ? Color.white.opacity(0.08) : .clear,
                     in: RoundedRectangle(cornerRadius: 8))
         .contentShape(Rectangle())
-        .onHover { hoveredRow = $0 ? AnyHashable(child.id) : (hoveredRow == AnyHashable(child.id) ? nil : hoveredRow) }
+        // Hovering the row drives the shared highlight; the checkbox is a
+        // separate control, so a row click drills in without toggling removal.
+        .onHover { hovering in
+            if hovering { viewModel.highlightedNodeID = child.id }
+            else if viewModel.highlightedNodeID == child.id { viewModel.highlightedNodeID = nil }
+        }
+        .onTapGesture {
+            if child.isDirectory { viewModel.drillDown(into: child) }
+        }
         .accessibilityIdentifier("space-lens.row.\(child.name)")
     }
 
@@ -150,24 +170,74 @@ struct SpaceLensListPanel: View {
     @ViewBuilder
     private func leadingControl(for child: DiskNode, selected: Bool) -> some View {
         if isProtected(child) {
-            Image(systemName: "info.circle")
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .frame(width: 20)
-                .help(SpaceLensProtection.category(url: child.url, isDirectory: child.isDirectory).displayName + " — protected from removal")
-                .accessibilityIdentifier("space-lens.protected.\(child.name)")
+            protectedBadge(child)
         } else {
             Button {
                 viewModel.selection.toggle(child)
             } label: {
-                Image(systemName: selected ? "checkmark.square.fill" : "square")
-                    .font(.body)
-                    .foregroundStyle(selected ? Color(red: 0.96, green: 0.20, blue: 0.78) : .secondary)
+                checkbox(isOn: selected)
             }
             .buttonStyle(.plain)
-            .frame(width: 20)
+            .frame(width: 22)
             .accessibilityIdentifier("space-lens.checkbox.\(child.name)")
         }
+    }
+
+    /// Pink rounded checkbox — filled with a white check when on, an outlined
+    /// square when off — matching the removal accent used across Space Lens.
+    private func checkbox(isOn: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+            .fill(isOn ? Self.accent : Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(isOn ? Color.clear : Color.secondary.opacity(0.6), lineWidth: 1.5)
+            )
+            .overlay(
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.white)
+                    .opacity(isOn ? 1 : 0)
+            )
+            .frame(width: 18, height: 18)
+    }
+
+    /// The "i" badge shown instead of a checkbox for a protected item, with a
+    /// hover tooltip explaining why it can't be removed.
+    private func protectedBadge(_ child: DiskNode) -> some View {
+        Image(systemName: "info.circle")
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .frame(width: 22)
+            .onHover { hovering in
+                if hovering { hoveredProtectedID = child.id }
+                else if hoveredProtectedID == child.id { hoveredProtectedID = nil }
+            }
+            .anchorPreference(key: ProtectedTooltipKey.self, value: .bounds) { anchor in
+                hoveredProtectedID == child.id
+                    ? ProtectedTooltipValue(anchor: anchor, text: Self.protectionMessage(for: child))
+                    : nil
+            }
+            .accessibilityIdentifier("space-lens.protected.\(child.name)")
+    }
+
+    /// The dark callout bubble shown beside a protected item's "i" badge.
+    private func tooltip(text: String) -> some View {
+        Text(text)
+            .font(.callout)
+            .foregroundStyle(.white)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(red: 0.16, green: 0.13, blue: 0.22))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(.white.opacity(0.12))
+            )
+            .shadow(color: .black.opacity(0.4), radius: 12, y: 4)
     }
 
     // MARK: - Other items
@@ -210,6 +280,16 @@ struct SpaceLensListPanel: View {
         SpaceLensProtection.isProtected(url: node.url, isDirectory: node.isDirectory)
     }
 
+    /// Why a protected item can't be removed, shown in its "i" badge tooltip.
+    static func protectionMessage(for node: DiskNode) -> String {
+        switch SpaceLensProtection.category(url: node.url, isDirectory: node.isDirectory) {
+        case .homeFolder:
+            return String(localized: "This is your home folder and it can't be removed here.")
+        case .systemFolder, .folder, .file:
+            return String(localized: "This is an essential system item and it cannot be deleted.")
+        }
+    }
+
     /// "3M items" / "155 items" — abbreviates large counts the way the
     /// reference header does.
     static func itemCountText(_ count: Int) -> String {
@@ -223,5 +303,19 @@ struct SpaceLensListPanel: View {
             number = count.formatted(.number)
         }
         return count == 1 ? String(localized: "1 item") : String(localized: "\(number) items")
+    }
+}
+
+/// The hovered protected item's badge bounds and tooltip text, hoisted to the
+/// panel root so the tooltip can draw above the scrolling rows without clipping.
+private struct ProtectedTooltipValue {
+    let anchor: Anchor<CGRect>
+    let text: String
+}
+
+private struct ProtectedTooltipKey: PreferenceKey {
+    static let defaultValue: ProtectedTooltipValue? = nil
+    static func reduce(value: inout ProtectedTooltipValue?, nextValue: () -> ProtectedTooltipValue?) {
+        value = value ?? nextValue()
     }
 }

--- a/VaderCleaner/SpaceLensReviewSheet.swift
+++ b/VaderCleaner/SpaceLensReviewSheet.swift
@@ -1,12 +1,13 @@
 // SpaceLensReviewSheet.swift
-// "Review files before removal" overlay — lists the selected items with their location and size, lets the user uncheck any, and moves the rest to the Trash.
+// "Review files before removal" overlay — pairs the 3D Space Lens hero with the list of selected items (location + size), lets the user uncheck any, and moves the kept selection to the Trash.
 
 import SwiftUI
 
-/// Confirmation overlay shown before Space Lens removes anything. Lists the
-/// top-level selected nodes (`SpaceLensSelection.selectedNodes`) with a
-/// per-item checkbox, the item's location breadcrumb, and its size, then routes
-/// the kept selection to `viewModel.removeSelected()` (move to Trash).
+/// Confirmation overlay shown before Space Lens removes anything. A two-column
+/// card: the 3D Space Lens hero on the leading edge, and on the trailing edge
+/// the title, the list of top-level selected nodes — each with a per-item
+/// checkbox, a location breadcrumb, and its size — and the running totals with
+/// the Remove action that routes the kept selection to `viewModel.removeSelected()`.
 struct SpaceLensReviewSheet: View {
 
     var viewModel: DiskScannerViewModel
@@ -15,14 +16,24 @@ struct SpaceLensReviewSheet: View {
 
     @State private var isRemoving = false
 
+    /// Snapshot of the items to review, captured when the overlay appears, so a
+    /// row stays visible (and re-checkable) after it's unchecked rather than
+    /// vanishing the moment it leaves `selection.selectedNodes()`.
+    @State private var reviewNodes: [DiskNode] = []
+
     private static let accent = Color(red: 0.96, green: 0.20, blue: 0.78)
 
     var body: some View {
-        let selected = viewModel.selection.selectedNodes()
         let totals = viewModel.selection.totals
 
         ZStack(alignment: .topLeading) {
-            content(selected: selected, totals: totals)
+            HStack(spacing: 24) {
+                hero
+                content(totals: totals)
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 28)
+
             Button {
                 viewModel.reviewActive = false
             } label: {
@@ -34,84 +45,120 @@ struct SpaceLensReviewSheet: View {
             .padding(12)
             .accessibilityIdentifier("space-lens.review.close")
         }
-        .frame(maxWidth: 760, maxHeight: 520)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))
-        .overlay(RoundedRectangle(cornerRadius: 20).strokeBorder(.white.opacity(0.08)))
+        .frame(maxWidth: 880, maxHeight: 540)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24))
+        .overlay(RoundedRectangle(cornerRadius: 24).strokeBorder(.white.opacity(0.08)))
         .shadow(radius: 30, y: 12)
         .padding(40)
         .accessibilityIdentifier("space-lens.review")
-    }
-
-    private func content(selected: [DiskNode], totals: (count: Int, size: Int64)) -> some View {
-        VStack(spacing: 0) {
-            VStack(spacing: 8) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 44))
-                    .foregroundStyle(Color(red: 0.62, green: 0.78, blue: 1.0))
-                    .padding(.top, 8)
-                Text("Review files before removal")
-                    .font(.title.weight(.semibold))
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.top, 24)
-
-            ScrollView {
-                LazyVStack(spacing: 2) {
-                    ForEach(selected) { node in
-                        reviewRow(node)
-                    }
-                }
-                .padding(.horizontal, 24)
-            }
-            .frame(maxHeight: .infinity)
-            .padding(.top, 20)
-
-            Divider().opacity(0.4)
-            footer(totals: totals, hasSelection: !selected.isEmpty)
+        .onAppear {
+            // Capture the selection once so unchecking keeps the row on screen.
+            reviewNodes = viewModel.selection.selectedNodes()
         }
     }
 
+    // MARK: - Hero
+
+    /// The 3D Space Lens art that anchors the leading column, matching the
+    /// section's icon elsewhere in the app.
+    private var hero: some View {
+        Image("spaceLens")
+            .resizable()
+            .interpolation(.high)
+            .scaledToFit()
+            .frame(maxWidth: 300, maxHeight: 300)
+            .shadow(color: .black.opacity(0.35), radius: 24, y: 12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Content
+
+    private func content(totals: (count: Int, size: Int64)) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Review files before removal")
+                .font(.system(size: 34, weight: .semibold))
+                .padding(.bottom, 24)
+
+            ScrollView {
+                LazyVStack(spacing: 4) {
+                    ForEach(reviewNodes) { node in
+                        reviewRow(node)
+                    }
+                }
+            }
+            .frame(maxHeight: .infinity)
+
+            footer(totals: totals, hasSelection: totals.count > 0)
+                .padding(.top, 16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
     private func reviewRow(_ node: DiskNode) -> some View {
-        HStack(spacing: 10) {
+        let isOn = viewModel.selection.isSelected(node)
+        return HStack(spacing: 14) {
             Button {
                 viewModel.selection.toggle(node)
             } label: {
-                Image(systemName: "checkmark.square.fill")
-                    .foregroundStyle(Self.accent)
+                checkbox(isOn: isOn)
             }
             .buttonStyle(.plain)
+
             Image(nsImage: iconCache.icon(for: node.url))
                 .resizable()
                 .interpolation(.high)
-                .frame(width: 22, height: 22)
-            VStack(alignment: .leading, spacing: 1) {
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
                 Text(node.name)
-                    .font(.callout.weight(.medium))
+                    .font(.body.weight(.semibold))
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Text(locationBreadcrumb(for: node))
-                    .font(.caption)
+                    .font(.callout)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.head)
             }
-            Spacer(minLength: 8)
+
+            Spacer(minLength: 12)
+
             Text(node.formattedSize)
-                .font(.callout.monospacedDigit())
+                .font(.body.monospacedDigit())
                 .foregroundStyle(.secondary)
         }
+        .opacity(isOn ? 1 : 0.45)
         .padding(.vertical, 8)
-        .padding(.horizontal, 8)
         .accessibilityIdentifier("space-lens.review.row.\(node.name)")
+    }
+
+    /// Pink rounded checkbox — filled with a white check when on, an outlined
+    /// square when off — matching the section's removal accent.
+    private func checkbox(isOn: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(isOn ? Self.accent : Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .strokeBorder(isOn ? Color.clear : Color.secondary.opacity(0.6), lineWidth: 1.5)
+            )
+            .overlay(
+                Image(systemName: "checkmark")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.white)
+                    .opacity(isOn ? 1 : 0)
+            )
+            .frame(width: 22, height: 22)
     }
 
     private func footer(totals: (count: Int, size: Int64), hasSelection: Bool) -> some View {
         HStack(spacing: 8) {
             Spacer()
             Image(systemName: "info.circle").foregroundStyle(.secondary)
-            Text(SpaceLensListPanel.itemCountText(totals.count) + " selected")
-                .font(.callout)
-            Text("·").foregroundStyle(.tertiary)
+            Text(Self.selectedCountText(totals.count))
+                .font(.callout.weight(.semibold))
+                .accessibilityIdentifier("space-lens.review.selectedCount")
+            Text("|").foregroundStyle(.tertiary)
             Text(ByteCountFormatter.string(fromByteCount: totals.size, countStyle: .binary))
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(.secondary)
@@ -134,8 +181,23 @@ struct SpaceLensReviewSheet: View {
             .disabled(!hasSelection || isRemoving)
             .accessibilityIdentifier("space-lens.review.remove")
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 16)
+    }
+
+    /// "983K Items selected" — abbreviates large counts the way the reference
+    /// footer does, with singular "1 Item selected".
+    static func selectedCountText(_ count: Int) -> String {
+        let number: String
+        switch count {
+        case 1_000_000...:
+            number = String(format: "%.0fM", Double(count) / 1_000_000)
+        case 10_000...:
+            number = String(format: "%.0fK", Double(count) / 1_000)
+        default:
+            number = count.formatted(.number)
+        }
+        return count == 1
+            ? String(localized: "1 Item selected")
+            : String(localized: "\(number) Items selected")
     }
 
     /// "Macintosh HD › Users" — the item's parent location, from the scan root

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -101,24 +101,45 @@ struct SpaceLensView: View {
         // selection, which are local to the subviews.
         let items = SpaceLensChildren.displayed(for: current)
         return ZStack {
-            VStack(spacing: 0) {
-                startOverBar
-                breadcrumbBar(current: current)
-                HStack(spacing: 20) {
-                    SpaceLensListPanel(viewModel: viewModel, node: current, items: items, iconCache: iconCache)
-                        .frame(width: 360)
-                    bubbleArea(current: current, items: items)
-                }
-                .padding(.horizontal, 24)
-                .padding(.top, 4)
-                .padding(.bottom, 8)
-                SpaceLensBottomBar(viewModel: viewModel)
-            }
+            // The explorer and the review overlay swap with the same
+            // slide-and-fade the left-nav sections use: opening Review sends
+            // the explorer up and out through the top, then the review window
+            // follows up from the bottom into place, so the explorer is never
+            // left sitting behind the window. Closing reverses through the
+            // same upward motion.
             if viewModel.reviewActive {
                 reviewOverlay(root: root)
+                    .transition(.spaceLensReview)
+            } else {
+                explorer(current: current, items: items)
+                    .transition(.spaceLensReview)
             }
         }
+        // Span the full sequential transition (exit + entry delay + entry
+        // ≈ 1.1s) so the delayed insertion isn't cancelled and snapped into
+        // place — matching the detail pane's section transaction.
+        .animation(.smooth(duration: 1.2), value: viewModel.reviewActive)
         .task(id: current.id) { await preloadIcons(items: items, current: current) }
+    }
+
+    /// The explorer screen: breadcrumb bar, the left list beside the bubble
+    /// chart, and the bottom volume/selection bar. Slides up and out when the
+    /// review overlay takes over.
+    private func explorer(current: DiskNode, items: [SpaceLensDisplayItem]) -> some View {
+        VStack(spacing: 0) {
+            startOverBar
+            breadcrumbBar(current: current)
+            HStack(spacing: 20) {
+                SpaceLensListPanel(viewModel: viewModel, node: current, items: items, iconCache: iconCache)
+                    .frame(width: 360)
+                bubbleArea(current: current, items: items)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 4)
+            .padding(.bottom, 8)
+            SpaceLensBottomBar(viewModel: viewModel)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     /// Pre-load the real icons for the current folder, its displayed children,
@@ -171,12 +192,16 @@ struct SpaceLensView: View {
 
     private func reviewOverlay(root: DiskNode) -> some View {
         ZStack {
-            Color.black.opacity(0.45)
+            // The explorer is swapped out beneath, so the window sits on the
+            // section backdrop with nothing behind it. A near-transparent
+            // catcher keeps the tap-outside-to-dismiss affordance without
+            // dimming the backdrop.
+            Color.black.opacity(0.001)
                 .ignoresSafeArea()
                 .onTapGesture { viewModel.reviewActive = false }
             SpaceLensReviewSheet(viewModel: viewModel, root: root, iconCache: iconCache)
         }
-        .transition(.opacity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Breadcrumb bar
@@ -263,6 +288,26 @@ struct SpaceLensView: View {
     }
 }
 
+private extension AnyTransition {
+    /// Slide-and-fade swap between the explorer and the review window, matching
+    /// the detail pane's upward section transition: the outgoing screen exits
+    /// through the top while the incoming screen follows up from the bottom.
+    /// The two halves run sequentially — the insertion is delayed until the
+    /// removal has cleared — so only one screen is on the way through at a time.
+    static var spaceLensReview: AnyTransition {
+        let exitDuration: Double = 0.55
+        let entryDuration: Double = 0.55
+        return .asymmetric(
+            insertion: .move(edge: .bottom)
+                .combined(with: .opacity)
+                .animation(.smooth(duration: entryDuration).delay(exitDuration)),
+            removal: .move(edge: .top)
+                .combined(with: .opacity)
+                .animation(.smooth(duration: exitDuration))
+        )
+    }
+}
+
 #Preview("Ready") {
     let child = DiskNode(url: URL(fileURLWithPath: "/Users/me/Movies"), name: "Movies",
                          size: 257_000_000_000, isDirectory: true, children: [], itemCount: 1200)
@@ -272,7 +317,7 @@ struct SpaceLensView: View {
                         size: 367_000_000_000, isDirectory: true, children: [child, docs], itemCount: 2000)
     let vm = DiskScannerViewModel(
         scanner: { _, _ in root },
-        volumeUsageProvider: { SpaceLensVolumeUsage(volumeName: "Macintosh HD", usedBytes: 1_300_000_000_000, totalBytes: 2_000_000_000_000) }
+        volumeUsageProvider: { _ in SpaceLensVolumeUsage(volumeName: "Macintosh HD", usedBytes: 1_300_000_000_000, totalBytes: 2_000_000_000_000) }
     )
     return SpaceLensView(viewModel: vm)
         .frame(width: 1000, height: 640)

--- a/VaderCleaner/SpaceLensVolumePicker.swift
+++ b/VaderCleaner/SpaceLensVolumePicker.swift
@@ -1,0 +1,173 @@
+// SpaceLensVolumePicker.swift
+// The Space Lens intro's scan-location selector — a translucent capsule showing the chosen volume or folder, with a menu listing the Mac's mounted volumes plus a "Choose folder…" option for any directory the next scan will walk.
+
+import SwiftUI
+import AppKit
+
+/// Lets the user choose what the Space Lens scan walks: one of the Mac's
+/// mounted volumes (the boot volume by default) or any folder picked via
+/// "Choose folder…". Shows the current selection as a capsule (icon + name +
+/// chevron). The choice lives on `DiskScannerViewModel.selectedVolumeURL`,
+/// which `beginScan()` reads as the scan root.
+struct SpaceLensVolumePicker: View {
+    @Environment(DiskScannerViewModel.self) private var viewModel
+
+    /// Section accent, used to tint the menu chevron so the control reads as
+    /// part of the Space Lens intro.
+    let accent: Color
+
+    var body: some View {
+        Menu {
+            // Rebuilt each time the menu opens, so a drive plugged in after
+            // launch shows up without relaunching.
+            ForEach(mountedVolumes(), id: \.self) { url in
+                Button {
+                    viewModel.selectedVolumeURL = url
+                } label: {
+                    menuItemLabel(url: url, isSelected: isActive(url))
+                }
+            }
+
+            // The active folder (when it isn't a mounted volume), shown checked
+            // so the menu reflects the current selection. Already selected, so
+            // the row is a no-op marker rather than an action.
+            if !selectionIsMountedVolume() {
+                Divider()
+                Button {} label: {
+                    menuItemLabel(url: viewModel.selectedVolumeURL, isSelected: true)
+                }
+            }
+
+            Divider()
+
+            Button {
+                presentFolderPanel()
+            } label: {
+                Label("Choose folder…", systemImage: "folder")
+            }
+        } label: {
+            capsule
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .fixedSize()
+        .accessibilityIdentifier("section.intro.spaceLens.volumePicker")
+    }
+
+    /// The resting capsule: the selected volume's real Finder icon, its name,
+    /// and a trailing chevron — matching the reference design.
+    private var capsule: some View {
+        HStack(spacing: 9) {
+            volumeIcon(for: viewModel.selectedVolumeURL)
+                .frame(width: 18, height: 18)
+            Text(displayName(for: viewModel.selectedVolumeURL))
+                .font(.system(size: 14, weight: .medium))
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            Image(systemName: "chevron.down")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(accent)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(minWidth: 230, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+        )
+    }
+
+    /// A menu row: the volume's real icon, its name, and a leading checkmark
+    /// when it is the active selection.
+    private func menuItemLabel(url: URL, isSelected: Bool) -> some View {
+        HStack(spacing: 6) {
+            if isSelected {
+                Image(systemName: "checkmark")
+            }
+            volumeIcon(for: url)
+            Text(displayName(for: url))
+        }
+    }
+
+    /// The genuine Finder icon for the volume mounted at `url`.
+    private func volumeIcon(for url: URL) -> some View {
+        Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+    }
+
+    /// Whether `url` is the active scan volume, compared by standardized path.
+    private func isActive(_ url: URL) -> Bool {
+        url.standardizedFileURL.path == viewModel.selectedVolumeURL.standardizedFileURL.path
+    }
+
+    /// The selection's display name — a volume root shows its Finder volume
+    /// name (e.g. "Macintosh HD"); a chosen folder shows its own folder name
+    /// rather than the containing volume's.
+    private func displayName(for url: URL) -> String {
+        if isVolumeRoot(url) {
+            if let name = (try? url.resourceValues(forKeys: [.volumeNameKey]))?.volumeName {
+                return name
+            }
+            return url.path == "/" ? "Macintosh HD" : url.lastPathComponent
+        }
+        return url.lastPathComponent
+    }
+
+    /// Whether `url` is a volume's root directory (so it should read as the
+    /// volume name) rather than a folder inside one.
+    private func isVolumeRoot(_ url: URL) -> Bool {
+        if url.path == "/" { return true }
+        let volumeURL = (try? url.resourceValues(forKeys: [.volumeURLKey]))?.volume
+        return volumeURL?.standardizedFileURL.path == url.standardizedFileURL.path
+    }
+
+    /// Whether the active selection is one of the mounted volumes (vs a folder
+    /// chosen via "Choose folder…").
+    private func selectionIsMountedVolume() -> Bool {
+        let selected = viewModel.selectedVolumeURL.standardizedFileURL.path
+        return mountedVolumes().contains { $0.standardizedFileURL.path == selected }
+    }
+
+    /// Opens a directory chooser; the picked folder becomes the scan root.
+    private func presentFolderPanel() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Scan"
+        panel.message = "Choose a folder to map with Space Lens"
+        panel.directoryURL = viewModel.selectedVolumeURL
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        viewModel.selectedVolumeURL = url
+    }
+
+    /// The browsable, local volumes the user can scan, always including the
+    /// boot volume so the default selection is offered even if the system
+    /// enumeration omits it.
+    private func mountedVolumes() -> [URL] {
+        let keys: [URLResourceKey] = [.volumeIsBrowsableKey, .volumeIsLocalKey]
+        let mounted = FileManager.default.mountedVolumeURLs(
+            includingResourceValuesForKeys: keys,
+            options: [.skipHiddenVolumes]
+        ) ?? []
+
+        let browsable = mounted.filter { url in
+            let values = try? url.resourceValues(forKeys: Set(keys))
+            return (values?.volumeIsBrowsable ?? true) && (values?.volumeIsLocal ?? true)
+        }
+
+        let bootVolume = DiskScannerViewModel.volumeRootURL
+        var ordered = browsable
+        if !ordered.contains(where: { $0.standardizedFileURL.path == bootVolume.path }) {
+            ordered.insert(bootVolume, at: 0)
+        }
+        return ordered
+    }
+}

--- a/VaderCleaner/SpaceLensVolumeUsage.swift
+++ b/VaderCleaner/SpaceLensVolumeUsage.swift
@@ -51,16 +51,15 @@ struct SpaceLensVolumeUsage: Equatable {
         return formatter
     }()
 
-    /// Reads the live boot-volume capacity. Mirrors
-    /// `SystemStatsService.readDiskStats` — `/` is the boot volume on every
-    /// macOS configuration we support. Falls back to zeroes (an empty gauge)
-    /// rather than throwing when the attributes can't be read.
-    static func current() -> SpaceLensVolumeUsage {
-        let root = URL(fileURLWithPath: "/")
-        let name = (try? root.resourceValues(forKeys: [.volumeNameKey]))?.volumeName
-            ?? "Macintosh HD"
+    /// Reads the live capacity of the volume mounted at `volumeURL` (the boot
+    /// volume `/` by default). Mirrors `SystemStatsService.readDiskStats`. Falls
+    /// back to zeroes (an empty gauge) rather than throwing when the attributes
+    /// can't be read.
+    static func current(for volumeURL: URL = URL(fileURLWithPath: "/")) -> SpaceLensVolumeUsage {
+        let resolvedName = (try? volumeURL.resourceValues(forKeys: [.volumeNameKey]))?.volumeName
+        let name = resolvedName ?? (volumeURL.path == "/" ? "Macintosh HD" : volumeURL.lastPathComponent)
 
-        guard let attrs = try? FileManager.default.attributesOfFileSystem(forPath: "/") else {
+        guard let attrs = try? FileManager.default.attributesOfFileSystem(forPath: volumeURL.path) else {
             return SpaceLensVolumeUsage(volumeName: name, usedBytes: 0, totalBytes: 0)
         }
         let total = (attrs[.systemSize] as? NSNumber)?.int64Value ?? 0

--- a/VaderCleanerTests/DiskScannerViewModelTests.swift
+++ b/VaderCleanerTests/DiskScannerViewModelTests.swift
@@ -37,6 +37,34 @@ final class DiskScannerViewModelTests: XCTestCase {
         XCTAssertEqual(vm.phase, .ready(synthetic))
     }
 
+    /// `beginScan()` must walk the volume chosen in the intro picker, not a
+    /// hardcoded boot volume — so changing `selectedVolumeURL` changes the
+    /// scan root the scanner receives.
+    func test_beginScan_usesSelectedVolumeAsScanRoot() async {
+        let recorder = RootRecorder()
+        let node = DiskNode(
+            url: URL(fileURLWithPath: "/Volumes/External"),
+            name: "External", size: 0, isDirectory: true, children: []
+        )
+        let vm = DiskScannerViewModel(
+            scanner: { root, _ in await recorder.record(root); return node },
+            volumeUsageProvider: { _ in SpaceLensVolumeUsage(volumeName: "External", usedBytes: 0, totalBytes: 0) }
+        )
+
+        vm.selectedVolumeURL = URL(fileURLWithPath: "/Volumes/External")
+        vm.beginScan()
+
+        // beginScan() kicks off an internal Task; let it run to the scanner.
+        var recorded: URL?
+        for _ in 0..<200 {
+            recorded = await recorder.value
+            if recorded != nil { break }
+            await Task.yield()
+        }
+
+        XCTAssertEqual(recorded?.path, "/Volumes/External")
+    }
+
     // MARK: - Failure path
 
     /// An error thrown by the injected scanner must surface as `.error`
@@ -386,7 +414,7 @@ final class DiskScannerViewModelTests: XCTestCase {
         let vm = DiskScannerViewModel(
             scanner: { _, _ in root },
             trash: { urls in await trashed.record(urls); return Set(urls) },
-            volumeUsageProvider: { SpaceLensVolumeUsage(volumeName: "T", usedBytes: 1, totalBytes: 10) }
+            volumeUsageProvider: { _ in SpaceLensVolumeUsage(volumeName: "T", usedBytes: 1, totalBytes: 10) }
         )
         await vm.startScan(root: URL(fileURLWithPath: "/tmp"), estimatedFileCount: 1)
         vm.selection.toggle(drop)
@@ -425,6 +453,13 @@ final class DiskScannerViewModelTests: XCTestCase {
     private actor Trashed {
         private(set) var urls: [URL] = []
         func record(_ newURLs: [URL]) { urls.append(contentsOf: newURLs) }
+    }
+
+    /// Captures the root URL the injected scanner is invoked with, so a test
+    /// can assert which volume `beginScan()` walked.
+    private actor RootRecorder {
+        private(set) var value: URL?
+        func record(_ url: URL) { if value == nil { value = url } }
     }
 
     /// Clicking a breadcrumb crumb truncates the path so the named node

--- a/VaderCleanerTests/SpaceLensProtectionMessageTests.swift
+++ b/VaderCleanerTests/SpaceLensProtectionMessageTests.swift
@@ -1,0 +1,23 @@
+// SpaceLensProtectionMessageTests.swift
+// Verifies the tooltip copy the Space Lens list shows for a protected item's "i" badge.
+
+import XCTest
+@testable import VaderCleaner
+
+final class SpaceLensProtectionMessageTests: XCTestCase {
+
+    private func node(_ url: URL) -> DiskNode {
+        DiskNode(url: url, name: url.lastPathComponent, size: 0, isDirectory: true, children: [])
+    }
+
+    func test_systemFolder_usesEssentialSystemMessage() {
+        let message = SpaceLensListPanel.protectionMessage(for: node(URL(fileURLWithPath: "/System")))
+        XCTAssertEqual(message, "This is an essential system item and it cannot be deleted.")
+    }
+
+    func test_homeFolder_usesHomeMessage() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let message = SpaceLensListPanel.protectionMessage(for: node(home))
+        XCTAssertEqual(message, "This is your home folder and it can't be removed here.")
+    }
+}


### PR DESCRIPTION
## Overview

Brings the Space Lens flow to feature-parity with the CleanMyMac-style reference design, fixes a few interaction gaps, and makes the intro's scan-location picker real and honored by the scan.

## What changed

### Review sheet (`SpaceLensReviewSheet`)
- Rebuilt "Review files before removal" as a two-column card: the 3D lens hero on the left, left-aligned title + item list + footer on the right (was a centered vertical stack with a `sparkles` symbol).
- Pink rounded (squircle) checkboxes. The reviewed items are snapshotted on appear so unchecking a row keeps it visible (dimmed) and re-checkable, instead of vanishing.
- Footer reads `983K Items selected | 296 GB` with an abbreviated count.

### Review transition (`SpaceLensView`)
- Opening/closing Review now uses the same slide-and-fade as the left-nav section transitions: the explorer slides up and out, then the review window slides up into place (and reverses on close). The explorer is swapped out of the hierarchy so nothing shows behind the window.

### List + bubbles (`SpaceLensListPanel`, `SpaceLensBubbleView`, `DiskScannerViewModel`)
- Left-panel checkbox restyled to the rounded squircle, consistent with the bubble and review-sheet checkboxes.
- New shared `highlightedNodeID` focus state: hovering a row rings its bubble and vice versa, in lockstep. A row click drills into the folder without toggling the removal checkbox (the checkbox is a separate control).
- Protected-item info tooltip now works: a custom dark callout hoisted above the scrolling rows (via a preference key, so it isn't clipped), with context-aware copy ("This is an essential system item…" / home-folder variant).

### Intro (`SectionPresentation`, `SectionIntroView`, `SpaceLensVolumePicker`)
- Updated the Space Lens intro tagline and feature rows to the reference text: **Visual Storage Map**, **Hidden Files Uncovered**, **Large Folders Overview**.
- Added a real scan-location picker (new `SpaceLensVolumePicker`) listing the Mac's mounted volumes plus a **Choose folder…** option. The selection lives on `DiskScannerViewModel.selectedVolumeURL`, which `beginScan()` now uses as the scan root (previously hardcoded to `/`). The footer gauge reports the scanned volume's capacity via the now URL-parameterized `SpaceLensVolumeUsage.current(for:)`.

## Tests
- `test_beginScan_usesSelectedVolumeAsScanRoot` — proves the picker selection drives the scan root.
- `SpaceLensProtectionMessageTests` — protected-item tooltip copy by category.
- Full unit suite green (1,218 tests). App target builds clean.

## Reviewer notes
- The intro feature-row **icons** are my best read of the low-res mock (all valid SF Symbols); easy one-line swaps if you want different glyphs.
- When scanning a **non-boot** volume or an arbitrary folder, `SpaceLensProtection` (defined in absolute boot-volume paths) marks nothing protected, so everything is removable there. Reasonable for external drives, but flagging in case you'd prefer to scope the picker to the boot volume only.
- UI was verified via build + unit tests; the visual transitions and the `NSOpenPanel` folder picker couldn't be screenshotted from the terminal and are worth a quick manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Space Lens volume picker so users can choose a different scan location or pick a folder.
  * Updated Space Lens visuals and messaging, including new feature highlights and clearer protection tooltips.
  * Improved review and list interactions with shared hover highlighting and smoother transitions.

* **Bug Fixes**
  * Fixed scan and storage calculations to reflect the selected scan location.
  * Prevented protected-item tooltips from being clipped and kept reviewed items visible after toggling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->