### PR TITLE
Manager perf + split, Smart Scan pre-warm, and full Notifications settings pane

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */; };
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		753D0372717545D89CC0A6C6 /* ConnectedDevicesMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218E411D3045401D9A955CE7 /* ConnectedDevicesMonitor.swift */; };
+		76E3EEE8D1DA95B2FCA60B93 /* ScanCompletionNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA948F9A1557934D6C51A6B /* ScanCompletionNotifier.swift */; };
 		771932E96231B65B69F5FC9E /* SmartCareReminderSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE0A87F7A4FBC3866E5DB3 /* SmartCareReminderSchedulerTests.swift */; };
 		77276E4F2CF13E1CBA3B7240 /* NotificationMonitors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC338BF1C5C87EDBF54A74F /* NotificationMonitors.swift */; };
 		7A3F6FF5FA5DC9E2E74C568B /* VolumeMountMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3D78EB1ABBA9055137FCC /* VolumeMountMonitor.swift */; };
@@ -350,6 +351,7 @@
 		F7CA4D7A9B843507613DEEBE /* BundledClamAVRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282664DFAA58CB5A5C87FFE /* BundledClamAVRuntime.swift */; };
 		F94ECD82ABC16F6465EEDA6C /* PerformanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935433C10308C1F2DDF51097 /* PerformanceView.swift */; };
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
+		FC5355702BCBC1A1C4DD43AC /* ScanCompletionNotifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E174B0BDF4FBEE8C025626 /* ScanCompletionNotifierTests.swift */; };
 		FE156E2CD69BA8F894E9078D /* FloatingScanButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A35775D85A4E890A04EE26 /* FloatingScanButtonTests.swift */; };
 		FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */; };
 		FF8163DBE33C05789BE5F41C /* MaintenanceTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D83104C36AA0A0E85DB7698 /* MaintenanceTask.swift */; };
@@ -656,6 +658,7 @@
 		B51321F0F77F5813E6777822 /* performance.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = performance.usdz; sourceTree = "<group>"; };
 		B5347E39C28AE8B7F020B233 /* SpaceLensVolumePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensVolumePicker.swift; sourceTree = "<group>"; };
 		B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensHoverCard.swift; sourceTree = "<group>"; };
+		B6E174B0BDF4FBEE8C025626 /* ScanCompletionNotifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCompletionNotifierTests.swift; sourceTree = "<group>"; };
 		B79E0766E335360E04FC6A53 /* AppDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDiscovery.swift; sourceTree = "<group>"; };
 		B8D99E37C2929F79D0A6DD11 /* SpaceLensSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensSelection.swift; sourceTree = "<group>"; };
 		BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModelTests.swift; sourceTree = "<group>"; };
@@ -712,6 +715,7 @@
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
 		DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewSubviews.swift; sourceTree = "<group>"; };
 		DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceRunLogTests.swift; sourceTree = "<group>"; };
+		DEA948F9A1557934D6C51A6B /* ScanCompletionNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCompletionNotifier.swift; sourceTree = "<group>"; };
 		DEAFBD23ECABA75AF3D1F33B /* BrowserPrivacyInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrivacyInspector.swift; sourceTree = "<group>"; };
 		DEB9C7A07E62C19FD94824B5 /* SmartScanViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanViewSubviews.swift; sourceTree = "<group>"; };
 		DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItemTests.swift; sourceTree = "<group>"; };
@@ -946,6 +950,7 @@
 				2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */,
 				2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */,
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
+				DEA948F9A1557934D6C51A6B /* ScanCompletionNotifier.swift */,
 				AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */,
 				3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */,
 				48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */,
@@ -1163,6 +1168,7 @@
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
+				B6E174B0BDF4FBEE8C025626 /* ScanCompletionNotifierTests.swift */,
 				3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */,
 				2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */,
 				BC72C9CBA70B1BBF45D6B8C1 /* ScanDiscWindowFrameTests.swift */,
@@ -1493,6 +1499,7 @@
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				3D65654B589EFF2972927ED7 /* ScanAccessPopoverTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
+				FC5355702BCBC1A1C4DD43AC /* ScanCompletionNotifierTests.swift in Sources */,
 				1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */,
 				102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */,
 				F106EE57A074D89D42E2872B /* ScanDiscWindowFrameTests.swift in Sources */,
@@ -1693,6 +1700,7 @@
 				56E0A50749CEFC070968439D /* SMCReader.swift in Sources */,
 				45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */,
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,
+				76E3EEE8D1DA95B2FCA60B93 /* ScanCompletionNotifier.swift in Sources */,
 				9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */,
 				67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */,
 				BA47B242AAAE6EAD08CC7D23 /* ScanDiscWindowController.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		024AB33FD8CD602332568895 /* SpaceLensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897C2A71D7CABB3FA25241A2 /* SpaceLensView.swift */; };
 		03546E424E99155428A6D25F /* HelperConnectionErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E776BF468380DFF621C6063C /* HelperConnectionErrorTests.swift */; };
 		03E56C4EFC8903CA9291A959 /* InstallationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C612F641A894AE10ADDA8F /* InstallationFile.swift */; };
+		042E4D668BD6A77F841EF13A /* TrashedAppMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9421F25B9FC2D1162925F2E7 /* TrashedAppMonitorTests.swift */; };
 		04327D324A0E8B4DA1AA55AA /* SpaceLensReviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42005C1A322A1B5ED65AE376 /* SpaceLensReviewSheet.swift */; };
 		04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */; };
 		04D9468D00A7CFE2758CDF8E /* LaunchAgentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */; };
@@ -20,6 +21,7 @@
 		070022969C225740C90D111D /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = CE304A4C8973520C602AE369 /* AppIcon.icon */; };
 		0839BF8CC096B1771BFF313C /* ScanningPreferencesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193D790F046085F3D309FF8C /* ScanningPreferencesUITests.swift */; };
 		0849175D7723A3D6B17FACF1 /* ApplicationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FD7F60311101E723D73E11 /* ApplicationsUITests.swift */; };
+		090CB8BE2FE82898922C54D4 /* TrashedAppMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944FFBC8E11AA4D85C33A981 /* TrashedAppMonitor.swift */; };
 		094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */; };
 		09F3933E9C2A8A09E3E8BAEB /* UnsupportedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF58D340F13A253CAAB153AC /* UnsupportedApp.swift */; };
 		0CD80916F38AE797C4CC96F8 /* SystemJunkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */; };
@@ -157,6 +159,7 @@
 		65B572321C38997952E456EF /* MyClutterManagerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558B0A2338BD9E61BDB7CE68 /* MyClutterManagerModel.swift */; };
 		65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */; };
+		667CDB738F03027C97828C68 /* HungAppMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603884BF695008972AC925C8 /* HungAppMonitorTests.swift */; };
 		67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */; };
 		688FEF65720EAF3D51754EC6 /* MyClutterManagerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */; };
 		6A34CA9DF4F4B0D1326A965C /* performance.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B51321F0F77F5813E6777822 /* performance.usdz */; };
@@ -175,6 +178,9 @@
 		725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */; };
 		730791446114BB6991798518 /* FileIconCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090134A72001DE6262436F3 /* FileIconCache.swift */; };
 		753D0372717545D89CC0A6C6 /* ConnectedDevicesMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218E411D3045401D9A955CE7 /* ConnectedDevicesMonitor.swift */; };
+		771932E96231B65B69F5FC9E /* SmartCareReminderSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE0A87F7A4FBC3866E5DB3 /* SmartCareReminderSchedulerTests.swift */; };
+		77276E4F2CF13E1CBA3B7240 /* NotificationMonitors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC338BF1C5C87EDBF54A74F /* NotificationMonitors.swift */; };
+		7A3F6FF5FA5DC9E2E74C568B /* VolumeMountMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F3D78EB1ABBA9055137FCC /* VolumeMountMonitor.swift */; };
 		7AA8E6E6FEE2767FD3C9AA20 /* HelperDeletionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02734346BE66CC759A92FB83 /* HelperDeletionPolicy.swift */; };
 		7B825804432A018484ED0E41 /* PerformanceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA263A6D9D0599684FD70A /* PerformanceViewModelTests.swift */; };
 		7BB62CCBF7BE84455A11531C /* ExtensionItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF25FB1100269A03B1F75269 /* ExtensionItemTests.swift */; };
@@ -198,6 +204,7 @@
 		85EAEABDF5D8CF95024CCD3C /* BrowserDataClearer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */; };
 		87193C2089A602109732C183 /* ProtectionPrivacyModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A836556BF25E11501EEE128 /* ProtectionPrivacyModelTests.swift */; };
 		892A824D29FE8A399773AA56 /* ExtensionsManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB7206FA1E88D8D440C77B /* ExtensionsManagerViewModel.swift */; };
+		8970C68164C01FF10E15F906 /* VolumeMountMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448786867041AFF7B9206B86 /* VolumeMountMonitorTests.swift */; };
 		89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */; };
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8AB1E73B111F38CE182AD9D3 /* ObservationRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462B37702C713BE1630DC992 /* ObservationRecording.swift */; };
@@ -209,7 +216,9 @@
 		90CEF79E082F50E5AB75C886 /* SpaceLensBubbleLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE4B778A9C7809CCF464005 /* SpaceLensBubbleLayoutTests.swift */; };
 		92BA2AB6A76731911DB04EF2 /* HealthMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */; };
 		9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */; };
+		95DF391560155E2EB9EE94D0 /* DeviceBatteryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F68C06D676F1E9305250846 /* DeviceBatteryMonitor.swift */; };
 		9686BE4A7CD0C6399070CC1B /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC2C4931BAD804306463545 /* ApplicationsDashboardSubviews.swift */; };
+		96D6310BF326A52494BCEB42 /* HungAppMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ECCA0AFF573341EB7FB454 /* HungAppMonitor.swift */; };
 		97F42752FD75E7F3E6CAF219 /* SpaceLensHoverCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */; };
 		99B965EE0BB2762D13896FF6 /* EmptyStateFullDiskAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */; };
 		99E2DC0FF5C29F7EFFC4F8D7 /* ColorDeepenedForWhiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588B33B31E27D3E193DF5889 /* ColorDeepenedForWhiteTests.swift */; };
@@ -281,6 +290,7 @@
 		C75E96295ED70F91F6B2A0F1 /* SectionTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */; };
 		C7CC2B5E09E8E3A89C39815E /* MacHealthStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BF07D3C75C31A0EA7E9037 /* MacHealthStatus.swift */; };
 		C848FD080F1DED2282ADC12E /* LocalSnapshotCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */; };
+		C882EE0A16D160B09E59AC50 /* TrashSizeMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4578EA7CB74F883F99837D /* TrashSizeMonitor.swift */; };
 		C92E74A78ED42228B081950D /* ProtectionManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA431DBFA6491AFA47651BD /* ProtectionManagerView.swift */; };
 		C9DB75A7B6E045D306393638 /* PrivacyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */; };
 		CEBC297EB683F3AAE3EA841E /* PerformanceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1675ADBCF352BE496572E655 /* PerformanceUITests.swift */; };
@@ -292,6 +302,7 @@
 		D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06573FAC4E25FCAF7BD166AF /* LanguageFileLocator.swift */; };
 		D62E869A1721F311F4599726 /* SpaceLensVolumeUsage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C27EE261148D623AC319C6D /* SpaceLensVolumeUsage.swift */; };
 		D6C17A4A7EE7DABEBDE62F94 /* BrowserPrivacyRemoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A4A9DC4B07D250A7F369C1 /* BrowserPrivacyRemoverTests.swift */; };
+		D6F3053273871EB277D1B523 /* DeviceBatteryMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A69F8127A8C664B222B5691 /* DeviceBatteryMonitorTests.swift */; };
 		D911FAA1B6067442C5D36F11 /* UpdateProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE71FA16E4B413D837F097E2 /* UpdateProbeTests.swift */; };
 		D96306C95D6F2DF780F02A5F /* AppUninstallerViewSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */; };
 		DAED579ECA147A7B4C6B91AD /* BrowserPrivacyInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A81CE206B5C749BA85DE09 /* BrowserPrivacyInspectorTests.swift */; };
@@ -302,6 +313,8 @@
 		DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */; };
 		DE57DC92B2179CB856E0D558 /* ScanProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3BFBAF09EA79BE34F2ABCF /* ScanProgressIndicator.swift */; };
 		E0420FF267A637AD7F530407 /* ExtensionDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B8D75FB7A02DE3D470F0C4 /* ExtensionDiscovery.swift */; };
+		E0FA768E0991A4FEDD8AEDBB /* SmartCareReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A46D48A6B426D060FC516CF0 /* SmartCareReminderScheduler.swift */; };
+		E18273F08878A4649BD2CE68 /* TrashSizeMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4001147A48C26B95F8DB07D8 /* TrashSizeMonitorTests.swift */; };
 		E1C1836BF10F1ED0E0B23E95 /* ManagerItemTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963EE90AA293C3991962768D /* ManagerItemTable.swift */; };
 		E2B25912B9BA5745454E137F /* SystemJunkUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */; };
 		E300A5469C97AE8F304FD051 /* BrowserDataCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E9C1B2D0698E37C9F9E385 /* BrowserDataCounter.swift */; };
@@ -431,6 +444,7 @@
 		193D790F046085F3D309FF8C /* ScanningPreferencesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanningPreferencesUITests.swift; sourceTree = "<group>"; };
 		1A06928276134E79D8ADFBF5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1A3DE098197EC0362C64AEF7 /* CleanupGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupGroup.swift; sourceTree = "<group>"; };
+		1A69F8127A8C664B222B5691 /* DeviceBatteryMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBatteryMonitorTests.swift; sourceTree = "<group>"; };
 		1B0FF6808EEAB9104DCC8D61 /* MyClutterDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterDashboardView.swift; sourceTree = "<group>"; };
 		1BED81B0628BEACAB6B965B9 /* MyClutterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterViewModelTests.swift; sourceTree = "<group>"; };
 		1C116D07B8F84B3D4F4307F6 /* SimilarImageScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarImageScanner.swift; sourceTree = "<group>"; };
@@ -481,13 +495,16 @@
 		3B254800CFACCE9FC59E66A4 /* BrowserDataPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviding.swift; sourceTree = "<group>"; };
 		3BEAD4C3A7D9B274C73AE97A /* privacy.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = privacy.usdz; sourceTree = "<group>"; };
 		3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanView.swift; sourceTree = "<group>"; };
+		3FC338BF1C5C87EDBF54A74F /* NotificationMonitors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMonitors.swift; sourceTree = "<group>"; };
 		3FFEFF66138A13C7E229C7E9 /* BrowserPrivacyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrivacyStore.swift; sourceTree = "<group>"; };
+		4001147A48C26B95F8DB07D8 /* TrashSizeMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashSizeMonitorTests.swift; sourceTree = "<group>"; };
 		416D1869BE7C552C78714296 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		42005C1A322A1B5ED65AE376 /* SpaceLensReviewSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensReviewSheet.swift; sourceTree = "<group>"; };
 		42925F5D185AFC988AD68E43 /* AppUpdaterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterViewModelTests.swift; sourceTree = "<group>"; };
 		42AF567A089D89B454DAE3C5 /* BrowserDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetectorTests.swift; sourceTree = "<group>"; };
 		42F300F77753120EDE3C73AF /* ExtensionsManagerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsManagerViewSubviews.swift; sourceTree = "<group>"; };
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
+		448786867041AFF7B9206B86 /* VolumeMountMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeMountMonitorTests.swift; sourceTree = "<group>"; };
 		44EE14A680D5C81A7BA681DD /* SpaceLensVolumeUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensVolumeUsageTests.swift; sourceTree = "<group>"; };
 		462B37702C713BE1630DC992 /* ObservationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationRecording.swift; sourceTree = "<group>"; };
 		46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpersTests.swift; sourceTree = "<group>"; };
@@ -503,6 +520,7 @@
 		4F4C43FBCF5B117B218E3A5F /* ProtectionDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectionDashboardSubviews.swift; sourceTree = "<group>"; };
 		4F5BB068BDD86F2C6D2FC966 /* ClamAVDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVDetector.swift; sourceTree = "<group>"; };
 		4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateCheckerTests.swift; sourceTree = "<group>"; };
+		4F68C06D676F1E9305250846 /* DeviceBatteryMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBatteryMonitor.swift; sourceTree = "<group>"; };
 		4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPFetching.swift; sourceTree = "<group>"; };
 		5163E14892EAA1E30C3EFFE5 /* VaderCleanerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VaderCleanerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		51FA263A6D9D0599684FD70A /* PerformanceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceViewModelTests.swift; sourceTree = "<group>"; };
@@ -525,6 +543,7 @@
 		5F498579A77E1DAED6AC00AF /* SmartScanMyClutterReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanMyClutterReview.swift; sourceTree = "<group>"; };
 		5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemsManagerTests.swift; sourceTree = "<group>"; };
 		5FD6A6FB847C87B47474C7A3 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
+		603884BF695008972AC925C8 /* HungAppMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HungAppMonitorTests.swift; sourceTree = "<group>"; };
 		603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScannerTests.swift; sourceTree = "<group>"; };
 		6085B6A39985DFF334821551 /* ExclusionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStore.swift; sourceTree = "<group>"; };
 		6090134A72001DE6262436F3 /* FileIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIconCache.swift; sourceTree = "<group>"; };
@@ -557,6 +576,7 @@
 		7267FCB6C8B06372BD90E59D /* ProcessLineStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessLineStreamerTests.swift; sourceTree = "<group>"; };
 		7322D2E167E70ED4D0FBFBA2 /* MenuRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRouter.swift; sourceTree = "<group>"; };
 		732FA87F80DF686871220B50 /* SectionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionPresentationTests.swift; sourceTree = "<group>"; };
+		74FE0A87F7A4FBC3866E5DB3 /* SmartCareReminderSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartCareReminderSchedulerTests.swift; sourceTree = "<group>"; };
 		785EECE3C6B84ECB7D0A3384 /* spaceLens.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = spaceLens.usdz; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7E800D4E6E10B7B99B2D1170 /* AppUninstallerViewModelMultiSelectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelMultiSelectTests.swift; sourceTree = "<group>"; };
@@ -592,6 +612,8 @@
 		92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResult.swift; sourceTree = "<group>"; };
 		933E3B42C683C14A7398939F /* MailReindexerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailReindexerTests.swift; sourceTree = "<group>"; };
 		935433C10308C1F2DDF51097 /* PerformanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceView.swift; sourceTree = "<group>"; };
+		9421F25B9FC2D1162925F2E7 /* TrashedAppMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashedAppMonitorTests.swift; sourceTree = "<group>"; };
+		944FFBC8E11AA4D85C33A981 /* TrashedAppMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashedAppMonitor.swift; sourceTree = "<group>"; };
 		952CFA79F6F0E89198DED8E3 /* SmartScanPerformanceReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanPerformanceReview.swift; sourceTree = "<group>"; };
 		9546ABE698D709FA5CB9ED29 /* BrowserDataClearer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataClearer.swift; sourceTree = "<group>"; };
 		963EE90AA293C3991962768D /* ManagerItemTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagerItemTable.swift; sourceTree = "<group>"; };
@@ -599,6 +621,7 @@
 		973FCD99A18392D82D543907 /* MyClutterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterViewModel.swift; sourceTree = "<group>"; };
 		9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionThemeTests.swift; sourceTree = "<group>"; };
 		98D7B18095634307C5D7223D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		98ECCA0AFF573341EB7FB454 /* HungAppMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HungAppMonitor.swift; sourceTree = "<group>"; };
 		9B77D1A002F58496087AF3E3 /* SmartScanByteFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanByteFormatter.swift; sourceTree = "<group>"; };
 		9C1D85C87621345FBF7CDC41 /* UnusedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScanner.swift; sourceTree = "<group>"; };
 		9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
@@ -613,6 +636,7 @@
 		A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerApp.swift; sourceTree = "<group>"; };
 		A3852658DC221FB8B03631D1 /* HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocol.swift; sourceTree = "<group>"; };
 		A457B6C8523278A91D85120D /* SimilarImageScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarImageScannerTests.swift; sourceTree = "<group>"; };
+		A46D48A6B426D060FC516CF0 /* SmartCareReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartCareReminderScheduler.swift; sourceTree = "<group>"; };
 		A4982BBDB43C7E3F9323EACE /* CleanupManagerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupManagerStore.swift; sourceTree = "<group>"; };
 		A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareThreatRemoverTests.swift; sourceTree = "<group>"; };
 		A75EF6CEA94213CDD0564C48 /* SpaceLensSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensSelectionTests.swift; sourceTree = "<group>"; };
@@ -683,6 +707,7 @@
 		D631EBC782CB95D9221AD977 /* AppLeftover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLeftover.swift; sourceTree = "<group>"; };
 		D747E37C520E51FA10D0A08F /* ProtectionDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectionDashboardView.swift; sourceTree = "<group>"; };
 		D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRailView.swift; sourceTree = "<group>"; };
+		D7F3D78EB1ABBA9055137FCC /* VolumeMountMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeMountMonitor.swift; sourceTree = "<group>"; };
 		D9E9C1B2D0698E37C9F9E385 /* BrowserDataCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataCounter.swift; sourceTree = "<group>"; };
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
 		DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewSubviews.swift; sourceTree = "<group>"; };
@@ -727,6 +752,7 @@
 		FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VaderCleaner.entitlements; sourceTree = "<group>"; };
 		FAA431DBFA6491AFA47651BD /* ProtectionManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectionManagerView.swift; sourceTree = "<group>"; };
 		FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceRunLog.swift; sourceTree = "<group>"; };
+		FC4578EA7CB74F883F99837D /* TrashSizeMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashSizeMonitor.swift; sourceTree = "<group>"; };
 		FCA2D3E58D656FF184F406A0 /* SpaceLensBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensBubbleView.swift; sourceTree = "<group>"; };
 		FD357ABDE3B8870727141BD5 /* LaunchAgentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManagerTests.swift; sourceTree = "<group>"; };
 		FE6697CA6EEE719B2E2D46CE /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -829,6 +855,7 @@
 				218E411D3045401D9A955CE7 /* ConnectedDevicesMonitor.swift */,
 				C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */,
 				232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */,
+				4F68C06D676F1E9305250846 /* DeviceBatteryMonitor.swift */,
 				B39407E2EA6D045893F1BA4B /* DiskNode.swift */,
 				C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */,
 				613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */,
@@ -855,6 +882,7 @@
 				43596249B222D18142F961E2 /* HelperConnectionManager.swift */,
 				22401E5D2CFF7ED31D591C9B /* HelperRegistration.swift */,
 				4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */,
+				98ECCA0AFF573341EB7FB454 /* HungAppMonitor.swift */,
 				98D7B18095634307C5D7223D /* Info.plist */,
 				F2C612F641A894AE10ADDA8F /* InstallationFile.swift */,
 				574D2DD309CA4FA07640FAA0 /* InstallationFileScanner.swift */,
@@ -892,6 +920,7 @@
 				D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */,
 				2DE93B076C67D0851F0F7C0F /* NavigationSection.swift */,
 				B3CD8C98E8253953444DD99F /* NotificationManager.swift */,
+				3FC338BF1C5C87EDBF54A74F /* NotificationMonitors.swift */,
 				0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */,
 				EE225F3A130C0DDEE2E31DBF /* PerformanceDashboardSubviews.swift */,
 				F31CF01651B0768E98E36F3E /* PerformanceRecommendationEngine.swift */,
@@ -932,6 +961,7 @@
 				09D3DDA2AD38124F925AA572 /* SettingsRouter.swift */,
 				331110971EA8F8690773FE88 /* SimilarImageGroup.swift */,
 				1C116D07B8F84B3D4F4307F6 /* SimilarImageScanner.swift */,
+				A46D48A6B426D060FC516CF0 /* SmartCareReminderScheduler.swift */,
 				215EFDDDC81E5E7C6DBD72AB /* SmartScanApplicationsReview.swift */,
 				9B77D1A002F58496087AF3E3 /* SmartScanByteFormatter.swift */,
 				E67824DA18085247812F6E08 /* SmartScanJunkReview.swift */,
@@ -966,6 +996,8 @@
 				D1CC391B523110720320AD89 /* SystemPathProviding.swift */,
 				02167EA31F576ABDAC69EF9D /* SystemStatsFormatters.swift */,
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
+				944FFBC8E11AA4D85C33A981 /* TrashedAppMonitor.swift */,
+				FC4578EA7CB74F883F99837D /* TrashSizeMonitor.swift */,
 				EF58D340F13A253CAAB153AC /* UnsupportedApp.swift */,
 				0976ECD3B6F65080DAE55EF5 /* UnsupportedAppScanner.swift */,
 				EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */,
@@ -977,6 +1009,7 @@
 				A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */,
 				F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */,
 				CEAF96E747AD4C1378B4043D /* VersionComparator.swift */,
+				D7F3D78EB1ABBA9055137FCC /* VolumeMountMonitor.swift */,
 				416D1869BE7C552C78714296 /* WindowAccessor.swift */,
 				46466A1909A880757A7C4B31 /* Localizable.strings */,
 				329FBD86F55918272AF0EF2A /* Localizable.stringsdict */,
@@ -1069,6 +1102,7 @@
 				1071E99E2EFBE2C48C528D41 /* ConnectedDevicesMonitorTests.swift */,
 				3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */,
 				EC956EC0DA96B13BC471FE24 /* DefaultSystemPathProviderTests.swift */,
+				1A69F8127A8C664B222B5691 /* DeviceBatteryMonitorTests.swift */,
 				E6E70D995D68953417DB5C7A /* DiskNodeTests.swift */,
 				3A89B9E06E1B08BFF9C46D41 /* DiskScannerTests.swift */,
 				BAFC6A15E9745E05B3EF36B7 /* DiskScannerViewModelTests.swift */,
@@ -1087,6 +1121,7 @@
 				0951FF1C6116BA863CE6E438 /* HelperConnectionManagerTests.swift */,
 				2B7A5776AEA9716FAB1C8C1A /* HelperDeletionPolicyTests.swift */,
 				811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */,
+				603884BF695008972AC925C8 /* HungAppMonitorTests.swift */,
 				CFF1BAC0B12BDB540F250299 /* InstallationFileScannerTests.swift */,
 				1CE0B536A27CFB7B30895829 /* LanguageFileLocatorTests.swift */,
 				603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */,
@@ -1136,6 +1171,7 @@
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */,
 				A457B6C8523278A91D85120D /* SimilarImageScannerTests.swift */,
+				74FE0A87F7A4FBC3866E5DB3 /* SmartCareReminderSchedulerTests.swift */,
 				CDCDF1D60580818B27EFBB56 /* SmartScanSettingsStoreTests.swift */,
 				2B7A2E8519B0A29788748060 /* SmartScanViewModelTests.swift */,
 				2BE4B778A9C7809CCF464005 /* SpaceLensBubbleLayoutTests.swift */,
@@ -1151,11 +1187,14 @@
 				DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */,
 				6B72F3BD5C48C77AE99F8D4E /* SystemStatsServiceTests.swift */,
 				46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */,
+				9421F25B9FC2D1162925F2E7 /* TrashedAppMonitorTests.swift */,
+				4001147A48C26B95F8DB07D8 /* TrashSizeMonitorTests.swift */,
 				1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */,
 				382745ACB652CA50CA393BD5 /* UnusedAppScannerTests.swift */,
 				B46943B264F72B3753075A8C /* UpdateInfoTests.swift */,
 				CE71FA16E4B413D837F097E2 /* UpdateProbeTests.swift */,
 				1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */,
+				448786867041AFF7B9206B86 /* VolumeMountMonitorTests.swift */,
 				E149BD1FE4E65D6589292B84 /* Helpers */,
 			);
 			path = VaderCleanerTests;
@@ -1393,6 +1432,7 @@
 				6FEEC4B62B2D99B25975B8DE /* ConnectedDevicesMonitorTests.swift in Sources */,
 				ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */,
 				DD92247860ECAD88096590A9 /* DefaultSystemPathProviderTests.swift in Sources */,
+				D6F3053273871EB277D1B523 /* DeviceBatteryMonitorTests.swift in Sources */,
 				FEFC9C434D8719662403778A /* DiskNodeTests.swift in Sources */,
 				82114340C443D23D241B67EE /* DiskScannerTests.swift in Sources */,
 				2A28D67DA396B3D2B6DB13D5 /* DiskScannerViewModelTests.swift in Sources */,
@@ -1411,6 +1451,7 @@
 				6FA0978FAEE1204135FC6B45 /* HelperConnectionManagerTests.swift in Sources */,
 				04328806E7CBEC5AB0C6D3E0 /* HelperDeletionPolicyTests.swift in Sources */,
 				17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */,
+				667CDB738F03027C97828C68 /* HungAppMonitorTests.swift in Sources */,
 				B86DA7DFDECF401C5BCCAC24 /* InstallationFileScannerTests.swift in Sources */,
 				57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */,
 				50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */,
