### PR TITLE
Add dynamic tile recommendation system to section dashboards

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		501740B00BAF4BDC50747510 /* MaintenanceTaskRunnersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F08CF19441CB25F982CDCD2 /* MaintenanceTaskRunnersTests.swift */; };
 		50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */; };
 		516A5B2D445E5E62807A8E2A /* ProtectionDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4C43FBCF5B117B218E3A5F /* ProtectionDashboardSubviews.swift */; };
+		52D10BA2CB08E461B2A87A7D /* SectionRecommendationSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04B389DB9840D533358345D /* SectionRecommendationSelectorTests.swift */; };
 		52E7E444ACD88BC4E77BD2FC /* FileScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB49EDAF88E02A105E9B9FE /* FileScanner.swift */; };
 		531F2D5021B6E412A27E9C73 /* SpaceLensListPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B05E87FC3B6F889CABCCA6 /* SpaceLensListPanel.swift */; };
 		5325F2401AF35C69086E2056 /* NavigationRailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */; };
@@ -150,6 +151,7 @@
 		5F2AB607564A60D0DCBFABEC /* PermissionOnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */; };
 		5FCAAC81ED67F40178636235 /* HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3852658DC221FB8B03631D1 /* HelperProtocol.swift */; };
 		5FE19122629FE05486A04159 /* smartScan.usdz in Resources */ = {isa = PBXBuildFile; fileRef = BBE51C5A592BB78EAB7E3A5D /* smartScan.usdz */; };
+		60575BCA4F77B77577F8B504 /* ReassuranceCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91F61D9C54461DBA18D930E /* ReassuranceCard.swift */; };
 		606F83D96B25967FDEED6E35 /* CleanupManagerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534B9A580343E03496BD5FCD /* CleanupManagerModel.swift */; };
 		62008FB47BE4AAA0214310C4 /* MyClutterFolderPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA622E5E85D2E2FD626F480C /* MyClutterFolderPicker.swift */; };
 		62A51901AE4CA4CE8FB58349 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 46466A1909A880757A7C4B31 /* Localizable.strings */; };
@@ -211,6 +213,7 @@
 		8A20457B5482358F10385DB2 /* LoginItemManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */; };
 		8AB1E73B111F38CE182AD9D3 /* ObservationRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462B37702C713BE1630DC992 /* ObservationRecording.swift */; };
 		8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */; };
+		8B988F3F94B085674B032A7B /* MyClutterTileKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183D94243CDA9FABBF5A22E5 /* MyClutterTileKindTests.swift */; };
 		8C8A94A741DBC80FA3FB4DE2 /* CleanupManagerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8565FBD4555B1398F2752F8 /* CleanupManagerModelTests.swift */; };
 		8C90B9AC0EA622B41E8E9C10 /* SpaceLensSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75EF6CEA94213CDD0564C48 /* SpaceLensSelectionTests.swift */; };
 		8E1380FA2309534993EC3136 /* SparkleUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */; };
@@ -221,6 +224,7 @@
 		95DF391560155E2EB9EE94D0 /* DeviceBatteryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F68C06D676F1E9305250846 /* DeviceBatteryMonitor.swift */; };
 		9686BE4A7CD0C6399070CC1B /* ApplicationsDashboardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC2C4931BAD804306463545 /* ApplicationsDashboardSubviews.swift */; };
 		96D6310BF326A52494BCEB42 /* HungAppMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ECCA0AFF573341EB7FB454 /* HungAppMonitor.swift */; };
+		97C6A7C19CA10485B3FFBB98 /* SectionRecommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9F703D11227A0065BFDEE7 /* SectionRecommendation.swift */; };
 		97F42752FD75E7F3E6CAF219 /* SpaceLensHoverCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58947E04248EE1D262DD27F /* SpaceLensHoverCard.swift */; };
 		98DC9BE36B940D2EB2CEB36D /* DeveloperProjectScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7BE9092B9FDB00D32553FC /* DeveloperProjectScannerTests.swift */; };
 		99B965EE0BB2762D13896FF6 /* EmptyStateFullDiskAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2AA1946F04527938EFF60D /* EmptyStateFullDiskAccessTests.swift */; };
@@ -448,6 +452,7 @@
 		16E73AF8C540E0F2A4BA092D /* SystemJunkDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleter.swift; sourceTree = "<group>"; };
 		175A6E5DE9F8C11D0560DB04 /* MyClutterScanScopeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterScanScopeStoreTests.swift; sourceTree = "<group>"; };
 		17630CA93451A0E1A29ED6A1 /* CleanupGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupGroupTests.swift; sourceTree = "<group>"; };
+		183D94243CDA9FABBF5A22E5 /* MyClutterTileKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterTileKindTests.swift; sourceTree = "<group>"; };
 		193D790F046085F3D309FF8C /* ScanningPreferencesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanningPreferencesUITests.swift; sourceTree = "<group>"; };
 		1A06928276134E79D8ADFBF5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1A3DE098197EC0362C64AEF7 /* CleanupGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupGroup.swift; sourceTree = "<group>"; };
@@ -656,6 +661,7 @@
 		ABEC9B327E4ABAF6A05D6A7D /* DeveloperProjectScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperProjectScanner.swift; sourceTree = "<group>"; };
 		AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCoordinating.swift; sourceTree = "<group>"; };
 		AE43D4A4C7D499E8C2889832 /* HealthMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMonitorView.swift; sourceTree = "<group>"; };
+		AE9F703D11227A0065BFDEE7 /* SectionRecommendation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionRecommendation.swift; sourceTree = "<group>"; };
 		AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunner.swift; sourceTree = "<group>"; };
 		AF6EA6E0EC8BFB813F89FAAE /* WebDevScanScopeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDevScanScopeStoreTests.swift; sourceTree = "<group>"; };
 		B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannedFile.swift; sourceTree = "<group>"; };
@@ -692,6 +698,7 @@
 		C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStoreTests.swift; sourceTree = "<group>"; };
 		C8565FBD4555B1398F2752F8 /* CleanupManagerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupManagerModelTests.swift; sourceTree = "<group>"; };
 		C889492FDFBDFBFC410FF577 /* DuplicateScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateScannerTests.swift; sourceTree = "<group>"; };
+		C91F61D9C54461DBA18D930E /* ReassuranceCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReassuranceCard.swift; sourceTree = "<group>"; };
 		C95F9F1598CDBA6E90EC82B4 /* AppUninstallerViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewSubviews.swift; sourceTree = "<group>"; };
 		CAC2037BDF5D632418393BD9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		CB3763B221D5E92E4B06A824 /* DownloadsScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsScannerTests.swift; sourceTree = "<group>"; };
@@ -707,6 +714,7 @@
 		CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterManagerModelTests.swift; sourceTree = "<group>"; };
 		CFF1BAC0B12BDB540F250299 /* InstallationFileScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScannerTests.swift; sourceTree = "<group>"; };
 		D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingRunOverlay.swift; sourceTree = "<group>"; };
+		D04B389DB9840D533358345D /* SectionRecommendationSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionRecommendationSelectorTests.swift; sourceTree = "<group>"; };
 		D100906EEB9D4F9BF793858C /* ClamAVOutputParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVOutputParser.swift; sourceTree = "<group>"; };
 		D1CC391B523110720320AD89 /* SystemPathProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPathProviding.swift; sourceTree = "<group>"; };
 		D1D5689879C5C19243A7AF1E /* malwareRemoval.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = malwareRemoval.usdz; sourceTree = "<group>"; };
@@ -958,6 +966,7 @@
 				C2D5840FAF0F143B4E943E0F /* ProtectionPrivacyModel.swift */,
 				F0CE1F46BB605C6493C886C4 /* ProtectionSettingsStore.swift */,
 				9D5CB08F96767D10B1271970 /* RAMManager.swift */,
+				C91F61D9C54461DBA18D930E /* ReassuranceCard.swift */,
 				2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */,
 				2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */,
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
@@ -973,6 +982,7 @@
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
 				9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */,
 				2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */,
+				AE9F703D11227A0065BFDEE7 /* SectionRecommendation.swift */,
 				01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */,
 				09D3DDA2AD38124F925AA572 /* SettingsRouter.swift */,
 				331110971EA8F8690773FE88 /* SimilarImageGroup.swift */,
@@ -1162,6 +1172,7 @@
 				CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */,
 				CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */,
 				175A6E5DE9F8C11D0560DB04 /* MyClutterScanScopeStoreTests.swift */,
+				183D94243CDA9FABBF5A22E5 /* MyClutterTileKindTests.swift */,
 				1BED81B0628BEACAB6B965B9 /* MyClutterViewModelTests.swift */,
 				133467A06193C406B027D97C /* NavigationSectionTests.swift */,
 				C2F2C63241236DBFD9176410 /* NotificationManagerTests.swift */,
@@ -1189,6 +1200,7 @@
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
 				6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
+				D04B389DB9840D533358345D /* SectionRecommendationSelectorTests.swift */,
 				9815EB34FC1894653528A9E0 /* SectionThemeTests.swift */,
 				A457B6C8523278A91D85120D /* SimilarImageScannerTests.swift */,
 				74FE0A87F7A4FBC3866E5DB3 /* SmartCareReminderSchedulerTests.swift */,
@@ -1495,6 +1507,7 @@
 				C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */,
 				688FEF65720EAF3D51754EC6 /* MyClutterManagerModelTests.swift in Sources */,
 				BDAF9DD5414C50F4546C239B /* MyClutterScanScopeStoreTests.swift in Sources */,
