### PR TITLE
Expose all System Junk categories in Smart Scan settings

### DIFF
--- a/VaderCleaner/PreferencesView.swift
+++ b/VaderCleaner/PreferencesView.swift
@@ -60,7 +60,7 @@ struct PreferencesView: View {
 /// modules with glossy colored badge icons. The Cleanup parent carries a
 /// disclosure triangle and a native tri-state checkbox over its category
 /// children; disabling a module greys out and excludes its whole subtree.
-private struct ScanningTab: View {
+struct ScanningTab: View {
 
     /// Left-list selection: the whole Smart Care profile, or the Cleanup module
     /// drilled down to its own sub-tree.
@@ -225,12 +225,28 @@ private struct ScanningTab: View {
             state: { self.settings.junkCategoryState },
             toggle: self.toggleCleanup,
             isEnabled: { true },
-            children: [
-                systemJunkGroupNode,
-                categoryNode(.mailAttachments, title: "Mail Attachments", badge: "scanBadgeMailAttachments"),
-                categoryNode(.trash, title: "Trash Bins", badge: "scanBadgeTrash"),
-            ]
+            children: [systemJunkGroupNode] + Self.cleanupLeafDisplays.map {
+                categoryNode($0.category, title: $0.title, badge: $0.badge)
+            }
         )
+    }
+
+    /// The category leaves shown directly under Cleanup, beside the System Junk
+    /// sub-group — distinct user-data stores rather than named system-junk kinds.
+    /// Each title/badge is a display label over a real `ScanCategory` toggle.
+    private static let cleanupLeafDisplays: [(category: ScanCategory, title: String, badge: String)] = [
+        (.mailAttachments, "Mail Attachments", "scanBadgeMailAttachments"),
+        (.iosBackups, "iOS Backups", "scanBadgeIosBackups"),
+        (.trash, "Trash Bins", "scanBadgeTrash"),
+    ]
+
+    /// Every System Junk `ScanCategory` the Cleanup tree renders a toggle for —
+    /// the System Junk sub-group plus the Cleanup-level leaves. Exposed so a test
+    /// can assert the tree covers every scannable junk category, guarding against
+    /// a category that is scanned and filtered but has no user-facing toggle.
+    static var toggleableJunkCategories: Set<ScanCategory> {
+        Set(systemJunkDisplays.map(\.category))
+            .union(cleanupLeafDisplays.map(\.category))
     }
 
     /// The named System Junk categories shown under Cleanup, matching the
@@ -239,9 +255,12 @@ private struct ScanningTab: View {
     private static let systemJunkDisplays: [(category: ScanCategory, title: String, badge: String)] = [
         (.systemCache, "Broken Preferences", "scanBadgeSystemJunk"),
         (.userLogs, "User Log Files", "scanBadgeLogs"),
+        (.systemLogs, "System Log Files", "scanBadgeLogs"),
         (.documentVersions, "Document Versions", "scanBadgeDocumentVersions"),
         (.userCache, "User Cache Files", "scanBadgeUserCacheFiles"),
+        (.languageFiles, "Language Files", "scanBadgeLanguageFiles"),
         (.xcodeJunk, "Xcode Junk", "scanBadgeXcodeJunk"),
+        (.webDevJunk, "Web Development Junk", "scanBadgeWebDevJunk"),
     ]
 
     /// The "System Junk" sub-group: a tri-state over the named categories above.

--- a/VaderCleanerTests/SmartScanSettingsStoreTests.swift
+++ b/VaderCleanerTests/SmartScanSettingsStoreTests.swift
@@ -56,6 +56,15 @@ final class SmartScanSettingsStoreTests: XCTestCase {
         XCTAssertEqual(Set(SmartScanSettingsStore.junkCategories), expected)
     }
 
+    func test_scanningTab_offersToggleForEveryJunkCategory() {
+        // Every category the scanner can emit and the store filters on must have
+        // a toggle in Settings → Scanning; otherwise it is silently always-on.
+        XCTAssertEqual(
+            ScanningTab.toggleableJunkCategories,
+            Set(SmartScanSettingsStore.junkCategories)
+        )
+    }
+
     // MARK: - Toggling modules
 
     func test_setModule_disablesAndEnables() {


### PR DESCRIPTION
## What

Adds the 4 missing System Junk category rows to the **Settings → Scanning** ("Customize Smart Care") tree so all 11 categories the scanner produces are individually toggleable:

- **System Log Files** (`.systemLogs`), **Language Files** (`.languageFiles`), **Web Development Junk** (`.webDevJunk`) → added to the System Junk sub-group.
- **iOS Backups** (`.iosBackups`) → added to the Cleanup-level leaves beside Mail Attachments and Trash.

All four reuse badge art already present in the asset catalog (`scanBadgeLanguageFiles`, `scanBadgeWebDevJunk`, `scanBadgeIosBackups`; System Logs shares `scanBadgeLogs` with User Logs).

## Why

`SmartScanSettingsStore` manages 11 junk categories (every `ScanCategory` except `.largeFile`/`.oldFile`), defaults them all to enabled, and `SmartScanViewModel.scan()` filters junk results against that set. But the settings tree only rendered checkboxes for 7 of them — so System Logs, Language Files, iOS Backups, and Web Development Junk were scanned and always-on with no way for the user to exclude them.

## How

- Extracted the Cleanup-level leaves into a `cleanupLeafDisplays` list (mirroring `systemJunkDisplays`) so both category groups are list-driven.
- Exposed `ScanningTab.toggleableJunkCategories` as a single source of truth (union of the two display lists).
- Added a guard test, `test_scanningTab_offersToggleForEveryJunkCategory`, asserting the tree covers every `SmartScanSettingsStore.junkCategories` entry — so a future scanner category can't ship without a toggle.

## Testing

TDD: the new test failed first (reporting exactly the 4 uncovered categories), then passed after adding the rows. Full `SmartScanSettingsStoreTests` suite green (14/14) via `xcodebuild test ... CODE_SIGNING_ALLOWED=NO`.

## Reviewer notes

- `.webDevJunk` now has both a category checkbox and the existing `WebDevScanFolderPicker` — complementary: the checkbox turns the category on/off, the picker constrains which folders get walked.
- The System Junk sub-group now lists 8 rows; worth a glance that the Preferences window height still fits without unexpected scrolling (couldn't verify UI rendering in this environment).
- Pre-existing, out of scope: the "Broken Preferences" label maps to `.systemCache` whose `displayName` is "System Caches" — a label/semantics mismatch left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Smart Care scanning options to show more junk-cleanup categories, including additional cleanup items and iOS backup cleanup.
  * Updated the category list order and coverage so the available cleanup choices are more complete and consistent.

* **Tests**
  * Added coverage to ensure every junk category has a matching toggle in the scanning view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->