@@ -1460,6 +1501,7 @@
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				2D8DAC3191BC1733AE762C03 /* SectionThemeTests.swift in Sources */,
 				54C07EBB0CD76D45308A2E9E /* SimilarImageScannerTests.swift in Sources */,
+				771932E96231B65B69F5FC9E /* SmartCareReminderSchedulerTests.swift in Sources */,
 				22ABAB2520C6640036561DEC /* SmartScanSettingsStoreTests.swift in Sources */,
 				7DF943BE41A3AA6E705402C2 /* SmartScanViewModelTests.swift in Sources */,
 				90CEF79E082F50E5AB75C886 /* SpaceLensBubbleLayoutTests.swift in Sources */,
@@ -1476,11 +1518,14 @@
 				5DF68FC234F70DA478496658 /* SystemStatsServiceTests.swift in Sources */,
 				C26E98922A61A57DB9369C60 /* TestHelpers.swift in Sources */,
 				109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */,
+				E18273F08878A4649BD2CE68 /* TrashSizeMonitorTests.swift in Sources */,
+				042E4D668BD6A77F841EF13A /* TrashedAppMonitorTests.swift in Sources */,
 				F4BF8822B044CE3445A144E7 /* UnsupportedAppScannerTests.swift in Sources */,
 				48EF0257049EE6954E00E936 /* UnusedAppScannerTests.swift in Sources */,
 				218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */,
 				D911FAA1B6067442C5D36F11 /* UpdateProbeTests.swift in Sources */,
 				3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */,
+				8970C68164C01FF10E15F906 /* VolumeMountMonitorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1555,6 +1600,7 @@
 				753D0372717545D89CC0A6C6 /* ConnectedDevicesMonitor.swift in Sources */,
 				3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */,
 				BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */,
+				95DF391560155E2EB9EE94D0 /* DeviceBatteryMonitor.swift in Sources */,
 				B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */,
 				D008B92465730BE5BA8FB071 /* DiskScanner.swift in Sources */,
 				F25011B395398F5A2C18C25E /* DiskScannerViewModel.swift in Sources */,
@@ -1583,6 +1629,7 @@
 				65DC450717EC1648D41BE82D /* HelperDeletionPolicy.swift in Sources */,
 				55C5A32390A164FEC4DEBE0C /* HelperProtocol.swift in Sources */,
 				2DD748D16E344D435A5C3E24 /* HelperRegistration.swift in Sources */,
+				96D6310BF326A52494BCEB42 /* HungAppMonitor.swift in Sources */,
 				03E56C4EFC8903CA9291A959 /* InstallationFile.swift in Sources */,
 				55B6AD3998807918EE9FD2AF /* InstallationFileScanner.swift in Sources */,
 				D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */,
@@ -1619,6 +1666,7 @@
 				5325F2401AF35C69086E2056 /* NavigationRailView.swift in Sources */,
 				F42BBC5917D4AB650D50B4B8 /* NavigationSection.swift in Sources */,
 				65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */,
+				77276E4F2CF13E1CBA3B7240 /* NotificationMonitors.swift in Sources */,
 				B60909E266277B691B876E63 /* NotificationThresholdMonitor.swift in Sources */,
 				162D663EBCC70A0702F4304A /* PerformanceDashboardSubviews.swift in Sources */,
 				6E0D8F255BA67DF884857717 /* PerformanceRecommendationEngine.swift in Sources */,
@@ -1660,6 +1708,7 @@
 				067E5321D0D1EC27BCB91421 /* SettingsRouter.swift in Sources */,
 				AFE3EC8473F0D6BC1141FD07 /* SimilarImageGroup.swift in Sources */,
 				3C5FEDACD30210E5D23F3ABB /* SimilarImageScanner.swift in Sources */,
+				E0FA768E0991A4FEDD8AEDBB /* SmartCareReminderScheduler.swift in Sources */,
 				6EF22E5516F91C461FBBB850 /* SmartScanApplicationsReview.swift in Sources */,
 				7D9F720BEBBC9861727E8189 /* SmartScanByteFormatter.swift in Sources */,
 				472FECDAABC513309987AA5E /* SmartScanJunkReview.swift in Sources */,
@@ -1693,6 +1742,8 @@
 				BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */,
 				9A250FE3659363C1A7E4F1E9 /* SystemStatsFormatters.swift in Sources */,
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
+				C882EE0A16D160B09E59AC50 /* TrashSizeMonitor.swift in Sources */,
+				090CB8BE2FE82898922C54D4 /* TrashedAppMonitor.swift in Sources */,
 				09F3933E9C2A8A09E3E8BAEB /* UnsupportedApp.swift in Sources */,
 				533BAE450469983F721BF936 /* UnsupportedAppScanner.swift in Sources */,
 				6D2476F58F6EDCF6C12C844D /* UnusedApp.swift in Sources */,
@@ -1703,6 +1754,7 @@
 				BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */,
 				A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */,
 				B51203EFD0B1E0734609E427 /* VersionComparator.swift in Sources */,
