### PR TITLE
Fix Settings cache toggle label and fit the expanded Cleanup tree

### DIFF
--- a/VaderCleaner/PreferencesView.swift
+++ b/VaderCleaner/PreferencesView.swift
@@ -43,11 +43,13 @@ struct PreferencesView: View {
                 .tabItem { Label("Ignore List", systemImage: "nosign") }
                 .tag(SettingsTab.exclusions)
         }
-        // Fixed width so all tabs share the same window size and the window
-        // doesn't jump as the user switches tabs. The width accommodates the
-        // Scanning tab's two-pane Smart Care layout; the form-based tabs simply
-        // have more breathing room.
-        .frame(width: 620, height: 580)
+        // Fixed size so all tabs share the same window and it doesn't jump as
+        // the user switches tabs. The width accommodates the Scanning tab's
+        // two-pane Smart Care layout; the height fits the fully-expanded Cleanup
+        // tree (the System Junk sub-group plus its Cleanup-level leaves and the
+        // Web Development Junk folder picker) without scrolling. The form-based
+        // tabs simply have more breathing room.
+        .frame(width: 620, height: 740)
     }
 }
 
@@ -253,7 +255,7 @@ struct ScanningTab: View {
     /// reference screenshot's set and order. Each title/badge is a display label
     /// over a real `ScanCategory` toggle.
     private static let systemJunkDisplays: [(category: ScanCategory, title: String, badge: String)] = [
-        (.systemCache, "Broken Preferences", "scanBadgeSystemJunk"),
+        (.systemCache, "System Caches", "scanBadgeSystemJunk"),
         (.userLogs, "User Log Files", "scanBadgeLogs"),
         (.systemLogs, "System Log Files", "scanBadgeLogs"),
         (.documentVersions, "Document Versions", "scanBadgeDocumentVersions"),


### PR DESCRIPTION
## What changed

- **Renamed the "Broken Preferences" toggle to "System Caches"** in the Scanning tab (`PreferencesView.swift`). That toggle maps to the `.systemCache` category, whose `displayName` is "System Caches" everywhere else in the app (System Junk preview rows, Smart Scan summary cards). The old label described an unrelated concept while silently controlling system-cache scanning.
- **Raised the shared Settings window height from 580pt to 740pt.** The System Junk sub-group now lists 8 rows, so the fully-expanded Cleanup pane — sub-group + the Cleanup-level leaves (Mail Attachments, iOS Backups, Trash Bins) + the Web Development Junk folder picker — no longer fit at 580pt.

## Why

- The label/behavior mismatch was pre-existing (introduced when the Settings tabs were reworked to match the reference design). Aligning the label to the category's `displayName` removes the confusion of the same category showing two different, unrelated names.
- After exposing all System Junk categories, the densest Cleanup expansion overflowed the fixed window.

## Reviewer notes

- The tree already lives inside a `ScrollView`, so nothing was ever clipped out of reach — the height bump is purely to avoid scrolling in the worst-case expansion.
- **The 740pt value is estimated from row metrics, not a rendered measurement** (UI couldn't be verified in-session). Worth an eyeball on Settings → Scanning → Cleanup to confirm the last row/picker clears the bottom.
- The height is shared across all Settings tabs (single fixed `.frame`), so the simpler Form-based tabs (General, Notifications, Menu) will show more empty space at the bottom. That's the trade for a window that doesn't resize as you switch tabs.
- No tests or `.strings` entries referenced the old "Broken Preferences" string; the guard test asserting the tree covers every scannable junk category is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Increased the Preferences window height so the Cleanup section shows more content without scrolling.
  * Updated the displayed label for one System Junk item from “Broken Preferences” to “System Caches.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->