+				8B988F3F94B085674B032A7B /* MyClutterTileKindTests.swift in Sources */,
 				AD3DF5C0E560EB93A7D89410 /* MyClutterViewModelTests.swift in Sources */,
 				BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */,
 				2A46AEBD95B9E1561264D0F0 /* NotificationManagerTests.swift in Sources */,
@@ -1522,6 +1535,7 @@
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
+				52D10BA2CB08E461B2A87A7D /* SectionRecommendationSelectorTests.swift in Sources */,
 				2D8DAC3191BC1733AE762C03 /* SectionThemeTests.swift in Sources */,
 				54C07EBB0CD76D45308A2E9E /* SimilarImageScannerTests.swift in Sources */,
 				771932E96231B65B69F5FC9E /* SmartCareReminderSchedulerTests.swift in Sources */,
@@ -1714,6 +1728,7 @@
 				4368849EA97B0EC0AF5C63E0 /* ProtectionPrivacyModel.swift in Sources */,
 				BF18064F6E3DD9B598B15D00 /* ProtectionSettingsStore.swift in Sources */,
 				7E8BF51A566655FA6DCFCB0B /* RAMManager.swift in Sources */,
+				60575BCA4F77B77577F8B504 /* ReassuranceCard.swift in Sources */,
 				567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */,
 				56E0A50749CEFC070968439D /* SMCReader.swift in Sources */,
 				45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */,
@@ -1730,6 +1745,7 @@
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				9D44F12D7502363B814F2DF9 /* SectionIntroView.swift in Sources */,
 				89A63858E545AE129CCB7EA0 /* SectionPresentation.swift in Sources */,