+				7A3F6FF5FA5DC9E2E74C568B /* VolumeMountMonitor.swift in Sources */,
 				C25D4D4F9A47A82CFA3B8810 /* WindowAccessor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VaderCleaner/AppUninstallerViewModel.swift
+++ b/VaderCleaner/AppUninstallerViewModel.swift
@@ -51,6 +51,11 @@ final class AppUninstallerViewModel {
     typealias Discover     = @Sendable (_ includingSystemApps: Bool) async throws -> [AppInfo]
     typealias FindFiles    = @Sendable (_ bundleID: String) async -> [AssociatedFile]
     typealias MeasureSize  = @Sendable (_ bundleURL: URL) async -> Int64
+    /// Batch metrics walk for the Applications Manager's uninstaller list:
+    /// returns each app's bundle size and Spotlight last-opened date. Batched
+    /// (rather than reusing per-app `MeasureSize`) so the whole list is measured
+    /// in one background pass — the size walk over many bundles is expensive.
+    typealias MeasureListMetrics = @Sendable (_ apps: [AppInfo]) async -> (sizes: [AppInfo.ID: Int64], dates: [AppInfo.ID: Date])
     /// Recycler contract: takes the `.app` bundle URL and the associated
     /// file URLs separately so the production implementation can verify
     /// the bundle itself was moved (and not just the user-writable
@@ -78,9 +83,28 @@ final class AppUninstallerViewModel {
     /// list and the detail inspector don't fight over one selection.
     private(set) var uninstallSelection: Set<AppInfo.ID> = []
 
+    /// Session-scoped per-app size and last-opened caches the Applications
+    /// Manager's uninstaller list sorts and renders by. Populated once by
+    /// `loadListMetrics()` and retained for the session so reopening the manager
+    /// reuses them instead of re-walking the disk. Observable so the list
+    /// re-renders when the measured values land.
+    private(set) var listSizes: [AppInfo.ID: Int64] = [:]
+    private(set) var listLastOpened: [AppInfo.ID: Date] = [:]
+    /// Apps that have completed a metrics pass, tracked separately from the
+    /// value caches because a `nil` last-opened date is a valid result (Spotlight
+    /// has no record) — inferring "measured" from the dictionaries would re-walk
+    /// those apps forever.
+    @ObservationIgnored private var measuredListMetricApps: Set<AppInfo.ID> = []
+    /// Bumped after every batch of freshly-measured metrics so the manager's
+    /// memoized list recomputes its order once the values arrive. The dictionary
+    /// updates above already re-render the rows; this gives the order a single
+    /// cheap change to observe rather than diffing the dictionaries.
+    private(set) var listMetricsRevision: Int = 0
+
     @ObservationIgnored private let discover: Discover
     @ObservationIgnored private let findFiles: FindFiles
     @ObservationIgnored private let measureSize: MeasureSize
+    @ObservationIgnored private let measureListMetrics: MeasureListMetrics
     @ObservationIgnored private let recycle: Recycle
     @ObservationIgnored private let reinstallHelperService: ReinstallHelper
     @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
@@ -104,12 +128,14 @@ final class AppUninstallerViewModel {
         discover: @escaping Discover,
         findFiles: @escaping FindFiles,
         measureSize: @escaping MeasureSize = { _ in 0 },
+        measureListMetrics: @escaping MeasureListMetrics = { _ in ([:], [:]) },
         recycle: @escaping Recycle,
         reinstallHelper: @escaping ReinstallHelper = {}
     ) {
         self.discover = discover
         self.findFiles = findFiles
         self.measureSize = measureSize
+        self.measureListMetrics = measureListMetrics
         self.recycle = recycle
         self.reinstallHelperService = reinstallHelper
     }
@@ -199,6 +225,23 @@ final class AppUninstallerViewModel {
     /// list reflects the new filter immediately.
     func reloadApps() async {
         await loadApps()
+    }
+
+    /// Measures size and last-opened date for every app not already in the
+    /// `listSizes` / `listLastOpened` caches, then merges the results.
+    /// Idempotent: apps measured earlier in the session are skipped, so the
+    /// expensive disk walk runs once per app and reopening the manager reuses
+    /// the cache. A no-op when nothing is pending — the revision only bumps when
+    /// new metrics actually land.
+    func loadListMetrics() async {
+        let pending = apps.filter { !measuredListMetricApps.contains($0.id) }
+        guard !pending.isEmpty else { return }
+        let measured = await measureListMetrics(pending)
+        // Merge rather than replace so apps already measured keep their values.
+        listSizes.merge(measured.sizes) { _, new in new }
+        listLastOpened.merge(measured.dates) { _, new in new }
+        for app in pending { measuredListMetricApps.insert(app.id) }
+        listMetricsRevision &+= 1
     }
 
     /// Select an app by ID. Drives an async associated-files lookup AND
@@ -469,6 +512,21 @@ extension AppUninstallerViewModel {
             },
             measureSize: { url in
                 await discovery.bundleSize(at: url)
+            },
+            measureListMetrics: { apps in
+                // One background pass over the whole list: the bundle-size walk
+                // is the expensive measurement discovery deliberately skips, so
+                // it runs detached off the main actor.
+                await Task.detached(priority: .utility) {
+                    var sizes: [AppInfo.ID: Int64] = [:]
+                    var dates: [AppInfo.ID: Date] = [:]
+                    let fileManager = FileManager.default
+                    for app in apps {
+                        sizes[app.id] = DefaultAppDiscovery.bundleSize(at: app.bundleURL, fileManager: fileManager)
+                        dates[app.id] = DefaultUnusedAppScanner.spotlightLastUsedDate(app)
+                    }
+                    return (sizes, dates)
+                }.value
             },
             recycle: { bundleURL, associatedURLs in
                 try await Self.recycleViaWorkspace(

--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -25,31 +25,11 @@ struct ApplicationsManagerView: View {
         case leftovers
     }
 
-    /// Which sub-list the Leftovers pane shows in its right column.
-    private enum LeftoverSection: Hashable {
-        case installers
-        case leftoverFiles
-    }
-
     /// The reference Manager uses a magenta accent on a white surface, the same
     /// one the My Clutter / Cleanup Managers adopt — independent of the
     /// Applications section's own hue.
-    private static let accent = ManagerChrome.accent
-    private static let selectionFill = Color(red: 0.45, green: 0.30, blue: 0.85).opacity(0.14)
-
-    /// Middle-pane facet for the Updater pane.
-    private enum UpdaterFacet: Hashable {
-        case all
-        case selected
-        case store(isAppStore: Bool)
-    }
-
-    /// Middle-pane facet for the Extensions pane.
-    private enum ExtensionsFacet: Hashable {
-        case all
-        case selected
-        case type(ExtensionType)
-    }
+    private static let accent = ApplicationsManagerChrome.accent
+    private static let selectionFill = ApplicationsManagerChrome.selectionFill
 
     @State private var pane: Pane
     @State private var search = ""
@@ -70,15 +50,18 @@ struct ApplicationsManagerView: View {
     @State private var inspectingAppID: AppInfo.ID?
     /// Confirmation for the footer's batch uninstall (the checkbox selection).
     @State private var showUninstallConfirmation = false
-    /// Confirmation for the single app open in the chevron detail.
-    @State private var showSingleUninstallConfirmation = false
 
-    // Off-main metrics for the uninstaller list: per-app size and last-opened
-    // date. Rebuilt when the app list changes — the size walk is the expensive
-    // pass discovery deliberately skips, so it runs detached, like
-    // `MyClutterManagerView.rebuildCaches()`.
-    @State private var sizes: [AppInfo.ID: Int64] = [:]
-    @State private var lastOpened: [AppInfo.ID: Date] = [:]
+    // The filtered, sorted uninstaller list, memoized so a checkbox toggle
+    // re-renders the rows without re-running the O(n log n) filter + sort over
+    // every app. Recomputed only when an input that actually changes the list
+    // changes — facet, search, sort, the app roster, the measured metrics, and
+    // (only under the Selected facet) the selection.
+    @State private var displayedApps: [AppInfo] = []
+    // The Updater and Extensions lists, memoized for the same reason: their
+    // filter (and the Extensions sort) ran on every render, so toggling a row's
+    // checkbox re-filtered the whole list. Recomputed only on their real inputs.
+    @State private var displayedUpdates: [UpdateInfo] = []
+    @State private var displayedExtensions: [ExtensionItem] = []
 
     init(
         viewModel: ApplicationsViewModel,
@@ -107,9 +90,7 @@ struct ApplicationsManagerView: View {
             HStack(spacing: 0) {
                 navigationPane.frame(width: 220)
                 Divider().opacity(0.4)
-                middlePane.frame(width: 320)
-                Divider().opacity(0.4)
-                rightPane.frame(maxWidth: .infinity)
+                paneContent
             }
             Divider().opacity(0.4)
             footer
@@ -133,7 +114,7 @@ struct ApplicationsManagerView: View {
         .task {
             if extensionsManagerViewModel.phase == .idle { await extensionsManagerViewModel.refresh() }
         }
-        .task(id: uninstallerViewModel.apps.map(\.id)) { await rebuildMetrics() }
+        .task(id: uninstallerViewModel.apps.map(\.id)) { await uninstallerViewModel.loadListMetrics() }
         .alert(uninstallConfirmationTitle, isPresented: $showUninstallConfirmation) {
             Button(String(localized: "Cancel", comment: "Cancel button on the uninstall confirmation."), role: .cancel) {}
             Button(String(localized: "Uninstall", comment: "Confirm batch uninstall."), role: .destructive) {
@@ -141,14 +122,6 @@ struct ApplicationsManagerView: View {
             }
         } message: {
             Text(uninstallConfirmationMessage)
-        }
-        .alert(singleUninstallConfirmationTitle, isPresented: $showSingleUninstallConfirmation) {
-            Button(String(localized: "Cancel", comment: "Cancel button on the uninstall confirmation."), role: .cancel) {}
-            Button(String(localized: "Uninstall", comment: "Confirm single-app uninstall."), role: .destructive) {
-                Task { await uninstallerViewModel.uninstall() }
-            }
-        } message: {
-            Text(singleUninstallConfirmationMessage)
         }
     }
 
@@ -221,615 +194,48 @@ struct ApplicationsManagerView: View {
         .accessibilityIdentifier(identifier)
     }
 
-    // MARK: - Middle pane
+    // MARK: - Pane content
 
+    /// The center of the manager: the active pane's facet column and right pane.
+    /// Each pane is its own subview, so a checkbox toggle re-renders only that
+    /// pane rather than the whole manager.
     @ViewBuilder
-    private var middlePane: some View {
+    private var paneContent: some View {
         switch pane {
         case .uninstaller:
-            VStack(alignment: .leading, spacing: 0) {
-                paneHeader(
-                    title: String(localized: "Uninstaller", comment: "Uninstaller pane title."),
-                    description: String(localized: "Correctly remove entire applications with all of the related files.", comment: "Uninstaller pane description.")
-                )
-                ScrollView { uninstallerFacets.padding(8) }
-            }
-        case .leftovers:
-            VStack(alignment: .leading, spacing: 0) {
-                paneHeader(
-                    title: String(localized: "Leftovers", comment: "Leftovers pane title."),
-                    description: String(localized: "If you manually remove an application file, all of its related items remain on your system. VaderCleaner locates and removes these leftovers even if the main app is already gone.", comment: "Leftovers pane description.")
-                )
-                ScrollView { leftoverSections.padding(8) }
-            }
+            UninstallerPaneView(
+                uninstallerViewModel: uninstallerViewModel,
+                result: result,
+                iconCache: iconCache,
+                search: search,
+                sort: sort,
+                facet: $uninstallerFacet,
+                inspectingAppID: $inspectingAppID,
+                displayedApps: $displayedApps
+            )
         case .updater:
-            VStack(alignment: .leading, spacing: 0) {
-                paneHeader(
-                    title: String(localized: "Updater", comment: "Updater pane title."),
-                    description: String(localized: "Keep your apps current with the latest fixes and features.", comment: "Updater pane description.")
-                )
-                ScrollView { updaterFacets.padding(8) }
-            }
+            UpdaterPaneView(
+                updaterViewModel: updaterViewModel,
+                iconCache: iconCache,
+                search: search,
+                facet: $updaterFacet,
+                selection: $updateSelection,
+                displayed: $displayedUpdates
+            )
         case .extensions:
-            VStack(alignment: .leading, spacing: 0) {
-                paneHeader(
-                    title: String(localized: "Extensions", comment: "Extensions pane title."),
-                    description: String(localized: "Manage the add-ons and plug-ins installed into your browsers and apps.", comment: "Extensions pane description.")
-                )
-                ScrollView { extensionsFacets.padding(8) }
-            }
-        }
-    }
-
-    private var uninstallerFacets: some View {
-        let apps = uninstallerViewModel.apps
-        let stores = ApplicationsManagerModel.storeCounts(apps: apps)
-        let vendors = ApplicationsManagerModel.vendorCounts(apps: apps)
-        return VStack(spacing: 4) {
-            facetRow(.all, String(localized: "All Applications", comment: "Uninstaller facet."), apps.count)
-            facetRow(.unused, String(localized: "Unused", comment: "Uninstaller facet."), unusedIDs.count)
-            facetRow(.suspicious, String(localized: "Suspicious", comment: "Uninstaller facet."), 0)
-            facetRow(.selected, String(localized: "Selected", comment: "Uninstaller facet."), uninstallerViewModel.uninstallSelection.count)
-
-            facetSectionHeader(String(localized: "Stores", comment: "Uninstaller facet group header."))
-            facetRow(.store(isAppStore: true), String(localized: "App Store", comment: "Uninstaller store facet."), stores.appStore)
-            facetRow(.store(isAppStore: false), String(localized: "Other", comment: "Uninstaller store facet."), stores.other)
-
-            if !vendors.isEmpty {
-                facetSectionHeader(String(localized: "Vendors", comment: "Uninstaller facet group header."))
-                ForEach(vendors, id: \.vendor) { entry in
-                    facetRow(.vendor(entry.vendor), entry.vendor.title, entry.count)
-                }
-            }
-        }
-    }
-
-    private func facetRow(_ facet: AppManagerFacet, _ label: String, _ count: Int) -> some View {
-        selectableRow(selected: uninstallerFacet == facet) {
-            uninstallerFacet = facet
-            inspectingAppID = nil
-        } content: {
-            HStack {
-                Text(label).font(.body.weight(.medium))
-                Spacer()
-                Text("\(count)").font(.callout).foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    private var leftoverSections: some View {
-        VStack(spacing: 4) {
-            leftoverRow(.installers,
-                        Image("installerDmg"),
-                        String(localized: "Installers", comment: "Leftovers section."),
-                        result.installationFilesTotalBytes)
-            leftoverRow(.leftoverFiles,
-                        Image(systemName: "puzzlepiece.extension.fill"),
-                        String(localized: "Leftover Files", comment: "Leftovers section."),
-                        result.leftoversTotalBytes)
-        }
-    }
-
-    private func leftoverRow(_ section: LeftoverSection, _ icon: Image, _ label: String, _ bytes: Int64) -> some View {
-        selectableRow(selected: leftoverSection == section) {
-            leftoverSection = section
-        } content: {
-            HStack(spacing: 12) {
-                icon.resizable().aspectRatio(contentMode: .fit).frame(width: 32, height: 32)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(label).font(.body.weight(.medium))
-                    Text(byteText(bytes)).font(.caption).foregroundStyle(.secondary)
-                }
-                Spacer()
-            }
-        }
-    }
-
-    private func facetSectionHeader(_ title: String) -> some View {
-        Text(title)
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .padding(.top, 12)
-            .padding(.bottom, 2)
-    }
-
-    // MARK: Updater middle pane
-
-    private var updaterFacets: some View {
-        let updates = updaterViewModel.availableUpdates
-        let appStore = updates.filter { $0.source == .appStore }.count
-        return VStack(spacing: 4) {
-            updaterFacetRow(.all, String(localized: "All Updates", comment: "Updater facet."), updates.count)
-            updaterFacetRow(.selected, String(localized: "Selected", comment: "Updater facet."), updateSelection.count)
-
-            facetSectionHeader(String(localized: "Stores", comment: "Updater facet group header."))
-            updaterFacetRow(.store(isAppStore: true), String(localized: "App Store", comment: "Updater store facet."), appStore)
-            updaterFacetRow(.store(isAppStore: false), String(localized: "Other", comment: "Updater store facet."), updates.count - appStore)
-        }
-    }
-
-    private func updaterFacetRow(_ facet: UpdaterFacet, _ label: String, _ count: Int) -> some View {
-        selectableRow(selected: updaterFacet == facet) {
-            updaterFacet = facet
-        } content: {
-            HStack {
-                Text(label).font(.body.weight(.medium))
-                Spacer()
-                Text("\(count)").font(.callout).foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    // MARK: Extensions middle pane
-
-    private var extensionsFacets: some View {
-        let grouped = extensionsManagerViewModel.groupedByType
-        return VStack(spacing: 4) {
-            extensionsFacetRow(.all, String(localized: "All Extensions", comment: "Extensions facet."), extensionsManagerViewModel.items.count)
-            extensionsFacetRow(.selected, String(localized: "Selected", comment: "Extensions facet."), extensionSelection.count)
-
-            if !grouped.isEmpty {
-                facetSectionHeader(String(localized: "Categories", comment: "Extensions facet group header."))
-                ForEach(grouped, id: \.0) { type, entries in
-                    extensionsFacetRow(.type(type), localizedExtensionType(type), entries.count)
-                }
-            }
-        }
-    }
-
-    private func extensionsFacetRow(_ facet: ExtensionsFacet, _ label: String, _ count: Int) -> some View {
-        selectableRow(selected: extensionsFacet == facet) {
-            extensionsFacet = facet
-        } content: {
-            HStack {
-                Text(label).font(.body.weight(.medium))
-                Spacer()
-                Text("\(count)").font(.callout).foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    private func localizedExtensionType(_ type: ExtensionType) -> String {
-        switch type {
-        case .safariExtension:  return String(localized: "Safari Extensions", comment: "Extension category.")
-        case .chromeExtension:  return String(localized: "Chrome Extensions", comment: "Extension category.")
-        case .firefoxExtension: return String(localized: "Firefox Extensions", comment: "Extension category.")
-        case .mailPlugin:       return String(localized: "Mail Plugins", comment: "Extension category.")
-        case .internetPlugin:   return String(localized: "Browser Plug-ins", comment: "Extension category.")
-        }
-    }
-
-    // MARK: - Right pane
-
-    private var uninstallerRightPaneTitle: String {
-        switch uninstallerFacet {
-        case .all:              return String(localized: "All Applications", comment: "Uninstaller right pane title.")
-        case .unused:           return String(localized: "Unused", comment: "Uninstaller right pane title.")
-        case .suspicious:       return String(localized: "Suspicious", comment: "Uninstaller right pane title.")
-        case .selected:         return String(localized: "Selected", comment: "Uninstaller right pane title.")
-        case .store(true):      return String(localized: "App Store", comment: "Uninstaller right pane title.")
-        case .store(false):     return String(localized: "Other", comment: "Uninstaller right pane title.")
-        case .vendor(let v):    return v.title
-        }
-    }
-
-    private var uninstallerRightPaneDescription: String {
-        switch uninstallerFacet {
-        case .all:              return String(localized: "Every app installed on this Mac.", comment: "Uninstaller right pane description.")
-        case .unused:           return String(localized: "Apps you haven't opened recently.", comment: "Uninstaller right pane description.")
-        case .suspicious:       return String(localized: "Apps flagged as potentially unwanted.", comment: "Uninstaller right pane description.")
-        case .selected:         return String(localized: "Apps you've marked for removal.", comment: "Uninstaller right pane description.")
-        case .store(true):      return String(localized: "Apps installed from the Mac App Store.", comment: "Uninstaller right pane description.")
-        case .store(false):     return String(localized: "Apps installed outside the Mac App Store.", comment: "Uninstaller right pane description.")
-        case .vendor(let v):    return String(localized: "Apps from \(v.title).", comment: "Uninstaller right pane description for a vendor.")
-        }
-    }
-
-    private var updaterRightPaneTitle: String {
-        switch updaterFacet {
-        case .all:              return String(localized: "All Updates", comment: "Updater right pane title.")
-        case .selected:         return String(localized: "Selected", comment: "Updater right pane title.")
-        case .store(true):      return String(localized: "App Store", comment: "Updater right pane title.")
-        case .store(false):     return String(localized: "Other", comment: "Updater right pane title.")
-        }
-    }
-
-    private var updaterRightPaneDescription: String {
-        switch updaterFacet {
-        case .all:              return String(localized: "Apps with new versions available.", comment: "Updater right pane description.")
-        case .selected:         return String(localized: "Updates you've chosen to install.", comment: "Updater right pane description.")
-        case .store(true):      return String(localized: "Updates available through the Mac App Store.", comment: "Updater right pane description.")
-        case .store(false):     return String(localized: "Updates available from developer websites.", comment: "Updater right pane description.")
-        }
-    }
-
-    private var extensionsRightPaneTitle: String {
-        switch extensionsFacet {
-        case .all:              return String(localized: "All Extensions", comment: "Extensions right pane title.")
-        case .selected:         return String(localized: "Selected", comment: "Extensions right pane title.")
-        case .type(let t):      return localizedExtensionType(t)
-        }
-    }
-
-    private var extensionsRightPaneDescription: String {
-        switch extensionsFacet {
-        case .all:              return String(localized: "Every extension and plug-in installed on this Mac.", comment: "Extensions right pane description.")
-        case .selected:         return String(localized: "Extensions you've chosen to remove.", comment: "Extensions right pane description.")
-        case .type(let t):
-            switch t {
-            case .safariExtension:  return String(localized: "Extensions installed in Safari.", comment: "Safari extensions right pane description.")
-            case .chromeExtension:  return String(localized: "Extensions installed in Google Chrome.", comment: "Chrome extensions right pane description.")
-            case .firefoxExtension: return String(localized: "Extensions installed in Firefox.", comment: "Firefox extensions right pane description.")
-            case .mailPlugin:       return String(localized: "Plug-ins installed in the Mail app.", comment: "Mail plugins right pane description.")
-            case .internetPlugin:   return String(localized: "Legacy plug-ins used by web browsers.", comment: "Browser plug-ins right pane description.")
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var rightPane: some View {
-        switch pane {
-        case .uninstaller:
-            if let id = inspectingAppID {
-                appDetail(id)
-            } else if uninstallerViewModel.apps.isEmpty, uninstallerViewModel.phase == .loading {
-                loadingPane
-            } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    paneHeader(title: uninstallerRightPaneTitle, description: uninstallerRightPaneDescription)
-                    uninstallerList
-                }
-            }
-        case .updater:
-            VStack(alignment: .leading, spacing: 0) {
-                paneHeader(title: updaterRightPaneTitle, description: updaterRightPaneDescription)
-                updaterPane
-            }
-        case .extensions:
-            VStack(alignment: .leading, spacing: 0) {
-                paneHeader(title: extensionsRightPaneTitle, description: extensionsRightPaneDescription)
-                extensionsPane
-            }
+            ExtensionsPaneView(
+                extensionsManagerViewModel: extensionsManagerViewModel,
+                search: search,
+                facet: $extensionsFacet,
+                selection: $extensionSelection,
+                displayed: $displayedExtensions
+            )
         case .leftovers:
-            leftoverList
-        }
-    }
-
-    private var displayedApps: [AppInfo] {
-        let filtered = ApplicationsManagerModel.filter(
-            uninstallerViewModel.apps,
-            facet: uninstallerFacet,
-            search: search,
-            unusedIDs: unusedIDs,
-            selectedIDs: uninstallerViewModel.uninstallSelection
-        )
-        return ApplicationsManagerModel.sort(filtered, by: sort, sizes: sizes, dates: lastOpened)
-    }
-
-    private var uninstallerList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(displayedApps) { app in
-                    appRow(app)
-                    Divider().opacity(0.3)
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-        }
-        .accessibilityIdentifier("applications.manager.uninstaller.list")
-    }
-
-    private func appRow(_ app: AppInfo) -> some View {
-        HStack(spacing: 12) {
-            checkbox(selected: uninstallerViewModel.isInUninstallSelection(app.id)) {
-                uninstallerViewModel.toggleUninstallSelection(app.id)
-            }
-            Image(nsImage: iconCache.icon(for: app.bundleURL))
-                .resizable().frame(width: 32, height: 32)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(app.name).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
-                if let version = app.version {
-                    Text(version).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer(minLength: 8)
-            // Decorative AI sparkle, matching the reference rows.
-            Image(systemName: "sparkles")
-                .font(.system(size: 13))
-                .foregroundStyle(Color.pink)
-            Text(dateText(lastOpened[app.id]))
-                .font(.callout).foregroundStyle(.secondary).frame(width: 96, alignment: .trailing)
-            Text(sizeText(sizes[app.id]))
-                .font(.callout.weight(.semibold)).frame(width: 72, alignment: .trailing)
-            Button {
-                inspectingAppID = app.id
-                uninstallerViewModel.select(app.id)
-            } label: {
-                Image(systemName: "chevron.right").foregroundStyle(.tint)
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("applications.manager.uninstaller.detail.\(app.bundleID)")
-        }
-        .padding(.vertical, 10)
-        .accessibilityIdentifier("applications.manager.uninstaller.row.\(app.bundleID)")
-    }
-
-    private func appDetail(_ id: AppInfo.ID) -> some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button {
-                    inspectingAppID = nil
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "chevron.left")
-                        Text(String(localized: "All Applications", comment: "Back to the full uninstaller list."))
-                    }
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("applications.manager.uninstaller.detail.back")
-                Spacer()
-            }
-            .padding(.horizontal, 16).padding(.vertical, 10)
-            Divider().opacity(0.4)
-            AppUninstallerDetailPane(
-                app: uninstallerViewModel.selectedApp,
-                bundleSize: uninstallerViewModel.selectedAppBundleSize,
-                isLoadingAssociatedFiles: uninstallerViewModel.isLoadingAssociatedFiles,
-                groupedFiles: uninstallerViewModel.associatedFilesByCategory,
-                totalReclaimableSize: uninstallerViewModel.totalReclaimableSize,
-                canUninstall: uninstallerViewModel.canUninstallSelectedApp,
-                onUninstall: { showSingleUninstallConfirmation = true },
-                iconCache: iconCache
+            LeftoversPaneView(
+                viewModel: viewModel,
+                result: result,
+                section: $leftoverSection
             )
-        }
-        .onChange(of: uninstallerViewModel.apps.map(\.id)) { _, ids in
-            // The app was uninstalled from the detail — return to the list.
-            if let id = inspectingAppID, !ids.contains(id) { inspectingAppID = nil }
-        }
-    }
-
-    // MARK: Updater right pane
-
-    private var displayedUpdates: [UpdateInfo] {
-        updaterViewModel.availableUpdates.filter { info in
-            let matchesFacet: Bool
-            switch updaterFacet {
-            case .all:                    matchesFacet = true
-            case .selected:               matchesFacet = updateSelection.contains(info.id)
-            case .store(let isAppStore):  matchesFacet = (info.source == .appStore) == isAppStore
-            }
-            guard matchesFacet else { return false }
-            let trimmed = search.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty || info.appName.localizedCaseInsensitiveContains(trimmed)
-        }
-    }
-
-    @ViewBuilder
-    private var updaterPane: some View {
-        if updaterViewModel.availableUpdates.isEmpty {
-            emptyState(
-                icon: "arrow.down.circle",
-                title: String(localized: "Updater", comment: "Updater empty-state title."),
-                detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Updater empty-state detail.")
-            )
-            .accessibilityIdentifier("applications.manager.updater.empty")
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(displayedUpdates) { info in
-                        updateRow(info)
-                        Divider().opacity(0.3)
-                    }
-                }
-                .padding(.horizontal, 16).padding(.vertical, 8)
-            }
-            .accessibilityIdentifier("applications.manager.updater.list")
-        }
-    }
-
-    private func updateRow(_ info: UpdateInfo) -> some View {
-        HStack(spacing: 12) {
-            checkbox(selected: updateSelection.contains(info.id)) {
-                toggle(&updateSelection, info.id)
-            }
-            Image(nsImage: iconCache.icon(for: info.bundleURL))
-                .resizable().frame(width: 32, height: 32)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(info.appName).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
-                Text(versionTransition(info)).font(.caption).foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 8)
-            Text(info.source == .appStore
-                 ? String(localized: "App Store", comment: "Update source label.")
-                 : String(localized: "Web", comment: "Update source label."))
-                .font(.caption).foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 10)
-        .accessibilityIdentifier("applications.manager.updater.row.\(info.bundleID)")
-    }
-
-    private func versionTransition(_ info: UpdateInfo) -> String {
-        let format = String(localized: "%1$@ → %2$@", comment: "Update row version change; installed → latest.")
-        return String.localizedStringWithFormat(format, info.installedVersion, info.latestVersion)
-    }
-
-    // MARK: Extensions right pane
-
-    private var displayedExtensions: [ExtensionItem] {
-        let items = extensionsManagerViewModel.items.filter { item in
-            let matchesFacet: Bool
-            switch extensionsFacet {
-            case .all:              matchesFacet = true
-            case .selected:         matchesFacet = extensionSelection.contains(item.id)
-            case .type(let type):   matchesFacet = item.type == type
-            }
-            guard matchesFacet else { return false }
-            let trimmed = search.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty || item.name.localizedCaseInsensitiveContains(trimmed)
-        }
-        return items.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-    }
-
-    @ViewBuilder
-    private var extensionsPane: some View {
-        if extensionsManagerViewModel.items.isEmpty {
-            emptyState(
-                icon: "puzzlepiece.extension",
-                title: String(localized: "Extensions", comment: "Extensions empty-state title."),
-                detail: String(localized: "No browser extensions or plug-ins were found.", comment: "Extensions empty-state detail.")
-            )
-            .accessibilityIdentifier("applications.manager.extensions.empty")
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(displayedExtensions) { item in
-                        extensionRow(item)
-                        Divider().opacity(0.3)
-                    }
-                }
-                .padding(.horizontal, 16).padding(.vertical, 8)
-            }
-            .accessibilityIdentifier("applications.manager.extensions.list")
-        }
-    }
-
-    private func extensionRow(_ item: ExtensionItem) -> some View {
-        HStack(spacing: 12) {
-            checkbox(selected: extensionSelection.contains(item.id)) {
-                toggle(&extensionSelection, item.id)
-            }
-            Image(systemName: extensionSymbol(item.type))
-                .font(.system(size: 18))
-                .foregroundStyle(.tint)
-                .frame(width: 32)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(item.name).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
-                Text(localizedExtensionType(item.type)).font(.caption).foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 8)
-            Text(byteText(item.size)).font(.callout.weight(.semibold)).foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 10)
-        .accessibilityIdentifier("applications.manager.extensions.row.\(item.id.path)")
-    }
-
-    private func extensionSymbol(_ type: ExtensionType) -> String {
-        switch type {
-        case .safariExtension:  return "safari"
-        case .chromeExtension:  return "globe"
-        case .firefoxExtension: return "globe"
-        case .mailPlugin:       return "envelope"
-        case .internetPlugin:   return "puzzlepiece.extension"
-        }
-    }
-
-    /// Toggles `id` in a selection set in place.
-    private func toggle<ID: Hashable>(_ set: inout Set<ID>, _ id: ID) {
-        if set.contains(id) { set.remove(id) } else { set.insert(id) }
-    }
-
-    @ViewBuilder
-    private var leftoverList: some View {
-        switch leftoverSection {
-        case .installers:
-            leftoverFileList(
-                title: String(localized: "Unused DMG Files", comment: "Installers list title."),
-                description: String(localized: "Save space by removing unneeded DMGs or other installation files of applications.", comment: "Installers list description."),
-                rows: result.installationFiles.map { file in
-                    LeftoverDisplayRow(id: file.url.path, name: file.name, bytes: file.sizeBytes,
-                                       selected: viewModel.isInstallationFileSelected(file),
-                                       toggle: { viewModel.toggleInstallationFile(file) })
-                },
-                onSelectNone: viewModel.clearInstallationFileSelection,
-                onSelectAll: viewModel.selectAllInstallationFiles,
-                usesDiskIcon: true
-            )
-        case .leftoverFiles:
-            leftoverFileList(
-                title: String(localized: "Leftover Files", comment: "Leftover files list title."),
-                description: String(localized: "Support files left behind by apps you've removed.", comment: "Leftover files list description."),
-                rows: result.leftovers.map { group in
-                    LeftoverDisplayRow(id: group.bundleID, name: group.displayName, bytes: group.totalBytes,
-                                       selected: viewModel.isLeftoverSelected(group),
-                                       toggle: { viewModel.toggleLeftover(group) })
-                },
-                onSelectNone: viewModel.clearLeftoverSelection,
-                onSelectAll: viewModel.selectAllLeftovers,
-                usesDiskIcon: false
-            )
-        }
-    }
-
-    /// One row's display data for the Leftovers lists, with its own toggle so a
-    /// single renderer serves both installers and leftover groups.
-    private struct LeftoverDisplayRow: Identifiable {
-        let id: String
-        let name: String
-        let bytes: Int64
-        let selected: Bool
-        let toggle: () -> Void
-    }
-
-    private func leftoverFileList(
-        title: String,
-        description: String,
-        rows: [LeftoverDisplayRow],
-        onSelectNone: @escaping () -> Void,
-        onSelectAll: @escaping () -> Void,
-        usesDiskIcon: Bool
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title).font(.title3.weight(.semibold))
-                Text(description).font(.callout).foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                HStack(spacing: 6) {
-                    Text(String(localized: "Select:", comment: "Manager bulk-select label.")).foregroundStyle(.secondary)
-                    Menu {
-                        Button(String(localized: "All", comment: "Select all.")) { onSelectAll() }
-                        Button(String(localized: "None", comment: "Deselect all.")) { onSelectNone() }
-                    } label: {
-                        Text(rows.contains(where: \.selected)
-                             ? String(localized: "Some", comment: "Some selected.")
-                             : String(localized: "None", comment: "None selected."))
-                        .foregroundStyle(.tint)
-                    }
-                    .menuStyle(.borderlessButton).fixedSize()
-                }
-                .padding(.top, 4)
-            }
-            .padding(.horizontal, 24).padding(.top, 16).padding(.bottom, 12)
-            if rows.isEmpty {
-                emptyState(icon: "checkmark.seal.fill",
-                           title: String(localized: "Nothing to remove", comment: "Empty leftovers list."),
-                           detail: String(localized: "There are no items in this area.", comment: "Empty leftovers detail."))
-            } else {
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        ForEach(rows) { row in
-                            HStack(spacing: 12) {
-                                checkbox(selected: row.selected, action: row.toggle)
-                                if usesDiskIcon {
-                                    Image("installerDmg").resizable().aspectRatio(contentMode: .fit).frame(width: 28, height: 28)
-                                } else {
-                                    Image(systemName: "folder.badge.minus").font(.system(size: 18)).foregroundStyle(.secondary).frame(width: 28)
-                                }
-                                Text(row.name).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
-                                Spacer(minLength: 8)
-                                Text(byteText(row.bytes)).font(.callout.weight(.semibold)).foregroundStyle(.secondary)
-                            }
-                            .padding(.vertical, 10)
-                            .contentShape(Rectangle())
-                            .onTapGesture { row.toggle() }
-                            Divider().opacity(0.3)
-                        }
-                    }
-                    .padding(.horizontal, 16).padding(.vertical, 8)
-                }
-            }
         }
     }
 
@@ -930,71 +336,22 @@ struct ApplicationsManagerView: View {
 
     // MARK: - Shared pieces
 
-    private func paneHeader(title: String, description: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title).font(.title3.weight(.semibold))
-            Text(description).font(.callout).foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 24).padding(.top, 16).padding(.bottom, 12)
-    }
-
     private func selectableRow<Content: View>(
         selected: Bool,
         action: @escaping () -> Void,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        Button(action: action) {
-            content()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 12).padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(selected ? Self.selectionFill : .clear)
-                )
-                .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func checkbox(selected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: selected ? "checkmark.square.fill" : "square")
-                .font(.system(size: 18))
-                .foregroundStyle(selected ? Self.accent : Color.secondary)
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var loadingPane: some View {
-        VStack { Spacer(); ProgressView().controlSize(.large); Spacer() }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .accessibilityIdentifier("applications.manager.loading")
-    }
-
-    private func emptyState(icon: String, title: String, detail: String) -> some View {
-        VStack(spacing: 12) {
-            Image(systemName: icon).font(.system(size: 44)).foregroundStyle(.tint.opacity(0.7))
-            Text(title).font(.title2.weight(.semibold))
-            Text(detail).font(.callout).foregroundStyle(.secondary).multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ApplicationsManagerSelectableRow(selected: selected, action: action, content: content)
     }
 
     // MARK: - Derived values
-
-    /// `AppInfo.ID` (bundle-URL path) of every app the scan flagged as unused.
-    private var unusedIDs: Set<AppInfo.ID> {
-        Set(result.unusedApps.map { $0.app.id })
-    }
 
     private var uninstallSummary: String {
         let selection = uninstallerViewModel.uninstallSelection
         guard !selection.isEmpty else {
             return String(localized: "No Applications Selected", comment: "Uninstaller footer, nothing selected.")
         }
-        let bytes = selection.reduce(Int64(0)) { $0 + (sizes[$1] ?? 0) }
+        let bytes = selection.reduce(Int64(0)) { $0 + (uninstallerViewModel.listSizes[$1] ?? 0) }
         let count = String.localizedStringWithFormat(
             String(localized: "%lld Applications Selected", comment: "Uninstaller footer selected count."),
             Int64(selection.count)
@@ -1047,6 +404,261 @@ struct ApplicationsManagerView: View {
         String(localized: "The selected applications and their associated files will be moved to the Trash. You can restore them until you empty it.", comment: "Batch uninstall confirmation message.")
     }
 
+    // MARK: - Formatting
+
+    private func byteText(_ bytes: Int64) -> String {
+        ApplicationsManagerChrome.byteText(bytes)
+    }
+}
+
+// MARK: - Uninstaller pane
+
+/// The Uninstaller pane — the facet column plus the app list (or an app's
+/// associated-files detail). Extracted from `ApplicationsManagerView` so a
+/// checkbox toggle re-renders only this pane, not the whole manager. `facet`,
+/// the drill-in, and the memoized list are owned by the parent (via bindings) so
+/// they persist across pane switches; the batch metrics preload stays on the
+/// parent, this pane just reads the resulting caches.
+private struct UninstallerPaneView: View {
+    let uninstallerViewModel: AppUninstallerViewModel
+    let result: ApplicationsScanResult
+    let iconCache: AppIconCache
+    let search: String
+    let sort: AppManagerSort
+    @Binding var facet: AppManagerFacet
+    @Binding var inspectingAppID: AppInfo.ID?
+    @Binding var displayedApps: [AppInfo]
+
+    /// Confirmation for the single app open in the chevron detail.
+    @State private var showSingleUninstallConfirmation = false
+
+    var body: some View {
+        HStack(spacing: 0) {
+            middleColumn.frame(width: 320)
+            Divider().opacity(0.4)
+            rightColumn.frame(maxWidth: .infinity)
+        }
+        .alert(singleUninstallConfirmationTitle, isPresented: $showSingleUninstallConfirmation) {
+            Button(String(localized: "Cancel", comment: "Cancel button on the uninstall confirmation."), role: .cancel) {}
+            Button(String(localized: "Uninstall", comment: "Confirm single-app uninstall."), role: .destructive) {
+                Task { await uninstallerViewModel.uninstall() }
+            }
+        } message: {
+            Text(singleUninstallConfirmationMessage)
+        }
+    }
+
+    // MARK: Middle (facets)
+
+    private var middleColumn: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ApplicationsManagerPaneHeader(
+                title: String(localized: "Uninstaller", comment: "Uninstaller pane title."),
+                description: String(localized: "Correctly remove entire applications with all of the related files.", comment: "Uninstaller pane description.")
+            )
+            ScrollView { facets.padding(8) }
+        }
+    }
+
+    private var facets: some View {
+        let apps = uninstallerViewModel.apps
+        let stores = ApplicationsManagerModel.storeCounts(apps: apps)
+        let vendors = ApplicationsManagerModel.vendorCounts(apps: apps)
+        return VStack(spacing: 4) {
+            facetRow(.all, String(localized: "All Applications", comment: "Uninstaller facet."), apps.count)
+            facetRow(.unused, String(localized: "Unused", comment: "Uninstaller facet."), unusedIDs.count)
+            facetRow(.suspicious, String(localized: "Suspicious", comment: "Uninstaller facet."), 0)
+            facetRow(.selected, String(localized: "Selected", comment: "Uninstaller facet."), uninstallerViewModel.uninstallSelection.count)
+
+            ApplicationsManagerFacetSectionHeader(title: String(localized: "Stores", comment: "Uninstaller facet group header."))
+            facetRow(.store(isAppStore: true), String(localized: "App Store", comment: "Uninstaller store facet."), stores.appStore)
+            facetRow(.store(isAppStore: false), String(localized: "Other", comment: "Uninstaller store facet."), stores.other)
+
+            if !vendors.isEmpty {
+                ApplicationsManagerFacetSectionHeader(title: String(localized: "Vendors", comment: "Uninstaller facet group header."))
+                ForEach(vendors, id: \.vendor) { entry in
+                    facetRow(.vendor(entry.vendor), entry.vendor.title, entry.count)
+                }
+            }
+        }
+    }
+
+    private func facetRow(_ target: AppManagerFacet, _ label: String, _ count: Int) -> some View {
+        ApplicationsManagerSelectableRow(selected: facet == target) {
+            facet = target
+            inspectingAppID = nil
+        } content: {
+            HStack {
+                Text(label).font(.body.weight(.medium))
+                Spacer()
+                Text("\(count)").font(.callout).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    /// `AppInfo.ID` (bundle-URL path) of every app the scan flagged as unused.
+    private var unusedIDs: Set<AppInfo.ID> {
+        Set(result.unusedApps.map { $0.app.id })
+    }
+
+    private var rightPaneTitle: String {
+        switch facet {
+        case .all:              return String(localized: "All Applications", comment: "Uninstaller right pane title.")
+        case .unused:           return String(localized: "Unused", comment: "Uninstaller right pane title.")
+        case .suspicious:       return String(localized: "Suspicious", comment: "Uninstaller right pane title.")
+        case .selected:         return String(localized: "Selected", comment: "Uninstaller right pane title.")
+        case .store(true):      return String(localized: "App Store", comment: "Uninstaller right pane title.")
+        case .store(false):     return String(localized: "Other", comment: "Uninstaller right pane title.")
+        case .vendor(let v):    return v.title
+        }
+    }
+
+    private var rightPaneDescription: String {
+        switch facet {
+        case .all:              return String(localized: "Every app installed on this Mac.", comment: "Uninstaller right pane description.")
+        case .unused:           return String(localized: "Apps you haven't opened recently.", comment: "Uninstaller right pane description.")
+        case .suspicious:       return String(localized: "Apps flagged as potentially unwanted.", comment: "Uninstaller right pane description.")
+        case .selected:         return String(localized: "Apps you've marked for removal.", comment: "Uninstaller right pane description.")
+        case .store(true):      return String(localized: "Apps installed from the Mac App Store.", comment: "Uninstaller right pane description.")
+        case .store(false):     return String(localized: "Apps installed outside the Mac App Store.", comment: "Uninstaller right pane description.")
+        case .vendor(let v):    return String(localized: "Apps from \(v.title).", comment: "Uninstaller right pane description for a vendor.")
+        }
+    }
+
+    // MARK: Right (list / detail)
+
+    @ViewBuilder
+    private var rightColumn: some View {
+        if let id = inspectingAppID {
+            appDetail(id)
+        } else if uninstallerViewModel.apps.isEmpty, uninstallerViewModel.phase == .loading {
+            ApplicationsManagerLoadingPane()
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                ApplicationsManagerPaneHeader(title: rightPaneTitle, description: rightPaneDescription)
+                list
+            }
+        }
+    }
+
+    /// Recomputes the memoized `displayedApps`. Called from the list's
+    /// `onAppear` and the `onChange` hooks below — never from `body` — so the
+    /// filter + sort runs only when an input that changes the list changes, not
+    /// on every re-render (e.g. a checkbox toggle, which only needs the tapped
+    /// row to redraw).
+    private func recompute() {
+        let filtered = ApplicationsManagerModel.filter(
+            uninstallerViewModel.apps,
+            facet: facet,
+            search: search,
+            unusedIDs: unusedIDs,
+            selectedIDs: uninstallerViewModel.uninstallSelection
+        )
+        displayedApps = ApplicationsManagerModel.sort(
+            filtered,
+            by: sort,
+            sizes: uninstallerViewModel.listSizes,
+            dates: uninstallerViewModel.listLastOpened
+        )
+    }
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(displayedApps) { app in
+                    appRow(app)
+                    Divider().opacity(0.3)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+        .onAppear { recompute() }
+        .onChange(of: facet) { _, _ in recompute() }
+        .onChange(of: search) { _, _ in recompute() }
+        .onChange(of: sort) { _, _ in recompute() }
+        .onChange(of: uninstallerViewModel.apps.map(\.id)) { _, _ in recompute() }
+        // The measured metrics land asynchronously; recompute the order once
+        // when they do so a size/date sort settles to its final arrangement.
+        .onChange(of: uninstallerViewModel.listMetricsRevision) { _, _ in recompute() }
+        // Selection only changes the visible list under the Selected facet;
+        // under every other facet a toggle leaves the list untouched, so the
+        // expensive recompute is skipped.
+        .onChange(of: uninstallerViewModel.uninstallSelection) { _, _ in
+            if facet == .selected { recompute() }
+        }
+        .accessibilityIdentifier("applications.manager.uninstaller.list")
+    }
+
+    private func appRow(_ app: AppInfo) -> some View {
+        HStack(spacing: 12) {
+            ApplicationsManagerCheckbox(selected: uninstallerViewModel.isInUninstallSelection(app.id)) {
+                uninstallerViewModel.toggleUninstallSelection(app.id)
+            }
+            Image(nsImage: iconCache.icon(for: app.bundleURL))
+                .resizable().frame(width: 32, height: 32)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(app.name).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
+                if let version = app.version {
+                    Text(version).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 8)
+            // Decorative AI sparkle, matching the reference rows.
+            Image(systemName: "sparkles")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.pink)
+            Text(dateText(uninstallerViewModel.listLastOpened[app.id]))
+                .font(.callout).foregroundStyle(.secondary).frame(width: 96, alignment: .trailing)
+            Text(sizeText(uninstallerViewModel.listSizes[app.id]))
+                .font(.callout.weight(.semibold)).frame(width: 72, alignment: .trailing)
+            Button {
+                inspectingAppID = app.id
+                uninstallerViewModel.select(app.id)
+            } label: {
+                Image(systemName: "chevron.right").foregroundStyle(.tint)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("applications.manager.uninstaller.detail.\(app.bundleID)")
+        }
+        .padding(.vertical, 10)
+        .accessibilityIdentifier("applications.manager.uninstaller.row.\(app.bundleID)")
+    }
+
+    private func appDetail(_ id: AppInfo.ID) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button {
+                    inspectingAppID = nil
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text(String(localized: "All Applications", comment: "Back to the full uninstaller list."))
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("applications.manager.uninstaller.detail.back")
+                Spacer()
+            }
+            .padding(.horizontal, 16).padding(.vertical, 10)
+            Divider().opacity(0.4)
+            AppUninstallerDetailPane(
+                app: uninstallerViewModel.selectedApp,
+                bundleSize: uninstallerViewModel.selectedAppBundleSize,
+                isLoadingAssociatedFiles: uninstallerViewModel.isLoadingAssociatedFiles,
+                groupedFiles: uninstallerViewModel.associatedFilesByCategory,
+                totalReclaimableSize: uninstallerViewModel.totalReclaimableSize,
+                canUninstall: uninstallerViewModel.canUninstallSelectedApp,
+                onUninstall: { showSingleUninstallConfirmation = true },
+                iconCache: iconCache
+            )
+        }
+        .onChange(of: uninstallerViewModel.apps.map(\.id)) { _, ids in
+            // The app was uninstalled from the detail — return to the list.
+            if let id = inspectingAppID, !ids.contains(id) { inspectingAppID = nil }
+        }
+    }
+
     private var singleUninstallConfirmationTitle: String {
         guard let app = uninstallerViewModel.selectedApp else {
             return String(localized: "Move this app and its data to Trash?", comment: "Single uninstall confirmation title fallback.")
@@ -1057,31 +669,6 @@ struct ApplicationsManagerView: View {
 
     private var singleUninstallConfirmationMessage: String {
         String(localized: "The application and its associated files will be moved to the Trash. You can restore them until you empty it.", comment: "Single uninstall confirmation message.")
-    }
-
-    // MARK: - Metrics
-
-    private func rebuildMetrics() async {
-        let apps = uninstallerViewModel.apps
-        guard !apps.isEmpty else { sizes = [:]; lastOpened = [:]; return }
-        let computed = await Task.detached(priority: .utility) { () -> (sizes: [AppInfo.ID: Int64], dates: [AppInfo.ID: Date]) in
-            var sizes: [AppInfo.ID: Int64] = [:]
-            var dates: [AppInfo.ID: Date] = [:]
-            let fileManager = FileManager.default
-            for app in apps {
-                sizes[app.id] = DefaultAppDiscovery.bundleSize(at: app.bundleURL, fileManager: fileManager)
-                dates[app.id] = DefaultUnusedAppScanner.spotlightLastUsedDate(app)
-            }
-            return (sizes, dates)
-        }.value
-        sizes = computed.sizes
-        lastOpened = computed.dates
-    }
-
-    // MARK: - Formatting
-
-    private func byteText(_ bytes: Int64) -> String {
-        smartScanByteFormatter.string(fromByteCount: bytes)
     }
 
     private func sizeText(_ bytes: Int64?) -> String {
@@ -1100,4 +687,633 @@ struct ApplicationsManagerView: View {
         formatter.timeStyle = .none
         return formatter
     }()
+}
+
+// MARK: - Leftovers pane
+
+/// Which sub-list the Leftovers pane shows in its right column.
+private enum LeftoverSection: Hashable {
+    case installers
+    case leftoverFiles
+}
+
+/// The Leftovers pane — the Installers / Leftover Files section column plus the
+/// matching file list. Extracted from `ApplicationsManagerView`; the section
+/// selection stays on the parent (the footer's Remove action reads it too) and
+/// is passed in as a binding.
+private struct LeftoversPaneView: View {
+    let viewModel: ApplicationsViewModel
+    let result: ApplicationsScanResult
+    @Binding var section: LeftoverSection
+
+    var body: some View {
+        HStack(spacing: 0) {
+            middleColumn.frame(width: 320)
+            Divider().opacity(0.4)
+            rightColumn.frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: Middle (sections)
+
+    private var middleColumn: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ApplicationsManagerPaneHeader(
+                title: String(localized: "Leftovers", comment: "Leftovers pane title."),
+                description: String(localized: "If you manually remove an application file, all of its related items remain on your system. VaderCleaner locates and removes these leftovers even if the main app is already gone.", comment: "Leftovers pane description.")
+            )
+            ScrollView { sections.padding(8) }
+        }
+    }
+
+    private var sections: some View {
+        VStack(spacing: 4) {
+            sectionRow(.installers,
+                       Image("installerDmg"),
+                       String(localized: "Installers", comment: "Leftovers section."),
+                       result.installationFilesTotalBytes)
+            sectionRow(.leftoverFiles,
+                       Image(systemName: "puzzlepiece.extension.fill"),
+                       String(localized: "Leftover Files", comment: "Leftovers section."),
+                       result.leftoversTotalBytes)
+        }
+    }
+
+    private func sectionRow(_ target: LeftoverSection, _ icon: Image, _ label: String, _ bytes: Int64) -> some View {
+        ApplicationsManagerSelectableRow(selected: section == target) {
+            section = target
+        } content: {
+            HStack(spacing: 12) {
+                icon.resizable().aspectRatio(contentMode: .fit).frame(width: 32, height: 32)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label).font(.body.weight(.medium))
+                    Text(ApplicationsManagerChrome.byteText(bytes)).font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: Right (file list)
+
+    @ViewBuilder
+    private var rightColumn: some View {
+        switch section {
+        case .installers:
+            fileList(
+                title: String(localized: "Unused DMG Files", comment: "Installers list title."),
+                description: String(localized: "Save space by removing unneeded DMGs or other installation files of applications.", comment: "Installers list description."),
+                rows: result.installationFiles.map { file in
+                    DisplayRow(id: file.url.path, name: file.name, bytes: file.sizeBytes,
+                               selected: viewModel.isInstallationFileSelected(file),
+                               toggle: { viewModel.toggleInstallationFile(file) })
+                },
+                onSelectNone: viewModel.clearInstallationFileSelection,
+                onSelectAll: viewModel.selectAllInstallationFiles,
+                usesDiskIcon: true
+            )
+        case .leftoverFiles:
+            fileList(
+                title: String(localized: "Leftover Files", comment: "Leftover files list title."),
+                description: String(localized: "Support files left behind by apps you've removed.", comment: "Leftover files list description."),
+                rows: result.leftovers.map { group in
+                    DisplayRow(id: group.bundleID, name: group.displayName, bytes: group.totalBytes,
+                               selected: viewModel.isLeftoverSelected(group),
+                               toggle: { viewModel.toggleLeftover(group) })
+                },
+                onSelectNone: viewModel.clearLeftoverSelection,
+                onSelectAll: viewModel.selectAllLeftovers,
+                usesDiskIcon: false
+            )
+        }
+    }
+
+    /// One row's display data for the Leftovers lists, with its own toggle so a
+    /// single renderer serves both installers and leftover groups.
+    private struct DisplayRow: Identifiable {
+        let id: String
+        let name: String
+        let bytes: Int64
+        let selected: Bool
+        let toggle: () -> Void
+    }
+
+    private func fileList(
+        title: String,
+        description: String,
+        rows: [DisplayRow],
+        onSelectNone: @escaping () -> Void,
+        onSelectAll: @escaping () -> Void,
+        usesDiskIcon: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title).font(.title3.weight(.semibold))
+                Text(description).font(.callout).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 6) {
+                    Text(String(localized: "Select:", comment: "Manager bulk-select label.")).foregroundStyle(.secondary)
+                    Menu {
+                        Button(String(localized: "All", comment: "Select all.")) { onSelectAll() }
+                        Button(String(localized: "None", comment: "Deselect all.")) { onSelectNone() }
+                    } label: {
+                        Text(rows.contains(where: \.selected)
+                             ? String(localized: "Some", comment: "Some selected.")
+                             : String(localized: "None", comment: "None selected."))
+                        .foregroundStyle(.tint)
+                    }
+                    .menuStyle(.borderlessButton).fixedSize()
+                }
+                .padding(.top, 4)
+            }
+            .padding(.horizontal, 24).padding(.top, 16).padding(.bottom, 12)
+            if rows.isEmpty {
+                ApplicationsManagerEmptyState(
+                    icon: "checkmark.seal.fill",
+                    title: String(localized: "Nothing to remove", comment: "Empty leftovers list."),
+                    detail: String(localized: "There are no items in this area.", comment: "Empty leftovers detail.")
+                )
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(rows) { row in
+                            HStack(spacing: 12) {
+                                ApplicationsManagerCheckbox(selected: row.selected, action: row.toggle)
+                                if usesDiskIcon {
+                                    Image("installerDmg").resizable().aspectRatio(contentMode: .fit).frame(width: 28, height: 28)
+                                } else {
+                                    Image(systemName: "folder.badge.minus").font(.system(size: 18)).foregroundStyle(.secondary).frame(width: 28)
+                                }
+                                Text(row.name).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
+                                Spacer(minLength: 8)
+                                Text(ApplicationsManagerChrome.byteText(row.bytes)).font(.callout.weight(.semibold)).foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 10)
+                            .contentShape(Rectangle())
+                            .onTapGesture { row.toggle() }
+                            Divider().opacity(0.3)
+                        }
+                    }
+                    .padding(.horizontal, 16).padding(.vertical, 8)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Updater pane
+
+/// Middle-pane facet for the Updater pane.
+private enum UpdaterFacet: Hashable {
+    case all
+    case selected
+    case store(isAppStore: Bool)
+}
+
+/// The Updater pane — the facet column plus the available-updates list.
+/// Extracted from `ApplicationsManagerView`; the facet, selection, and memoized
+/// list are owned by the parent (the footer's Update action reads the selection)
+/// and passed in as bindings.
+private struct UpdaterPaneView: View {
+    let updaterViewModel: AppUpdaterViewModel
+    let iconCache: AppIconCache
+    let search: String
+    @Binding var facet: UpdaterFacet
+    @Binding var selection: Set<UpdateInfo.ID>
+    @Binding var displayed: [UpdateInfo]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            middleColumn.frame(width: 320)
+            Divider().opacity(0.4)
+            rightColumn.frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: Middle (facets)
+
+    private var middleColumn: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ApplicationsManagerPaneHeader(
+                title: String(localized: "Updater", comment: "Updater pane title."),
+                description: String(localized: "Keep your apps current with the latest fixes and features.", comment: "Updater pane description.")
+            )
+            ScrollView { facets.padding(8) }
+        }
+    }
+
+    private var facets: some View {
+        let updates = updaterViewModel.availableUpdates
+        let appStore = updates.filter { $0.source == .appStore }.count
+        return VStack(spacing: 4) {
+            facetRow(.all, String(localized: "All Updates", comment: "Updater facet."), updates.count)
+            facetRow(.selected, String(localized: "Selected", comment: "Updater facet."), selection.count)
+
+            ApplicationsManagerFacetSectionHeader(title: String(localized: "Stores", comment: "Updater facet group header."))
+            facetRow(.store(isAppStore: true), String(localized: "App Store", comment: "Updater store facet."), appStore)
+            facetRow(.store(isAppStore: false), String(localized: "Other", comment: "Updater store facet."), updates.count - appStore)
+        }
+    }
+
+    private func facetRow(_ target: UpdaterFacet, _ label: String, _ count: Int) -> some View {
+        ApplicationsManagerSelectableRow(selected: facet == target) {
+            facet = target
+        } content: {
+            HStack {
+                Text(label).font(.body.weight(.medium))
+                Spacer()
+                Text("\(count)").font(.callout).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var rightPaneTitle: String {
+        switch facet {
+        case .all:              return String(localized: "All Updates", comment: "Updater right pane title.")
+        case .selected:         return String(localized: "Selected", comment: "Updater right pane title.")
+        case .store(true):      return String(localized: "App Store", comment: "Updater right pane title.")
+        case .store(false):     return String(localized: "Other", comment: "Updater right pane title.")
+        }
+    }
+
+    private var rightPaneDescription: String {
+        switch facet {
+        case .all:              return String(localized: "Apps with new versions available.", comment: "Updater right pane description.")
+        case .selected:         return String(localized: "Updates you've chosen to install.", comment: "Updater right pane description.")
+        case .store(true):      return String(localized: "Updates available through the Mac App Store.", comment: "Updater right pane description.")
+        case .store(false):     return String(localized: "Updates available from developer websites.", comment: "Updater right pane description.")
+        }
+    }
+
+    // MARK: Right (list)
+
+    private var rightColumn: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ApplicationsManagerPaneHeader(title: rightPaneTitle, description: rightPaneDescription)
+            list
+        }
+    }
+
+    private func recompute() {
+        displayed = updaterViewModel.availableUpdates.filter { info in
+            let matchesFacet: Bool
+            switch facet {
+            case .all:                    matchesFacet = true
+            case .selected:               matchesFacet = selection.contains(info.id)
+            case .store(let isAppStore):  matchesFacet = (info.source == .appStore) == isAppStore
+            }
+            guard matchesFacet else { return false }
+            let trimmed = search.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty || info.appName.localizedCaseInsensitiveContains(trimmed)
+        }
+    }
+
+    @ViewBuilder
+    private var list: some View {
+        if updaterViewModel.availableUpdates.isEmpty {
+            ApplicationsManagerEmptyState(
+                icon: "arrow.down.circle",
+                title: String(localized: "Updater", comment: "Updater empty-state title."),
+                detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Updater empty-state detail.")
+            )
+            .accessibilityIdentifier("applications.manager.updater.empty")
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(displayed) { info in
+                        row(info)
+                        Divider().opacity(0.3)
+                    }
+                }
+                .padding(.horizontal, 16).padding(.vertical, 8)
+            }
+            .onAppear { recompute() }
+            .onChange(of: facet) { _, _ in recompute() }
+            .onChange(of: search) { _, _ in recompute() }
+            .onChange(of: updaterViewModel.availableUpdates.map(\.id)) { _, _ in recompute() }
+            // The selection only changes the visible list under the Selected facet.
+            .onChange(of: selection) { _, _ in
+                if facet == .selected { recompute() }
+            }
+            .accessibilityIdentifier("applications.manager.updater.list")
+        }
+    }
+
+    private func row(_ info: UpdateInfo) -> some View {
+        HStack(spacing: 12) {
+            ApplicationsManagerCheckbox(selected: selection.contains(info.id)) {
+                if selection.contains(info.id) { selection.remove(info.id) } else { selection.insert(info.id) }
+            }
+            Image(nsImage: iconCache.icon(for: info.bundleURL))
+                .resizable().frame(width: 32, height: 32)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(info.appName).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
+                Text(versionTransition(info)).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            Text(info.source == .appStore
+                 ? String(localized: "App Store", comment: "Update source label.")
+                 : String(localized: "Web", comment: "Update source label."))
+                .font(.caption).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 10)
+        .accessibilityIdentifier("applications.manager.updater.row.\(info.bundleID)")
+    }
+
+    private func versionTransition(_ info: UpdateInfo) -> String {
+        let format = String(localized: "%1$@ → %2$@", comment: "Update row version change; installed → latest.")
+        return String.localizedStringWithFormat(format, info.installedVersion, info.latestVersion)
+    }
+}
+
+// MARK: - Extensions pane
+
+/// Middle-pane facet for the Extensions pane.
+private enum ExtensionsFacet: Hashable {
+    case all
+    case selected
+    case type(ExtensionType)
+}
+
+/// The Extensions pane — the facet column plus the extensions/plug-ins list.
+/// Extracted from `ApplicationsManagerView`; the facet, selection, and memoized
+/// list are owned by the parent (the footer's Remove action reads the selection)
+/// and passed in as bindings.
+private struct ExtensionsPaneView: View {
+    let extensionsManagerViewModel: ExtensionsManagerViewModel
+    let search: String
+    @Binding var facet: ExtensionsFacet
+    @Binding var selection: Set<ExtensionItem.ID>
+    @Binding var displayed: [ExtensionItem]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            middleColumn.frame(width: 320)
+            Divider().opacity(0.4)
+            rightColumn.frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: Middle (facets)
+
+    private var middleColumn: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ApplicationsManagerPaneHeader(
+                title: String(localized: "Extensions", comment: "Extensions pane title."),
+                description: String(localized: "Manage the add-ons and plug-ins installed into your browsers and apps.", comment: "Extensions pane description.")
+            )
+            ScrollView { facets.padding(8) }
+        }
+    }
+
+    private var facets: some View {
+        let grouped = extensionsManagerViewModel.groupedByType
+        return VStack(spacing: 4) {
+            facetRow(.all, String(localized: "All Extensions", comment: "Extensions facet."), extensionsManagerViewModel.items.count)
+            facetRow(.selected, String(localized: "Selected", comment: "Extensions facet."), selection.count)
+
+            if !grouped.isEmpty {
+                ApplicationsManagerFacetSectionHeader(title: String(localized: "Categories", comment: "Extensions facet group header."))
+                ForEach(grouped, id: \.0) { type, entries in
+                    facetRow(.type(type), localizedExtensionType(type), entries.count)
+                }
+            }
+        }
+    }
+
+    private func facetRow(_ target: ExtensionsFacet, _ label: String, _ count: Int) -> some View {
+        ApplicationsManagerSelectableRow(selected: facet == target) {
+            facet = target
+        } content: {
+            HStack {
+                Text(label).font(.body.weight(.medium))
+                Spacer()
+                Text("\(count)").font(.callout).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func localizedExtensionType(_ type: ExtensionType) -> String {
+        switch type {
+        case .safariExtension:  return String(localized: "Safari Extensions", comment: "Extension category.")
+        case .chromeExtension:  return String(localized: "Chrome Extensions", comment: "Extension category.")
+        case .firefoxExtension: return String(localized: "Firefox Extensions", comment: "Extension category.")
+        case .mailPlugin:       return String(localized: "Mail Plugins", comment: "Extension category.")
+        case .internetPlugin:   return String(localized: "Browser Plug-ins", comment: "Extension category.")
+        }
+    }
+
+    private var rightPaneTitle: String {
+        switch facet {
+        case .all:              return String(localized: "All Extensions", comment: "Extensions right pane title.")
+        case .selected:         return String(localized: "Selected", comment: "Extensions right pane title.")
+        case .type(let t):      return localizedExtensionType(t)
+        }
+    }
+
+    private var rightPaneDescription: String {
+        switch facet {
+        case .all:              return String(localized: "Every extension and plug-in installed on this Mac.", comment: "Extensions right pane description.")
+        case .selected:         return String(localized: "Extensions you've chosen to remove.", comment: "Extensions right pane description.")
+        case .type(let t):
+            switch t {
+            case .safariExtension:  return String(localized: "Extensions installed in Safari.", comment: "Safari extensions right pane description.")
+            case .chromeExtension:  return String(localized: "Extensions installed in Google Chrome.", comment: "Chrome extensions right pane description.")
+            case .firefoxExtension: return String(localized: "Extensions installed in Firefox.", comment: "Firefox extensions right pane description.")
+            case .mailPlugin:       return String(localized: "Plug-ins installed in the Mail app.", comment: "Mail plugins right pane description.")
+            case .internetPlugin:   return String(localized: "Legacy plug-ins used by web browsers.", comment: "Browser plug-ins right pane description.")
+            }
+        }
+    }
+
+    // MARK: Right (list)
+
+    private var rightColumn: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ApplicationsManagerPaneHeader(title: rightPaneTitle, description: rightPaneDescription)
+            list
+        }
+    }
+
+    private func recompute() {
+        let items = extensionsManagerViewModel.items.filter { item in
+            let matchesFacet: Bool
+            switch facet {
+            case .all:              matchesFacet = true
+            case .selected:         matchesFacet = selection.contains(item.id)
+            case .type(let type):   matchesFacet = item.type == type
+            }
+            guard matchesFacet else { return false }
+            let trimmed = search.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty || item.name.localizedCaseInsensitiveContains(trimmed)
+        }
+        displayed = items.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    @ViewBuilder
+    private var list: some View {
+        if extensionsManagerViewModel.items.isEmpty {
+            ApplicationsManagerEmptyState(
+                icon: "puzzlepiece.extension",
+                title: String(localized: "Extensions", comment: "Extensions empty-state title."),
+                detail: String(localized: "No browser extensions or plug-ins were found.", comment: "Extensions empty-state detail.")
+            )
+            .accessibilityIdentifier("applications.manager.extensions.empty")
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(displayed) { item in
+                        row(item)
+                        Divider().opacity(0.3)
+                    }
+                }
+                .padding(.horizontal, 16).padding(.vertical, 8)
+            }
+            .onAppear { recompute() }
+            .onChange(of: facet) { _, _ in recompute() }
+            .onChange(of: search) { _, _ in recompute() }
+            .onChange(of: extensionsManagerViewModel.items.map(\.id)) { _, _ in recompute() }
+            // The selection only changes the visible list under the Selected facet.
+            .onChange(of: selection) { _, _ in
+                if facet == .selected { recompute() }
+            }
+            .accessibilityIdentifier("applications.manager.extensions.list")
+        }
+    }
+
+    private func row(_ item: ExtensionItem) -> some View {
+        HStack(spacing: 12) {
+            ApplicationsManagerCheckbox(selected: selection.contains(item.id)) {
+                if selection.contains(item.id) { selection.remove(item.id) } else { selection.insert(item.id) }
+            }
+            Image(systemName: symbol(item.type))
+                .font(.system(size: 18))
+                .foregroundStyle(.tint)
+                .frame(width: 32)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.name).font(.body.weight(.medium)).lineLimit(1).truncationMode(.middle)
+                Text(localizedExtensionType(item.type)).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            Text(ApplicationsManagerChrome.byteText(item.size)).font(.callout.weight(.semibold)).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 10)
+        .accessibilityIdentifier("applications.manager.extensions.row.\(item.id.path)")
+    }
+
+    private func symbol(_ type: ExtensionType) -> String {
+        switch type {
+        case .safariExtension:  return "safari"
+        case .chromeExtension:  return "globe"
+        case .firefoxExtension: return "globe"
+        case .mailPlugin:       return "envelope"
+        case .internetPlugin:   return "puzzlepiece.extension"
+        }
+    }
+}
+
+// MARK: - Shared chrome
+
+/// Constants and helpers shared by the Applications Manager and its pane
+/// subviews. The accent is the standalone Manager magenta; the selection fill is
+/// this manager's own quieter purple pill (distinct from `NavRow`'s accent fill).
+enum ApplicationsManagerChrome {
+    static let accent = ManagerChrome.accent
+    static let selectionFill = Color(red: 0.45, green: 0.30, blue: 0.85).opacity(0.14)
+
+    static func byteText(_ bytes: Int64) -> String {
+        smartScanByteFormatter.string(fromByteCount: bytes)
+    }
+}
+
+/// A pane's title + description block, above its facet list or item list.
+struct ApplicationsManagerPaneHeader: View {
+    let title: String
+    let description: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.title3.weight(.semibold))
+            Text(description).font(.callout).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24).padding(.top, 16).padding(.bottom, 12)
+    }
+}
+
+/// A nav / facet / section row with the manager's selection pill.
+struct ApplicationsManagerSelectableRow<Content: View>: View {
+    let selected: Bool
+    let action: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        Button(action: action) {
+            content()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12).padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(selected ? ApplicationsManagerChrome.selectionFill : .clear)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// A row checkbox tinted with the manager accent when selected.
+struct ApplicationsManagerCheckbox: View {
+    let selected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: selected ? "checkmark.square.fill" : "square")
+                .font(.system(size: 18))
+                .foregroundStyle(selected ? ApplicationsManagerChrome.accent : Color.secondary)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// A quiet group header inside a facet column ("Stores", "Vendors", …).
+struct ApplicationsManagerFacetSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 2)
+    }
+}
+
+/// Centered icon + title + detail empty state for a pane with no items.
+struct ApplicationsManagerEmptyState: View {
+    let icon: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: icon).font(.system(size: 44)).foregroundStyle(.tint.opacity(0.7))
+            Text(title).font(.title2.weight(.semibold))
+            Text(detail).font(.callout).foregroundStyle(.secondary).multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// The right pane's loading spinner while the app list is still discovering.
+struct ApplicationsManagerLoadingPane: View {
+    var body: some View {
+        VStack { Spacer(); ProgressView().controlSize(.large); Spacer() }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("applications.manager.loading")
+    }
 }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @Environment(SystemStatsService.self) private var systemStats
     @Environment(NotificationThresholdMonitor.self) private var notificationMonitor
     @Environment(NotificationMonitors.self) private var notificationMonitors
+    @Environment(ScanCompletionNotifier.self) private var scanCompletionNotifier
     @Environment(MenuRouter.self) private var menuRouter
     @Environment(\.scenePhase) private var scenePhase
     private let systemJunkViewModel: SystemJunkViewModel
@@ -217,7 +218,8 @@ struct ContentView: View {
                 scanDiscController.attach(
                     to: window,
                     railWidth: railWidth,
-                    appState: appState
+                    appState: appState,
+                    scanCompletionNotifier: scanCompletionNotifier
                 )
             }
         )
@@ -334,6 +336,7 @@ struct ContentView: View {
         // Only Smart Scan auto-starts from the menu's "Run Smart Scan" — the
         // other deep-links just reveal the section and let the user act.
         if startScan, target == .smartScan {
+            scanCompletionNotifier.armScan(section: .smartScan, coordinator: smartScanViewModel)
             smartScanViewModel.beginScan()
         }
     }
@@ -496,5 +499,6 @@ private extension AnyTransition {
             dispatcher: notificationManager
         ))
         .environment(NotificationMonitors(preferences: prefs, dispatcher: notificationManager))
+        .environment(ScanCompletionNotifier(preferences: prefs, dispatcher: notificationManager))
         .environment(MenuRouter())
 }

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @Environment(PermissionOnboardingViewModel.self) private var onboarding
     @Environment(SystemStatsService.self) private var systemStats
     @Environment(NotificationThresholdMonitor.self) private var notificationMonitor
+    @Environment(NotificationMonitors.self) private var notificationMonitors
     @Environment(MenuRouter.self) private var menuRouter
     @Environment(\.scenePhase) private var scenePhase
     private let systemJunkViewModel: SystemJunkViewModel
@@ -19,7 +20,6 @@ struct ContentView: View {
     private let applicationsViewModel: ApplicationsViewModel
     private let extensionsManagerViewModel: ExtensionsManagerViewModel
     private let performanceViewModel: PerformanceViewModel
-    private let malwareViewModel: MalwareViewModel
     private let protectionDashboardViewModel: ProtectionDashboardViewModel
     private let smartScanViewModel: SmartScanViewModel
     @State private var selectedSection: NavigationSection? = .smartScan
@@ -87,7 +87,6 @@ struct ContentView: View {
         applicationsViewModel: ApplicationsViewModel,
         extensionsManagerViewModel: ExtensionsManagerViewModel,
         performanceViewModel: PerformanceViewModel,
-        malwareViewModel: MalwareViewModel,
         protectionDashboardViewModel: ProtectionDashboardViewModel,
         smartScanViewModel: SmartScanViewModel
     ) {
@@ -99,7 +98,6 @@ struct ContentView: View {
         self.applicationsViewModel = applicationsViewModel
         self.extensionsManagerViewModel = extensionsManagerViewModel
         self.performanceViewModel = performanceViewModel
-        self.malwareViewModel = malwareViewModel
         self.protectionDashboardViewModel = protectionDashboardViewModel
         self.smartScanViewModel = smartScanViewModel
         _scanDiscController = State(initialValue: ScanDiscWindowController(
@@ -114,32 +112,33 @@ struct ContentView: View {
         // When a Smart Scan completes, populate every standalone section so the
         // user never has to scan a section by hand after a Smart Scan.
         //
-        // System Junk, Large & Old Files, and Malware run the exact same
-        // scanners Smart Scan already used, so they're seeded with the results
-        // directly — instant, no extra work.
+        // System Junk and Protection's malware tile run the exact same scanners
+        // Smart Scan already used, so they're seeded with the results directly —
+        // instant, no extra work.
         //
-        // Applications and Performance need heavier, multi-step scans that
-        // Smart Scan does not perform (full app analysis: updates, unused,
-        // unsupported, leftovers, installers; and launch agents / RAM /
-        // snapshots). Rather than show partial data, kick off each section's own
-        // full scan now so it finishes in the background and is ready by the
-        // time the user opens it.
+        // Large & Old Files, Applications, Performance, Protection's privacy
+        // preview, and Space Lens need scans Smart Scan does not perform (four
+        // composite clutter scans; full app analysis: updates, unused,
+        // unsupported, leftovers, installers; launch agents / RAM / snapshots;
+        // the per-browser privacy preview; and a full-volume disk map). Rather
+        // than show partial data, kick off each section's own scan now so it
+        // finishes in the background and is ready by the time the user opens it.
         //
         // Every section is only populated when it is still idle, so this never
         // disrupts a section the user has already scanned themselves.
-        smartScanViewModel.onScanCompleted = { [systemJunkViewModel, myClutterViewModel, malwareViewModel, applicationsViewModel, performanceViewModel] result in
+        smartScanViewModel.onScanCompleted = { [systemJunkViewModel, myClutterViewModel, spaceLensViewModel, applicationsViewModel, performanceViewModel, protectionDashboardViewModel] result in
             systemJunkViewModel.seed(with: result.junkResult)
-            malwareViewModel.seed(
+            // Seeds Protection's malware tile from the Smart Scan results and
+            // kicks off the privacy preview, without re-running the malware scan.
+            protectionDashboardViewModel.prewarmFromSmartScan(
                 threats: result.threats,
                 clamAVAvailable: result.clamAVAvailable,
                 scannedAt: Date()
             )
-            // The My Clutter section runs four composite scans Smart Scan
-            // doesn't produce, so it can't be seeded from the result — kick off
-            // its own scan instead, like the other sections below.
             if case .idle = myClutterViewModel.phase { myClutterViewModel.beginScan() }
             if case .idle = applicationsViewModel.phase { applicationsViewModel.beginScan() }
             if case .idle = performanceViewModel.phase { performanceViewModel.beginScan() }
+            if case .idle = spaceLensViewModel.phase { spaceLensViewModel.beginScan() }
         }
     }
 
@@ -347,6 +346,9 @@ struct ContentView: View {
         guard appState.hasFullDiskAccess || onboarding.isDismissed else { return }
         didRequestNotificationPermission = true
         await notificationMonitor.requestPermission()
+        // Permission has resolved — start the Notifications-pane background
+        // monitors so their banners can present.
+        notificationMonitors.start()
     }
 
     /// Routes the selected sidebar section to its detail view. The switch is
@@ -474,7 +476,6 @@ private extension AnyTransition {
         applicationsViewModel: ApplicationsViewModel.live(),
         extensionsManagerViewModel: ExtensionsManagerViewModel.live(),
         performanceViewModel: PerformanceViewModel.live(systemStats: stats, preferences: prefs),
-        malwareViewModel: malware,
         protectionDashboardViewModel: ProtectionDashboardViewModel(
             malware: malware,
             privacy: privacy,
@@ -494,5 +495,6 @@ private extension AnyTransition {
             preferences: prefs,
             dispatcher: notificationManager
         ))
+        .environment(NotificationMonitors(preferences: prefs, dispatcher: notificationManager))
         .environment(MenuRouter())
 }

--- a/VaderCleaner/DeviceBatteryMonitor.swift
+++ b/VaderCleaner/DeviceBatteryMonitor.swift
@@ -1,0 +1,110 @@
+// DeviceBatteryMonitor.swift
+// Best-effort low-battery alerts for connected input devices (mouse, keyboard, trackpad).
+
+import Foundation
+import IOKit
+
+/// A connected device's reported battery level.
+struct DeviceBattery: Equatable {
+    let name: String
+    let percent: Int
+}
+
+/// Notifies when a connected input device's battery drops to/under
+/// `lowThreshold`, gated by `notifyDeviceBatteryLow` and a per-device cooldown.
+///
+/// The battery read is best-effort and quarantined in `readDeviceBatteries()`:
+/// macOS exposes no public API for peripheral battery level, so it scrapes the
+/// `AppleDeviceManagementHIDEventService` IORegistry entries and may return
+/// nothing on some setups or break across OS releases. The reader is injected so
+/// the firing logic stays fully unit-testable.
+@MainActor
+final class DeviceBatteryMonitor {
+
+    typealias Reader = @Sendable () -> [DeviceBattery]
+
+    private let preferences: PreferencesStore
+    private let dispatcher: NotificationDispatching
+    private let reader: Reader
+    private let lowThreshold: Int
+    private let cooldown: TimeInterval
+    private let pollInterval: TimeInterval
+    private let now: () -> Date
+
+    private var lastFired: [String: Date] = [:]
+    private var timer: Timer?
+
+    init(
+        preferences: PreferencesStore,
+        dispatcher: NotificationDispatching,
+        reader: @escaping Reader = { DeviceBatteryMonitor.readDeviceBatteries() },
+        lowThreshold: Int = 20,
+        cooldown: TimeInterval = 12 * 60 * 60,
+        pollInterval: TimeInterval = 15 * 60,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.preferences = preferences
+        self.dispatcher = dispatcher
+        self.reader = reader
+        self.lowThreshold = lowThreshold
+        self.cooldown = cooldown
+        self.pollInterval = pollInterval
+        self.now = now
+    }
+
+    /// Pure decision: fires for each device at/under the low threshold whose
+    /// per-device cooldown has elapsed.
+    func evaluate(devices: [DeviceBattery]) {
+        guard preferences.notifyDeviceBatteryLow else { return }
+        for device in devices where device.percent <= lowThreshold {
+            if let last = lastFired[device.name], now().timeIntervalSince(last) < cooldown { continue }
+            dispatcher.sendDeviceBatteryLowNotification(deviceName: device.name, percent: device.percent)
+            lastFired[device.name] = now()
+        }
+    }
+
+    func start() {
+        timer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.poll() }
+        }
+        self.timer = timer
+        poll()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func poll() {
+        guard preferences.notifyDeviceBatteryLow else { return }
+        evaluate(devices: reader())
+    }
+
+    /// Best-effort peripheral battery read via IORegistry. Returns `[]` when no
+    /// device reports a level.
+    nonisolated static func readDeviceBatteries() -> [DeviceBattery] {
+        guard let matching = IOServiceMatching("AppleDeviceManagementHIDEventService") else { return [] }
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) == KERN_SUCCESS else { return [] }
+        defer { IOObjectRelease(iterator) }
+
+        var result: [DeviceBattery] = []
+        var service = IOIteratorNext(iterator)
+        while service != 0 {
+            if let percent = property(service, "BatteryPercent") as? Int {
+                let name = (property(service, "Product") as? String) ?? "Device"
+                result.append(DeviceBattery(name: name, percent: percent))
+            }
+            IOObjectRelease(service)
+            service = IOIteratorNext(iterator)
+        }
+        return result
+    }
+
+    nonisolated private static func property(_ service: io_service_t, _ key: String) -> Any? {
+        IORegistryEntryCreateCFProperty(service, key as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue()
+    }
+}

--- a/VaderCleaner/FloatingScanOverlay.swift
+++ b/VaderCleaner/FloatingScanOverlay.swift
@@ -21,6 +21,8 @@ struct FloatingScanOverlay<Coordinator: ScanCoordinating>: View {
 
     /// Observed so a Scan tap can be gated on the live Full Disk Access flag.
     @Environment(AppState.self) private var appState
+    /// Armed when the user starts a scan here, so its completion notifies.
+    @Environment(ScanCompletionNotifier.self) private var scanCompletionNotifier
 
     /// Drives the Full Disk Access popover anchored to the Scan disc. Set true
     /// when the user taps Scan on an FDA-sensitive section without access; the
@@ -68,7 +70,7 @@ struct FloatingScanOverlay<Coordinator: ScanCoordinating>: View {
                         },
                         onScanAnyway: {
                             showFullDiskAccessPrompt = false
-                            coordinator.beginScan()
+                            startScan()
                         }
                     )
                 }
@@ -91,9 +93,17 @@ struct FloatingScanOverlay<Coordinator: ScanCoordinating>: View {
             hasFullDiskAccess: appState.hasFullDiskAccess
         ) {
         case .beginScan:
-            coordinator.beginScan()
+            startScan()
         case .promptForFullDiskAccess:
             showFullDiskAccessPrompt = true
         }
+    }
+
+    /// Arms the completion notification for this section, then starts the scan.
+    /// Both user-facing Scan paths (the disc tap and "Scan Anyway") route here so
+    /// the "scan finished" banner only fires for scans the user initiated.
+    private func startScan() {
+        scanCompletionNotifier.armScan(section: section, coordinator: coordinator)
+        coordinator.beginScan()
     }
 }

--- a/VaderCleaner/HungAppMonitor.swift
+++ b/VaderCleaner/HungAppMonitor.swift
@@ -1,0 +1,110 @@
+// HungAppMonitor.swift
+// Best-effort "application not responding" alerts for running apps.
+
+import Foundation
+import AppKit
+import ApplicationServices
+
+/// A running app the monitor can probe.
+struct RunningAppInfo: Equatable {
+    let name: String
+    let pid: pid_t
+}
+
+/// Notifies when a running app stops responding, gated by `notifyHungApps` and a
+/// per-process cooldown.
+///
+/// Responsiveness is best-effort: it probes the app over the Accessibility API
+/// with a short messaging timeout and only when the process is Accessibility-
+/// trusted (otherwise every app would look hung). Both the app list and the
+/// responsiveness probe are injected so the firing logic is unit-testable.
+@MainActor
+final class HungAppMonitor {
+
+    typealias AppLister = () -> [RunningAppInfo]
+    typealias ResponsivenessProbe = (pid_t) -> Bool
+
+    private let preferences: PreferencesStore
+    private let dispatcher: NotificationDispatching
+    private let appLister: AppLister
+    private let isResponsive: ResponsivenessProbe
+    private let cooldown: TimeInterval
+    private let pollInterval: TimeInterval
+    private let now: () -> Date
+
+    private var lastFired: [pid_t: Date] = [:]
+    private var timer: Timer?
+
+    init(
+        preferences: PreferencesStore,
+        dispatcher: NotificationDispatching,
+        appLister: @escaping AppLister = { HungAppMonitor.runningApps() },
+        isResponsive: @escaping ResponsivenessProbe = { HungAppMonitor.probeResponsive($0) },
+        cooldown: TimeInterval = 60 * 60,
+        pollInterval: TimeInterval = 30,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.preferences = preferences
+        self.dispatcher = dispatcher
+        self.appLister = appLister
+        self.isResponsive = isResponsive
+        self.cooldown = cooldown
+        self.pollInterval = pollInterval
+        self.now = now
+    }
+
+    /// Pure decision: fires for each unresponsive app whose per-process cooldown
+    /// has elapsed, and forgets apps that have since recovered or quit.
+    func evaluate() {
+        guard preferences.notifyHungApps else { return }
+        let apps = appLister()
+        let livePIDs = Set(apps.map(\.pid))
+
+        for app in apps where !isResponsive(app.pid) {
+            if let last = lastFired[app.pid], now().timeIntervalSince(last) < cooldown { continue }
+            dispatcher.sendHungAppNotification(appName: app.name)
+            lastFired[app.pid] = now()
+        }
+        // Drop bookkeeping for apps that recovered or quit so a future hang
+        // alerts again.
+        for pid in lastFired.keys where !livePIDs.contains(pid) {
+            lastFired[pid] = nil
+        }
+        for app in apps where isResponsive(app.pid) {
+            lastFired[app.pid] = nil
+        }
+    }
+
+    func start() {
+        timer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.evaluate() }
+        }
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// The user-facing apps currently running (regular activation policy).
+    nonisolated static func runningApps() -> [RunningAppInfo] {
+        NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular && !$0.isTerminated }
+            .map { RunningAppInfo(name: $0.localizedName ?? "An app", pid: $0.processIdentifier) }
+    }
+
+    /// Best-effort responsiveness probe. Returns `true` (responsive) when the
+    /// process can't be probed — no Accessibility trust — so a missing
+    /// permission never produces false "not responding" alerts.
+    nonisolated static func probeResponsive(_ pid: pid_t) -> Bool {
+        guard AXIsProcessTrusted() else { return true }
+        let app = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(app, 0.5)
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(app, kAXTitleAttribute as CFString, &value)
+        // A hung app fails to answer the message within the timeout window.
+        return result != .cannotComplete
+    }
+}

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -276,14 +276,20 @@ final class MenuBarViewModel {
         }
     }
 
+    /// Allocated once: `RelativeDateTimeFormatter` carries per-instance state, so
+    /// reusing one avoids rebuilding it on each Protection-card refresh.
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter
+    }()
+
     /// "Last scan 3 days ago" / "No scans yet" detail for the Protection card.
     static func lastScanString(_ date: Date?) -> String {
         guard let date else {
             return String(localized: "No scans yet", comment: "Protection card detail when no scan has run.")
         }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        let relative = formatter.localizedString(for: date, relativeTo: Date())
+        let relative = relativeFormatter.localizedString(for: date, relativeTo: Date())
         let format = String(localized: "Last scan %@", comment: "Protection card detail; %@ is a relative date.")
         return String(format: format, relative)
     }

--- a/VaderCleaner/MyClutterDashboardView.swift
+++ b/VaderCleaner/MyClutterDashboardView.swift
@@ -19,11 +19,15 @@ struct MyClutterDashboardView: View {
     let onReviewDownloads: () -> Void
     let onStartOver: () -> Void
 
-    private var byteFormatter: ByteCountFormatter {
+    // Allocated once for the process: `ByteCountFormatter` builds measurable
+    // internal state per instance, so a stored static avoids rebuilding it on
+    // each access during a render. Matches the convention used across the app's
+    // other dashboards.
+    private static let byteFormatter: ByteCountFormatter = {
         let f = ByteCountFormatter()
         f.countStyle = .file
         return f
-    }
+    }()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -132,7 +136,7 @@ struct MyClutterDashboardView: View {
             ),
             subtitle: String.localizedStringWithFormat(
                 String(localized: "Remove %@ of duplicate files.", comment: "Duplicates card subtitle; %@ is a size."),
-                byteFormatter.string(fromByteCount: viewModel.duplicateReclaimableBytes)
+                Self.byteFormatter.string(fromByteCount: viewModel.duplicateReclaimableBytes)
             ),
             accent: accent,
             thumbnails: Array(viewModel.duplicateCopies.prefix(3).map(\.url)),
@@ -152,7 +156,7 @@ struct MyClutterDashboardView: View {
             ),
             subtitle: String.localizedStringWithFormat(
                 String(localized: "%@ of nearly identical photos.", comment: "Similar Images card subtitle; %@ is a size."),
-                byteFormatter.string(fromByteCount: viewModel.similarReclaimableBytes)
+                Self.byteFormatter.string(fromByteCount: viewModel.similarReclaimableBytes)
             ),
             accent: accent,
             thumbnails: Array(viewModel.similarCopies.prefix(3).map(\.url)),
@@ -167,7 +171,7 @@ struct MyClutterDashboardView: View {
         MyClutterCard(
             title: String.localizedStringWithFormat(
                 String(localized: "%@ of Large and Old Files Found", comment: "Large & Old card title; %@ is a size."),
-                byteFormatter.string(fromByteCount: viewModel.largeOldBytes)
+                Self.byteFormatter.string(fromByteCount: viewModel.largeOldBytes)
             ),
             subtitle: nil,
             accent: accent,
@@ -202,7 +206,7 @@ struct MyClutterDashboardView: View {
     }
 
     private var downloadsTitle: String {
-        let size = byteFormatter.string(fromByteCount: viewModel.downloadsBytes)
+        let size = Self.byteFormatter.string(fromByteCount: viewModel.downloadsBytes)
         if let source = viewModel.dominantDownloadSource {
             let format = String(
                 localized: "%1$@ of %2$@ Downloads Found",

--- a/VaderCleaner/NotificationManager.swift
+++ b/VaderCleaner/NotificationManager.swift
@@ -12,10 +12,17 @@ import os.log
 @MainActor
 protocol NotificationDispatching: AnyObject {
     func requestPermission() async
-    func sendLowDiskNotification(freePercent: Double)
+    func sendLowDiskNotification(freeBytes: Int64)
     func sendHighRAMNotification(pressureLevel: String)
     func sendMalwareDetectedNotification(threatName: String)
     func sendLargeFilesFoundNotification(count: Int, totalSize: Int64)
+    // Notifications pane parity.
+    func sendTrashSizeNotification(sizeBytes: Int64)
+    func sendDeviceBatteryLowNotification(deviceName: String, percent: Int)
+    func sendDriveConnectedNotification(volumeName: String)
+    func sendOverfilledDriveNotification(volumeName: String, freeBytes: Int64, totalBytes: Int64)
+    func sendAppTrashedNotification(appName: String)
+    func sendHungAppNotification(appName: String)
 }
 
 /// Production `NotificationDispatching` backed by
@@ -123,8 +130,8 @@ final class NotificationManager: NSObject, NotificationDispatching, UNUserNotifi
 
     // MARK: - Dispatch entry points
 
-    func sendLowDiskNotification(freePercent: Double) {
-        deliver(content: Self.makeLowDiskContent(freePercent: freePercent))
+    func sendLowDiskNotification(freeBytes: Int64) {
+        deliver(content: Self.makeLowDiskContent(freeBytes: freeBytes))
     }
 
     func sendHighRAMNotification(pressureLevel: String) {
@@ -138,6 +145,30 @@ final class NotificationManager: NSObject, NotificationDispatching, UNUserNotifi
     func sendLargeFilesFoundNotification(count: Int, totalSize: Int64) {
         deliver(content: Self.makeLargeFilesFoundContent(count: count,
                                                          totalSize: totalSize))
+    }
+
+    func sendTrashSizeNotification(sizeBytes: Int64) {
+        deliver(content: Self.makeTrashSizeContent(sizeBytes: sizeBytes))
+    }
+
+    func sendDeviceBatteryLowNotification(deviceName: String, percent: Int) {
+        deliver(content: Self.makeDeviceBatteryLowContent(deviceName: deviceName, percent: percent))
+    }
+
+    func sendDriveConnectedNotification(volumeName: String) {
+        deliver(content: Self.makeDriveConnectedContent(volumeName: volumeName))
+    }
+
+    func sendOverfilledDriveNotification(volumeName: String, freeBytes: Int64, totalBytes: Int64) {
+        deliver(content: Self.makeOverfilledDriveContent(volumeName: volumeName, freeBytes: freeBytes, totalBytes: totalBytes))
+    }
+
+    func sendAppTrashedNotification(appName: String) {
+        deliver(content: Self.makeAppTrashedContent(appName: appName))
+    }
+
+    func sendHungAppNotification(appName: String) {
+        deliver(content: Self.makeHungAppContent(appName: appName))
     }
 
     /// Schedules `content` for immediate delivery. A unique request identifier
@@ -161,14 +192,13 @@ final class NotificationManager: NSObject, NotificationDispatching, UNUserNotifi
 
     // MARK: - Content builders (pure — unit-test surface)
 
-    static func makeLowDiskContent(freePercent: Double) -> UNMutableNotificationContent {
+    static func makeLowDiskContent(freeBytes: Int64) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = "Low Disk Space"
-        // Round to whole percent so the banner reads cleanly. The threshold
-        // setting is itself an integer-feeling slider in Preferences, so a
-        // sub-percent reading would look out of place next to it.
-        let rounded = Int(freePercent.rounded())
-        content.body = "Only \(rounded)% of disk space is free. Consider cleaning system junk."
+        // Reads in the same Finder-style units the Notifications picker offers
+        // ("Less than 10 GB"), so the banner and the setting speak the same way.
+        let free = ByteCountFormatter.string(fromByteCount: freeBytes, countStyle: .file)
+        content.body = "Only \(free) of disk space is free. Consider cleaning system junk."
         content.sound = .default
         return content
     }
@@ -194,6 +224,64 @@ final class NotificationManager: NSObject, NotificationDispatching, UNUserNotifi
         content.title = "Large Files Found"
         let formattedSize = byteCountFormatter.string(fromByteCount: totalSize)
         content.body = "Found \(count) large or old files totaling \(formattedSize)."
+        content.sound = .default
+        return content
+    }
+
+    static func makeSmartCareReminderContent() -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Time for Smart Care"
+        content.body = "Run a Smart Scan to keep your Mac clean, fast, and protected."
+        content.sound = .default
+        return content
+    }
+
+    static func makeTrashSizeContent(sizeBytes: Int64) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Trash Is Filling Up"
+        let size = ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+        content.body = "Your Trash holds \(size). Empty it to reclaim the space."
+        content.sound = .default
+        return content
+    }
+
+    static func makeDeviceBatteryLowContent(deviceName: String, percent: Int) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Device Battery Low"
+        content.body = "\(deviceName) is at \(percent)%. Consider charging it soon."
+        content.sound = .default
+        return content
+    }
+
+    static func makeDriveConnectedContent(volumeName: String) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Drive Connected"
+        content.body = "\(volumeName) was mounted. Scan it with Space Lens to see what's using the space."
+        content.sound = .default
+        return content
+    }
+
+    static func makeOverfilledDriveContent(volumeName: String, freeBytes: Int64, totalBytes: Int64) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "External Drive Almost Full"
+        let free = ByteCountFormatter.string(fromByteCount: freeBytes, countStyle: .file)
+        content.body = "\(volumeName) has only \(free) free. Clean it up to make room."
+        content.sound = .default
+        return content
+    }
+
+    static func makeAppTrashedContent(appName: String) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Uninstall \(appName) Completely?"
+        content.body = "You moved \(appName) to the Trash. Open Applications to remove its leftover files too."
+        content.sound = .default
+        return content
+    }
+
+    static func makeHungAppContent(appName: String) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "\(appName) Is Not Responding"
+        content.body = "\(appName) stopped responding. You can force quit it from the menu bar."
         content.sound = .default
         return content
     }

--- a/VaderCleaner/NotificationManager.swift
+++ b/VaderCleaner/NotificationManager.swift
@@ -23,6 +23,7 @@ protocol NotificationDispatching: AnyObject {
     func sendOverfilledDriveNotification(volumeName: String, freeBytes: Int64, totalBytes: Int64)
     func sendAppTrashedNotification(appName: String)
     func sendHungAppNotification(appName: String)
+    func sendScanFinishedNotification(scanName: String)
 }
 
 /// Production `NotificationDispatching` backed by
@@ -171,6 +172,10 @@ final class NotificationManager: NSObject, NotificationDispatching, UNUserNotifi
         deliver(content: Self.makeHungAppContent(appName: appName))
     }
 
+    func sendScanFinishedNotification(scanName: String) {
+        deliver(content: Self.makeScanFinishedContent(scanName: scanName))
+    }
+
     /// Schedules `content` for immediate delivery. A unique request identifier
     /// per call avoids collapsing into a still-displayed banner from a previous
     /// firing — the monitor's per-kind cooldown already prevents spam, and
@@ -282,6 +287,14 @@ final class NotificationManager: NSObject, NotificationDispatching, UNUserNotifi
         let content = UNMutableNotificationContent()
         content.title = "\(appName) Is Not Responding"
         content.body = "\(appName) stopped responding. You can force quit it from the menu bar."
+        content.sound = .default
+        return content
+    }
+
+    static func makeScanFinishedContent(scanName: String) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Scan Complete"
+        content.body = "Your \(scanName) scan has finished. Open VaderCleaner to review the results."
         content.sound = .default
         return content
     }

--- a/VaderCleaner/NotificationMonitors.swift
+++ b/VaderCleaner/NotificationMonitors.swift
@@ -1,0 +1,65 @@
+// NotificationMonitors.swift
+// Owns and starts the background monitors behind the Notifications settings (trash, drives, devices, hung apps, trashed apps, Smart Care reminder).
+
+import Foundation
+import Observation
+
+/// App-scoped aggregator for the notification monitors introduced alongside the
+/// Notifications settings pane. It constructs each monitor against the shared
+/// `PreferencesStore` + `NotificationDispatching`, starts them once, and keeps
+/// the Smart Care reminder in sync as its preference changes.
+///
+/// Held as `@State` by `VaderCleanerApp` and started from the same post-launch
+/// path that requests notification permission, so the OS prompt has resolved
+/// before any banner can fire.
+@MainActor
+@Observable
+final class NotificationMonitors {
+
+    @ObservationIgnored private let preferences: PreferencesStore
+    @ObservationIgnored private let trashSize: TrashSizeMonitor
+    @ObservationIgnored private let volumeMount: VolumeMountMonitor
+    @ObservationIgnored private let deviceBattery: DeviceBatteryMonitor
+    @ObservationIgnored private let hungApp: HungAppMonitor
+    @ObservationIgnored private let trashedApp: TrashedAppMonitor
+    @ObservationIgnored private let smartCare: SmartCareReminderScheduler
+    @ObservationIgnored private var started = false
+
+    init(preferences: PreferencesStore, dispatcher: NotificationDispatching) {
+        self.preferences = preferences
+        self.trashSize = TrashSizeMonitor(preferences: preferences, dispatcher: dispatcher)
+        self.volumeMount = VolumeMountMonitor(preferences: preferences, dispatcher: dispatcher)
+        self.deviceBattery = DeviceBatteryMonitor(preferences: preferences, dispatcher: dispatcher)
+        self.hungApp = HungAppMonitor(preferences: preferences, dispatcher: dispatcher)
+        self.trashedApp = TrashedAppMonitor(preferences: preferences, dispatcher: dispatcher)
+        self.smartCare = SmartCareReminderScheduler(preferences: preferences)
+    }
+
+    /// Starts every monitor and schedules the Smart Care reminder. Idempotent.
+    func start() {
+        guard !started else { return }
+        started = true
+        trashSize.start()
+        volumeMount.start()
+        deviceBattery.start()
+        hungApp.start()
+        trashedApp.start()
+        smartCare.update()
+        observeSmartCarePreference()
+    }
+
+    /// Re-applies the Smart Care reminder whenever its toggle or cadence changes,
+    /// re-arming the observation each time (Observation fires once per change).
+    private func observeSmartCarePreference() {
+        withObservationTracking {
+            _ = preferences.remindSmartCare
+            _ = preferences.smartCareFrequency
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.smartCare.update()
+                self.observeSmartCarePreference()
+            }
+        }
+    }
+}

--- a/VaderCleaner/NotificationThresholdMonitor.swift
+++ b/VaderCleaner/NotificationThresholdMonitor.swift
@@ -78,8 +78,8 @@ final class NotificationThresholdMonitor {
     ///   - stats: Source of disk/RAM readings. The monitor subscribes to
     ///     `$diskSpace` and `$ramUsage` and forwards each new value to the
     ///     `evaluate(disk:)` / `evaluate(ram:)` paths below.
-    ///   - preferences: Backing store for the four notification toggles and
-    ///     `diskSpaceThresholdPercent`.
+    ///   - preferences: Backing store for the notification toggles and
+    ///     `diskFreeThresholdGB`.
     ///   - dispatcher: Notification sink. Production passes
     ///     `NotificationManager()`; tests pass a recording stub.
     ///   - cooldown: Per-kind minimum interval between successive dispatches.
@@ -170,7 +170,7 @@ final class NotificationThresholdMonitor {
     /// if all four conditions hold:
     ///   1. Permission has been resolved (see `hasResolvedPermission`).
     ///   2. The user has `notifyLowDisk` enabled.
-    ///   3. Free percentage is strictly below `diskSpaceThresholdPercent`.
+    ///   3. Free space is strictly below `diskFreeThresholdGB` gigabytes.
     ///   4. The low-disk cooldown has elapsed since the last firing.
     /// `totalBytes == 0` short-circuits to no-op — that is the pre-first-
     /// refresh placeholder and would otherwise compute a 0% free reading.
@@ -182,12 +182,13 @@ final class NotificationThresholdMonitor {
         let freeBytes = disk.totalBytes > disk.usedBytes
             ? disk.totalBytes - disk.usedBytes
             : 0
-        let freePercent = Double(freeBytes) / Double(disk.totalBytes) * 100.0
+        // Decimal GB to match the Finder-style sizes the picker and banner show.
+        let thresholdBytes = UInt64(max(0, preferences.diskFreeThresholdGB)) * 1_000_000_000
 
-        guard freePercent < preferences.diskSpaceThresholdPercent else { return }
+        guard freeBytes < thresholdBytes else { return }
         guard isCooldownElapsed(.lowDisk) else { return }
 
-        dispatcher.sendLowDiskNotification(freePercent: freePercent)
+        dispatcher.sendLowDiskNotification(freeBytes: Int64(freeBytes))
         lastFired[.lowDisk] = now()
     }
 

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -169,26 +169,33 @@ struct PerformanceSummaryCard: View {
 struct AppIconCluster: View {
     let bundleIDs: [String]
 
-    private var icons: [NSImage] {
-        bundleIDs.prefix(3).compactMap { id in
-            NSWorkspace.shared.urlForApplication(withBundleIdentifier: id)
-                .map { NSWorkspace.shared.icon(forFile: $0.path) }
-        }
-    }
+    // Resolved once per `bundleIDs` rather than on every render: the lookup does
+    // a synchronous LaunchServices query per id, and this cluster sits on the
+    // Performance dashboard whose live stats re-render the parent frequently.
+    @State private var icons: [NSImage] = []
 
     var body: some View {
-        let resolved = icons
-        if resolved.isEmpty {
-            TaskIconBadge(symbol: "person.crop.circle.badge.checkmark", tint: Color(red: 0.55, green: 0.45, blue: 0.95))
-        } else {
-            HStack(spacing: -12) {
-                ForEach(Array(resolved.enumerated()), id: \.offset) { _, icon in
-                    Image(nsImage: icon)
-                        .resizable()
-                        .interpolation(.high)
-                        .frame(width: 40, height: 40)
+        Group {
+            if icons.isEmpty {
+                TaskIconBadge(symbol: "person.crop.circle.badge.checkmark", tint: Color(red: 0.55, green: 0.45, blue: 0.95))
+            } else {
+                HStack(spacing: -12) {
+                    ForEach(Array(icons.enumerated()), id: \.offset) { _, icon in
+                        Image(nsImage: icon)
+                            .resizable()
+                            .interpolation(.high)
+                            .frame(width: 40, height: 40)
+                    }
                 }
             }
+        }
+        .task(id: bundleIDs) { resolveIcons() }
+    }
+
+    private func resolveIcons() {
+        icons = bundleIDs.prefix(3).compactMap { id in
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: id)
+                .map { NSWorkspace.shared.icon(forFile: $0.path) }
         }
     }
 }
@@ -243,6 +250,13 @@ struct PerformanceTaskCatalogView: View {
     @State private var sort: ManagerSort = .name
     @State private var confirmRemove = false
 
+    // The Login Items and Background Items rows, mapped once from the inputs and
+    // memoized. The login mapping does a synchronous LaunchServices lookup per
+    // item, so rebuilding it on every render — e.g. each checkbox toggle — was a
+    // real cost; recompute only when the underlying items change.
+    @State private var loginManagerItems: [ManagerItem] = []
+    @State private var agentManagerItems: [ManagerItem] = []
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -261,6 +275,15 @@ struct PerformanceTaskCatalogView: View {
         .tint(ManagerChrome.accent)
         .environment(\.sectionAccent, ManagerChrome.accent)
         .accessibilityIdentifier("performance.catalog")
+        // Build the row models once, and again only when the inputs change, so
+        // the per-item LaunchServices lookup never runs during an ordinary
+        // re-render such as a checkbox toggle.
+        .onAppear {
+            recomputeLoginManagerItems()
+            recomputeAgentManagerItems()
+        }
+        .onChange(of: loginItems) { _, _ in recomputeLoginManagerItems() }
+        .onChange(of: userAgents) { _, _ in recomputeAgentManagerItems() }
         .alert(
             String(localized: "Remove the selected items?", comment: "Title of the Performance Manager remove confirmation."),
             isPresented: $confirmRemove
@@ -571,8 +594,8 @@ struct PerformanceTaskCatalogView: View {
 
     // MARK: - Item models
 
-    private var loginManagerItems: [ManagerItem] {
-        loginItems.map { item in
+    private func recomputeLoginManagerItems() {
+        loginManagerItems = loginItems.map { item in
             let iconPath = NSWorkspace.shared.urlForApplication(withBundleIdentifier: item.id)?.path
             return ManagerItem(
                 id: item.id,
@@ -588,8 +611,8 @@ struct PerformanceTaskCatalogView: View {
         }
     }
 
-    private var agentManagerItems: [ManagerItem] {
-        userAgents.map { agent in
+    private func recomputeAgentManagerItems() {
+        agentManagerItems = userAgents.map { agent in
             ManagerItem(
                 id: agent.id,
                 title: agent.label,

--- a/VaderCleaner/PreferencesStore.swift
+++ b/VaderCleaner/PreferencesStore.swift
@@ -65,6 +65,7 @@ final class PreferencesStore {
         // Notifications pane parity (General / Disk Space / Applications).
         static let remindSmartCare = "preferences.remindSmartCare"
         static let smartCareFrequency = "preferences.smartCareFrequency"
+        static let notifyScanFinished = "preferences.notifyScanFinished"
         static let notifyTrashSize = "preferences.notifyTrashSize"
         static let trashSizeThresholdGB = "preferences.trashSizeThresholdGB"
         static let notifyDeviceBatteryLow = "preferences.notifyDeviceBatteryLow"
@@ -92,6 +93,7 @@ final class PreferencesStore {
     // reference design.
     static let defaultRemindSmartCare = true
     static let defaultSmartCareFrequency = SmartCareFrequency.weekly
+    static let defaultNotifyScanFinished = true
     static let defaultNotifyTrashSize = true
     static let defaultTrashSizeThresholdGB = 2
     static let defaultNotifyDeviceBatteryLow = true
@@ -145,6 +147,11 @@ final class PreferencesStore {
 
     var remindSmartCare: Bool {
         didSet { defaults.set(remindSmartCare, forKey: Key.remindSmartCare) }
+    }
+
+    /// Notify when a scan the user started finishes, naming the section.
+    var notifyScanFinished: Bool {
+        didSet { defaults.set(notifyScanFinished, forKey: Key.notifyScanFinished) }
     }
 
     var smartCareFrequency: SmartCareFrequency {
@@ -247,6 +254,8 @@ final class PreferencesStore {
             ?? Self.defaultDiskFreeThresholdGB
         self.remindSmartCare = (defaults.object(forKey: Key.remindSmartCare) as? Bool)
             ?? Self.defaultRemindSmartCare
+        self.notifyScanFinished = (defaults.object(forKey: Key.notifyScanFinished) as? Bool)
+            ?? Self.defaultNotifyScanFinished
         self.smartCareFrequency = (defaults.object(forKey: Key.smartCareFrequency) as? String)
             .flatMap(SmartCareFrequency.init(rawValue:)) ?? Self.defaultSmartCareFrequency
         self.notifyTrashSize = (defaults.object(forKey: Key.notifyTrashSize) as? Bool)

--- a/VaderCleaner/PreferencesStore.swift
+++ b/VaderCleaner/PreferencesStore.swift
@@ -4,6 +4,23 @@
 import Foundation
 import Observation
 
+/// How often the "Remind to run regular Smart Care" notification repeats.
+enum SmartCareFrequency: String, CaseIterable, Identifiable, Sendable {
+    case daily
+    case weekly
+    case monthly
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .daily:   return String(localized: "Daily", comment: "Smart Care reminder frequency.")
+        case .weekly:  return String(localized: "Weekly", comment: "Smart Care reminder frequency.")
+        case .monthly: return String(localized: "Monthly", comment: "Smart Care reminder frequency.")
+        }
+    }
+}
+
 /// Single source of truth for user-tweakable settings (notifications, disk threshold,
 /// launch-at-login, menu bar visibility). Backed by `UserDefaults` so changes survive
 /// app relaunch.
@@ -41,10 +58,20 @@ final class PreferencesStore {
         static let notifyHighRAM = "preferences.notifyHighRAM"
         static let notifyMalwareFound = "preferences.notifyMalwareFound"
         static let notifyLargeFilesFound = "preferences.notifyLargeFilesFound"
-        static let diskSpaceThresholdPercent = "preferences.diskSpaceThresholdPercent"
+        static let diskFreeThresholdGB = "preferences.diskFreeThresholdGB"
         static let launchAtLogin = "preferences.launchAtLogin"
         static let showMenuBar = "preferences.showMenuBar"
         static let menuBarShowsReading = "preferences.menuBarShowsReading"
+        // Notifications pane parity (General / Disk Space / Applications).
+        static let remindSmartCare = "preferences.remindSmartCare"
+        static let smartCareFrequency = "preferences.smartCareFrequency"
+        static let notifyTrashSize = "preferences.notifyTrashSize"
+        static let trashSizeThresholdGB = "preferences.trashSizeThresholdGB"
+        static let notifyDeviceBatteryLow = "preferences.notifyDeviceBatteryLow"
+        static let notifyDriveConnected = "preferences.notifyDriveConnected"
+        static let notifyOverfilledDrives = "preferences.notifyOverfilledDrives"
+        static let offerUninstallOnTrash = "preferences.offerUninstallOnTrash"
+        static let notifyHungApps = "preferences.notifyHungApps"
     }
 
     // MARK: - Defaults
@@ -55,9 +82,23 @@ final class PreferencesStore {
     static let defaultNotifyHighRAM = true
     static let defaultNotifyMalwareFound = true
     static let defaultNotifyLargeFilesFound = true
-    static let defaultDiskSpaceThresholdPercent = 10.0
+    /// Warn when free space drops below this many gigabytes (decimal GB, matching
+    /// the Finder-style sizes the rest of the app shows). Replaces the former
+    /// percent threshold so the Notifications pane can offer an absolute GB picker.
+    static let defaultDiskFreeThresholdGB = 10
     static let defaultLaunchAtLogin = true
     static let defaultShowMenuBar = true
+    // Notifications pane parity defaults — every row ships enabled, as in the
+    // reference design.
+    static let defaultRemindSmartCare = true
+    static let defaultSmartCareFrequency = SmartCareFrequency.weekly
+    static let defaultNotifyTrashSize = true
+    static let defaultTrashSizeThresholdGB = 2
+    static let defaultNotifyDeviceBatteryLow = true
+    static let defaultNotifyDriveConnected = true
+    static let defaultNotifyOverfilledDrives = true
+    static let defaultOfferUninstallOnTrash = true
+    static let defaultNotifyHungApps = true
     /// Off by default: the menu bar shows just the icon. A wide live reading is
     /// prone to being hidden behind the notch on a crowded menu bar, so showing
     /// it is opt-in.
@@ -95,8 +136,51 @@ final class PreferencesStore {
         didSet { defaults.set(notifyLargeFilesFound, forKey: Key.notifyLargeFilesFound) }
     }
 
-    var diskSpaceThresholdPercent: Double {
-        didSet { defaults.set(diskSpaceThresholdPercent, forKey: Key.diskSpaceThresholdPercent) }
+    /// Warn when free disk space drops below this many gigabytes.
+    var diskFreeThresholdGB: Int {
+        didSet { defaults.set(diskFreeThresholdGB, forKey: Key.diskFreeThresholdGB) }
+    }
+
+    // MARK: Notifications — General
+
+    var remindSmartCare: Bool {
+        didSet { defaults.set(remindSmartCare, forKey: Key.remindSmartCare) }
+    }
+
+    var smartCareFrequency: SmartCareFrequency {
+        didSet { defaults.set(smartCareFrequency.rawValue, forKey: Key.smartCareFrequency) }
+    }
+
+    var notifyTrashSize: Bool {
+        didSet { defaults.set(notifyTrashSize, forKey: Key.notifyTrashSize) }
+    }
+
+    var trashSizeThresholdGB: Int {
+        didSet { defaults.set(trashSizeThresholdGB, forKey: Key.trashSizeThresholdGB) }
+    }
+
+    var notifyDeviceBatteryLow: Bool {
+        didSet { defaults.set(notifyDeviceBatteryLow, forKey: Key.notifyDeviceBatteryLow) }
+    }
+
+    // MARK: Notifications — Disk Space
+
+    var notifyDriveConnected: Bool {
+        didSet { defaults.set(notifyDriveConnected, forKey: Key.notifyDriveConnected) }
+    }
+
+    var notifyOverfilledDrives: Bool {
+        didSet { defaults.set(notifyOverfilledDrives, forKey: Key.notifyOverfilledDrives) }
+    }
+
+    // MARK: Notifications — Applications
+
+    var offerUninstallOnTrash: Bool {
+        didSet { defaults.set(offerUninstallOnTrash, forKey: Key.offerUninstallOnTrash) }
+    }
+
+    var notifyHungApps: Bool {
+        didSet { defaults.set(notifyHungApps, forKey: Key.notifyHungApps) }
     }
 
     var launchAtLogin: Bool {
@@ -159,8 +243,26 @@ final class PreferencesStore {
             ?? Self.defaultNotifyMalwareFound
         self.notifyLargeFilesFound = (defaults.object(forKey: Key.notifyLargeFilesFound) as? Bool)
             ?? Self.defaultNotifyLargeFilesFound
-        self.diskSpaceThresholdPercent = (defaults.object(forKey: Key.diskSpaceThresholdPercent) as? Double)
-            ?? Self.defaultDiskSpaceThresholdPercent
+        self.diskFreeThresholdGB = (defaults.object(forKey: Key.diskFreeThresholdGB) as? Int)
+            ?? Self.defaultDiskFreeThresholdGB
+        self.remindSmartCare = (defaults.object(forKey: Key.remindSmartCare) as? Bool)
+            ?? Self.defaultRemindSmartCare
+        self.smartCareFrequency = (defaults.object(forKey: Key.smartCareFrequency) as? String)
+            .flatMap(SmartCareFrequency.init(rawValue:)) ?? Self.defaultSmartCareFrequency
+        self.notifyTrashSize = (defaults.object(forKey: Key.notifyTrashSize) as? Bool)
+            ?? Self.defaultNotifyTrashSize
+        self.trashSizeThresholdGB = (defaults.object(forKey: Key.trashSizeThresholdGB) as? Int)
+            ?? Self.defaultTrashSizeThresholdGB
+        self.notifyDeviceBatteryLow = (defaults.object(forKey: Key.notifyDeviceBatteryLow) as? Bool)
+            ?? Self.defaultNotifyDeviceBatteryLow
+        self.notifyDriveConnected = (defaults.object(forKey: Key.notifyDriveConnected) as? Bool)
+            ?? Self.defaultNotifyDriveConnected
+        self.notifyOverfilledDrives = (defaults.object(forKey: Key.notifyOverfilledDrives) as? Bool)
+            ?? Self.defaultNotifyOverfilledDrives
+        self.offerUninstallOnTrash = (defaults.object(forKey: Key.offerUninstallOnTrash) as? Bool)
+            ?? Self.defaultOfferUninstallOnTrash
+        self.notifyHungApps = (defaults.object(forKey: Key.notifyHungApps) as? Bool)
+            ?? Self.defaultNotifyHungApps
         self.launchAtLogin = (defaults.object(forKey: Key.launchAtLogin) as? Bool)
             ?? Self.defaultLaunchAtLogin
         self.showMenuBar = (defaults.object(forKey: Key.showMenuBar) as? Bool)

--- a/VaderCleaner/PreferencesView.swift
+++ b/VaderCleaner/PreferencesView.swift
@@ -549,37 +549,97 @@ private struct NotificationsTab: View {
 
     @Environment(PreferencesStore.self) private var preferences
 
+    /// Picker option sets for the inline dropdowns.
+    private let trashSizeOptions = [1, 2, 5, 10, 20]
+    private let diskFreeOptions = [5, 10, 25, 50, 100, 200]
+
     var body: some View {
         @Bindable var preferences = preferences
         Form {
-            Section("Alert me when") {
-                Toggle("Disk space is running low", isOn: $preferences.notifyLowDisk)
-                Toggle("RAM usage is high", isOn: $preferences.notifyHighRAM)
-                Toggle("Malware is found", isOn: $preferences.notifyMalwareFound)
-                Toggle("Large files are detected", isOn: $preferences.notifyLargeFilesFound)
+            Section("General") {
+                toggleWithPicker(
+                    "Remind to run regular Smart Care",
+                    isOn: $preferences.remindSmartCare
+                ) {
+                    Picker("", selection: $preferences.smartCareFrequency) {
+                        ForEach(SmartCareFrequency.allCases) { freq in
+                            Text(freq.label).tag(freq)
+                        }
+                    }
+                }
+
+                toggleWithPicker(
+                    "Notify if Trash size exceeds",
+                    isOn: $preferences.notifyTrashSize
+                ) {
+                    Picker("", selection: $preferences.trashSizeThresholdGB) {
+                        ForEach(trashSizeOptions, id: \.self) { gb in
+                            Text("\(gb) GB").tag(gb)
+                        }
+                    }
+                }
+
+                Toggle("Warn when connected device batteries are running low", isOn: $preferences.notifyDeviceBatteryLow)
+                Toggle("Notify when too low on free RAM", isOn: $preferences.notifyHighRAM)
+
+                // Kept from the prior Notifications tab — not in the reference
+                // design but still useful alerts the app already supports.
+                Toggle("Notify when malware is found", isOn: $preferences.notifyMalwareFound)
+                Toggle("Notify when large files are detected", isOn: $preferences.notifyLargeFilesFound)
             }
 
-            Section("Disk space threshold") {
-                VStack(alignment: .leading, spacing: 4) {
-                    Slider(
-                        value: $preferences.diskSpaceThresholdPercent,
-                        in: 1...50,
-                        step: 1
-                    ) {
-                        Text("Disk space threshold")
-                    } minimumValueLabel: {
-                        Text("1%")
-                    } maximumValueLabel: {
-                        Text("50%")
+            Section("Disk Space") {
+                toggleWithPicker(
+                    "Warn when free space is less than",
+                    isOn: $preferences.notifyLowDisk
+                ) {
+                    Picker("", selection: $preferences.diskFreeThresholdGB) {
+                        ForEach(diskFreeOptions, id: \.self) { gb in
+                            Text("\(gb) GB").tag(gb)
+                        }
                     }
-                    Text("Notify when free space drops below \(Int(preferences.diskSpaceThresholdPercent))%")
+                }
+
+                Toggle("Notify when a drive is connected to the Mac", isOn: $preferences.notifyDriveConnected)
+                Toggle("Suggest to clean up overfilled external drives", isOn: $preferences.notifyOverfilledDrives)
+            }
+
+            Section("Applications") {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Offer to uninstall applications correctly", isOn: $preferences.offerUninstallOnTrash)
+                    Text("If you put an application into Trash, you will be offered to uninstall it correctly.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                .disabled(!preferences.notifyLowDisk)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Notify about hung applications", isOn: $preferences.notifyHungApps)
+                    Text("If any of your apps stop responding, use an easy way of force quitting them.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .formStyle(.grouped)
+    }
+
+    /// A checkbox row with an inline trailing dropdown, gated so the picker
+    /// disables when the toggle is off — the pattern the reference design uses
+    /// for the frequency / threshold rows.
+    @ViewBuilder
+    private func toggleWithPicker(
+        _ title: String,
+        isOn: Binding<Bool>,
+        @ViewBuilder picker: () -> some View
+    ) -> some View {
+        HStack {
+            Toggle(title, isOn: isOn)
+            Spacer(minLength: 12)
+            picker()
+                .labelsHidden()
+                .fixedSize()
+                .disabled(!isOn.wrappedValue)
+        }
     }
 }
 

--- a/VaderCleaner/PreferencesView.swift
+++ b/VaderCleaner/PreferencesView.swift
@@ -581,6 +581,7 @@ private struct NotificationsTab: View {
 
                 Toggle("Warn when connected device batteries are running low", isOn: $preferences.notifyDeviceBatteryLow)
                 Toggle("Notify when too low on free RAM", isOn: $preferences.notifyHighRAM)
+                Toggle("Notify when a scan finishes", isOn: $preferences.notifyScanFinished)
 
                 // Kept from the prior Notifications tab — not in the reference
                 // design but still useful alerts the app already supports.

--- a/VaderCleaner/ProtectionDashboardViewModel.swift
+++ b/VaderCleaner/ProtectionDashboardViewModel.swift
@@ -83,6 +83,42 @@ final class ProtectionDashboardViewModel {
             return false
         }
     }
+
+    /// Whether the malware scan has settled into a non-scanning state — a real
+    /// result, a clean bill, a finished removal, a failure, or "needs install"
+    /// (ClamAV absent, so nothing more will happen).
+    private var malwareSettled: Bool {
+        switch malware.phase {
+        case .results, .clean, .done, .failed, .needsInstall:
+            return true
+        case .idle, .checkingClamAV, .updatingDatabase, .scanning, .removing:
+            return false
+        }
+    }
+
+    /// Whether the privacy preview has settled (finished previewing, cleared, or
+    /// failed) rather than still being in flight.
+    private var privacySettled: Bool {
+        switch privacy.phase {
+        case .preview, .complete, .failed:
+            return true
+        case .idle, .scanning, .clearing:
+            return false
+        }
+    }
+}
+
+// MARK: - ScanCompletionReporting
+
+extension ProtectionDashboardViewModel: ScanCompletionReporting {
+
+    /// True once a scan started here has finished both halves — the malware scan
+    /// and the privacy preview. The dashboard's `scanPresentation` reaches
+    /// `.results` the moment scanning starts (it streams tiles in), so the scan-
+    /// finished banner keys off this instead.
+    var isScanComplete: Bool {
+        hasScanned && malwareSettled && privacySettled
+    }
 }
 
 // MARK: - ScanCoordinating

--- a/VaderCleaner/ProtectionDashboardViewModel.swift
+++ b/VaderCleaner/ProtectionDashboardViewModel.swift
@@ -50,6 +50,19 @@ final class ProtectionDashboardViewModel {
         privacy.beginScan()
     }
 
+    /// Populates the dashboard from a completed Smart Scan so the user never has
+    /// to scan Protection by hand afterwards. The malware tile is seeded from the
+    /// scan's own results (no re-scan), and the fast privacy preview is kicked off
+    /// so its tiles are ready too — unlike `beginScan()`, which would redundantly
+    /// re-run the malware scan. A no-op once the user has scanned here, so it
+    /// never disrupts a scan they started themselves.
+    func prewarmFromSmartScan(threats: [MalwareThreat], clamAVAvailable: Bool, scannedAt date: Date) {
+        guard !hasScanned else { return }
+        hasScanned = true
+        malware.seed(threats: threats, clamAVAvailable: clamAVAvailable, scannedAt: date)
+        if case .idle = privacy.phase { privacy.beginScan() }
+    }
+
     /// Resets both flows to idle and returns the section to its intro screen.
     func startOver() {
         // `cancel()` returns the malware flow to idle from any phase (scanning,

--- a/VaderCleaner/ScanCompletionNotifier.swift
+++ b/VaderCleaner/ScanCompletionNotifier.swift
@@ -1,0 +1,101 @@
+// ScanCompletionNotifier.swift
+// Notifies the user when a scan they started finishes, naming the section that completed.
+
+import Foundation
+import Observation
+import os.log
+
+/// Adopted by a coordinator whose `scanPresentation` reaches `.results` before
+/// its scan actually finishes — e.g. a live dashboard that streams tiles in and
+/// so has no separate `.working` phase. The completion notifier watches
+/// `isScanComplete` for these instead of the coarse presentation, so the banner
+/// fires on real completion rather than when the surface first appears.
+@MainActor
+protocol ScanCompletionReporting: AnyObject {
+    var isScanComplete: Bool { get }
+}
+
+/// Fires a "scan complete" notification when a scan the user started reaches its
+/// results, naming the section so the banner says what finished.
+///
+/// Notifications are *armed* explicitly at the user-facing scan entry points
+/// (the floating Scan disc and the Smart Scan triggers) — never for the
+/// background pre-warm scans Smart Scan kicks off — so completing a Smart Scan
+/// doesn't fan out into a banner per pre-warmed section. Once armed, the
+/// notifier observes the coordinator's `scanPresentation` and fires on the
+/// `working → results` transition, then disarms.
+@MainActor
+@Observable
+final class ScanCompletionNotifier {
+
+    @ObservationIgnored private let preferences: PreferencesStore
+    @ObservationIgnored private let dispatcher: NotificationDispatching
+    /// Sections with a user-initiated scan in flight, keyed to the coordinator
+    /// whose completion should notify.
+    @ObservationIgnored private var armed: [NavigationSection: any ScanCoordinating] = [:]
+    @ObservationIgnored private let log = Logger(subsystem: "com.personal.VaderCleaner",
+                                                 category: "ScanCompletionNotifier")
+
+    init(preferences: PreferencesStore, dispatcher: NotificationDispatching) {
+        self.preferences = preferences
+        self.dispatcher = dispatcher
+    }
+
+    /// Records that the user just started a scan for `section`, so its
+    /// completion notifies. A no-op when the toggle is off. Idempotent — a
+    /// re-tap just refreshes the armed coordinator.
+    func armScan(section: NavigationSection, coordinator: any ScanCoordinating) {
+        guard preferences.notifyScanFinished else {
+            log.debug("armScan(\(section.title, privacy: .public)) ignored — notifyScanFinished is off")
+            return
+        }
+        log.debug("Armed scan-finished notification for \(section.title, privacy: .public)")
+        armed[section] = coordinator
+        observe(section)
+    }
+
+    /// Re-evaluates an armed section after its coordinator changes. Internal so
+    /// the firing logic is unit-testable without driving real observation.
+    func evaluate(section: NavigationSection) {
+        guard let coordinator = armed[section] else { return }
+
+        // A coordinator that reaches `.results` before its work finishes reports
+        // completion explicitly; watch that instead of the coarse presentation.
+        if let reporter = coordinator as? ScanCompletionReporting {
+            if reporter.isScanComplete {
+                log.debug("Firing scan-finished notification for \(section.title, privacy: .public) (reporter complete)")
+                dispatcher.sendScanFinishedNotification(scanName: section.title)
+                armed[section] = nil
+            } else {
+                observe(section)
+            }
+            return
+        }
+
+        switch coordinator.scanPresentation {
+        case .results:
+            log.debug("Firing scan-finished notification for \(section.title, privacy: .public) (results)")
+            dispatcher.sendScanFinishedNotification(scanName: section.title)
+            armed[section] = nil
+        case .intro:
+            // The user started over / cancelled before any result — disarm.
+            armed[section] = nil
+        case .working:
+            // Still scanning; keep watching.
+            observe(section)
+        }
+    }
+
+    private func observe(_ section: NavigationSection) {
+        guard let coordinator = armed[section] else { return }
+        withObservationTracking {
+            if let reporter = coordinator as? ScanCompletionReporting {
+                _ = reporter.isScanComplete
+            } else {
+                _ = coordinator.scanPresentation
+            }
+        } onChange: { [weak self] in
+            Task { @MainActor in self?.evaluate(section: section) }
+        }
+    }
+}

--- a/VaderCleaner/ScanDiscWindowController.swift
+++ b/VaderCleaner/ScanDiscWindowController.swift
@@ -44,6 +44,7 @@ final class ScanDiscWindowController {
     @ObservationIgnored private var panel: NSPanel?
     @ObservationIgnored private weak var parentWindow: NSWindow?
     @ObservationIgnored private var appState: AppState?
+    @ObservationIgnored private var scanCompletionNotifier: ScanCompletionNotifier?
     @ObservationIgnored private var railWidth: CGFloat = 0
     @ObservationIgnored private var isFullScreen = false
     @ObservationIgnored private var observers: [NSObjectProtocol] = []
@@ -70,9 +71,15 @@ final class ScanDiscWindowController {
     /// re-attaching to the same window only re-positions, and attaching to a
     /// different window detaches the old one first — `ContentView.onAppear` can
     /// fire more than once across a window close/reopen.
-    func attach(to window: NSWindow, railWidth: CGFloat, appState: AppState) {
+    func attach(
+        to window: NSWindow,
+        railWidth: CGFloat,
+        appState: AppState,
+        scanCompletionNotifier: ScanCompletionNotifier
+    ) {
         self.railWidth = railWidth
         self.appState = appState
+        self.scanCompletionNotifier = scanCompletionNotifier
 
         if parentWindow === window, panel != nil {
             reposition()
@@ -81,7 +88,7 @@ final class ScanDiscWindowController {
         if parentWindow != nil { detach() }
 
         parentWindow = window
-        let panel = makePanel(appState: appState)
+        let panel = makePanel(appState: appState, scanCompletionNotifier: scanCompletionNotifier)
         self.panel = panel
         window.addChildWindow(panel, ordered: .above)
         isFullScreen = window.styleMask.contains(.fullScreen)
@@ -116,7 +123,7 @@ final class ScanDiscWindowController {
 
     // MARK: - Panel construction
 
-    private func makePanel(appState: AppState) -> NSPanel {
+    private func makePanel(appState: AppState, scanCompletionNotifier: ScanCompletionNotifier) -> NSPanel {
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelSize, height: panelSize),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -143,6 +150,7 @@ final class ScanDiscWindowController {
         panel.contentView = NSHostingView(
             rootView: ScanDiscHostView(controller: self)
                 .environment(appState)
+                .environment(scanCompletionNotifier)
         )
         return panel
     }

--- a/VaderCleaner/SmartCareReminderScheduler.swift
+++ b/VaderCleaner/SmartCareReminderScheduler.swift
@@ -1,0 +1,70 @@
+// SmartCareReminderScheduler.swift
+// Schedules a repeating "time for Smart Care" reminder at the user's chosen cadence.
+
+import Foundation
+import UserNotifications
+
+/// Keeps a single repeating reminder notification in sync with the
+/// `remindSmartCare` toggle and `smartCareFrequency`. The schedule/cancel sinks
+/// are injected so `update()` can be unit-tested without scheduling against the
+/// real `UNUserNotificationCenter`.
+@MainActor
+final class SmartCareReminderScheduler {
+
+    /// Stable identifier so re-applying replaces the existing reminder rather
+    /// than stacking duplicates.
+    static let reminderIdentifier = "com.personal.VaderCleaner.smartCareReminder"
+
+    typealias Schedule = (UNNotificationRequest) -> Void
+    typealias Cancel = ([String]) -> Void
+
+    private let preferences: PreferencesStore
+    private let schedule: Schedule
+    private let cancel: Cancel
+
+    init(
+        preferences: PreferencesStore,
+        schedule: @escaping Schedule = { UNUserNotificationCenter.current().add($0) },
+        cancel: @escaping Cancel = { UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: $0) }
+    ) {
+        self.preferences = preferences
+        self.schedule = schedule
+        self.cancel = cancel
+    }
+
+    /// (Re)applies the reminder from the current preferences: schedules a
+    /// repeating notification at the chosen cadence, or cancels it when the
+    /// toggle is off. Idempotent — always clears the prior request first.
+    func update() {
+        cancel([Self.reminderIdentifier])
+        guard preferences.remindSmartCare else { return }
+
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: Self.dateComponents(for: preferences.smartCareFrequency),
+            repeats: true
+        )
+        let request = UNNotificationRequest(
+            identifier: Self.reminderIdentifier,
+            content: NotificationManager.makeSmartCareReminderContent(),
+            trigger: trigger
+        )
+        schedule(request)
+    }
+
+    /// The calendar match for a cadence. All fire at 10:00 local time; weekly
+    /// lands on Monday and monthly on the 1st, so the reminder is predictable.
+    static func dateComponents(for frequency: SmartCareFrequency) -> DateComponents {
+        var components = DateComponents()
+        components.hour = 10
+        components.minute = 0
+        switch frequency {
+        case .daily:
+            break
+        case .weekly:
+            components.weekday = 2   // Monday (1 = Sunday)
+        case .monthly:
+            components.day = 1
+        }
+        return components
+    }
+}

--- a/VaderCleaner/TrashSizeMonitor.swift
+++ b/VaderCleaner/TrashSizeMonitor.swift
@@ -1,0 +1,98 @@
+// TrashSizeMonitor.swift
+// Polls the Trash's total size and notifies when it grows past the user's threshold.
+
+import Foundation
+
+/// Watches the user's Trash and dispatches a "Trash is filling up" notification
+/// when its size exceeds `PreferencesStore.trashSizeThresholdGB`, gated by the
+/// `notifyTrashSize` toggle and a cooldown so a full Trash alerts at most once
+/// per window. The size measurement is injected so the decision logic is
+/// unit-testable without walking a real Trash directory.
+@MainActor
+final class TrashSizeMonitor {
+
+    /// Returns the total bytes currently in the user's Trash. Production walks
+    /// `~/.Trash`; tests inject a fixed value.
+    typealias SizeReader = @Sendable () async -> Int64
+
+    private let preferences: PreferencesStore
+    private let dispatcher: NotificationDispatching
+    private let sizeReader: SizeReader
+    private let cooldown: TimeInterval
+    private let pollInterval: TimeInterval
+    private let now: () -> Date
+
+    private var lastFired: Date?
+    private var timer: Timer?
+
+    init(
+        preferences: PreferencesStore,
+        dispatcher: NotificationDispatching,
+        sizeReader: @escaping SizeReader = TrashSizeMonitor.measureTrashSize,
+        cooldown: TimeInterval = 6 * 60 * 60,
+        pollInterval: TimeInterval = 10 * 60,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.preferences = preferences
+        self.dispatcher = dispatcher
+        self.sizeReader = sizeReader
+        self.cooldown = cooldown
+        self.pollInterval = pollInterval
+        self.now = now
+    }
+
+    /// Pure decision: dispatches when the toggle is on, the size is over the
+    /// threshold, and the cooldown has elapsed.
+    func evaluate(sizeBytes: Int64) {
+        guard preferences.notifyTrashSize else { return }
+        let thresholdBytes = Int64(max(0, preferences.trashSizeThresholdGB)) * 1_000_000_000
+        guard sizeBytes > thresholdBytes else { return }
+        if let last = lastFired, now().timeIntervalSince(last) < cooldown { return }
+
+        dispatcher.sendTrashSizeNotification(sizeBytes: sizeBytes)
+        lastFired = now()
+    }
+
+    /// Begins polling the Trash size on a timer.
+    func start() {
+        timer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.poll() }
+        }
+        self.timer = timer
+        Task { await poll() }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func poll() async {
+        guard preferences.notifyTrashSize else { return }
+        let size = await sizeReader()
+        evaluate(sizeBytes: size)
+    }
+
+    /// Production size reader: sums the file sizes in the user's Trash off the
+    /// main actor. Best-effort — unreadable entries are skipped.
+    nonisolated static let measureTrashSize: SizeReader = {
+        await Task.detached(priority: .utility) { () -> Int64 in
+            let fileManager = FileManager.default
+            guard let trash = try? fileManager.url(
+                for: .trashDirectory, in: .userDomainMask, appropriateFor: nil, create: false
+            ) else { return 0 }
+            guard let enumerator = fileManager.enumerator(
+                at: trash,
+                includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey],
+                options: []
+            ) else { return 0 }
+            var total: Int64 = 0
+            while let url = enumerator.nextObject() as? URL {
+                let values = try? url.resourceValues(forKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey])
+                total += Int64(values?.totalFileAllocatedSize ?? values?.fileAllocatedSize ?? 0)
+            }
+            return total
+        }.value
+    }
+}

--- a/VaderCleaner/TrashedAppMonitor.swift
+++ b/VaderCleaner/TrashedAppMonitor.swift
@@ -1,0 +1,97 @@
+// TrashedAppMonitor.swift
+// Offers correct uninstallation when the user drags an app into the Trash.
+
+import Foundation
+
+/// Watches the user's Trash for newly-added `.app` bundles and, when
+/// `offerUninstallOnTrash` is on, dispatches a notification offering to remove
+/// the app's leftover files too. The Trash listing is injected so the
+/// new-app diff is unit-testable without a real Trash directory.
+@MainActor
+final class TrashedAppMonitor {
+
+    /// Returns the display names of `.app` bundles currently in the Trash.
+    typealias AppLister = @Sendable () -> [String]
+
+    private let preferences: PreferencesStore
+    private let dispatcher: NotificationDispatching
+    private let appLister: AppLister
+
+    /// Apps already seen in the Trash, so only *newly* trashed apps notify.
+    private var seen: Set<String> = []
+    private var source: DispatchSourceFileSystemObject?
+    private var watchedDescriptor: Int32 = -1
+
+    init(
+        preferences: PreferencesStore,
+        dispatcher: NotificationDispatching,
+        appLister: @escaping AppLister = { TrashedAppMonitor.listTrashedApps() }
+    ) {
+        self.preferences = preferences
+        self.dispatcher = dispatcher
+        self.appLister = appLister
+    }
+
+    /// Pure decision: notifies for each app that appears in the Trash for the
+    /// first time. When the toggle is off it still advances the baseline so
+    /// turning it on later doesn't replay apps trashed in the meantime.
+    func evaluate(trashedAppNames: [String]) {
+        let current = Set(trashedAppNames)
+        defer { seen = current }
+        guard preferences.offerUninstallOnTrash else { return }
+        for name in current.subtracting(seen).sorted() {
+            dispatcher.sendAppTrashedNotification(appName: name)
+        }
+    }
+
+    func start() {
+        // Prime the baseline so apps already in the Trash don't notify on launch.
+        seen = Set(appLister())
+
+        let trash = Self.trashURL()
+        let descriptor = open(trash.path, O_EVTONLY)
+        guard descriptor >= 0 else { return }
+        watchedDescriptor = descriptor
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .extend],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            MainActor.assumeIsolated { self?.poll() }
+        }
+        source.setCancelHandler { [weak self] in
+            if let fd = self?.watchedDescriptor, fd >= 0 { close(fd) }
+            self?.watchedDescriptor = -1
+        }
+        self.source = source
+        source.resume()
+    }
+
+    func stop() {
+        source?.cancel()
+        source = nil
+    }
+
+    private func poll() {
+        evaluate(trashedAppNames: appLister())
+    }
+
+    nonisolated private static func trashURL() -> URL {
+        (try? FileManager.default.url(
+            for: .trashDirectory, in: .userDomainMask, appropriateFor: nil, create: false
+        )) ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".Trash")
+    }
+
+    /// Production listing: the `.app` bundles at the top level of the Trash.
+    nonisolated static func listTrashedApps() -> [String] {
+        let trash = trashURL()
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: trash, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+        )) ?? []
+        return contents
+            .filter { $0.pathExtension == "app" }
+            .map { $0.deletingPathExtension().lastPathComponent }
+    }
+}

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -67,6 +67,8 @@ struct VaderCleanerApp: App {
     // size, drive mounts, device batteries, hung apps, trashed apps, Smart Care
     // reminder). Started from the same post-launch path that requests permission.
     @State private var notificationMonitors: NotificationMonitors
+    // Fires a "scan complete" banner when a user-initiated scan finishes.
+    @State private var scanCompletionNotifier: ScanCompletionNotifier
     @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
@@ -192,6 +194,9 @@ struct VaderCleanerApp: App {
         _notificationMonitors = State(
             initialValue: NotificationMonitors(preferences: prefs, dispatcher: notificationManager)
         )
+        _scanCompletionNotifier = State(
+            initialValue: ScanCompletionNotifier(preferences: prefs, dispatcher: notificationManager)
+        )
     }
 
     /// Surfaces a launchd registration failure to the user. Kept on the App
@@ -271,6 +276,7 @@ struct VaderCleanerApp: App {
                 .environment(systemStats)
                 .environment(notificationMonitor)
                 .environment(notificationMonitors)
+                .environment(scanCompletionNotifier)
                 .environment(menuRouter)
         }
         // Hide the title bar so no section title is drawn beside the traffic

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -63,6 +63,10 @@ struct VaderCleanerApp: App {
     // long as the app and so the per-kind cooldown table survives across
     // window open/close cycles.
     @State private var notificationMonitor: NotificationThresholdMonitor
+    // App-scope aggregator for the Notifications-pane background monitors (trash
+    // size, drive mounts, device batteries, hung apps, trashed apps, Smart Care
+    // reminder). Started from the same post-launch path that requests permission.
+    @State private var notificationMonitors: NotificationMonitors
     @NSApplicationDelegateAdaptor(VaderCleanerAppDelegate.self) private var appDelegate
 
     init() {
@@ -183,6 +187,11 @@ struct VaderCleanerApp: App {
                 dispatcher: notificationManager
             )
         )
+        // The Notifications-pane background monitors share the same preferences
+        // and dispatcher; they're started after the permission prompt resolves.
+        _notificationMonitors = State(
+            initialValue: NotificationMonitors(preferences: prefs, dispatcher: notificationManager)
+        )
     }
 
     /// Surfaces a launchd registration failure to the user. Kept on the App
@@ -248,7 +257,6 @@ struct VaderCleanerApp: App {
                 applicationsViewModel: applicationsViewModel,
                 extensionsManagerViewModel: extensionsManagerViewModel,
                 performanceViewModel: performanceViewModel,
-                malwareViewModel: malwareViewModel,
                 protectionDashboardViewModel: protectionDashboardViewModel,
                 smartScanViewModel: smartScanViewModel
             )
@@ -262,6 +270,7 @@ struct VaderCleanerApp: App {
                 .environment(settingsRouter)
                 .environment(systemStats)
                 .environment(notificationMonitor)
+                .environment(notificationMonitors)
                 .environment(menuRouter)
         }
         // Hide the title bar so no section title is drawn beside the traffic

--- a/VaderCleaner/VolumeMountMonitor.swift
+++ b/VaderCleaner/VolumeMountMonitor.swift
@@ -1,0 +1,109 @@
+// VolumeMountMonitor.swift
+// Notifies when a drive is mounted and suggests cleanup when an external drive is nearly full.
+
+import Foundation
+import AppKit
+
+/// Read-only snapshot of a mounted volume used by `VolumeMountMonitor`'s
+/// decision logic. Injected so the firing rules can be unit-tested without a
+/// real mount.
+struct MountedVolumeInfo: Equatable {
+    let name: String
+    /// External/removable volumes are the ones the "overfilled drive" suggestion
+    /// applies to — the boot volume has its own low-disk alert.
+    let isExternal: Bool
+    let freeBytes: Int64
+    let totalBytes: Int64
+
+    var freeFraction: Double {
+        totalBytes > 0 ? Double(freeBytes) / Double(totalBytes) : 1
+    }
+}
+
+/// Observes volume mounts via `NSWorkspace` and dispatches:
+///   - a "drive connected" notification (`notifyDriveConnected`), and
+///   - an "external drive almost full" suggestion (`notifyOverfilledDrives`)
+///     when a freshly-mounted external volume is below `overfilledFreeFraction`.
+/// The per-URL volume read is injected so `evaluate(mountedVolume:)` is testable.
+@MainActor
+final class VolumeMountMonitor {
+
+    typealias VolumeReader = (URL) -> MountedVolumeInfo?
+
+    private let preferences: PreferencesStore
+    private let dispatcher: NotificationDispatching
+    private let volumeReader: VolumeReader
+    /// An external volume with less than this fraction free is "overfilled".
+    private let overfilledFreeFraction: Double
+
+    private var observer: NSObjectProtocol?
+
+    init(
+        preferences: PreferencesStore,
+        dispatcher: NotificationDispatching,
+        volumeReader: @escaping VolumeReader = VolumeMountMonitor.readVolume,
+        overfilledFreeFraction: Double = 0.10
+    ) {
+        self.preferences = preferences
+        self.dispatcher = dispatcher
+        self.volumeReader = volumeReader
+        self.overfilledFreeFraction = overfilledFreeFraction
+    }
+
+    /// Pure decision for a single mounted volume.
+    func evaluate(mountedVolume url: URL) {
+        guard let info = volumeReader(url) else { return }
+
+        if preferences.notifyDriveConnected {
+            dispatcher.sendDriveConnectedNotification(volumeName: info.name)
+        }
+
+        if preferences.notifyOverfilledDrives,
+           info.isExternal,
+           info.totalBytes > 0,
+           info.freeFraction < overfilledFreeFraction {
+            dispatcher.sendOverfilledDriveNotification(
+                volumeName: info.name,
+                freeBytes: info.freeBytes,
+                totalBytes: info.totalBytes
+            )
+        }
+    }
+
+    func start() {
+        stop()
+        observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didMountNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let url = note.userInfo?[NSWorkspace.volumeURLUserInfoKey] as? URL else { return }
+            MainActor.assumeIsolated { self?.evaluate(mountedVolume: url) }
+        }
+    }
+
+    func stop() {
+        if let observer {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+        observer = nil
+    }
+
+    /// Production volume reader: pulls name, external/removable status, and
+    /// capacity from the volume's resource values.
+    nonisolated static func readVolume(_ url: URL) -> MountedVolumeInfo? {
+        let keys: Set<URLResourceKey> = [
+            .volumeNameKey, .volumeIsInternalKey, .volumeIsRemovableKey,
+            .volumeAvailableCapacityKey, .volumeTotalCapacityKey
+        ]
+        guard let values = try? url.resourceValues(forKeys: keys) else { return nil }
+        let isInternal = values.volumeIsInternal ?? false
+        let isRemovable = values.volumeIsRemovable ?? false
+        return MountedVolumeInfo(
+            name: values.volumeName ?? url.lastPathComponent,
+            isExternal: isRemovable || !isInternal,
+            freeBytes: Int64(values.volumeAvailableCapacity ?? 0),
+            totalBytes: Int64(values.volumeTotalCapacity ?? 0)
+        )
+    }
+}

--- a/VaderCleanerTests/AppUninstallerViewModelTests.swift
+++ b/VaderCleanerTests/AppUninstallerViewModelTests.swift
@@ -588,12 +588,110 @@ final class AppUninstallerViewModelTests: XCTestCase {
         XCTAssertFalse(outcome.bundlePermanentlyRemoved, "Bundle was Trashed by NSWorkspace, not escalated")
     }
 
+    // MARK: - List metrics cache
+
+    /// `loadListMetrics()` populates the session-scoped per-app size and
+    /// last-opened caches the manager's uninstaller list sorts and renders by.
+    func test_loadListMetrics_populatesSizesAndDates() async {
+        let appA = makeApp(name: "Alpha", bundleID: "com.acme.alpha")
+        let appB = makeApp(name: "Bravo", bundleID: "com.acme.bravo")
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let vm = makeViewModel(
+            discover: { _ in [appA, appB] },
+            measureListMetrics: { apps in
+                var sizes: [AppInfo.ID: Int64] = [:]
+                var dates: [AppInfo.ID: Date] = [:]
+                for app in apps {
+                    sizes[app.id] = 1_000
+                    dates[app.id] = date
+                }
+                return (sizes, dates)
+            }
+        )
+        await vm.loadApps()
+        await vm.loadListMetrics()
+
+        XCTAssertEqual(vm.listSizes[appA.id], 1_000)
+        XCTAssertEqual(vm.listSizes[appB.id], 1_000)
+        XCTAssertEqual(vm.listLastOpened[appA.id], date)
+        XCTAssertEqual(vm.listLastOpened[appB.id], date)
+    }
+
+    /// The metrics walk is the expensive pass, so once an app is measured it is
+    /// never re-measured for the session — reopening the manager reuses the
+    /// cache instead of re-walking the disk.
+    func test_loadListMetrics_isIdempotent_skipsAlreadyMeasured() async {
+        let app = makeApp(name: "Alpha", bundleID: "com.acme.alpha")
+        let measuredApps = ActorBox<[[AppInfo.ID]]>([])
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            measureListMetrics: { apps in
+                await measuredApps.mutate { $0.append(apps.map(\.id)) }
+                return (Dictionary(uniqueKeysWithValues: apps.map { ($0.id, Int64(1)) }), [:])
+            }
+        )
+        await vm.loadApps()
+        await vm.loadListMetrics()
+        await vm.loadListMetrics()
+
+        let calls = await measuredApps.value
+        XCTAssertEqual(calls.count, 1, "The second call must find every app cached and skip the walk")
+    }
+
+    /// New apps that appear after a reload are measured without re-walking the
+    /// apps already cached.
+    func test_loadListMetrics_measuresOnlyNewlyAppearedApps() async {
+        let appA = makeApp(name: "Alpha", bundleID: "com.acme.alpha")
+        let appB = makeApp(name: "Bravo", bundleID: "com.acme.bravo")
+        let measuredApps = ActorBox<[[AppInfo.ID]]>([])
+        var roster = [appA]
+        let vm = makeViewModel(
+            discover: { _ in roster },
+            measureListMetrics: { apps in
+                await measuredApps.mutate { $0.append(apps.map(\.id)) }
+                return (Dictionary(uniqueKeysWithValues: apps.map { ($0.id, Int64(1)) }), [:])
+            }
+        )
+        await vm.loadApps()
+        await vm.loadListMetrics()
+
+        roster = [appA, appB]
+        await vm.reloadApps()
+        await vm.loadListMetrics()
+
+        let calls = await measuredApps.value
+        XCTAssertEqual(calls, [[appA.id], [appB.id]], "Only the newly-appeared app is measured on the second pass")
+        XCTAssertEqual(vm.listSizes[appA.id], 1)
+        XCTAssertEqual(vm.listSizes[appB.id], 1)
+    }
+
+    /// Each batch of freshly-measured metrics bumps the revision so the
+    /// manager's memoized list recomputes its order once the values land.
+    func test_loadListMetrics_bumpsRevisionWhenMetricsLand() async {
+        let app = makeApp(name: "Alpha", bundleID: "com.acme.alpha")
+        let vm = makeViewModel(
+            discover: { _ in [app] },
+            measureListMetrics: { apps in
+                (Dictionary(uniqueKeysWithValues: apps.map { ($0.id, Int64(1)) }), [:])
+            }
+        )
+        let before = vm.listMetricsRevision
+        await vm.loadApps()
+        await vm.loadListMetrics()
+        XCTAssertEqual(vm.listMetricsRevision, before + 1)
+
+        // No pending apps the second time — nothing lands, revision is steady.
+        await vm.loadListMetrics()
+        XCTAssertEqual(vm.listMetricsRevision, before + 1)
+    }
+
     // MARK: - Helpers
 
     private func makeViewModel(
         discover: @escaping AppUninstallerViewModel.Discover = { _ in [] },
         findFiles: @escaping AppUninstallerViewModel.FindFiles = { _ in [] },
         measureSize: @escaping AppUninstallerViewModel.MeasureSize = { _ in 0 },
+        measureListMetrics: @escaping AppUninstallerViewModel.MeasureListMetrics = { _ in ([:], [:]) },
         recycle: @escaping AppUninstallerViewModel.Recycle = { _, _ in
             AppUninstallerViewModel.RecycleOutcome(bytesFreed: 0, bundlePermanentlyRemoved: false)
         },
@@ -603,6 +701,7 @@ final class AppUninstallerViewModelTests: XCTestCase {
             discover: discover,
             findFiles: findFiles,
             measureSize: measureSize,
+            measureListMetrics: measureListMetrics,
             recycle: recycle,
             reinstallHelper: reinstallHelper
         )
@@ -654,6 +753,7 @@ private actor ActorBox<Value: Sendable> {
     private(set) var value: Value
     init(_ initial: Value) { self.value = initial }
     func set(_ newValue: Value) { value = newValue }
+    func mutate(_ body: (inout Value) -> Void) { body(&value) }
 }
 
 private extension ActorBox where Value == Int {

--- a/VaderCleanerTests/DeviceBatteryMonitorTests.swift
+++ b/VaderCleanerTests/DeviceBatteryMonitorTests.swift
@@ -1,0 +1,75 @@
+// DeviceBatteryMonitorTests.swift
+// Verifies device low-battery dispatch against the threshold, toggle, and per-device cooldown.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class DeviceBatteryMonitorTests: XCTestCase {
+
+    private var preferences: PreferencesStore!
+    private var dispatcher: StubNotificationDispatcher!
+    private var virtualNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults(suiteName: "VaderCleanerTests.DeviceBattery.\(UUID().uuidString)")!
+        preferences = PreferencesStore(defaults: defaults)
+        dispatcher = StubNotificationDispatcher()
+    }
+
+    private func makeMonitor() -> DeviceBatteryMonitor {
+        DeviceBatteryMonitor(
+            preferences: preferences,
+            dispatcher: dispatcher,
+            reader: { [] },
+            lowThreshold: 20,
+            cooldown: 12 * 60 * 60,
+            now: { [unowned self] in self.virtualNow }
+        )
+    }
+
+    func test_fires_forDeviceAtOrUnderThreshold() {
+        preferences.notifyDeviceBatteryLow = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(devices: [DeviceBattery(name: "Magic Mouse", percent: 15)])
+
+        XCTAssertEqual(dispatcher.calls, [.deviceBatteryLow(deviceName: "Magic Mouse", percent: 15)])
+    }
+
+    func test_doesNotFire_aboveThreshold() {
+        preferences.notifyDeviceBatteryLow = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(devices: [DeviceBattery(name: "Magic Keyboard", percent: 80)])
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_doesNotFire_whenToggleOff() {
+        preferences.notifyDeviceBatteryLow = false
+        let monitor = makeMonitor()
+
+        monitor.evaluate(devices: [DeviceBattery(name: "Trackpad", percent: 5)])
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_cooldown_isPerDevice() {
+        preferences.notifyDeviceBatteryLow = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(devices: [DeviceBattery(name: "Mouse", percent: 10)])
+        // Same device again inside cooldown — suppressed; a different low device fires.
+        monitor.evaluate(devices: [
+            DeviceBattery(name: "Mouse", percent: 9),
+            DeviceBattery(name: "Keyboard", percent: 8)
+        ])
+
+        XCTAssertEqual(dispatcher.calls, [
+            .deviceBatteryLow(deviceName: "Mouse", percent: 10),
+            .deviceBatteryLow(deviceName: "Keyboard", percent: 8)
+        ])
+    }
+}

--- a/VaderCleanerTests/HungAppMonitorTests.swift
+++ b/VaderCleanerTests/HungAppMonitorTests.swift
@@ -1,0 +1,86 @@
+// HungAppMonitorTests.swift
+// Verifies hung-app dispatch against the responsiveness probe, toggle, and per-process cooldown.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class HungAppMonitorTests: XCTestCase {
+
+    private var preferences: PreferencesStore!
+    private var dispatcher: StubNotificationDispatcher!
+    private var virtualNow = Date(timeIntervalSince1970: 1_700_000_000)
+    private var apps: [RunningAppInfo] = []
+    private var unresponsivePIDs: Set<pid_t> = []
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults(suiteName: "VaderCleanerTests.HungApp.\(UUID().uuidString)")!
+        preferences = PreferencesStore(defaults: defaults)
+        dispatcher = StubNotificationDispatcher()
+        apps = []
+        unresponsivePIDs = []
+    }
+
+    private func makeMonitor() -> HungAppMonitor {
+        HungAppMonitor(
+            preferences: preferences,
+            dispatcher: dispatcher,
+            appLister: { [unowned self] in self.apps },
+            isResponsive: { [unowned self] pid in !self.unresponsivePIDs.contains(pid) },
+            cooldown: 60 * 60,
+            now: { [unowned self] in self.virtualNow }
+        )
+    }
+
+    func test_fires_forUnresponsiveAppWhenOn() {
+        preferences.notifyHungApps = true
+        apps = [RunningAppInfo(name: "Safari", pid: 42)]
+        unresponsivePIDs = [42]
+        let monitor = makeMonitor()
+
+        monitor.evaluate()
+
+        XCTAssertEqual(dispatcher.calls, [.hungApp(appName: "Safari")])
+    }
+
+    func test_doesNotFire_forResponsiveApp() {
+        preferences.notifyHungApps = true
+        apps = [RunningAppInfo(name: "Mail", pid: 7)]
+        let monitor = makeMonitor()
+
+        monitor.evaluate()
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_doesNotFire_whenToggleOff() {
+        preferences.notifyHungApps = false
+        apps = [RunningAppInfo(name: "Xcode", pid: 9)]
+        unresponsivePIDs = [9]
+        let monitor = makeMonitor()
+
+        monitor.evaluate()
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_cooldown_perProcessAndResetsWhenRecovered() {
+        preferences.notifyHungApps = true
+        apps = [RunningAppInfo(name: "Notes", pid: 5)]
+        unresponsivePIDs = [5]
+        let monitor = makeMonitor()
+
+        monitor.evaluate()                                  // fires
+        monitor.evaluate()                                  // still hung, inside cooldown — suppressed
+        XCTAssertEqual(dispatcher.calls.count, 1)
+
+        // The app recovers, then hangs again — the bookkeeping reset means it
+        // alerts once more even within the original cooldown window.
+        unresponsivePIDs = []
+        monitor.evaluate()
+        unresponsivePIDs = [5]
+        monitor.evaluate()
+        XCTAssertEqual(dispatcher.calls.count, 2)
+    }
+}

--- a/VaderCleanerTests/NotificationManagerTests.swift
+++ b/VaderCleanerTests/NotificationManagerTests.swift
@@ -41,13 +41,12 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertTrue(content.body.contains("Eicar-Test-Signature"))
     }
 
-    /// Low-disk notification embeds the free percentage so the user sees the
-    /// severity without opening the app. The percentage is rounded to whole
-    /// percent for readability.
-    func test_lowDisk_buildsContentWithPercent() {
-        let content = NotificationManager.makeLowDiskContent(freePercent: 7.4)
+    /// Low-disk notification embeds the free space (Finder-style units) so the
+    /// user sees the severity without opening the app.
+    func test_lowDisk_buildsContentWithFreeSpace() {
+        let content = NotificationManager.makeLowDiskContent(freeBytes: 8_000_000_000)
         XCTAssertTrue(content.title.lowercased().contains("disk"))
-        XCTAssertTrue(content.body.contains("7%") || content.body.contains("7.4"))
+        XCTAssertTrue(content.body.contains("GB"))
     }
 
     /// High-RAM notification surfaces the pressure level string verbatim so a

--- a/VaderCleanerTests/NotificationThresholdMonitorTests.swift
+++ b/VaderCleanerTests/NotificationThresholdMonitorTests.swift
@@ -21,6 +21,7 @@ final class StubNotificationDispatcher: NotificationDispatching {
         case overfilledDrive(volumeName: String, freeBytes: Int64, totalBytes: Int64)
         case appTrashed(appName: String)
         case hungApp(appName: String)
+        case scanFinished(scanName: String)
     }
 
     private(set) var calls: [Call] = []
@@ -55,6 +56,9 @@ final class StubNotificationDispatcher: NotificationDispatching {
     }
     func sendHungAppNotification(appName: String) {
         calls.append(.hungApp(appName: appName))
+    }
+    func sendScanFinishedNotification(scanName: String) {
+        calls.append(.scanFinished(scanName: scanName))
     }
 }
 

--- a/VaderCleanerTests/NotificationThresholdMonitorTests.swift
+++ b/VaderCleanerTests/NotificationThresholdMonitorTests.swift
@@ -11,17 +11,23 @@ final class StubNotificationDispatcher: NotificationDispatching {
 
     enum Call: Equatable {
         case requestPermission
-        case lowDisk(freePercent: Double)
+        case lowDisk(freeBytes: Int64)
         case highRAM(pressureLevel: String)
         case malware(threatName: String)
         case largeFiles(count: Int, totalSize: Int64)
+        case trashSize(sizeBytes: Int64)
+        case deviceBatteryLow(deviceName: String, percent: Int)
+        case driveConnected(volumeName: String)
+        case overfilledDrive(volumeName: String, freeBytes: Int64, totalBytes: Int64)
+        case appTrashed(appName: String)
+        case hungApp(appName: String)
     }
 
     private(set) var calls: [Call] = []
 
     func requestPermission() async { calls.append(.requestPermission) }
-    func sendLowDiskNotification(freePercent: Double) {
-        calls.append(.lowDisk(freePercent: freePercent))
+    func sendLowDiskNotification(freeBytes: Int64) {
+        calls.append(.lowDisk(freeBytes: freeBytes))
     }
     func sendHighRAMNotification(pressureLevel: String) {
         calls.append(.highRAM(pressureLevel: pressureLevel))
@@ -31,6 +37,24 @@ final class StubNotificationDispatcher: NotificationDispatching {
     }
     func sendLargeFilesFoundNotification(count: Int, totalSize: Int64) {
         calls.append(.largeFiles(count: count, totalSize: totalSize))
+    }
+    func sendTrashSizeNotification(sizeBytes: Int64) {
+        calls.append(.trashSize(sizeBytes: sizeBytes))
+    }
+    func sendDeviceBatteryLowNotification(deviceName: String, percent: Int) {
+        calls.append(.deviceBatteryLow(deviceName: deviceName, percent: percent))
+    }
+    func sendDriveConnectedNotification(volumeName: String) {
+        calls.append(.driveConnected(volumeName: volumeName))
+    }
+    func sendOverfilledDriveNotification(volumeName: String, freeBytes: Int64, totalBytes: Int64) {
+        calls.append(.overfilledDrive(volumeName: volumeName, freeBytes: freeBytes, totalBytes: totalBytes))
+    }
+    func sendAppTrashedNotification(appName: String) {
+        calls.append(.appTrashed(appName: appName))
+    }
+    func sendHungAppNotification(appName: String) {
+        calls.append(.hungApp(appName: appName))
     }
 }
 
@@ -83,12 +107,12 @@ final class NotificationThresholdMonitorTests: XCTestCase {
         )
     }
 
-    /// Builds a `DiskStats` with the requested free percentage. `total` is held
-    /// constant at 1 TB so the math is easy to read in test bodies.
-    private func disk(freePercent: Double) -> DiskStats {
+    /// Builds a `DiskStats` with the requested free gigabytes (decimal GB).
+    /// `total` is held constant at 1 TB so the math is easy to read in test bodies.
+    private func disk(freeGB: Int) -> DiskStats {
         let total: UInt64 = 1_000_000_000_000
-        let free = UInt64(Double(total) * (freePercent / 100.0))
-        let used = total - free
+        let free = UInt64(freeGB) * 1_000_000_000
+        let used = total > free ? total - free : 0
         return DiskStats(usedBytes: used, totalBytes: total)
     }
 
@@ -108,18 +132,18 @@ final class NotificationThresholdMonitorTests: XCTestCase {
 
     // MARK: - Low-disk dispatch
 
-    func test_lowDisk_firesWhenFreePercentBelowThresholdAndToggleOn() {
+    func test_lowDisk_firesWhenFreeBelowThresholdAndToggleOn() {
         preferences.notifyLowDisk = true
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = makeMonitor()
 
-        monitor.evaluate(disk: disk(freePercent: 8.0))
+        monitor.evaluate(disk: disk(freeGB: 8))
 
         XCTAssertEqual(dispatcher.calls.count, 1)
-        if case .lowDisk(let freePercent)? = dispatcher.calls.first {
-            // Free percent passed through unchanged so the notification can
-            // format it however it wants.
-            XCTAssertEqual(freePercent, 8.0, accuracy: 0.01)
+        if case .lowDisk(let freeBytes)? = dispatcher.calls.first {
+            // Free bytes pass through unchanged so the notification can format
+            // them however it wants (8 decimal GB here).
+            XCTAssertEqual(freeBytes, 8_000_000_000)
         } else {
             XCTFail("Expected a .lowDisk call, got \(dispatcher.calls)")
         }
@@ -127,10 +151,10 @@ final class NotificationThresholdMonitorTests: XCTestCase {
 
     func test_lowDisk_doesNotFireWhenToggleOff() {
         preferences.notifyLowDisk = false
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = makeMonitor()
 
-        monitor.evaluate(disk: disk(freePercent: 5.0))
+        monitor.evaluate(disk: disk(freeGB: 5))
 
         XCTAssertTrue(dispatcher.calls.isEmpty,
                       "Notification must respect the user's preference toggle")
@@ -138,24 +162,24 @@ final class NotificationThresholdMonitorTests: XCTestCase {
 
     func test_lowDisk_doesNotFireAboveThreshold() {
         preferences.notifyLowDisk = true
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = makeMonitor()
 
-        monitor.evaluate(disk: disk(freePercent: 15.0))
+        monitor.evaluate(disk: disk(freeGB: 15))
 
         XCTAssertTrue(dispatcher.calls.isEmpty)
     }
 
     func test_lowDisk_doesNotReFireWithinCooldown() {
         preferences.notifyLowDisk = true
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = makeMonitor()
 
         // First crossing fires.
-        monitor.evaluate(disk: disk(freePercent: 8.0))
+        monitor.evaluate(disk: disk(freeGB: 8))
         // 4:59 later — still under the 5-minute cooldown.
         virtualNow = virtualNow.addingTimeInterval(299)
-        monitor.evaluate(disk: disk(freePercent: 6.0))
+        monitor.evaluate(disk: disk(freeGB: 6))
 
         XCTAssertEqual(dispatcher.calls.count, 1,
                        "Second sample inside the cooldown must not re-trigger")
@@ -163,13 +187,13 @@ final class NotificationThresholdMonitorTests: XCTestCase {
 
     func test_lowDisk_reFiresAfterCooldownElapses() {
         preferences.notifyLowDisk = true
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = makeMonitor()
 
-        monitor.evaluate(disk: disk(freePercent: 8.0))
+        monitor.evaluate(disk: disk(freeGB: 8))
         // Step past the 5-minute boundary.
         virtualNow = virtualNow.addingTimeInterval(301)
-        monitor.evaluate(disk: disk(freePercent: 6.0))
+        monitor.evaluate(disk: disk(freeGB: 6))
 
         XCTAssertEqual(dispatcher.calls.count, 2)
     }
@@ -226,10 +250,10 @@ final class NotificationThresholdMonitorTests: XCTestCase {
     func test_cooldownsAreIndependentPerKind() {
         preferences.notifyLowDisk = true
         preferences.notifyHighRAM = true
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = makeMonitor()
 
-        monitor.evaluate(disk: disk(freePercent: 5.0))
+        monitor.evaluate(disk: disk(freeGB: 5))
         // Still inside the disk cooldown, but RAM has its own clock.
         monitor.evaluate(ram: memory(forLevel: .critical))
 
@@ -267,7 +291,7 @@ final class NotificationThresholdMonitorTests: XCTestCase {
     /// permission.
     func test_doesNotDispatchBeforePermissionResolved() {
         preferences.notifyLowDisk = true
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = NotificationThresholdMonitor(
             stats: stats,
             preferences: preferences,
@@ -277,7 +301,7 @@ final class NotificationThresholdMonitorTests: XCTestCase {
             // assumesPermissionResolved defaults to false
         )
 
-        monitor.evaluate(disk: disk(freePercent: 5.0))
+        monitor.evaluate(disk: disk(freeGB: 5))
         monitor.evaluate(ram: memory(forLevel: .critical))
         monitor.triggerMalwareDetected(threatName: "X")
         monitor.triggerLargeFilesFound(count: 1, totalSize: 1)
@@ -293,7 +317,7 @@ final class NotificationThresholdMonitorTests: XCTestCase {
     func test_dispatchesImmediatelyAfterPermissionResolves() async {
         preferences.notifyLowDisk = true
         preferences.notifyHighRAM = true
-        preferences.diskSpaceThresholdPercent = 10.0
+        preferences.diskFreeThresholdGB = 10
         let monitor = NotificationThresholdMonitor(
             stats: stats,
             preferences: preferences,
@@ -303,19 +327,19 @@ final class NotificationThresholdMonitorTests: XCTestCase {
         )
 
         // Pre-resolution: gate suppresses everything.
-        monitor.evaluate(disk: disk(freePercent: 5.0))
+        monitor.evaluate(disk: disk(freeGB: 5))
         XCTAssertTrue(dispatcher.calls.filter { !isPermissionRequest($0) }.isEmpty)
 
         // Resolve.
         await monitor.requestPermission()
 
         // Post-resolution: dispatch fires.
-        monitor.evaluate(disk: disk(freePercent: 5.0))
+        monitor.evaluate(disk: disk(freeGB: 5))
 
         let dispatches = dispatcher.calls.filter { !isPermissionRequest($0) }
         XCTAssertEqual(dispatches.count, 1, "Post-grant low-disk alert should fire on the next reading")
-        if case .lowDisk(let pct) = dispatches.first {
-            XCTAssertEqual(pct, 5.0, accuracy: 0.01)
+        if case .lowDisk(let freeBytes) = dispatches.first {
+            XCTAssertEqual(freeBytes, 5_000_000_000)
         } else {
             XCTFail("Expected a .lowDisk dispatch, got \(dispatches)")
         }

--- a/VaderCleanerTests/PreferencesStoreTests.swift
+++ b/VaderCleanerTests/PreferencesStoreTests.swift
@@ -35,10 +35,20 @@ final class PreferencesStoreTests: XCTestCase {
         XCTAssertTrue(sut.notifyHighRAM)
         XCTAssertTrue(sut.notifyMalwareFound)
         XCTAssertTrue(sut.notifyLargeFilesFound)
-        XCTAssertEqual(sut.diskSpaceThresholdPercent, 10.0, accuracy: 0.001)
+        XCTAssertEqual(sut.diskFreeThresholdGB, 10)
         XCTAssertTrue(sut.launchAtLogin)
         XCTAssertTrue(sut.showMenuBar)
         XCTAssertFalse(sut.menuBarShowsReading)
+        // Notifications pane parity defaults — every row ships enabled.
+        XCTAssertTrue(sut.remindSmartCare)
+        XCTAssertEqual(sut.smartCareFrequency, .weekly)
+        XCTAssertTrue(sut.notifyTrashSize)
+        XCTAssertEqual(sut.trashSizeThresholdGB, 2)
+        XCTAssertTrue(sut.notifyDeviceBatteryLow)
+        XCTAssertTrue(sut.notifyDriveConnected)
+        XCTAssertTrue(sut.notifyOverfilledDrives)
+        XCTAssertTrue(sut.offerUninstallOnTrash)
+        XCTAssertTrue(sut.notifyHungApps)
     }
 
     // MARK: - Persistence
@@ -53,10 +63,34 @@ final class PreferencesStoreTests: XCTestCase {
 
     func test_persistsThresholdAcrossInstances() {
         let writer = PreferencesStore(defaults: defaults)
-        writer.diskSpaceThresholdPercent = 25.0
+        writer.diskFreeThresholdGB = 25
 
         let reader = PreferencesStore(defaults: defaults)
-        XCTAssertEqual(reader.diskSpaceThresholdPercent, 25.0, accuracy: 0.001)
+        XCTAssertEqual(reader.diskFreeThresholdGB, 25)
+    }
+
+    func test_persistsNotificationPaneSettingsAcrossInstances() {
+        let writer = PreferencesStore(defaults: defaults)
+        writer.remindSmartCare = false
+        writer.smartCareFrequency = .monthly
+        writer.notifyTrashSize = false
+        writer.trashSizeThresholdGB = 5
+        writer.notifyDeviceBatteryLow = false
+        writer.notifyDriveConnected = false
+        writer.notifyOverfilledDrives = false
+        writer.offerUninstallOnTrash = false
+        writer.notifyHungApps = false
+
+        let reader = PreferencesStore(defaults: defaults)
+        XCTAssertFalse(reader.remindSmartCare)
+        XCTAssertEqual(reader.smartCareFrequency, .monthly)
+        XCTAssertFalse(reader.notifyTrashSize)
+        XCTAssertEqual(reader.trashSizeThresholdGB, 5)
+        XCTAssertFalse(reader.notifyDeviceBatteryLow)
+        XCTAssertFalse(reader.notifyDriveConnected)
+        XCTAssertFalse(reader.notifyOverfilledDrives)
+        XCTAssertFalse(reader.offerUninstallOnTrash)
+        XCTAssertFalse(reader.notifyHungApps)
     }
 
     func test_persistsAllNotificationToggles() {

--- a/VaderCleanerTests/ProtectionDashboardViewModelTests.swift
+++ b/VaderCleanerTests/ProtectionDashboardViewModelTests.swift
@@ -90,6 +90,26 @@ final class ProtectionDashboardViewModelTests: XCTestCase {
                        "Pre-warm is gated on hasScanned, so it must not re-seed the malware flow")
     }
 
+    // MARK: - Scan completion (drives the "scan finished" notification)
+
+    /// `isScanComplete` is false before a scan and true only once both the
+    /// malware scan and the privacy preview have settled — the signal the
+    /// completion notifier keys off (since `scanPresentation` is `.results` the
+    /// moment scanning starts).
+    func test_isScanComplete_falseBeforeScan_trueWhenBothChildrenSettle() async {
+        let sut = makeSUT(
+            malwareScan: { _, _ in [] },     // clean
+            privacyDetector: { [] }          // no browsers → lands in .preview
+        )
+        XCTAssertFalse(sut.isScanComplete, "No scan has started yet")
+
+        sut.beginScan()
+        await waitUntil { sut.malware.phase == .clean }
+        await waitUntil { sut.privacy.phase == .preview }
+
+        XCTAssertTrue(sut.isScanComplete)
+    }
+
     // MARK: - Stop
 
     func test_stoppingMalware_keepsDashboardVisible() {

--- a/VaderCleanerTests/ProtectionDashboardViewModelTests.swift
+++ b/VaderCleanerTests/ProtectionDashboardViewModelTests.swift
@@ -52,6 +52,44 @@ final class ProtectionDashboardViewModelTests: XCTestCase {
         XCTAssertEqual(sut.scanPresentation, .results)
     }
 
+    // MARK: - Smart Scan pre-warm
+
+    /// After a Smart Scan, the dashboard seeds its malware tile from the scan's
+    /// results and kicks off the fast privacy preview so both are ready when the
+    /// user opens Protection — without re-running the (already-completed) malware
+    /// scan.
+    func test_prewarmFromSmartScan_seedsMalwareAndStartsPrivacyPreview() async {
+        let sut = makeSUT(privacyDetector: { [] })   // no browsers → lands in .preview
+
+        sut.prewarmFromSmartScan(threats: [threat], clamAVAvailable: true, scannedAt: Date())
+
+        XCTAssertTrue(sut.hasScanned)
+        XCTAssertEqual(sut.scanPresentation, .results)
+        XCTAssertEqual(sut.malware.phase, .results([threat]))
+        await waitUntil { sut.privacy.phase == .preview }
+        XCTAssertEqual(sut.privacy.phase, .preview)
+    }
+
+    /// A clean Smart Scan (no threats) seeds the malware tile to `.clean`.
+    func test_prewarmFromSmartScan_seedsCleanWhenNoThreats() {
+        let sut = makeSUT()
+        sut.prewarmFromSmartScan(threats: [], clamAVAvailable: true, scannedAt: Date())
+        XCTAssertEqual(sut.malware.phase, .clean)
+    }
+
+    /// If the user already scanned Protection here, a later Smart Scan pre-warm
+    /// must not disturb the flow.
+    func test_prewarmFromSmartScan_isNoOpWhenAlreadyScanned() {
+        let sut = makeSUT()
+        sut.beginScan()
+        let malwarePhaseBefore = sut.malware.phase
+
+        sut.prewarmFromSmartScan(threats: [threat], clamAVAvailable: true, scannedAt: Date())
+
+        XCTAssertEqual(sut.malware.phase, malwarePhaseBefore,
+                       "Pre-warm is gated on hasScanned, so it must not re-seed the malware flow")
+    }
+
     // MARK: - Stop
 
     func test_stoppingMalware_keepsDashboardVisible() {

--- a/VaderCleanerTests/ScanCompletionNotifierTests.swift
+++ b/VaderCleanerTests/ScanCompletionNotifierTests.swift
@@ -1,0 +1,128 @@
+// ScanCompletionNotifierTests.swift
+// Verifies a "scan complete" notification fires only for armed (user-initiated) scans that reach results.
+
+import XCTest
+@testable import VaderCleaner
+
+/// Minimal `ScanCoordinating` whose presentation the test drives directly.
+@MainActor
+@Observable
+private final class FakeScanCoordinator: ScanCoordinating {
+    var scanPresentation: ScanPresentation
+    init(_ presentation: ScanPresentation = .intro) { scanPresentation = presentation }
+    func beginScan() { scanPresentation = .working }
+}
+
+/// A coordinator that, like the Protection dashboard, sits at `.results` while
+/// still scanning and reports real completion separately.
+@MainActor
+@Observable
+private final class FakeReportingCoordinator: ScanCoordinating, ScanCompletionReporting {
+    var scanPresentation: ScanPresentation = .results
+    var isScanComplete: Bool = false
+    func beginScan() { isScanComplete = false }
+}
+
+@MainActor
+final class ScanCompletionNotifierTests: XCTestCase {
+
+    private var preferences: PreferencesStore!
+    private var dispatcher: StubNotificationDispatcher!
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults(suiteName: "VaderCleanerTests.ScanCompletion.\(UUID().uuidString)")!
+        preferences = PreferencesStore(defaults: defaults)
+        dispatcher = StubNotificationDispatcher()
+    }
+
+    private func makeNotifier() -> ScanCompletionNotifier {
+        ScanCompletionNotifier(preferences: preferences, dispatcher: dispatcher)
+    }
+
+    func test_fires_whenArmedScanReachesResults() {
+        preferences.notifyScanFinished = true
+        let coordinator = FakeScanCoordinator(.working)
+        let notifier = makeNotifier()
+
+        notifier.armScan(section: .systemJunk, coordinator: coordinator)
+        coordinator.scanPresentation = .results
+        notifier.evaluate(section: .systemJunk)
+
+        XCTAssertEqual(dispatcher.calls, [.scanFinished(scanName: NavigationSection.systemJunk.title)])
+    }
+
+    func test_doesNotFire_whenNotArmed() {
+        preferences.notifyScanFinished = true
+        let notifier = makeNotifier()
+
+        notifier.evaluate(section: .applications)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_doesNotArm_whenToggleOff() {
+        preferences.notifyScanFinished = false
+        let coordinator = FakeScanCoordinator(.working)
+        let notifier = makeNotifier()
+
+        notifier.armScan(section: .applications, coordinator: coordinator)
+        coordinator.scanPresentation = .results
+        notifier.evaluate(section: .applications)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_firesOnce_perScan() {
+        preferences.notifyScanFinished = true
+        let coordinator = FakeScanCoordinator(.working)
+        let notifier = makeNotifier()
+
+        notifier.armScan(section: .performance, coordinator: coordinator)
+        coordinator.scanPresentation = .results
+        notifier.evaluate(section: .performance)
+        notifier.evaluate(section: .performance)   // already disarmed
+
+        XCTAssertEqual(dispatcher.calls.count, 1)
+    }
+
+    // MARK: - Completion-reporting coordinators (e.g. Protection)
+
+    func test_reportingCoordinator_doesNotFireWhileScanIncompleteEvenAtResults() {
+        preferences.notifyScanFinished = true
+        let coordinator = FakeReportingCoordinator()   // .results but isScanComplete == false
+        let notifier = makeNotifier()
+
+        notifier.armScan(section: .malwareRemoval, coordinator: coordinator)
+        notifier.evaluate(section: .malwareRemoval)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty,
+                      "A live dashboard sitting at .results must not notify until its scan actually completes")
+    }
+
+    func test_reportingCoordinator_firesWhenScanCompletes() {
+        preferences.notifyScanFinished = true
+        let coordinator = FakeReportingCoordinator()
+        let notifier = makeNotifier()
+
+        notifier.armScan(section: .malwareRemoval, coordinator: coordinator)
+        coordinator.isScanComplete = true
+        notifier.evaluate(section: .malwareRemoval)
+
+        XCTAssertEqual(dispatcher.calls, [.scanFinished(scanName: NavigationSection.malwareRemoval.title)])
+    }
+
+    func test_disarms_whenScanReturnsToIntro() {
+        preferences.notifyScanFinished = true
+        let coordinator = FakeScanCoordinator(.working)
+        let notifier = makeNotifier()
+
+        notifier.armScan(section: .spaceLens, coordinator: coordinator)
+        coordinator.scanPresentation = .intro       // started over / cancelled
+        notifier.evaluate(section: .spaceLens)
+        coordinator.scanPresentation = .results
+        notifier.evaluate(section: .spaceLens)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty, "A cancelled scan must not notify on a later result")
+    }
+}

--- a/VaderCleanerTests/SmartCareReminderSchedulerTests.swift
+++ b/VaderCleanerTests/SmartCareReminderSchedulerTests.swift
@@ -1,0 +1,70 @@
+// SmartCareReminderSchedulerTests.swift
+// Verifies the Smart Care reminder schedules/cancels per the toggle and maps each cadence to the right calendar match.
+
+import XCTest
+import UserNotifications
+@testable import VaderCleaner
+
+@MainActor
+final class SmartCareReminderSchedulerTests: XCTestCase {
+
+    private var preferences: PreferencesStore!
+    private var scheduled: [UNNotificationRequest] = []
+    private var cancelled: [[String]] = []
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults(suiteName: "VaderCleanerTests.SmartCare.\(UUID().uuidString)")!
+        preferences = PreferencesStore(defaults: defaults)
+        scheduled = []
+        cancelled = []
+    }
+
+    private func makeScheduler() -> SmartCareReminderScheduler {
+        SmartCareReminderScheduler(
+            preferences: preferences,
+            schedule: { [unowned self] in self.scheduled.append($0) },
+            cancel: { [unowned self] in self.cancelled.append($0) }
+        )
+    }
+
+    func test_dateComponents_mapEachFrequency() {
+        let daily = SmartCareReminderScheduler.dateComponents(for: .daily)
+        XCTAssertNil(daily.weekday)
+        XCTAssertNil(daily.day)
+        XCTAssertEqual(daily.hour, 10)
+
+        let weekly = SmartCareReminderScheduler.dateComponents(for: .weekly)
+        XCTAssertEqual(weekly.weekday, 2)
+
+        let monthly = SmartCareReminderScheduler.dateComponents(for: .monthly)
+        XCTAssertEqual(monthly.day, 1)
+    }
+
+    func test_update_schedulesRepeatingReminderWhenOn() {
+        preferences.remindSmartCare = true
+        preferences.smartCareFrequency = .weekly
+        let scheduler = makeScheduler()
+
+        scheduler.update()
+
+        // Always clears the prior request before scheduling the new one.
+        XCTAssertEqual(cancelled, [[SmartCareReminderScheduler.reminderIdentifier]])
+        XCTAssertEqual(scheduled.count, 1)
+        let request = scheduled.first
+        XCTAssertEqual(request?.identifier, SmartCareReminderScheduler.reminderIdentifier)
+        let trigger = request?.trigger as? UNCalendarNotificationTrigger
+        XCTAssertEqual(trigger?.repeats, true)
+        XCTAssertEqual(trigger?.dateComponents.weekday, 2)
+    }
+
+    func test_update_cancelsWithoutSchedulingWhenOff() {
+        preferences.remindSmartCare = false
+        let scheduler = makeScheduler()
+
+        scheduler.update()
+
+        XCTAssertEqual(cancelled, [[SmartCareReminderScheduler.reminderIdentifier]])
+        XCTAssertTrue(scheduled.isEmpty)
+    }
+}

--- a/VaderCleanerTests/TrashSizeMonitorTests.swift
+++ b/VaderCleanerTests/TrashSizeMonitorTests.swift
@@ -1,0 +1,75 @@
+// TrashSizeMonitorTests.swift
+// Verifies the Trash-size monitor fires only past the threshold, respects the toggle, and honors its cooldown.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class TrashSizeMonitorTests: XCTestCase {
+
+    private var preferences: PreferencesStore!
+    private var dispatcher: StubNotificationDispatcher!
+    private var virtualNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults(suiteName: "VaderCleanerTests.TrashSize.\(UUID().uuidString)")!
+        preferences = PreferencesStore(defaults: defaults)
+        dispatcher = StubNotificationDispatcher()
+    }
+
+    private func makeMonitor() -> TrashSizeMonitor {
+        TrashSizeMonitor(
+            preferences: preferences,
+            dispatcher: dispatcher,
+            sizeReader: { 0 },
+            cooldown: 6 * 60 * 60,
+            now: { [unowned self] in self.virtualNow }
+        )
+    }
+
+    func test_fires_whenSizeOverThresholdAndToggleOn() {
+        preferences.notifyTrashSize = true
+        preferences.trashSizeThresholdGB = 2
+        let monitor = makeMonitor()
+
+        monitor.evaluate(sizeBytes: 3_000_000_000)
+
+        XCTAssertEqual(dispatcher.calls, [.trashSize(sizeBytes: 3_000_000_000)])
+    }
+
+    func test_doesNotFire_whenToggleOff() {
+        preferences.notifyTrashSize = false
+        preferences.trashSizeThresholdGB = 2
+        let monitor = makeMonitor()
+
+        monitor.evaluate(sizeBytes: 9_000_000_000)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_doesNotFire_atOrBelowThreshold() {
+        preferences.notifyTrashSize = true
+        preferences.trashSizeThresholdGB = 2
+        let monitor = makeMonitor()
+
+        monitor.evaluate(sizeBytes: 2_000_000_000)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_cooldown_suppressesThenAllowsRefire() {
+        preferences.notifyTrashSize = true
+        preferences.trashSizeThresholdGB = 1
+        let monitor = makeMonitor()
+
+        monitor.evaluate(sizeBytes: 2_000_000_000)
+        virtualNow = virtualNow.addingTimeInterval(60)         // within cooldown
+        monitor.evaluate(sizeBytes: 2_000_000_000)
+        XCTAssertEqual(dispatcher.calls.count, 1)
+
+        virtualNow = virtualNow.addingTimeInterval(6 * 60 * 60 + 1)  // past cooldown
+        monitor.evaluate(sizeBytes: 2_000_000_000)
+        XCTAssertEqual(dispatcher.calls.count, 2)
+    }
+}

--- a/VaderCleanerTests/TrashedAppMonitorTests.swift
+++ b/VaderCleanerTests/TrashedAppMonitorTests.swift
@@ -1,0 +1,70 @@
+// TrashedAppMonitorTests.swift
+// Verifies the trashed-app monitor notifies only for newly-trashed apps and respects the toggle.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class TrashedAppMonitorTests: XCTestCase {
+
+    private var preferences: PreferencesStore!
+    private var dispatcher: StubNotificationDispatcher!
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults(suiteName: "VaderCleanerTests.TrashedApp.\(UUID().uuidString)")!
+        preferences = PreferencesStore(defaults: defaults)
+        dispatcher = StubNotificationDispatcher()
+    }
+
+    private func makeMonitor() -> TrashedAppMonitor {
+        TrashedAppMonitor(preferences: preferences, dispatcher: dispatcher, appLister: { [] })
+    }
+
+    func test_fires_forNewlyTrashedApp() {
+        preferences.offerUninstallOnTrash = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(trashedAppNames: ["Spotify"])
+
+        XCTAssertEqual(dispatcher.calls, [.appTrashed(appName: "Spotify")])
+    }
+
+    func test_doesNotReFire_forAlreadySeenApp() {
+        preferences.offerUninstallOnTrash = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(trashedAppNames: ["Spotify"])
+        monitor.evaluate(trashedAppNames: ["Spotify"])   // still there, not new
+
+        XCTAssertEqual(dispatcher.calls.count, 1)
+    }
+
+    func test_firesForEachNewApp_acrossPolls() {
+        preferences.offerUninstallOnTrash = true
+        let monitor = makeMonitor()
+
+        monitor.evaluate(trashedAppNames: ["Spotify"])
+        monitor.evaluate(trashedAppNames: ["Spotify", "Slack"])
+
+        XCTAssertEqual(dispatcher.calls, [.appTrashed(appName: "Spotify"), .appTrashed(appName: "Slack")])
+    }
+
+    func test_toggleOff_suppressesButAdvancesBaseline() {
+        preferences.offerUninstallOnTrash = false
+        let monitor = makeMonitor()
+
+        // Seen while off — must not notify and must be remembered.
+        monitor.evaluate(trashedAppNames: ["Spotify"])
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+
+        // Turning it on later must not replay the already-present app.
+        preferences.offerUninstallOnTrash = true
+        monitor.evaluate(trashedAppNames: ["Spotify"])
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+
+        // A genuinely new app still notifies.
+        monitor.evaluate(trashedAppNames: ["Spotify", "Discord"])
+        XCTAssertEqual(dispatcher.calls, [.appTrashed(appName: "Discord")])
+    }
+}

--- a/VaderCleanerTests/VolumeMountMonitorTests.swift
+++ b/VaderCleanerTests/VolumeMountMonitorTests.swift
@@ -1,0 +1,80 @@
+// VolumeMountMonitorTests.swift
+// Verifies drive-connected and overfilled-drive dispatch rules against injected volume info.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class VolumeMountMonitorTests: XCTestCase {
+
+    private var preferences: PreferencesStore!
+    private var dispatcher: StubNotificationDispatcher!
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults(suiteName: "VaderCleanerTests.VolumeMount.\(UUID().uuidString)")!
+        preferences = PreferencesStore(defaults: defaults)
+        dispatcher = StubNotificationDispatcher()
+    }
+
+    private func makeMonitor(_ info: MountedVolumeInfo?) -> VolumeMountMonitor {
+        VolumeMountMonitor(
+            preferences: preferences,
+            dispatcher: dispatcher,
+            volumeReader: { _ in info },
+            overfilledFreeFraction: 0.10
+        )
+    }
+
+    private let anyURL = URL(fileURLWithPath: "/Volumes/USB")
+
+    func test_driveConnected_firesWhenToggleOn() {
+        preferences.notifyDriveConnected = true
+        preferences.notifyOverfilledDrives = false
+        let monitor = makeMonitor(MountedVolumeInfo(name: "USB", isExternal: true, freeBytes: 500, totalBytes: 1000))
+
+        monitor.evaluate(mountedVolume: anyURL)
+
+        XCTAssertEqual(dispatcher.calls, [.driveConnected(volumeName: "USB")])
+    }
+
+    func test_overfilled_firesForNearlyFullExternalVolume() {
+        preferences.notifyDriveConnected = false
+        preferences.notifyOverfilledDrives = true
+        let monitor = makeMonitor(MountedVolumeInfo(name: "USB", isExternal: true, freeBytes: 50, totalBytes: 1000))
+
+        monitor.evaluate(mountedVolume: anyURL)
+
+        XCTAssertEqual(dispatcher.calls, [.overfilledDrive(volumeName: "USB", freeBytes: 50, totalBytes: 1000)])
+    }
+
+    func test_overfilled_doesNotFireForInternalVolume() {
+        preferences.notifyDriveConnected = false
+        preferences.notifyOverfilledDrives = true
+        let monitor = makeMonitor(MountedVolumeInfo(name: "Macintosh HD", isExternal: false, freeBytes: 10, totalBytes: 1000))
+
+        monitor.evaluate(mountedVolume: anyURL)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_overfilled_doesNotFireWhenEnoughFree() {
+        preferences.notifyDriveConnected = false
+        preferences.notifyOverfilledDrives = true
+        let monitor = makeMonitor(MountedVolumeInfo(name: "USB", isExternal: true, freeBytes: 500, totalBytes: 1000))
+
+        monitor.evaluate(mountedVolume: anyURL)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+
+    func test_bothTogglesOff_firesNothing() {
+        preferences.notifyDriveConnected = false
+        preferences.notifyOverfilledDrives = false
+        let monitor = makeMonitor(MountedVolumeInfo(name: "USB", isExternal: true, freeBytes: 1, totalBytes: 1000))
+
+        monitor.evaluate(mountedVolume: anyURL)
+
+        XCTAssertTrue(dispatcher.calls.isEmpty)
+    }
+}


### PR DESCRIPTION
This branch bundles four related improvements to the section/manager experience. Build + full unit suite green (**1258 tests, 0 failures**).

---

## 1. Applications Manager — performance + structural split

**Performance**
- Session-scoped per-app size/last-opened cache on `AppUninstallerViewModel` (no disk re-walk / list reflow on reopen).
- Memoized the Uninstaller / Updater / Extensions lists so a checkbox toggle no longer re-filters the whole list.
- Performance Manager: memoized the Login/Background row mappings (LaunchServices lookup was running per item per render).
- `AppIconCluster` resolves icons once per id set via `.task(id:)`; hoisted two per-call formatters to `static`.

**Refactor**
- Split the ~1100-line `ApplicationsManagerView` into four dedicated pane `View` types (`UninstallerPaneView`, `LeftoversPaneView`, `UpdaterPaneView`, `ExtensionsPaneView`) + an `ApplicationsManagerChrome` namespace. Parent `body` is now `header / nav | paneContent / footer`, so a toggle re-renders only the active pane. Layout and all 18 accessibility identifiers preserved verbatim.

## 2. Smart Scan pre-warms every section

- **Space Lens** now kicks off its own scan after a Smart Scan.
- **Protection** gains `prewarmFromSmartScan(...)` — seeds the malware tile from the scan results and starts the privacy preview **without** re-running the malware scan.
- Removes the now-dead `malwareViewModel` reference from `ContentView`.

## 3. Full Notifications settings pane (CleanMyMac-style parity)

Three sections — **General / Disk Space / Applications** — with toggles, inline dropdown pickers (Smart Care cadence, Trash GB, disk-free GB), and the Applications descriptions.

- ~10 new persisted settings in `PreferencesStore` (+ `SmartCareFrequency`); disk threshold migrated **percent → absolute GB**.
- New `NotificationManager` dispatch methods + pure content factories.
- New background monitors, each with its system-API touch **injected** so the decision logic is unit-tested and the native read is quarantined: `TrashSizeMonitor`, `VolumeMountMonitor` (drive-connected + overfilled), `SmartCareReminderScheduler`, `TrashedAppMonitor`, `DeviceBatteryMonitor`, `HungAppMonitor`. A `NotificationMonitors` aggregator owns/starts them, started after the permission prompt resolves.

**Honest caveats (intentional, agreed up front):** peripheral-battery (IORegistry) and hung-app (Accessibility messaging-timeout, gated on AX trust) reads are best-effort and can break across macOS versions or return nothing — only their *logic* is CI-tested.

## 4. "Scan finished" notification

When a scan the user started completes, a banner names what finished (e.g. "Your Smart Scan scan has finished").

- New `notifyScanFinished` toggle (default on) in the Notifications pane.
- `ScanCompletionNotifier` is **armed only at user-facing scan entry points** (the floating Scan disc + the menu's Run Smart Scan), so the background pre-warm scans never notify. Threaded into the disc's child panel via `attach(...)` (the panel doesn't inherit the main window environment).
- Protection's dashboard reaches `.results` the instant scanning starts, so a new `ScanCompletionReporting` protocol lets it report real completion (`isScanComplete` = malware + privacy both settled). The notifier watches that for such coordinators and the coarse `working → results` transition for everyone else — correct on all seven scannable sections.

---

## Verification
- Build + **1258 unit tests green**.
- All 18 Applications-manager accessibility identifiers preserved; `build-for-testing` compiles `ApplicationsUITests`.
- The XCUITest runner can't bootstrap from the dev terminal, so the live UI/notification behaviors were verified by running the app.

## Notes for reviewers
- This PR grew well beyond the original manager-split scope (per request, kept on one branch). Reasonable to review as four logical chunks.
- Pre-existing, out of scope: `@Sendable` conversion warnings in `UnusedAppScanner.swift:36`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new notification options for Smart Care reminders, trash size, low battery, connected drives, overfilled drives, trashed apps, and hung/unresponsive apps.
  * Introduced Smart Care scheduling plus background monitors that watch trash, mounted volumes, battery level, hung apps, and newly trashed apps.
  * Added Smart Scan completion notifications with smarter Protection dashboard prewarming.

* **Bug Fixes**
  * Updated low-disk alerts to use free-space bytes/GB instead of percentages for clearer messaging.
  * Improved app-uninstaller list metric loading to reduce repeated work and keep ordering in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->