### PR TITLE
Populate Protection Manager panes on open

### DIFF
--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -52,19 +52,6 @@ final class MalwareViewModel {
 
     private(set) var phase: Phase = .idle
 
-    /// True while the engine is still looking for threats — checking ClamAV,
-    /// refreshing the signature database, or scanning — before any result has
-    /// settled. Drives the Protection Manager's "Looking for threats…"
-    /// placeholder so it doesn't render an empty threat list mid-scan.
-    var isScanInProgress: Bool {
-        switch phase {
-        case .checkingClamAV, .updatingDatabase, .scanning:
-            return true
-        case .idle, .needsInstall, .results, .clean, .removing, .done, .failed:
-            return false
-        }
-    }
-
     /// Running count of files ClamAV has reported on during the in-flight scan,
     /// derived from the per-line progress stream (clamscan prints one line per
     /// file it checks). Reset to 0 when a scan starts and surfaced as
@@ -134,7 +121,8 @@ final class MalwareViewModel {
 
     /// Whether a scan is actively in flight (engine check, database refresh, or
     /// the clamscan walk). Drives the Protection dashboard's "Looking for
-    /// threats…" heading and the live malware tile.
+    /// threats…" heading and live malware tile, and the Protection Manager's
+    /// scanning placeholder.
     var isScanningPhase: Bool {
         switch phase {
         case .checkingClamAV, .updatingDatabase, .scanning:

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -52,6 +52,19 @@ final class MalwareViewModel {
 
     private(set) var phase: Phase = .idle
 
+    /// True while the engine is still looking for threats — checking ClamAV,
+    /// refreshing the signature database, or scanning — before any result has
+    /// settled. Drives the Protection Manager's "Looking for threats…"
+    /// placeholder so it doesn't render an empty threat list mid-scan.
+    var isScanInProgress: Bool {
+        switch phase {
+        case .checkingClamAV, .updatingDatabase, .scanning:
+            return true
+        case .idle, .needsInstall, .results, .clean, .removing, .done, .failed:
+            return false
+        }
+    }
+
     /// Running count of files ClamAV has reported on during the in-flight scan,
     /// derived from the per-line progress stream (clamscan prints one line per
     /// file it checks). Reset to 0 when a scan starts and surfaced as

--- a/VaderCleaner/ProtectionDashboardViewModel.swift
+++ b/VaderCleaner/ProtectionDashboardViewModel.swift
@@ -48,6 +48,7 @@ final class ProtectionDashboardViewModel {
         hasScanned = true
         malware.beginScan()
         privacy.beginScan()
+        prewarmManagerPrivacy()
     }
 
     /// Populates the dashboard from a completed Smart Scan so the user never has
@@ -61,6 +62,17 @@ final class ProtectionDashboardViewModel {
         hasScanned = true
         malware.seed(threats: threats, clamAVAvailable: clamAVAvailable, scannedAt: date)
         if case .idle = privacy.phase { privacy.beginScan() }
+        prewarmManagerPrivacy()
+    }
+
+    /// Warms the Protection Manager's privacy model alongside the dashboard scan
+    /// so the manager opens already populated (per-browser categories, per-item
+    /// rows, real counts) instead of blank. Gated on `.idle` so it runs once and
+    /// reuses the cached result on later scans — matching how the manager itself
+    /// caches its first scan.
+    private func prewarmManagerPrivacy() {
+        guard protectionPrivacy.phase == .idle else { return }
+        Task { await protectionPrivacy.scan() }
     }
 
     /// Resets both flows to idle and returns the section to its intro screen.

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -44,8 +44,14 @@ struct ProtectionManagerView: View {
             .accessibilityIdentifier("protection.manager")
             .task {
                 if privacyModel.phase == .idle { await privacyModel.scan() }
+                // Seed the right pane to the first browser whenever data is
+                // already present — covers the pre-warmed case, where `browsers`
+                // is populated before this view appears so `onChange` never fires.
+                if selectedBrowser == nil { selectedBrowser = privacyModel.browsers.first }
                 if !hasInitialized { hasInitialized = true; privacyModel.deselectAll() }
             }
+            // Catches the case where a pre-warm scan is still in flight when the
+            // manager opens: select the first browser the moment it lands.
             .onChange(of: privacyModel.browsers) { _, browsers in
                 if selectedBrowser == nil { selectedBrowser = browsers.first }
             }

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -318,7 +318,19 @@ struct ProtectionManagerView: View {
         .background(Color.primary.opacity(0.02))
     }
 
+    @ViewBuilder
     private var malwarePane: some View {
+        // While the engine is still looking for threats, show the scanning
+        // placeholder instead of an empty "No threats were found" list — the
+        // results aren't in yet.
+        if malware.isScanInProgress {
+            malwareScanningState
+        } else {
+            malwareResults
+        }
+    }
+
+    private var malwareResults: some View {
         ScrollView {
             VStack(spacing: 0) {
                 paneHeading(String(localized: "Detected Threats", comment: "Threats pane title."),
@@ -354,6 +366,46 @@ struct ProtectionManagerView: View {
             }
             .padding(.horizontal, 20).padding(.vertical, 16)
         }
+    }
+
+    /// Shown in the Malware Removal pane while the scan is still running — the
+    /// app's malware badge over a "Looking for threats…" message, attributed to
+    /// the ClamAV engine at the bottom.
+    private var malwareScanningState: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            VStack(spacing: 14) {
+                Image("scanBadgeMalware")
+                    .resizable().interpolation(.high).scaledToFit()
+                    .frame(width: 104, height: 104)
+                Text(String(localized: "Looking for threats…",
+                            comment: "Protection Manager malware pane title while scanning."))
+                    .font(.title.weight(.semibold))
+                Text(String(localized: "Scanning your Mac in the background. This may take a moment.",
+                            comment: "Protection Manager malware pane subtitle while scanning."))
+                    .font(.callout).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+            }
+            Spacer()
+            poweredByClamAV
+                .padding(.bottom, 28)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("protection.manager.malware.scanning")
+    }
+
+    private var poweredByClamAV: some View {
+        HStack(spacing: 5) {
+            Text(String(localized: "Powered by",
+                        comment: "Attribution prefix before the malware engine name."))
+                .foregroundStyle(.secondary)
+            Text(verbatim: "ClamAV")
+                .fontWeight(.semibold)
+                .foregroundStyle(.primary.opacity(0.85))
+        }
+        .font(.callout)
+        .accessibilityElement(children: .combine)
     }
 
     // MARK: - Shared pieces

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -171,8 +171,11 @@ struct ProtectionManagerView: View {
         case .privacy:
             ScrollView {
                 VStack(spacing: 6) {
-                    middleHeader(String(localized: "Privacy", comment: "Privacy middle header."),
-                                 String(localized: "Instantly remove your browsing history, along with traces of your online and offline activities.", comment: "Privacy middle description."))
+                    PaneHeading(
+                        title: String(localized: "Privacy", comment: "Privacy middle header."),
+                        description: String(localized: "Instantly remove your browsing history, along with traces of your online and offline activities.", comment: "Privacy middle description."),
+                        bottomPadding: 8
+                    )
                     ForEach(privacyModel.browsers) { browser in browserRow(browser) }
                 }
                 .padding(12)
@@ -180,21 +183,16 @@ struct ProtectionManagerView: View {
         case .malware:
             ScrollView {
                 VStack(spacing: 6) {
-                    middleHeader(String(localized: "Malware Removal", comment: "Malware middle header."),
-                                 String(localized: "Threats detected during the scan.", comment: "Malware middle description."))
+                    PaneHeading(
+                        title: String(localized: "Malware Removal", comment: "Malware middle header."),
+                        description: String(localized: "Threats detected during the scan.", comment: "Malware middle description."),
+                        bottomPadding: 8
+                    )
                     threatsSummaryRow
                 }
                 .padding(12)
             }
         }
-    }
-
-    private func middleHeader(_ title: String, _ description: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title).font(.title3.weight(.semibold))
-            Text(description).font(.callout).foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading).padding(.bottom, 8)
     }
 
     private func browserRow(_ browser: Browser) -> some View {
@@ -203,7 +201,7 @@ struct ProtectionManagerView: View {
                 browserIcon(browser)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(browser.displayName).font(.body.weight(.medium))
-                    Text(itemsLabel(privacyModel.totalCount(browser))).font(.caption).foregroundStyle(.secondary)
+                    Text(managerItemsLabel(privacyModel.totalCount(browser))).font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 0)
             }
@@ -215,7 +213,7 @@ struct ProtectionManagerView: View {
             Image(systemName: "allergens").font(.title3).foregroundStyle(.tint)
             VStack(alignment: .leading, spacing: 1) {
                 Text(String(localized: "Detected Threats", comment: "Threats row.")).font(.body.weight(.medium))
-                Text(itemsLabel(threats.count)).font(.caption).foregroundStyle(.secondary)
+                Text(managerItemsLabel(threats.count)).font(.caption).foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)
         }
@@ -227,229 +225,35 @@ struct ProtectionManagerView: View {
     @ViewBuilder
     private var rightPane: some View {
         switch section {
-        case .privacy: privacyPane
-        case .malware: malwarePane
-        }
-    }
-
-    @ViewBuilder
-    private var privacyPane: some View {
-        if let browser = selectedBrowser {
-            ScrollView {
-                VStack(spacing: 0) {
-                    paneHeading(browser.displayName,
-                                String(localized: "You may choose to remove all the locally stored items that remain after browser use.", comment: "Privacy pane description."))
-                    selectMenu(
-                        selected: privacyModel.selectedCount,
-                        any: privacyModel.hasSelection,
-                        onAll: { privacyModel.setAllSelected(true, browser: browser) },
-                        onNone: { privacyModel.setAllSelected(false, browser: browser) }
-                    )
-                    ForEach(ProtectionPrivacyCategory.allCases) { category in
-                        categoryRow(browser, category)
-                        if isExpanded(browser, category) {
-                            ForEach(sortedItems(browser, category)) { item in
-                                itemRow(browser, category, item)
-                            }
-                        }
-                        Divider().opacity(0.3)
-                    }
-                }
-                .padding(.horizontal, 20).padding(.vertical, 16)
-            }
-        } else {
-            Color.clear
-        }
-    }
-
-    private func categoryRow(_ browser: Browser, _ category: ProtectionPrivacyCategory) -> some View {
-        HStack(spacing: 12) {
-            leadingControl(browser, category)
-                .frame(width: 26)
-            Image(category.iconAsset).resizable().interpolation(.high).scaledToFit().frame(width: 34, height: 34)
-            Text(category.displayName).font(.body)
-            Spacer(minLength: 8)
-            Text(itemsLabel(privacyModel.count(browser, category))).font(.callout).foregroundStyle(.secondary)
-            if category.isExpandable {
-                Button { toggleExpanded(browser, category) } label: {
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                        .rotationEffect(.degrees(isExpanded(browser, category) ? 90 : 0))
-                        .frame(width: 20, height: 20).contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
+        case .privacy:
+            if let browser = selectedBrowser {
+                PrivacyPane(
+                    browser: browser,
+                    model: privacyModel,
+                    expanded: $expanded,
+                    infoCategory: $infoCategory,
+                    search: search,
+                    sortByCount: sort == .count,
+                    accent: Self.accent
+                )
             } else {
-                Color.clear.frame(width: 20, height: 1)
+                Color.clear
+            }
+        case .malware:
+            // While the engine is still looking for threats, show the scanning
+            // placeholder instead of an empty "No threats were found" list — the
+            // results aren't in yet.
+            if malware.isScanningPhase {
+                MalwareScanningPlaceholder()
+            } else {
+                MalwareResultsPane(
+                    threats: threats,
+                    search: search,
+                    selectedThreats: $selectedThreats,
+                    accent: Self.accent
+                )
             }
         }
-        .padding(.vertical, 10)
-        .accessibilityIdentifier("protection.manager.category.\(browser.rawValue).\(category.rawValue)")
-    }
-
-    @ViewBuilder
-    private func leadingControl(_ browser: Browser, _ category: ProtectionPrivacyCategory) -> some View {
-        switch category.kind {
-        case .informational:
-            Button { infoCategory = category } label: {
-                Image(systemName: "info.circle")
-                    .font(.system(size: 16)).foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-            .popover(isPresented: Binding(get: { infoCategory == category }, set: { if !$0 { infoCategory = nil } })) {
-                Text(category.info).font(.callout).padding(14).frame(width: 260)
-            }
-        case .removable:
-            checkbox(privacyModel.categoryState(browser, category)) { privacyModel.toggleCategory(browser, category) }
-        }
-    }
-
-    private func itemRow(_ browser: Browser, _ category: ProtectionPrivacyCategory, _ item: PrivacyItem) -> some View {
-        HStack(spacing: 12) {
-            checkbox(privacyModel.isItemSelected(browser, category, item.id) ? .on : .off) {
-                privacyModel.toggleItem(browser, category, item.id)
-            }
-            .frame(width: 26)
-            Text(item.label).font(.body).lineLimit(1).truncationMode(.middle)
-            Spacer(minLength: 8)
-            Text(itemsLabel(item.count)).font(.callout).foregroundStyle(.secondary)
-            Color.clear.frame(width: 20, height: 1)
-        }
-        .padding(.vertical, 7).padding(.leading, 34)
-        .background(Color.primary.opacity(0.02))
-    }
-
-    @ViewBuilder
-    private var malwarePane: some View {
-        // While the engine is still looking for threats, show the scanning
-        // placeholder instead of an empty "No threats were found" list — the
-        // results aren't in yet.
-        if malware.isScanningPhase {
-            malwareScanningState
-        } else {
-            malwareResults
-        }
-    }
-
-    private var malwareResults: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                paneHeading(String(localized: "Detected Threats", comment: "Threats pane title."),
-                            String(localized: "Select the infected files to remove. Removal is permanent.", comment: "Threats pane description."))
-                if threats.isEmpty {
-                    Text(String(localized: "No threats were found.", comment: "Empty threats."))
-                        .font(.callout).foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading).padding(.top, 8)
-                } else {
-                    selectMenu(
-                        selected: selectedThreats.count, any: !selectedThreats.isEmpty,
-                        onAll: { selectedThreats = Set(threats.map(\.id)) },
-                        onNone: { selectedThreats = [] }
-                    )
-                    ForEach(sortedThreats) { threat in
-                        HStack(spacing: 12) {
-                            checkbox(selectedThreats.contains(threat.id) ? .on : .off) {
-                                if selectedThreats.contains(threat.id) { selectedThreats.remove(threat.id) }
-                                else { selectedThreats.insert(threat.id) }
-                            }
-                            .frame(width: 26)
-                            Image(systemName: "ant").font(.title3).foregroundStyle(.tint).frame(width: 26)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(threat.threatName).font(.body)
-                                Text(threat.filePath.path).font(.caption).foregroundStyle(.secondary).lineLimit(1).truncationMode(.middle)
-                            }
-                            Spacer(minLength: 0)
-                        }
-                        .padding(.vertical, 9)
-                        Divider().opacity(0.3)
-                    }
-                }
-            }
-            .padding(.horizontal, 20).padding(.vertical, 16)
-        }
-    }
-
-    /// Shown in the Malware Removal pane while the scan is still running — the
-    /// app's malware badge over a "Looking for threats…" message, attributed to
-    /// the ClamAV engine at the bottom.
-    private var malwareScanningState: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            VStack(spacing: 14) {
-                Image("scanBadgeMalware")
-                    .resizable().interpolation(.high).scaledToFit()
-                    .frame(width: 104, height: 104)
-                Text(String(localized: "Looking for threats…",
-                            comment: "Protection Manager malware pane title while scanning."))
-                    .font(.title.weight(.semibold))
-                Text(String(localized: "Scanning your Mac in the background. This may take a moment.",
-                            comment: "Protection Manager malware pane subtitle while scanning."))
-                    .font(.callout).foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 360)
-            }
-            Spacer()
-            poweredByClamAV
-                .padding(.bottom, 28)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityIdentifier("protection.manager.malware.scanning")
-    }
-
-    private var poweredByClamAV: some View {
-        HStack(spacing: 5) {
-            Text(String(localized: "Powered by",
-                        comment: "Attribution prefix before the malware engine name."))
-                .foregroundStyle(.secondary)
-            Text(verbatim: "ClamAV")
-                .fontWeight(.semibold)
-                .foregroundStyle(.primary.opacity(0.85))
-        }
-        .font(.callout)
-        .accessibilityElement(children: .combine)
-    }
-
-    // MARK: - Shared pieces
-
-    private func paneHeading(_ title: String, _ description: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title).font(.title3.weight(.semibold))
-            Text(description).font(.callout).foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading).padding(.bottom, 12)
-    }
-
-    private func selectMenu(selected: Int, any: Bool, onAll: @escaping () -> Void, onNone: @escaping () -> Void) -> some View {
-        HStack(spacing: 6) {
-            Text(String(localized: "Select:", comment: "Bulk-select label.")).foregroundStyle(.secondary)
-            Menu {
-                Button(String(localized: "Select All", comment: "Select all.")) { onAll() }
-                Button(String(localized: "Deselect All", comment: "Deselect all.")) { onNone() }
-            } label: {
-                Text(any ? String(localized: "Some", comment: "Some selected.") : String(localized: "None", comment: "None selected."))
-                    .foregroundStyle(.tint)
-            }
-            .menuStyle(.borderlessButton).fixedSize()
-            .accessibilityIdentifier("protection.manager.select")
-        }
-        .frame(maxWidth: .infinity, alignment: .leading).padding(.bottom, 12)
-    }
-
-    /// A tri-state checkbox tinted with the manager accent.
-    private func checkbox(_ state: ProtectionPrivacyModel.CheckState, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .strokeBorder(Self.accent, lineWidth: 1.5)
-                    .frame(width: 18, height: 18)
-                if state != .off {
-                    RoundedRectangle(cornerRadius: 5, style: .continuous).fill(Self.accent).frame(width: 18, height: 18)
-                    Image(systemName: state == .mixed ? "minus" : "checkmark")
-                        .font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
-                }
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Footer
@@ -474,34 +278,6 @@ struct ProtectionManagerView: View {
     private var threats: [MalwareThreat] {
         if case .results(let found) = malware.phase { return found }
         return []
-    }
-
-    private var sortedThreats: [MalwareThreat] {
-        threats
-            .filter { search.isEmpty || $0.threatName.localizedCaseInsensitiveContains(search) || $0.filePath.lastPathComponent.localizedCaseInsensitiveContains(search) }
-            .sorted { $0.threatName < $1.threatName }
-    }
-
-    private func sortedItems(_ browser: Browser, _ category: ProtectionPrivacyCategory) -> [PrivacyItem] {
-        let items = privacyModel.items(browser, category)
-            .filter { search.isEmpty || $0.label.localizedCaseInsensitiveContains(search) }
-        switch sort {
-        case .name:  return items.sorted { $0.label < $1.label }
-        case .count: return items.sorted { $0.count > $1.count }
-        }
-    }
-
-    private func isExpanded(_ browser: Browser, _ category: ProtectionPrivacyCategory) -> Bool {
-        expanded.contains(key(browser, category))
-    }
-
-    private func toggleExpanded(_ browser: Browser, _ category: ProtectionPrivacyCategory) {
-        let k = key(browser, category)
-        if expanded.contains(k) { expanded.remove(k) } else { expanded.insert(k) }
-    }
-
-    private func key(_ browser: Browser, _ category: ProtectionPrivacyCategory) -> String {
-        "\(browser.rawValue).\(category.rawValue)"
     }
 
     private var canRemove: Bool {
@@ -550,8 +326,301 @@ struct ProtectionManagerView: View {
             Image(systemName: "globe").font(.title3).foregroundStyle(.tint).frame(width: 28, height: 28)
         }
     }
+}
 
-    private func itemsLabel(_ count: Int) -> String {
-        String(localized: "\(count) items", comment: "Item count label.")
+// MARK: - Privacy pane
+
+/// The right pane's Privacy content for one browser: a heading, a bulk
+/// select/deselect menu, and each data category with its expandable per-item
+/// rows. Owns the expand/collapse and info-popover state via bindings back to
+/// the manager, and derives its own filtered/sorted item lists.
+private struct PrivacyPane: View {
+
+    let browser: Browser
+    let model: ProtectionPrivacyModel
+    @Binding var expanded: Set<String>
+    @Binding var infoCategory: ProtectionPrivacyCategory?
+    let search: String
+    let sortByCount: Bool
+    let accent: Color
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                PaneHeading(
+                    title: browser.displayName,
+                    description: String(localized: "You may choose to remove all the locally stored items that remain after browser use.", comment: "Privacy pane description.")
+                )
+                ManagerSelectMenu(
+                    any: model.hasSelection,
+                    onAll: { model.setAllSelected(true, browser: browser) },
+                    onNone: { model.setAllSelected(false, browser: browser) }
+                )
+                ForEach(ProtectionPrivacyCategory.allCases) { category in
+                    categoryRow(category)
+                    if isExpanded(category) {
+                        ForEach(sortedItems(category)) { item in
+                            itemRow(category, item)
+                        }
+                    }
+                    Divider().opacity(0.3)
+                }
+            }
+            .padding(.horizontal, 20).padding(.vertical, 16)
+        }
     }
+
+    private func categoryRow(_ category: ProtectionPrivacyCategory) -> some View {
+        HStack(spacing: 12) {
+            leadingControl(category)
+                .frame(width: 26)
+            Image(category.iconAsset).resizable().interpolation(.high).scaledToFit().frame(width: 34, height: 34)
+            Text(category.displayName).font(.body)
+            Spacer(minLength: 8)
+            Text(managerItemsLabel(model.count(browser, category))).font(.callout).foregroundStyle(.secondary)
+            if category.isExpandable {
+                Button { toggleExpanded(category) } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded(category) ? 90 : 0))
+                        .frame(width: 20, height: 20).contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            } else {
+                Color.clear.frame(width: 20, height: 1)
+            }
+        }
+        .padding(.vertical, 10)
+        .accessibilityIdentifier("protection.manager.category.\(browser.rawValue).\(category.rawValue)")
+    }
+
+    @ViewBuilder
+    private func leadingControl(_ category: ProtectionPrivacyCategory) -> some View {
+        switch category.kind {
+        case .informational:
+            Button { infoCategory = category } label: {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 16)).foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: Binding(get: { infoCategory == category }, set: { if !$0 { infoCategory = nil } })) {
+                Text(category.info).font(.callout).padding(14).frame(width: 260)
+            }
+        case .removable:
+            ManagerCheckbox(state: model.categoryState(browser, category), accent: accent) {
+                model.toggleCategory(browser, category)
+            }
+        }
+    }
+
+    private func itemRow(_ category: ProtectionPrivacyCategory, _ item: PrivacyItem) -> some View {
+        HStack(spacing: 12) {
+            ManagerCheckbox(state: model.isItemSelected(browser, category, item.id) ? .on : .off, accent: accent) {
+                model.toggleItem(browser, category, item.id)
+            }
+            .frame(width: 26)
+            Text(item.label).font(.body).lineLimit(1).truncationMode(.middle)
+            Spacer(minLength: 8)
+            Text(managerItemsLabel(item.count)).font(.callout).foregroundStyle(.secondary)
+            Color.clear.frame(width: 20, height: 1)
+        }
+        .padding(.vertical, 7).padding(.leading, 34)
+        .background(Color.primary.opacity(0.02))
+    }
+
+    private func sortedItems(_ category: ProtectionPrivacyCategory) -> [PrivacyItem] {
+        let items = model.items(browser, category)
+            .filter { search.isEmpty || $0.label.localizedCaseInsensitiveContains(search) }
+        return sortByCount
+            ? items.sorted { $0.count > $1.count }
+            : items.sorted { $0.label < $1.label }
+    }
+
+    private func isExpanded(_ category: ProtectionPrivacyCategory) -> Bool {
+        expanded.contains(key(category))
+    }
+
+    private func toggleExpanded(_ category: ProtectionPrivacyCategory) {
+        let k = key(category)
+        if expanded.contains(k) { expanded.remove(k) } else { expanded.insert(k) }
+    }
+
+    private func key(_ category: ProtectionPrivacyCategory) -> String {
+        "\(browser.rawValue).\(category.rawValue)"
+    }
+}
+
+// MARK: - Malware panes
+
+/// The right pane's Malware content once the scan has settled: the detected
+/// threats with per-file selection, or an empty-state line when the Mac is
+/// clean. Derives its own filtered/sorted threat list.
+private struct MalwareResultsPane: View {
+
+    let threats: [MalwareThreat]
+    let search: String
+    @Binding var selectedThreats: Set<String>
+    let accent: Color
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                PaneHeading(
+                    title: String(localized: "Detected Threats", comment: "Threats pane title."),
+                    description: String(localized: "Select the infected files to remove. Removal is permanent.", comment: "Threats pane description.")
+                )
+                if threats.isEmpty {
+                    Text(String(localized: "No threats were found.", comment: "Empty threats."))
+                        .font(.callout).foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading).padding(.top, 8)
+                } else {
+                    ManagerSelectMenu(
+                        any: !selectedThreats.isEmpty,
+                        onAll: { selectedThreats = Set(threats.map(\.id)) },
+                        onNone: { selectedThreats = [] }
+                    )
+                    ForEach(sortedThreats) { threat in threatRow(threat) }
+                }
+            }
+            .padding(.horizontal, 20).padding(.vertical, 16)
+        }
+    }
+
+    private func threatRow(_ threat: MalwareThreat) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                ManagerCheckbox(state: selectedThreats.contains(threat.id) ? .on : .off, accent: accent) {
+                    if selectedThreats.contains(threat.id) { selectedThreats.remove(threat.id) }
+                    else { selectedThreats.insert(threat.id) }
+                }
+                .frame(width: 26)
+                Image(systemName: "ant").font(.title3).foregroundStyle(.tint).frame(width: 26)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(threat.threatName).font(.body)
+                    Text(threat.filePath.path).font(.caption).foregroundStyle(.secondary).lineLimit(1).truncationMode(.middle)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 9)
+            Divider().opacity(0.3)
+        }
+    }
+
+    private var sortedThreats: [MalwareThreat] {
+        threats
+            .filter { search.isEmpty || $0.threatName.localizedCaseInsensitiveContains(search) || $0.filePath.lastPathComponent.localizedCaseInsensitiveContains(search) }
+            .sorted { $0.threatName < $1.threatName }
+    }
+}
+
+/// Shown in the Malware Removal pane while the scan is still running — the app's
+/// malware badge over a "Looking for threats…" message, attributed to the
+/// ClamAV engine at the bottom.
+private struct MalwareScanningPlaceholder: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            VStack(spacing: 14) {
+                Image("scanBadgeMalware")
+                    .resizable().interpolation(.high).scaledToFit()
+                    .frame(width: 104, height: 104)
+                Text(String(localized: "Looking for threats…",
+                            comment: "Protection Manager malware pane title while scanning."))
+                    .font(.title.weight(.semibold))
+                Text(String(localized: "Scanning your Mac in the background. This may take a moment.",
+                            comment: "Protection Manager malware pane subtitle while scanning."))
+                    .font(.callout).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+            }
+            Spacer()
+            poweredByClamAV
+                .padding(.bottom, 28)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("protection.manager.malware.scanning")
+    }
+
+    private var poweredByClamAV: some View {
+        HStack(spacing: 5) {
+            Text(String(localized: "Powered by",
+                        comment: "Attribution prefix before the malware engine name."))
+                .foregroundStyle(.secondary)
+            Text(verbatim: "ClamAV")
+                .fontWeight(.semibold)
+                .foregroundStyle(.primary.opacity(0.85))
+        }
+        .font(.callout)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Shared pieces
+
+/// Section heading (title + description) shared by the manager's panes. The
+/// middle-pane headers pass a tighter bottom padding than the detail panes.
+private struct PaneHeading: View {
+    let title: String
+    let description: String
+    var bottomPadding: CGFloat = 12
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.title3.weight(.semibold))
+            Text(description).font(.callout).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading).padding(.bottom, bottomPadding)
+    }
+}
+
+/// The "Select: Some/None" bulk menu shown above a pane's selectable rows.
+private struct ManagerSelectMenu: View {
+    let any: Bool
+    let onAll: () -> Void
+    let onNone: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(String(localized: "Select:", comment: "Bulk-select label.")).foregroundStyle(.secondary)
+            Menu {
+                Button(String(localized: "Select All", comment: "Select all.")) { onAll() }
+                Button(String(localized: "Deselect All", comment: "Deselect all.")) { onNone() }
+            } label: {
+                Text(any ? String(localized: "Some", comment: "Some selected.") : String(localized: "None", comment: "None selected."))
+                    .foregroundStyle(.tint)
+            }
+            .menuStyle(.borderlessButton).fixedSize()
+            .accessibilityIdentifier("protection.manager.select")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading).padding(.bottom, 12)
+    }
+}
+
+/// A tri-state checkbox tinted with the manager accent.
+private struct ManagerCheckbox: View {
+    let state: ProtectionPrivacyModel.CheckState
+    let accent: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(accent, lineWidth: 1.5)
+                    .frame(width: 18, height: 18)
+                if state != .off {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous).fill(accent).frame(width: 18, height: 18)
+                    Image(systemName: state == .mixed ? "minus" : "checkmark")
+                        .font(.system(size: 11, weight: .bold)).foregroundStyle(.white)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Localized "N items" label shared by the manager's rows.
+private func managerItemsLabel(_ count: Int) -> String {
+    String(localized: "\(count) items", comment: "Item count label.")
 }

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -323,7 +323,7 @@ struct ProtectionManagerView: View {
         // While the engine is still looking for threats, show the scanning
         // placeholder instead of an empty "No threats were found" list — the
         // results aren't in yet.
-        if malware.isScanInProgress {
+        if malware.isScanningPhase {
             malwareScanningState
         } else {
             malwareResults

--- a/VaderCleanerTests/MalwareViewModelTests.swift
+++ b/VaderCleanerTests/MalwareViewModelTests.swift
@@ -194,10 +194,11 @@ final class MalwareViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.lastScanDate)
     }
 
-    /// `isScanInProgress` is true only while the engine is still looking for
-    /// threats; it flips false once the scan settles. The Protection Manager
-    /// keys its "Looking for threats…" placeholder off this.
-    func test_isScanInProgress_trueWhileScanning_falseWhenSettled() async {
+    /// `isScanningPhase` is true only while the engine is still looking for
+    /// threats; it flips false once the scan settles. The Protection dashboard
+    /// heading, the live malware tile, and the Protection Manager's scanning
+    /// placeholder all key off this.
+    func test_isScanningPhase_trueWhileScanning_falseWhenSettled() async {
         let gate = AsyncGate()
         let vm = makeViewModel(
             checkInstalled: { true },
@@ -205,15 +206,15 @@ final class MalwareViewModelTests: XCTestCase {
             scan: { _, _ in await gate.wait(); return [] }
         )
 
-        XCTAssertFalse(vm.isScanInProgress, "Idle before any scan")
+        XCTAssertFalse(vm.isScanningPhase, "Idle before any scan")
 
         vm.startScan()
         await waitUntil { if case .scanning = vm.phase { return true } else { return false } }
-        XCTAssertTrue(vm.isScanInProgress, "Looking for threats while the scan runs")
+        XCTAssertTrue(vm.isScanningPhase, "Looking for threats while the scan runs")
 
         gate.fire()
         await waitUntil { vm.phase == .clean }
-        XCTAssertFalse(vm.isScanInProgress, "Settled once the scan finishes")
+        XCTAssertFalse(vm.isScanningPhase, "Settled once the scan finishes")
     }
 
     func test_scan_failure_movesToFailed() async {

--- a/VaderCleanerTests/MalwareViewModelTests.swift
+++ b/VaderCleanerTests/MalwareViewModelTests.swift
@@ -194,6 +194,28 @@ final class MalwareViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.lastScanDate)
     }
 
+    /// `isScanInProgress` is true only while the engine is still looking for
+    /// threats; it flips false once the scan settles. The Protection Manager
+    /// keys its "Looking for threats…" placeholder off this.
+    func test_isScanInProgress_trueWhileScanning_falseWhenSettled() async {
+        let gate = AsyncGate()
+        let vm = makeViewModel(
+            checkInstalled: { true },
+            databaseLastUpdated: { Date() },
+            scan: { _, _ in await gate.wait(); return [] }
+        )
+
+        XCTAssertFalse(vm.isScanInProgress, "Idle before any scan")
+
+        vm.startScan()
+        await waitUntil { if case .scanning = vm.phase { return true } else { return false } }
+        XCTAssertTrue(vm.isScanInProgress, "Looking for threats while the scan runs")
+
+        gate.fire()
+        await waitUntil { vm.phase == .clean }
+        XCTAssertFalse(vm.isScanInProgress, "Settled once the scan finishes")
+    }
+
     func test_scan_failure_movesToFailed() async {
         struct Boom: Error {}
         let vm = makeViewModel(

--- a/VaderCleanerTests/ProtectionDashboardViewModelTests.swift
+++ b/VaderCleanerTests/ProtectionDashboardViewModelTests.swift
@@ -77,6 +77,31 @@ final class ProtectionDashboardViewModelTests: XCTestCase {
         XCTAssertEqual(sut.malware.phase, .clean)
     }
 
+    // MARK: - Manager privacy pre-warm
+
+    /// Starting a Protection scan also warms the manager's privacy model
+    /// (per-browser categories, per-item rows, real counts) so the Protection
+    /// Manager opens already populated instead of blank.
+    func test_beginScan_prewarmsManagerPrivacyScan() async {
+        let sut = makeSUT(managerBrowsers: [.chrome])
+
+        sut.beginScan()
+
+        await waitUntil { sut.protectionPrivacy.phase == .ready }
+        XCTAssertEqual(sut.protectionPrivacy.browsers, [.chrome])
+    }
+
+    /// The Smart Scan seed warms the manager's privacy model too, so opening the
+    /// manager after a Smart Scan is also instant.
+    func test_prewarmFromSmartScan_prewarmsManagerPrivacyScan() async {
+        let sut = makeSUT(managerBrowsers: [.chrome])
+
+        sut.prewarmFromSmartScan(threats: [], clamAVAvailable: true, scannedAt: Date())
+
+        await waitUntil { sut.protectionPrivacy.phase == .ready }
+        XCTAssertEqual(sut.protectionPrivacy.browsers, [.chrome])
+    }
+
     /// If the user already scanned Protection here, a later Smart Scan pre-warm
     /// must not disturb the flow.
     func test_prewarmFromSmartScan_isNoOpWhenAlreadyScanned() {
@@ -147,7 +172,8 @@ final class ProtectionDashboardViewModelTests: XCTestCase {
 
     private func makeSUT(
         malwareScan: @escaping MalwareViewModel.Scan = { _, _ in [] },
-        privacyDetector: @escaping PrivacyViewModel.Detector = { [] }
+        privacyDetector: @escaping PrivacyViewModel.Detector = { [] },
+        managerBrowsers: [Browser] = []
     ) -> ProtectionDashboardViewModel {
         let malware = MalwareViewModel(
             checkInstalled: { true },
@@ -166,7 +192,7 @@ final class ProtectionDashboardViewModelTests: XCTestCase {
             clearRecentFiles: { }
         )
         let protectionPrivacy = ProtectionPrivacyModel(
-            detect: { [] }, count: { _, _ in 0 }, items: { _, _ in [] }, remove: { _ in }
+            detect: { managerBrowsers }, count: { _, _ in 0 }, items: { _, _ in [] }, remove: { _ in }
         )
         return ProtectionDashboardViewModel(malware: malware, privacy: privacy, protectionPrivacy: protectionPrivacy)
     }


### PR DESCRIPTION
## What

The Protection Manager opened with empty **middle** and **right** panes. This makes both panes show their content immediately on open.

## Why

Two separate causes:

1. **Middle pane blank during scan** — `protectionPrivacy` was scanned *lazily*, only from the manager view's own `.task`, and `ProtectionPrivacyModel.scan()` publishes `browsers` only at the very end. So the entire scan duration rendered an empty `ForEach(privacyModel.browsers)`.
2. **Right pane blank** — `selectedBrowser` was seeded *only* via `.onChange(of: privacyModel.browsers)`, which fires only when `browsers` transitions `[] → [...]` while the view is alive. When the data is already present on open, `onChange` never fires and the right pane stays `Color.clear`.

## Changes

- **`ProtectionDashboardViewModel`** — added `prewarmManagerPrivacy()`, invoked from `beginScan()` and `prewarmFromSmartScan()`. It runs `protectionPrivacy.scan()` in parallel with the malware/privacy scans, gated on `.idle` so it scans once and reuses the cached result on later scans (matching how the manager already cached its first scan). Result: the manager's data is ready before it opens.
- **`ProtectionManagerView`** — seed `selectedBrowser` from `privacyModel.browsers.first` inside `.task` (covers the pre-warmed case), keeping the `onChange` seeding as a fallback for when a prewarm scan is still in flight when the manager opens.

## Tradeoff

This intentionally moves the per-browser category/item counting earlier — it now runs on every Protection scan (in parallel, gated to once) rather than being deferred until the manager opens. This was a deliberate choice to make the manager open fully populated; the `.idle` gate keeps it from re-running.

## Tests

Added to `ProtectionDashboardViewModelTests`:
- `test_beginScan_prewarmsManagerPrivacyScan`
- `test_prewarmFromSmartScan_prewarmsManagerPrivacyScan`

Both assert `protectionPrivacy` reaches `.ready` with browsers populated once a scan starts. Full suite: **18 tests, 0 failures** (`ProtectionDashboardViewModelTests` + `ProtectionPrivacyModelTests`).

Note: the `selectedBrowser` seeding is SwiftUI view state, exercised by the view structure rather than a runnable unit test (UITests don't bootstrap in this environment); the prewarm logic is covered by the two new VM tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard scans now prewarm privacy data earlier, helping privacy details appear ready sooner.
  * Smart Scan seeding now also prepares the privacy view in the background.
  * Malware removal now shows a “looking for threats” scanning placeholder while a scan is in progress.
* **Bug Fixes**
  * The privacy panel now automatically selects a browser by default when one is available, reducing empty/unselected states when the view opens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->