+				97C6A7C19CA10485B3FFBB98 /* SectionRecommendation.swift in Sources */,
 				C75E96295ED70F91F6B2A0F1 /* SectionTheme.swift in Sources */,
 				067E5321D0D1EC27BCB91421 /* SettingsRouter.swift in Sources */,
 				AFE3EC8473F0D6BC1141FD07 /* SimilarImageGroup.swift in Sources */,

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct ApplicationsDashboardView: View {
     let result: ApplicationsScanResult
     var iconCache: AppIconCache
+    /// Section accent, used to tint any reassurance backfill cards.
+    let accent: Color
     let onOpenManage: () -> Void
     let onOpenInstallationFiles: () -> Void
     let onOpenUnsupported: () -> Void
@@ -28,16 +30,10 @@ struct ApplicationsDashboardView: View {
     var body: some View {
         VStack(spacing: 18) {
             header
-            Group {
-                if result.recommendations.isEmpty {
-                    allClear
-                } else {
-                    cardLayout
-                }
-            }
             // The grid stays flexible (it absorbs any height squeeze) so the
             // hero keeps its standard size instead of being compressed.
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            cardLayout
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("applications.dashboard")
@@ -141,30 +137,29 @@ struct ApplicationsDashboardView: View {
         }
     }
 
-    /// One card per cleanup recommendation that has findings, in display order.
-    private var recommendationSpecs: [CardSpec] {
-        result.recommendations.map(spec(for:))
+    /// The ranked 2–4 cards this scan warrants, most actionable first.
+    private var tiles: [ApplicationsDashboardTile] {
+        result.recommendedTiles()
     }
 
-    /// The reference layout: the lead recommendation is a tall card on the left,
-    /// and the remaining findings sit in a right-hand column packed into rows of
-    /// two (an odd count leads with a single full-width row), mirroring the My
-    /// Clutter dashboard. Capping the right column at rows of two keeps the grid
-    /// bounded so it fills the pane without overflowing, however many findings
-    /// there are. With a single finding the card fills the whole pane.
+    /// The reference layout: the lead card is a tall card on the left, and the
+    /// remaining cards sit in a right-hand column packed into rows of two (an odd
+    /// count leads with a single full-width row), mirroring the My Clutter
+    /// dashboard. Capping the right column at rows of two keeps the grid bounded
+    /// so it fills the pane without overflowing, however many cards there are.
     @ViewBuilder
     private var cardLayout: some View {
-        let specs = recommendationSpecs
-        if specs.count <= 1 {
-            if let only = specs.first {
+        let tiles = self.tiles
+        if tiles.count <= 1 {
+            if let only = tiles.first {
                 card(only).frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         } else {
             GlassEffectContainer(spacing: 16) {
                 HStack(alignment: .top, spacing: 16) {
-                    card(specs[0])
+                    card(tiles[0])
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    rightColumn(Array(specs.dropFirst()))
+                    rightColumn(Array(tiles.dropFirst()))
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
@@ -172,14 +167,14 @@ struct ApplicationsDashboardView: View {
         }
     }
 
-    /// The right-hand findings, packed into rows of at most two so the column
-    /// never grows taller than the pane.
-    private func rightColumn(_ specs: [CardSpec]) -> some View {
+    /// The right-hand cards, packed into rows of at most two so the column never
+    /// grows taller than the pane.
+    private func rightColumn(_ tiles: [ApplicationsDashboardTile]) -> some View {
         VStack(spacing: 16) {
-            ForEach(rows(of: specs)) { row in
+            ForEach(rows(of: tiles)) { row in
                 HStack(spacing: 16) {
-                    ForEach(row.specs) { spec in
-                        card(spec).frame(maxWidth: .infinity, maxHeight: .infinity)
+                    ForEach(row.tiles) { tile in
+                        card(tile).frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -190,64 +185,46 @@ struct ApplicationsDashboardView: View {
     /// One row of right-column cards.
     private struct CardRow: Identifiable {
         let id: Int
-        let specs: [CardSpec]
+        let tiles: [ApplicationsDashboardTile]
     }
 
-    /// Chunks the right-column specs into rows of two. An odd count leads with a
+    /// Chunks the right-column cards into rows of two. An odd count leads with a
     /// single full-width row (matching My Clutter's "one then a pair" shape).
-    private func rows(of specs: [CardSpec]) -> [CardRow] {
+    private func rows(of tiles: [ApplicationsDashboardTile]) -> [CardRow] {
         var rows: [CardRow] = []
-        var remaining = specs
+        var remaining = tiles
         if remaining.count % 2 == 1 {
-            rows.append(CardRow(id: 0, specs: [remaining.removeFirst()]))
+            rows.append(CardRow(id: 0, tiles: [remaining.removeFirst()]))
         }
         while !remaining.isEmpty {
             let chunk = Array(remaining.prefix(2))
             remaining.removeFirst(chunk.count)
-            rows.append(CardRow(id: rows.count, specs: chunk))
+            rows.append(CardRow(id: rows.count, tiles: chunk))
         }
         return rows
     }
 
-    private func card(_ spec: CardSpec) -> some View {
-        ApplicationsDashboardCard(
-            title: spec.title,
-            detail: spec.detail,
-            icon: spec.icon,
-            primaryLabel: spec.primaryLabel,
-            primaryAction: spec.primaryAction,
-            secondaryLabel: spec.secondaryLabel,
-            secondaryAction: spec.secondaryAction,
-            identifier: spec.id,
-            iconCache: iconCache
-        )
-    }
-
-    /// Shown when no cleanup category has findings — the curated grid would
-    /// otherwise be empty. The header (count + Manage / Rescan) stays above.
-    /// Mirrors the Performance dashboard's empty state.
-    private var allClear: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "checkmark.seal.fill")
-                .font(.system(size: 48))
-                .foregroundStyle(.tint)
-            Text(String(
-                localized: "No cleanup needed right now",
-                comment: "Applications dashboard all-clear title when no cleanup recommendations remain."
-            ))
-            .font(.title3.weight(.semibold))
-            Text(String(
-                localized: "No unused or unsupported apps, available updates, leftovers, or installer files to review. Open Manage My Applications to browse everything you have installed.",
-                comment: "Applications dashboard all-clear detail shown when no recommendation category has findings."
-            ))
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: 460)
+    /// Renders one ranked tile with its recommendation card, or a reassurance
+    /// backfill.
+    @ViewBuilder
+    private func card(_ tile: ApplicationsDashboardTile) -> some View {
+        switch tile {
+        case .recommendation(let recommendation):
+            let spec = spec(for: recommendation)
+            ApplicationsDashboardCard(
+                title: spec.title,
+                detail: spec.detail,
+                icon: spec.icon,
+                primaryLabel: spec.primaryLabel,
+                primaryAction: spec.primaryAction,
+                secondaryLabel: spec.secondaryLabel,
+                secondaryAction: spec.secondaryAction,
+                identifier: spec.id,
+                iconCache: iconCache
+            )
+        case .reassurance(let content):
+            ReassuranceCard(content: content, accent: accent)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.top, 24)
-        .accessibilityIdentifier("applications.dashboard.allClear")
     }
 
     // MARK: Copy

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -91,6 +91,7 @@ struct ApplicationsView: View {
             ApplicationsDashboardView(
                 result: result,
                 iconCache: iconCache,
+                accent: NavigationSection.applications.theme.accent,
                 onOpenManage: { detail = .manage(.uninstaller) },
                 onOpenInstallationFiles: { detail = .installationFiles },
                 onOpenUnsupported: { detail = .unsupported },

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -60,7 +60,7 @@ struct ApplicationsScanResult: Equatable {
     /// The categories that currently have findings, ranked by severity (the
     /// `Recommendation` declaration order). The full installed-app list is
     /// deliberately excluded — it lives under "Manage My Applications", not as a
-    /// cleanup card. An empty result drives the dashboard's "all clear" state.
+    /// cleanup card.
     var recommendations: [Recommendation] {
         Recommendation.allCases.filter { recommendation in
             switch recommendation {
@@ -70,6 +70,82 @@ struct ApplicationsScanResult: Equatable {
             case .leftovers:         return leftoversCount > 0
             case .installationFiles: return installationFilesCount > 0
             }
+        }
+    }
+
+    /// Reclaimable size for a recommendation, used to rank the space-based
+    /// findings; `0` for the count-based ones (apps that need review rather than
+    /// bytes to free).
+    private func reclaimableBytes(for recommendation: Recommendation) -> Int64 {
+        switch recommendation {
+        case .leftovers:         return leftoversTotalBytes
+        case .installationFiles: return installationFilesTotalBytes
+        case .unsupported, .unused, .updates: return 0
+        }
+    }
+
+    /// The ranked 2–4 cards the dashboard shows: findings that need review lead,
+    /// then the space-based findings by how much they free (capped at four),
+    /// backfilled with reassurance cards when a scan finds fewer than two.
+    func recommendedTiles() -> [ApplicationsDashboardTile] {
+        let real = recommendations.map { recommendation in
+            RankedTile(payload: ApplicationsDashboardTile.recommendation(recommendation),
+                       urgency: recommendation.urgency,
+                       reclaimableBytes: reclaimableBytes(for: recommendation))
+        }
+        let reassurance = ApplicationsDashboardTile.reassurancePool.map { content in
+            RankedTile(payload: ApplicationsDashboardTile.reassurance(content),
+                       urgency: .reassurance,
+                       reclaimableBytes: 0)
+        }
+        return SectionRecommendationSelector.select(real: real, reassurance: reassurance)
+    }
+}
+
+/// One card on the Applications dashboard: a cleanup recommendation, or an "all
+/// good" reassurance card used to backfill the grid to its minimum count.
+enum ApplicationsDashboardTile: Identifiable {
+    case recommendation(ApplicationsScanResult.Recommendation)
+    case reassurance(ReassuranceContent)
+
+    var id: String {
+        switch self {
+        case .recommendation(let recommendation): return "recommendation.\(recommendation)"
+        case .reassurance(let content):           return "reassurance.\(content.id)"
+        }
+    }
+
+    /// Ordered pool of "all good" cards, drawn from in order when a scan finds
+    /// fewer than two cleanup categories so backfilling never repeats a card.
+    static let reassurancePool: [ReassuranceContent] = [
+        ReassuranceContent(
+            id: "applications.allClear",
+            title: String(localized: "Apps Look Healthy", comment: "Applications reassurance card title."),
+            detail: String(
+                localized: "No unused or unsupported apps, updates, leftovers, or installer files to review.",
+                comment: "Applications reassurance card detail."
+            ),
+            icon: "checkmark.seal"
+        ),
+        ReassuranceContent(
+            id: "applications.manage",
+            title: String(localized: "Manage Anytime", comment: "Applications reassurance card title."),
+            detail: String(
+                localized: "Open Manage My Applications to browse everything you have installed.",
+                comment: "Applications reassurance card detail."
+            ),
+            icon: "square.grid.2x2"
+        ),
+    ]
+}
+
+extension ApplicationsScanResult.Recommendation {
+    /// How strongly this finding demands attention. Apps that need review lead
+    /// the space-based cruft, matching the section's severity ordering.
+    var urgency: RecommendationUrgency {
+        switch self {
+        case .unsupported, .unused, .updates: return .attention
+        case .leftovers, .installationFiles:  return .space
         }
     }
 }

--- a/VaderCleaner/MyClutterDashboardView.swift
+++ b/VaderCleaner/MyClutterDashboardView.swift
@@ -5,6 +5,75 @@ import SwiftUI
 import QuickLookThumbnailing
 import AppKit
 
+/// One card on the My Clutter dashboard: a clutter category with findings, or
+/// an "all good" reassurance card used to backfill the grid to its minimum
+/// count when a scan finds fewer than two categories.
+enum MyClutterTileKind: Identifiable, Equatable {
+    case duplicates
+    case similar
+    case largeOld
+    case downloads
+    case reassurance(ReassuranceContent)
+
+    var id: String {
+        switch self {
+        case .duplicates:               return "duplicates"
+        case .similar:                  return "similar"
+        case .largeOld:                 return "largeOld"
+        case .downloads:                return "downloads"
+        case .reassurance(let content): return "reassurance.\(content.id)"
+        }
+    }
+
+    /// The ranked 2–4 cards the dashboard shows: the categories that actually
+    /// found files, largest reclaimable size first (capped at four), backfilled
+    /// with reassurance cards when a scan finds fewer than two categories. Each
+    /// category is passed as a `(count, bytes)` pair so an empty category is
+    /// dropped even if its byte total rounds to zero.
+    static func recommended(duplicates: (count: Int, bytes: Int64),
+                            similar: (count: Int, bytes: Int64),
+                            largeOld: (count: Int, bytes: Int64),
+                            downloads: (count: Int, bytes: Int64)) -> [MyClutterTileKind] {
+        var candidates: [RankedTile<MyClutterTileKind>] = []
+        func add(_ kind: MyClutterTileKind, _ category: (count: Int, bytes: Int64)) {
+            guard category.count > 0 else { return }
+            candidates.append(RankedTile(payload: kind, urgency: .space, reclaimableBytes: category.bytes))
+        }
+        add(.duplicates, duplicates)
+        add(.similar, similar)
+        add(.largeOld, largeOld)
+        add(.downloads, downloads)
+
+        let reassurance = reassurancePool.map { content in
+            RankedTile(payload: MyClutterTileKind.reassurance(content), urgency: .reassurance, reclaimableBytes: 0)
+        }
+        return SectionRecommendationSelector.select(real: candidates, reassurance: reassurance)
+    }
+
+    /// Ordered pool of "all good" cards, drawn from in order when a scan finds
+    /// fewer than two categories so backfilling never repeats a card.
+    static let reassurancePool: [ReassuranceContent] = [
+        ReassuranceContent(
+            id: "myClutter.organized",
+            title: String(localized: "Nicely Organized", comment: "My Clutter reassurance card title."),
+            detail: String(
+                localized: "No duplicates, look-alikes, or space hogs stood out in this scan.",
+                comment: "My Clutter reassurance card detail."
+            ),
+            icon: "checkmark.seal"
+        ),
+        ReassuranceContent(
+            id: "myClutter.reviewAll",
+            title: String(localized: "Browse Everything", comment: "My Clutter reassurance card title."),
+            detail: String(
+                localized: "Use Review All Files to look through your files whenever you like.",
+                comment: "My Clutter reassurance card detail."
+            ),
+            icon: "folder"
+        ),
+    ]
+}
+
 /// The My Clutter results dashboard. A "Start Over" bar, a centered header
 /// counting the files to sort through with a "Review All Files" button, then the
 /// four recommendation cards laid out as a tall Duplicates card on the left and
@@ -107,22 +176,82 @@ struct MyClutterDashboardView: View {
 
     // MARK: - Grid
 
+    /// Fixed width of the hero column so the lead card keeps a stable shape while
+    /// the remaining cards absorb the rest of the width — mirrors the Cleanup
+    /// dashboard so the two sections share one look.
+    private let heroColumnWidth: CGFloat = 340
+
+    /// The ranked 2–4 cards this scan warrants, largest reclaimable size first.
+    private var recommendedTiles: [MyClutterTileKind] {
+        MyClutterTileKind.recommended(
+            duplicates: (viewModel.duplicateCopies.count, viewModel.duplicateReclaimableBytes),
+            similar: (viewModel.similarCopies.count, viewModel.similarReclaimableBytes),
+            largeOld: (viewModel.largeOldFiles.count, viewModel.largeOldBytes),
+            downloads: (viewModel.downloads.count, viewModel.downloadsBytes)
+        )
+    }
+
+    /// The bento grid: the top-ranked card leads on the left, the rest fill the
+    /// right column (a wide card on top, the remainder in rows of two). Lower
+    /// card counts degrade gracefully so the pane never shows a lone card beside
+    /// empty space.
+    @ViewBuilder
     private var grid: some View {
-        HStack(alignment: .top, spacing: 16) {
-            duplicatesCard
+        let tiles = recommendedTiles
+        switch tiles.count {
+        case 0:
+            EmptyView()
+        case 1:
+            card(tiles[0])
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            VStack(spacing: 16) {
-                similarCard
+        default:
+            HStack(alignment: .top, spacing: 16) {
+                card(tiles[0])
+                    .frame(width: heroColumnWidth)
+                    .frame(maxHeight: .infinity)
+                rightColumn(Array(tiles.dropFirst()))
+            }
+        }
+    }
+
+    /// The non-hero cards: the first is a wide card spanning the column, the rest
+    /// flow in rows of two beneath it.
+    private func rightColumn(_ rest: [MyClutterTileKind]) -> some View {
+        VStack(spacing: 16) {
+            if let wide = rest.first {
+                card(wide)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            ForEach(Array(rows(of: Array(rest.dropFirst())).enumerated()), id: \.offset) { _, row in
                 HStack(spacing: 16) {
-                    largeOldCard
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    downloadsCard
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    ForEach(row) { tile in
+                        card(tile)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
                 .frame(maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Chunks the remaining cards into rows of at most two so the lower grid
+    /// reads as a balanced two-up arrangement.
+    private func rows(of tiles: [MyClutterTileKind]) -> [[MyClutterTileKind]] {
+        stride(from: 0, to: tiles.count, by: 2).map {
+            Array(tiles[$0..<min($0 + 2, tiles.count)])
+        }
+    }
+
+    /// Renders one ranked tile with its category card, or a reassurance backfill.
+    @ViewBuilder
+    private func card(_ kind: MyClutterTileKind) -> some View {
+        switch kind {
+        case .duplicates:               duplicatesCard
+        case .similar:                  similarCard
+        case .largeOld:                 largeOldCard
+        case .downloads:                downloadsCard
+        case .reassurance(let content): ReassuranceCard(content: content, accent: accent)
         }
     }
 

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -16,9 +16,53 @@ struct PerformanceDashboardView: View {
     /// Login Items summary card.
     let loginItemBundleIDs: [String]
     let backgroundItemCount: Int
+    /// Number of due maintenance-cocktail tasks — drives the Maintenance card.
+    let maintenanceTasksDue: Int
+    /// Section accent, used to tint any reassurance backfill cards.
+    let accent: Color
     let onViewAllTasks: () -> Void
     let onReviewLoginItems: () -> Void
     let onReviewBackgroundItems: () -> Void
+    let onReviewMaintenance: () -> Void
+
+    /// One card on the Performance dashboard: a summary of a category with
+    /// findings, or an "all good" reassurance card used to backfill the row to
+    /// its minimum count.
+    private enum Tile: Identifiable {
+        case loginItems
+        case backgroundItems
+        case maintenance
+        case reassurance(ReassuranceContent)
+
+        var id: String {
+            switch self {
+            case .loginItems:               return "loginItems"
+            case .backgroundItems:          return "backgroundItems"
+            case .maintenance:              return "maintenance"
+            case .reassurance(let content): return "reassurance.\(content.id)"
+            }
+        }
+    }
+
+    /// The ranked 2–4 summary cards this state warrants: only the categories
+    /// with findings appear, backfilled with reassurance cards when fewer than
+    /// two have anything to review.
+    private var tiles: [Tile] {
+        var real: [RankedTile<Tile>] = []
+        if loginItemCount > 0 {
+            real.append(RankedTile(payload: .loginItems, urgency: .attention, reclaimableBytes: 0))
+        }
+        if backgroundItemCount > 0 {
+            real.append(RankedTile(payload: .backgroundItems, urgency: .attention, reclaimableBytes: 0))
+        }
+        if maintenanceTasksDue > 0 {
+            real.append(RankedTile(payload: .maintenance, urgency: .attention, reclaimableBytes: 0))
+        }
+        let reassurance = Self.reassurancePool.map { content in
+            RankedTile(payload: Tile.reassurance(content), urgency: .reassurance, reclaimableBytes: 0)
+        }
+        return SectionRecommendationSelector.select(real: real, reassurance: reassurance)
+    }
 
     var body: some View {
         VStack(spacing: 24) {
@@ -61,35 +105,83 @@ struct PerformanceDashboardView: View {
         }
     }
 
-    /// The two summary cards along the bottom, refracting together in one glass
-    /// container so they read as a pair.
+    /// The ranked summary cards along the bottom, refracting together in one
+    /// glass container so they read as a set.
     private var summaryCards: some View {
         GlassEffectContainer(spacing: 16) {
             HStack(spacing: 16) {
-                PerformanceSummaryCard(
-                    title: loginItemsTitle,
-                    description: String(
-                        localized: "Review the list of applications that open automatically when you start up your Mac. You may want to disable some of them.",
-                        comment: "Login Items summary card description."
-                    ),
-                    accessory: .appIcons(loginItemBundleIDs),
-                    reviewIdentifier: "performance.reviewLoginItems",
-                    onReview: onReviewLoginItems
-                )
-                PerformanceSummaryCard(
-                    title: backgroundItemsTitle,
-                    description: String(
-                        localized: "Review the processes and apps that run in the background. You may not need or want part of them.",
-                        comment: "Background Items summary card description."
-                    ),
-                    accessory: .badge(symbol: "gearshape.2.fill", tint: Color(red: 0.96, green: 0.55, blue: 0.30)),
-                    reviewIdentifier: "performance.reviewBackgroundItems",
-                    onReview: onReviewBackgroundItems
-                )
+                ForEach(tiles) { tile in
+                    card(tile)
+                }
             }
         }
         .frame(height: 200)
     }
+
+    /// Renders one ranked summary card, or a reassurance backfill.
+    @ViewBuilder
+    private func card(_ tile: Tile) -> some View {
+        switch tile {
+        case .loginItems:
+            PerformanceSummaryCard(
+                title: loginItemsTitle,
+                description: String(
+                    localized: "Review the list of applications that open automatically when you start up your Mac. You may want to disable some of them.",
+                    comment: "Login Items summary card description."
+                ),
+                accessory: .appIcons(loginItemBundleIDs),
+                reviewIdentifier: "performance.reviewLoginItems",
+                onReview: onReviewLoginItems
+            )
+        case .backgroundItems:
+            PerformanceSummaryCard(
+                title: backgroundItemsTitle,
+                description: String(
+                    localized: "Review the processes and apps that run in the background. You may not need or want part of them.",
+                    comment: "Background Items summary card description."
+                ),
+                accessory: .badge(symbol: "gearshape.2.fill", tint: Color(red: 0.96, green: 0.55, blue: 0.30)),
+                reviewIdentifier: "performance.reviewBackgroundItems",
+                onReview: onReviewBackgroundItems
+            )
+        case .maintenance:
+            PerformanceSummaryCard(
+                title: maintenanceTitle,
+                description: String(
+                    localized: "Run the due maintenance tasks to keep your Mac in shape — rebuilding caches and tidying system housekeeping.",
+                    comment: "Maintenance summary card description."
+                ),
+                accessory: .badge(symbol: "wrench.and.screwdriver.fill", tint: accent),
+                reviewIdentifier: "performance.reviewMaintenance",
+                onReview: onReviewMaintenance
+            )
+        case .reassurance(let content):
+            ReassuranceCard(content: content, accent: accent)
+        }
+    }
+
+    /// Ordered pool of "all good" cards, drawn from in order when fewer than two
+    /// categories have anything to review so backfilling never repeats a card.
+    private static let reassurancePool: [ReassuranceContent] = [
+        ReassuranceContent(
+            id: "performance.tuned",
+            title: String(localized: "Running Smoothly", comment: "Performance reassurance card title."),
+            detail: String(
+                localized: "No login items, background items, or maintenance tasks need your attention.",
+                comment: "Performance reassurance card detail."
+            ),
+            icon: "gauge.with.needle"
+        ),
+        ReassuranceContent(
+            id: "performance.allTasks",
+            title: String(localized: "Fine-Tune Anytime", comment: "Performance reassurance card title."),
+            detail: String(
+                localized: "Open View All Tasks to run maintenance or review startup items whenever you like.",
+                comment: "Performance reassurance card detail."
+            ),
+            icon: "slider.horizontal.3"
+        ),
+    ]
 
     private var loginItemsTitle: String {
         String.localizedStringWithFormat(
@@ -102,6 +194,13 @@ struct PerformanceDashboardView: View {
         String.localizedStringWithFormat(
             String(localized: "%lld Background Items Found", comment: "Background Items summary card title; %lld is the count."),
             backgroundItemCount
+        )
+    }
+
+    private var maintenanceTitle: String {
+        String.localizedStringWithFormat(
+            String(localized: "%lld Maintenance Tasks Recommended", comment: "Maintenance summary card title; %lld is the count."),
+            maintenanceTasksDue
         )
     }
 }

--- a/VaderCleaner/PerformanceView.swift
+++ b/VaderCleaner/PerformanceView.swift
@@ -120,6 +120,8 @@ struct PerformanceView: View {
                 loginItemCount: viewModel.loginItems.count,
                 loginItemBundleIDs: viewModel.loginItems.map(\.id),
                 backgroundItemCount: viewModel.userAgents.count + viewModel.systemAgents.count,
+                maintenanceTasksDue: viewModel.maintenanceTasksDue,
+                accent: NavigationSection.performance.theme.accent,
                 onViewAllTasks: {
                     catalogPane = .maintenanceTasks
                     showAllTasks = true
@@ -130,6 +132,10 @@ struct PerformanceView: View {
                 },
                 onReviewBackgroundItems: {
                     catalogPane = .backgroundItems
+                    showAllTasks = true
+                },
+                onReviewMaintenance: {
+                    catalogPane = .maintenanceTasks
                     showAllTasks = true
                 }
             )

--- a/VaderCleaner/PerformanceViewModel.swift
+++ b/VaderCleaner/PerformanceViewModel.swift
@@ -319,6 +319,13 @@ final class PerformanceViewModel {
         }
     }
 
+    /// Number of maintenance-cocktail tasks currently due — the count behind the
+    /// dashboard's Maintenance card, scoped to the same tasks `runDueMaintenance()`
+    /// runs so the card and the action always agree.
+    var maintenanceTasksDue: Int {
+        runLog.staleTaskCount(among: availableCocktailIDs)
+    }
+
     /// Runs every due maintenance-cocktail task (the action behind the
     /// "Maintenance Tasks Recommended" card), so the card's count and its "Run
     /// Tasks" action cover the same set.

--- a/VaderCleaner/ProtectionDashboardView.swift
+++ b/VaderCleaner/ProtectionDashboardView.swift
@@ -237,23 +237,84 @@ struct ProtectionDashboardView: View {
     /// rows divide the height evenly and the two columns stay aligned, exactly
     /// like `ApplicationsDashboardView.cardLayout`. With no privacy findings the
     /// malware tile fills the whole pane.
+    /// The ranked 2–4 tiles the dashboard shows: the live malware scan always
+    /// leads (safety first — `.critical` once threats are found), then the
+    /// privacy findings by reclaimable size (capped so the grid never exceeds
+    /// four), backfilled with a reassurance card when privacy is clean.
+    private var selectedTiles: [ProtectionDashboardTile] {
+        let malwareHasThreats: Bool
+        if case .results(let threats) = malware.phase { malwareHasThreats = !threats.isEmpty }
+        else { malwareHasThreats = false }
+
+        var real: [RankedTile<ProtectionDashboardTile>] = [
+            RankedTile(payload: .malware,
+                       urgency: malwareHasThreats ? .critical : .attention,
+                       reclaimableBytes: 0)
+        ]
+        real.append(contentsOf: privacyTiles.map { tile in
+            RankedTile(payload: .privacy(tile), urgency: .space, reclaimableBytes: tile.bytes)
+        })
+        let reassurance = Self.reassurancePool.map { content in
+            RankedTile(payload: ProtectionDashboardTile.reassurance(content),
+                       urgency: .reassurance, reclaimableBytes: 0)
+        }
+        return SectionRecommendationSelector.select(real: real, reassurance: reassurance)
+    }
+
     @ViewBuilder
     private var grid: some View {
-        if privacyTiles.isEmpty {
-            malwareTile
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        let tiles = selectedTiles
+        if tiles.count <= 1 {
+            if let only = tiles.first {
+                tileView(only)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         } else {
             GlassEffectContainer(spacing: 16) {
                 HStack(alignment: .top, spacing: 16) {
-                    malwareTile
+                    tileView(tiles[0])
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    rightColumn
+                    rightColumn(Array(tiles.dropFirst()))
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
+
+    /// Renders one selected tile: the live malware scan, a privacy finding, or a
+    /// reassurance backfill.
+    @ViewBuilder
+    private func tileView(_ tile: ProtectionDashboardTile) -> some View {
+        switch tile {
+        case .malware:                  malwareTile
+        case .privacy(let privacyTile): privacyCard(privacyTile)
+        case .reassurance(let content): ReassuranceCard(content: content, accent: accent)
+        }
+    }
+
+    /// Ordered pool of "all good" cards, drawn from in order to backfill the grid
+    /// to its minimum count when a scan finds no privacy items to clear.
+    private static let reassurancePool: [ReassuranceContent] = [
+        ReassuranceContent(
+            id: "protection.privacyClean",
+            title: String(localized: "Privacy Is Clear", comment: "Protection reassurance card title."),
+            detail: String(
+                localized: "No browsing data or recent-item traces stood out to clean up.",
+                comment: "Protection reassurance card detail."
+            ),
+            icon: "hand.raised"
+        ),
+        ReassuranceContent(
+            id: "protection.protected",
+            title: String(localized: "You're Protected", comment: "Protection reassurance card title."),
+            detail: String(
+                localized: "Re-scan any time to keep checking for threats and privacy traces.",
+                comment: "Protection reassurance card detail."
+            ),
+            icon: "shield.lefthalf.filled"
+        ),
+    ]
 
     private var malwareTile: some View {
         ProtectionMalwareTile(
@@ -266,14 +327,14 @@ struct ProtectionDashboardView: View {
         )
     }
 
-    /// The privacy findings, packed into rows of at most two so the column never
+    /// The non-hero cards, packed into rows of at most two so the column never
     /// grows taller than the pane — exactly the Applications dashboard shape.
-    private var rightColumn: some View {
+    private func rightColumn(_ tiles: [ProtectionDashboardTile]) -> some View {
         VStack(spacing: 16) {
-            ForEach(privacyRows) { row in
+            ForEach(rows(of: tiles)) { row in
                 HStack(spacing: 16) {
                     ForEach(row.tiles) { tile in
-                        privacyCard(tile)
+                        tileView(tile)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                 }
@@ -295,28 +356,45 @@ struct ProtectionDashboardView: View {
     }
 
     /// One row of right-column cards.
-    private struct PrivacyRow: Identifiable {
+    private struct TileRow: Identifiable {
         let id: Int
-        let tiles: [PrivacyTile]
+        let tiles: [ProtectionDashboardTile]
     }
 
-    /// Chunks the privacy tiles into rows of two. An odd count leads with a
+    /// Chunks the right-column tiles into rows of two. An odd count leads with a
     /// single full-width row (matching the Applications / My Clutter shape).
-    private var privacyRows: [PrivacyRow] {
-        var rows: [PrivacyRow] = []
-        var remaining = privacyTiles
+    private func rows(of tiles: [ProtectionDashboardTile]) -> [TileRow] {
+        var rows: [TileRow] = []
+        var remaining = tiles
         if remaining.count % 2 == 1 {
-            rows.append(PrivacyRow(id: 0, tiles: [remaining.removeFirst()]))
+            rows.append(TileRow(id: 0, tiles: [remaining.removeFirst()]))
         }
         while !remaining.isEmpty {
             let chunk = Array(remaining.prefix(2))
             remaining.removeFirst(chunk.count)
-            rows.append(PrivacyRow(id: rows.count, tiles: chunk))
+            rows.append(TileRow(id: rows.count, tiles: chunk))
         }
         return rows
     }
 
     // MARK: - Privacy tiles model
+
+    /// One card on the Protection dashboard: the live malware scan, a privacy
+    /// finding, or an "all good" reassurance card used to backfill the grid to
+    /// its minimum count.
+    private enum ProtectionDashboardTile: Identifiable {
+        case malware
+        case privacy(PrivacyTile)
+        case reassurance(ReassuranceContent)
+
+        var id: String {
+            switch self {
+            case .malware:                  return "malware"
+            case .privacy(let tile):        return "privacy.\(tile.id)"
+            case .reassurance(let content): return "reassurance.\(content.id)"
+            }
+        }
+    }
 
     /// One privacy tile derived from the privacy preview. Browser tiles carry a
     /// size metric; the recent-items tile is a single fixed entry.
@@ -327,6 +405,9 @@ struct ProtectionDashboardView: View {
         let caption: String
         let systemImage: String
         let removal: PrivacyRemoval
+        /// Reclaimable size in bytes used to rank the tiles; `0` for the
+        /// recent-items tile, which carries no size metric.
+        let bytes: Int64
     }
 
     /// Tiles to render: one per detected browser with data, plus Recent Items —
@@ -349,7 +430,8 @@ struct ProtectionDashboardView: View {
                 caption: String(localized: "Remove your browser data to free up space and improve your privacy.",
                                 comment: "Protection browser-data tile caption."),
                 systemImage: "globe",
-                removal: .browser(browser)
+                removal: .browser(browser),
+                bytes: size
             ))
         }
         if !removedPrivacyTiles.contains("recents") {
@@ -361,7 +443,8 @@ struct ProtectionDashboardView: View {
                 caption: String(localized: "Remove the traces of your recent activities by cleaning up these lists.",
                                 comment: "Protection recent-items tile caption."),
                 systemImage: "list.bullet.rectangle",
-                removal: .recents
+                removal: .recents,
+                bytes: 0
             ))
         }
         return tiles

--- a/VaderCleaner/ReassuranceCard.swift
+++ b/VaderCleaner/ReassuranceCard.swift
@@ -1,0 +1,38 @@
+// ReassuranceCard.swift
+// The shared "all good" dashboard tile used to backfill a section's grid to its minimum count when there aren't enough real findings to fill it.
+
+import SwiftUI
+
+/// A calm, positive dashboard card shown when a section has fewer real findings
+/// than the minimum tile count. Shares the glass surface and corner radius of
+/// the app's other dashboard cards so a backfilled grid reads as one set.
+struct ReassuranceCard: View {
+    let content: ReassuranceContent
+    let accent: Color
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: content.icon)
+                .font(.system(size: 44, weight: .regular))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(accent)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 4) {
+                Text(content.title)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Text(content.detail)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("recommendation.reassurance.\(content.id)")
+    }
+}

--- a/VaderCleaner/SectionRecommendation.swift
+++ b/VaderCleaner/SectionRecommendation.swift
@@ -1,0 +1,100 @@
+// SectionRecommendation.swift
+// Shared, deterministic ranking core that turns each section's candidate tiles into the 2–4 recommendations its dashboard shows, ordered so the most important finding leads.
+
+import Foundation
+
+/// How strongly a candidate tile demands attention, independent of size. Ranked
+/// above reclaimable space so a safety or urgent finding always leads, matching
+/// how an ordinary person reads a cleaner dashboard: fix the scary thing first,
+/// then reclaim the most space.
+enum RecommendationUrgency: Int, Comparable {
+    /// "All good" filler, only used to reach the minimum tile count.
+    case reassurance
+    /// An ordinary reclaimable-space finding, ranked by how much it frees.
+    case space
+    /// Needs review but isn't a safety risk (unsupported apps, available
+    /// updates, login items).
+    case attention
+    /// A safety finding that should always lead (malware / threats found).
+    case critical
+
+    static func < (lhs: RecommendationUrgency, rhs: RecommendationUrgency) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// Copy for a reassurance tile — the "all good" card a dashboard shows when it
+/// has fewer than the minimum number of real findings. Each section supplies an
+/// ordered pool of these so backfilling to the floor never repeats a card.
+struct ReassuranceContent: Identifiable, Equatable {
+    /// Stable identifier, also used as the card's accessibility identifier stem.
+    let id: String
+    let title: String
+    let detail: String
+    /// SF Symbol name for the card's glyph.
+    let icon: String
+}
+
+/// A rankable tile: an opaque section payload plus the two ranking signals. The
+/// payload stays whatever the section already models (an enum, a tile struct),
+/// so the selector never dictates a section's rendering.
+struct RankedTile<Payload> {
+    let payload: Payload
+    let urgency: RecommendationUrgency
+    /// Reclaimable size in bytes, or `0` when the tile isn't space-based (a
+    /// count-only finding such as available updates).
+    let reclaimableBytes: Int64
+
+    init(payload: Payload, urgency: RecommendationUrgency, reclaimableBytes: Int64) {
+        self.payload = payload
+        self.urgency = urgency
+        self.reclaimableBytes = reclaimableBytes
+    }
+}
+
+/// Selects the 2–4 tiles a section dashboard shows from its candidates. Pure and
+/// deterministic so it is exhaustively unit-testable; the returned order is the
+/// dashboard layout order (the hero leads).
+enum SectionRecommendationSelector {
+
+    /// Floor: dashboards always show at least this many tiles, backfilling with
+    /// reassurance when there aren't this many real findings.
+    static let minimumTiles = 2
+    /// Cap: dashboards never show more than this many tiles; lower-ranked real
+    /// findings are dropped (still reachable via each section's "Review All").
+    static let maximumTiles = 4
+
+    /// Rank `real` by (urgency descending, then reclaimable bytes descending)
+    /// with a stable tiebreak on original order, cap the result at
+    /// `maximumTiles`, then top up from `reassurance` (in its given order) until
+    /// at least `minimumTiles` tiles are present. Reassurance never displaces or
+    /// reorders a real finding, and the floor is best-effort: if the reassurance
+    /// pool is too small the result can dip below the minimum rather than repeat
+    /// a tile.
+    static func select<Payload>(real: [RankedTile<Payload>],
+                                reassurance: [RankedTile<Payload>]) -> [Payload] {
+        // Pair each real candidate with its original index so equal-rank ties
+        // resolve to input order — `sorted(by:)` is not guaranteed stable.
+        let ranked = real.enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element.urgency != rhs.element.urgency {
+                    return lhs.element.urgency > rhs.element.urgency
+                }
+                if lhs.element.reclaimableBytes != rhs.element.reclaimableBytes {
+                    return lhs.element.reclaimableBytes > rhs.element.reclaimableBytes
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element.payload)
+
+        var selected = Array(ranked.prefix(maximumTiles))
+
+        // Backfill toward the floor with reassurance tiles, in pool order.
+        var pool = reassurance.makeIterator()
+        while selected.count < minimumTiles, let filler = pool.next() {
+            selected.append(filler.payload)
+        }
+
+        return selected
+    }
+}

--- a/VaderCleaner/SystemJunkDashboardSubviews.swift
+++ b/VaderCleaner/SystemJunkDashboardSubviews.swift
@@ -18,6 +18,63 @@ enum SystemJunkFormatting {
     }()
 }
 
+// MARK: - Dashboard tile
+
+/// One card on the Cleanup dashboard: either a junk group's card or an "all
+/// good" reassurance card used to backfill the grid to its minimum count when a
+/// scan finds fewer than two groups.
+enum CleanupDashboardTile: Identifiable {
+    case group(CleanupGroupTile)
+    case reassurance(ReassuranceContent)
+
+    var id: String {
+        switch self {
+        case .group(let tile):          return tile.id
+        case .reassurance(let content): return "reassurance.\(content.id)"
+        }
+    }
+
+    /// The 2–4 cards the Cleanup dashboard shows for a scan: the junk groups
+    /// with the most reclaimable space lead (capped at four), backfilled with
+    /// reassurance cards when a scan finds fewer than two groups.
+    static func recommended(from result: ScanResult) -> [CleanupDashboardTile] {
+        let real = CleanupGroupTile.tiles(from: result).map { tile in
+            RankedTile(payload: CleanupDashboardTile.group(tile),
+                       urgency: .space,
+                       reclaimableBytes: tile.totalBytes)
+        }
+        let reassurance = reassurancePool.map { content in
+            RankedTile(payload: CleanupDashboardTile.reassurance(content),
+                       urgency: .reassurance,
+                       reclaimableBytes: 0)
+        }
+        return SectionRecommendationSelector.select(real: real, reassurance: reassurance)
+    }
+
+    /// Ordered pool of "all good" cards, drawn from in order when a scan finds
+    /// fewer than two junk groups so backfilling never repeats a card.
+    static let reassurancePool: [ReassuranceContent] = [
+        ReassuranceContent(
+            id: "cleanup.tidy",
+            title: String(localized: "Your Mac Is Tidy", comment: "Cleanup reassurance card title."),
+            detail: String(
+                localized: "There's almost no junk to clear right now. Nicely kept.",
+                comment: "Cleanup reassurance card detail."
+            ),
+            icon: "sparkles"
+        ),
+        ReassuranceContent(
+            id: "cleanup.checkBack",
+            title: String(localized: "Check Back Later", comment: "Cleanup reassurance card title."),
+            detail: String(
+                localized: "Junk builds up as you use your Mac. Re-scan any time to keep it lean.",
+                comment: "Cleanup reassurance card detail."
+            ),
+            icon: "clock.arrow.circlepath"
+        ),
+    ]
+}
+
 // MARK: - Dashboard
 
 /// Post-scan landing surface for the Cleanup section: a "Start Over" bar, the
@@ -29,7 +86,9 @@ enum SystemJunkFormatting {
 /// cards also offer a direct Clean.
 struct SystemJunkDashboardView: View {
     let totalBytes: Int64
-    let tiles: [CleanupGroupTile]
+    let tiles: [CleanupDashboardTile]
+    /// Section accent, used to tint any reassurance backfill cards.
+    let accent: Color
     /// Drills into one group's combined file list.
     let onReview: (CleanupGroup) -> Void
     /// Cleans an entire group directly (only the cards that allow it call this).
@@ -146,7 +205,7 @@ struct SystemJunkDashboardView: View {
     /// The non-hero cards: the first is a wide card spanning the column, the rest
     /// flow in rows of two beneath it. Grouped in a `GlassEffectContainer` so the
     /// adjacent glass surfaces sample each other and refract consistently.
-    private func rightColumn(_ rest: [CleanupGroupTile]) -> some View {
+    private func rightColumn(_ rest: [CleanupDashboardTile]) -> some View {
         GlassEffectContainer(spacing: 16) {
             VStack(spacing: 16) {
                 if let wide = rest.first {
@@ -169,23 +228,29 @@ struct SystemJunkDashboardView: View {
 
     /// Chunks the compact cards into rows of at most two so the lower grid reads
     /// as a balanced two-up arrangement.
-    private func rows(of tiles: [CleanupGroupTile]) -> [[CleanupGroupTile]] {
+    private func rows(of tiles: [CleanupDashboardTile]) -> [[CleanupDashboardTile]] {
         stride(from: 0, to: tiles.count, by: 2).map {
             Array(tiles[$0..<min($0 + 2, tiles.count)])
         }
     }
 
-    private func card(_ tile: CleanupGroupTile, style: CleanupCardStyle) -> some View {
-        CleanupCard(
-            title: cardTitle(for: tile),
-            blurb: tile.group.blurb,
-            badgeAsset: tile.group.badgeAsset,
-            style: style,
-            showsClean: tile.group.allowsDirectClean,
-            identifierBase: "system-junk.card.\(tile.group.rawValue)",
-            onReview: { onReview(tile.group) },
-            onClean: { onClean(tile.group) }
-        )
+    @ViewBuilder
+    private func card(_ tile: CleanupDashboardTile, style: CleanupCardStyle) -> some View {
+        switch tile {
+        case .group(let groupTile):
+            CleanupCard(
+                title: cardTitle(for: groupTile),
+                blurb: groupTile.group.blurb,
+                badgeAsset: groupTile.group.badgeAsset,
+                style: style,
+                showsClean: groupTile.group.allowsDirectClean,
+                identifierBase: "system-junk.card.\(groupTile.group.rawValue)",
+                onReview: { onReview(groupTile.group) },
+                onClean: { onClean(groupTile.group) }
+            )
+        case .reassurance(let content):
+            ReassuranceCard(content: content, accent: accent)
+        }
     }
 
     /// "30.9 GB of System Junk Found" — the size-led title from the reference.

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -125,7 +125,8 @@ struct SystemJunkView: View {
             // the Large & Old Files section.
             SystemJunkDashboardView(
                 totalBytes: result.totalSize,
-                tiles: CleanupGroupTile.tiles(from: result),
+                tiles: CleanupDashboardTile.recommended(from: result),
+                accent: NavigationSection.systemJunk.theme.accent,
                 onReview: { group in
                     // Pre-select this card's whole group so the right pane opens
                     // all-checked and the selected total matches the card's size.

--- a/VaderCleanerTests/ApplicationsViewModelTests.swift
+++ b/VaderCleanerTests/ApplicationsViewModelTests.swift
@@ -650,7 +650,7 @@ final class ApplicationsViewModelTests: XCTestCase {
     }
 
     /// No cleanup findings → no recommendations, even though installed apps
-    /// exist. Drives the dashboard's "all clear" state.
+    /// exist. Drives the dashboard's reassurance backfill.
     func test_recommendations_emptyWhenNoCleanupFindings() {
         XCTAssertEqual(makeResult().recommendations, [])
     }
@@ -696,6 +696,61 @@ final class ApplicationsViewModelTests: XCTestCase {
             updates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
         )
         XCTAssertEqual(result.recommendations, [.unused, .updates, .installationFiles])
+    }
+
+    // MARK: - Dashboard tiles (ranked selection)
+
+    private func recommendations(
+        of tiles: [ApplicationsDashboardTile]
+    ) -> [ApplicationsScanResult.Recommendation] {
+        tiles.compactMap { tile in
+            if case .recommendation(let recommendation) = tile { return recommendation }
+            return nil
+        }
+    }
+
+    /// A scan with nothing to clean up still fills the grid with two distinct
+    /// reassurance cards.
+    func test_recommendedTiles_emptyScanBackfillsToTwoReassurance() {
+        let tiles = makeResult().recommendedTiles()
+
+        XCTAssertEqual(tiles.count, 2)
+        XCTAssertTrue(recommendations(of: tiles).isEmpty, "No real cards on an empty scan")
+        XCTAssertNotEqual(tiles[0].id, tiles[1].id, "Backfill cards must be distinct")
+    }
+
+    /// Review-worthy findings lead the space-reclaim cruft, and within the
+    /// space-reclaim tier the larger reclaimable size ranks first.
+    func test_recommendedTiles_ranksAttentionThenSpaceBySize() {
+        let result = makeResult(
+            installers: [makeInstaller(name: "Big.dmg", size: 5_000)],
+            leftovers: [makeLeftover(bundleID: "com.gone.app", paths: ["/tmp/a"], bytes: 10)],
+            updates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        )
+
+        // updates (attention) leads; then the space items by size: installers (5000) before leftovers (10).
+        XCTAssertEqual(
+            recommendations(of: result.recommendedTiles()),
+            [.updates, .installationFiles, .leftovers]
+        )
+    }
+
+    /// Never more than four cards: with all five categories present the
+    /// lowest-ranked space item is dropped (still reachable via Manage).
+    func test_recommendedTiles_capsAtFour_dropsSmallestSpaceItem() {
+        let result = makeResult(
+            installers: [makeInstaller(name: "Big.dmg", size: 5_000)],
+            unsupported: [makeUnsupported(name: "Legacy", bundleID: "com.legacy.app")],
+            unused: [makeUnused(name: "Old", bundleID: "com.old.app")],
+            leftovers: [makeLeftover(bundleID: "com.gone.app", paths: ["/tmp/a"], bytes: 10)],
+            updates: [makeUpdate(name: "Acme", bundleID: "com.acme.app", path: "/Applications/Acme.app")]
+        )
+
+        // attention trio in order, then the larger space item; leftovers (10) drops.
+        XCTAssertEqual(
+            recommendations(of: result.recommendedTiles()),
+            [.unsupported, .unused, .updates, .installationFiles]
+        )
     }
 }
 

--- a/VaderCleanerTests/CleanupGroupTests.swift
+++ b/VaderCleanerTests/CleanupGroupTests.swift
@@ -134,6 +134,39 @@ final class CleanupGroupTests: XCTestCase {
         XCTAssertEqual(tiles.map(\.group), [.systemJunk, .trashBins, .xcodeJunk, .documentVersions])
     }
 
+    // MARK: - Dashboard recommendation
+
+    /// The dashboard ranks its cards by reclaimable size (largest first) and
+    /// never shows more than four, so a five-group scan drops the smallest.
+    func test_recommended_ranksBySizeAndCapsAtFour() {
+        let result = ScanResult(items: [
+            file("cache", size: 500, category: .userCache),        // System Junk
+            file("trash", size: 900, category: .trash),            // Trash Bins
+            file("xcode", size: 700, category: .xcodeJunk),        // Xcode Junk
+            file("web", size: 300, category: .webDevJunk),         // Web Dev Junk
+            file("doc", size: 100, category: .documentVersions),   // Document Versions (smallest)
+        ])
+
+        let groups = CleanupDashboardTile.recommended(from: result).compactMap { tile -> CleanupGroup? in
+            if case .group(let g) = tile { return g.group }
+            return nil
+        }
+
+        XCTAssertEqual(groups, [.trashBins, .xcodeJunk, .systemJunk, .webDevJunk])
+    }
+
+    /// A scan with a single junk group is topped up to two cards with a
+    /// reassurance backfill so the grid never shows a lone card.
+    func test_recommended_backfillsReassuranceBelowFloor() {
+        let result = ScanResult(items: [file("t", size: 10, category: .trash)])
+
+        let tiles = CleanupDashboardTile.recommended(from: result)
+
+        XCTAssertEqual(tiles.count, 2)
+        guard case .group = tiles[0] else { return XCTFail("first tile should be the real group") }
+        guard case .reassurance = tiles[1] else { return XCTFail("second tile should be reassurance") }
+    }
+
     // MARK: - Helpers
 
     private func file(_ name: String, size: Int64, category: ScanCategory) -> ScannedFile {

--- a/VaderCleanerTests/MyClutterTileKindTests.swift
+++ b/VaderCleanerTests/MyClutterTileKindTests.swift
@@ -1,0 +1,66 @@
+// MyClutterTileKindTests.swift
+// Pins how the My Clutter dashboard turns its four clutter categories into the ranked 2–4 cards it shows: only categories with findings appear, largest reclaimable size leads, and a near-empty scan backfills with reassurance.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MyClutterTileKindTests: XCTestCase {
+
+    private let none = (count: 0, bytes: Int64(0))
+
+    /// Only categories that actually found files appear, ranked by reclaimable
+    /// size (largest first).
+    func test_recommended_showsOnlyFoundCategories_rankedBySize() {
+        let tiles = MyClutterTileKind.recommended(
+            duplicates: (count: 3, bytes: 500),
+            similar: none,
+            largeOld: (count: 2, bytes: 9_000),
+            downloads: (count: 1, bytes: 3_000)
+        )
+
+        XCTAssertEqual(tiles, [.largeOld, .downloads, .duplicates])
+    }
+
+    /// A category with a count but a rounding-to-zero byte total still appears —
+    /// presence is gated on the count, not the size.
+    func test_recommended_gatesOnCount_notBytes() {
+        let tiles = MyClutterTileKind.recommended(
+            duplicates: (count: 1, bytes: 0),
+            similar: (count: 5, bytes: 10),
+            largeOld: none,
+            downloads: none
+        )
+
+        XCTAssertEqual(tiles, [.similar, .duplicates])
+    }
+
+    /// A single found category is topped up to two cards with a reassurance
+    /// backfill so the grid never shows a lone card.
+    func test_recommended_backfillsReassuranceBelowFloor() {
+        let tiles = MyClutterTileKind.recommended(
+            duplicates: (count: 4, bytes: 1_000),
+            similar: none, largeOld: none, downloads: none
+        )
+
+        XCTAssertEqual(tiles.count, 2)
+        XCTAssertEqual(tiles.first, .duplicates)
+        guard case .reassurance = tiles[1] else {
+            return XCTFail("second tile should be a reassurance backfill")
+        }
+    }
+
+    /// An empty scan still shows two distinct reassurance cards.
+    func test_recommended_emptyScan_showsTwoReassurance() {
+        let tiles = MyClutterTileKind.recommended(
+            duplicates: none, similar: none, largeOld: none, downloads: none
+        )
+
+        XCTAssertEqual(tiles.count, 2)
+        XCTAssertNotEqual(tiles[0], tiles[1])
+        for tile in tiles {
+            guard case .reassurance = tile else {
+                return XCTFail("empty scan should show only reassurance cards")
+            }
+        }
+    }
+}

--- a/VaderCleanerTests/SectionRecommendationSelectorTests.swift
+++ b/VaderCleanerTests/SectionRecommendationSelectorTests.swift
@@ -1,0 +1,124 @@
+// SectionRecommendationSelectorTests.swift
+// Pins the shared tile ranking core: urgency outranks size, size breaks ties, ties are stable, the count is capped at four, and reassurance backfills to the floor of two without displacing real findings.
+
+import XCTest
+@testable import VaderCleaner
+
+final class SectionRecommendationSelectorTests: XCTestCase {
+
+    /// Builds a real (non-reassurance) candidate wrapping a String payload so the
+    /// tests can assert selection order by identity.
+    private func tile(_ payload: String,
+                      _ urgency: RecommendationUrgency,
+                      _ bytes: Int64) -> RankedTile<String> {
+        RankedTile(payload: payload, urgency: urgency, reclaimableBytes: bytes)
+    }
+
+    // MARK: - Ranking
+
+    /// Urgency dominates size: a zero-byte safety finding must lead a huge
+    /// space finding so an ordinary person sees the important thing first.
+    func test_urgency_outranksBytes() {
+        let selected = SectionRecommendationSelector.select(
+            real: [
+                tile("space", .space, 100_000_000_000),
+                tile("critical", .critical, 0),
+            ],
+            reassurance: []
+        )
+        XCTAssertEqual(selected, ["critical", "space"])
+    }
+
+    /// Within one urgency level the larger reclaimable size leads.
+    func test_withinUrgency_largerBytesLead() {
+        let selected = SectionRecommendationSelector.select(
+            real: [
+                tile("small", .space, 1_000),
+                tile("large", .space, 9_000),
+                tile("medium", .space, 5_000),
+            ],
+            reassurance: []
+        )
+        XCTAssertEqual(selected, ["large", "medium", "small"])
+    }
+
+    /// Equal urgency and equal size preserve the input order — the sort must be
+    /// stable so the layout never reshuffles between renders of identical data.
+    func test_equalRank_keepsInputOrder() {
+        let selected = SectionRecommendationSelector.select(
+            real: [
+                tile("first", .space, 4_000),
+                tile("second", .space, 4_000),
+                tile("third", .space, 4_000),
+            ],
+            reassurance: []
+        )
+        XCTAssertEqual(selected, ["first", "second", "third"])
+    }
+
+    // MARK: - Cap
+
+    /// Never more than four tiles: the lowest-ranked real findings are dropped.
+    func test_capsAtFour_droppingLowestRanked() {
+        let selected = SectionRecommendationSelector.select(
+            real: [
+                tile("a", .space, 5),
+                tile("b", .space, 4),
+                tile("c", .space, 3),
+                tile("d", .space, 2),
+                tile("e", .space, 1),
+            ],
+            reassurance: []
+        )
+        XCTAssertEqual(selected, ["a", "b", "c", "d"])
+    }
+
+    // MARK: - Floor
+
+    /// A single real finding is topped up to two with the first reassurance tile.
+    func test_oneReal_backfillsToTwo() {
+        let selected = SectionRecommendationSelector.select(
+            real: [tile("real", .space, 1_000)],
+            reassurance: [
+                tile("calm1", .reassurance, 0),
+                tile("calm2", .reassurance, 0),
+            ]
+        )
+        XCTAssertEqual(selected, ["real", "calm1"])
+    }
+
+    /// No real findings still yields two distinct reassurance tiles, in pool order.
+    func test_noReal_showsTwoDistinctReassurance() {
+        let selected = SectionRecommendationSelector.select(
+            real: [],
+            reassurance: [
+                tile("calm1", .reassurance, 0),
+                tile("calm2", .reassurance, 0),
+                tile("calm3", .reassurance, 0),
+            ]
+        )
+        XCTAssertEqual(selected, ["calm1", "calm2"])
+    }
+
+    /// Reassurance is only filler: two or more real findings suppress it entirely.
+    func test_reassurance_neverDisplacesReal() {
+        let selected = SectionRecommendationSelector.select(
+            real: [
+                tile("r1", .space, 2_000),
+                tile("r2", .space, 1_000),
+            ],
+            reassurance: [tile("calm", .reassurance, 0)]
+        )
+        XCTAssertEqual(selected, ["r1", "r2"])
+    }
+
+    /// The floor is best-effort: with too few reassurance tiles the result can
+    /// dip below two rather than repeating a card.
+    func test_floor_isBestEffort_whenReassuranceExhausted() {
+        let selected = SectionRecommendationSelector.select(
+            real: [],
+            reassurance: [tile("only", .reassurance, 0)]
+        )
+        XCTAssertEqual(selected, ["only"])
+    }
+}

--- a/VaderCleanerUITests/ApplicationsUITests.swift
+++ b/VaderCleanerUITests/ApplicationsUITests.swift
@@ -43,10 +43,10 @@ final class ApplicationsUITests: XCTestCase {
                       "Expected the floating Scan button on the Applications intro")
     }
 
-    /// Scan → the dashboard appears showing only recommendation cards (or the
-    /// all-clear state when nothing needs attention). Updates is one of the
-    /// ranked cards now; the old standalone Manage card is gone — Manage lives
-    /// behind the header button.
+    /// Scan → the dashboard appears showing the ranked recommendation cards (or
+    /// reassurance backfill cards when nothing needs attention). Updates is one
+    /// of the ranked cards now; the old standalone Manage card is gone — Manage
+    /// lives behind the header button.
     func test_applications_scanShowsDashboard() throws {
         dismissOnboardingIfNeeded()
         openApplicationsAndScan()
@@ -57,16 +57,17 @@ final class ApplicationsUITests: XCTestCase {
 
         // Which recommendation cards appear depends on the machine, so assert
         // the dashboard reaches a valid state: at least one recommendation card,
-        // or the all-clear state.
+        // or a reassurance backfill card.
         let validState = app.descendants(matching: .any)
             .matching(NSPredicate(format: "identifier IN {"
                 + "'applications.card.unsupported','applications.card.unused',"
                 + "'applications.card.updates','applications.card.leftovers',"
                 + "'applications.card.installationFiles',"
-                + "'applications.dashboard.allClear'}"))
+                + "'recommendation.reassurance.applications.allClear',"
+                + "'recommendation.reassurance.applications.manage'}"))
             .firstMatch
         XCTAssertTrue(validState.waitForExistence(timeout: 10),
-                      "Expected a recommendation card or the all-clear state")
+                      "Expected a recommendation card or a reassurance backfill card")
 
         // The standalone Manage card is gone — Manage is the header button now.
         XCTAssertFalse(app.buttons["applications.card.manage"].exists,
@@ -79,8 +80,8 @@ final class ApplicationsUITests: XCTestCase {
     /// dashboard. The dashboard now shows only cleanup categories that have
     /// findings, so the exact cards depend on the host — this exercises
     /// whichever recommendation card is present rather than assuming a specific
-    /// one. On a host with nothing to clean up the dashboard shows the all-clear
-    /// state and there is no card to open, which the test accepts.
+    /// one. On a host with nothing to clean up the dashboard shows reassurance
+    /// backfill cards and there is no review card to open, which the test accepts.
     func test_applications_recommendationCardOpensReviewAndBackReturns() throws {
         dismissOnboardingIfNeeded()
         openApplicationsAndScan()
@@ -96,10 +97,15 @@ final class ApplicationsUITests: XCTestCase {
             .firstMatch
 
         guard card.waitForExistence(timeout: 10) else {
-            // No findings → the all-clear state; there is no card to open.
+            // No findings → reassurance backfill cards; there is no card to open.
+            let reassurance = app.descendants(matching: .any)
+                .matching(NSPredicate(format: "identifier IN {"
+                    + "'recommendation.reassurance.applications.allClear',"
+                    + "'recommendation.reassurance.applications.manage'}"))
+                .firstMatch
             XCTAssertTrue(
-                app.descendants(matching: .any)["applications.dashboard.allClear"].exists,
-                "With no recommendation cards the dashboard must show the all-clear state"
+                reassurance.exists,
+                "With no recommendation cards the dashboard must show reassurance backfill cards"
             )
             return
         }


### PR DESCRIPTION
## What & why

Every section dashboard except Smart Scan and Health Monitor previously showed a **fixed** set of tiles regardless of what a scan found — My Clutter always rendered 4 cards (greyed when empty), Performance always rendered 2 summary cards, Protection always pinned the malware tile first, and Cleanup/Applications were dynamic but uncapped. This replaces that with a single recommendation engine so each section surfaces the **2–4 most relevant tiles** for what was actually found, ranked so an ordinary person sees what matters most first.

## How it works

**Shared core** — `SectionRecommendation.swift`
- `RecommendationUrgency` (`reassurance < space < attention < critical`), `RankedTile<Payload>`, and `SectionRecommendationSelector.select(real:reassurance:)`.
- Ranks by **urgency first, then reclaimable size**, with stable ties; **caps at 4**; **backfills reassurance to a floor of 2** without ever displacing a real finding.
- `ReassuranceCard` renders the "all good" backfill tiles in the app's glass chrome.

Each section keeps its existing bento layout and card rendering — only the tile *selection* becomes dynamic:

| Section | Before | Now |
|---|---|---|
| Cleanup | up to 5 fixed groups | top junk groups by size, capped 4, floor 2 |
| My Clutter | 4 always-shown cards | only categories with findings, ranked by size, 2–4 |
| Applications | dynamic but uncapped + full-pane all-clear | ranked (review-worthy → space by size), capped 4, reassurance replaces all-clear |
| Protection | malware + privacy always, malware pinned first | malware leads by urgency (`.critical` on threats), privacy by size, capped 4, floor 2 |
| Performance | 2 always-shown summary cards | Login Items / Background Items / Maintenance shown only when they have findings, ranked, floor 2 |

## Reviewer notes

- **Design decisions** (confirmed with the requester): Space Lens is excluded (it's a treemap, not a tile grid); layout stays per-section bento with dynamic content; ranking is impact = size with safety/urgency boosted; the floor backfills reassurance tiles rather than showing an empty state.
- **Deliberate scope limit on Performance:** its engine outputs *Free Up RAM* and *Thin Snapshots* carry run-actions tied to the floating run-overlay flow. Surfacing those as tiles would mean reworking that flow, so Performance keeps review-style cards (Login Items, Background Items, Maintenance) for now. Flagged as a possible follow-up.
- Two `ApplicationsUITests` were updated to reference the new reassurance identifiers instead of the removed `applications.dashboard.allClear` state.

## Testing

- New unit tests for the selector (ranking / cap / floor / stability) and for the Cleanup, My Clutter, and Applications candidate mappings.
- **All 1307 unit tests pass** on a clean build (`xcodebuild test … clean CODE_SIGNING_ALLOWED=NO`). App + UI-test targets compile (`build-for-testing`).
- Not visually verified (screenshots need Screen Recording permission locally) — worth a quick eyeball on each section, especially a near-empty scan to see the reassurance backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboards now show a dynamic mix of recommendation cards and reassuring “all good” cards instead of fixed empty-state layouts.
  * Added a new maintenance summary card and “Review Maintenance” navigation in Performance.
  * Added a reusable reassurance card style for clean or low-risk states.

* **Bug Fixes**
  * Improved card ranking so higher-priority findings appear first and low-priority items are capped more consistently.
  * Updated dashboard flows to handle empty or low-issue scans with backfilled reassurance cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->