### PR TITLE
Apply performance-audit fixes to scans, managers, and list rendering

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		1C8625B436085E36B99B5342 /* FinalPolishUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C8CB7BE63B3851A6E8503 /* FinalPolishUITests.swift */; };
 		1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */; };
 		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
+		1EE29E50BDE662F5B4BB4F61 /* LRUCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDD31CBAF12D911B31F6A0D /* LRUCache.swift */; };
 		1F7B67D271BC88E4A13A1AE8 /* MaintenanceTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */; };
 		1F88CDFF1571AB8A8DCB3F7D /* MailReindexerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933E3B42C683C14A7398939F /* MailReindexerTests.swift */; };
 		2094AB11AA0400630E413C6F /* BrowserPrivacyRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2BB8E9DD31E37B171CC32D /* BrowserPrivacyRemover.swift */; };
@@ -282,6 +283,7 @@
 		BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC391B523110720320AD89 /* SystemPathProviding.swift */; };
 		BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */; };
 		BDAF9DD5414C50F4546C239B /* MyClutterScanScopeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175A6E5DE9F8C11D0560DB04 /* MyClutterScanScopeStoreTests.swift */; };
+		BEC40738A60C102ECB8CA1C6 /* LRUCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F144C596261D524E3C0C40D0 /* LRUCacheTests.swift */; };
 		BEFCD2F309C985449A2901F5 /* SmartScanMyClutterReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F498579A77E1DAED6AC00AF /* SmartScanMyClutterReview.swift */; };
 		BF18064F6E3DD9B598B15D00 /* ProtectionSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CE1F46BB605C6493C886C4 /* ProtectionSettingsStore.swift */; };
 		C2542EE3974C2F9232EE74D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5E978BB01AD677AEDE122B1C /* Assets.xcassets */; };
@@ -296,6 +298,7 @@
 		C3F9A86A896DAD3A63EB8F9F /* ExclusionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6085B6A39985DFF334821551 /* ExclusionsStore.swift */; };
 		C4412F1E74ADFE53633DA41A /* SpaceLensBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA2D3E58D656FF184F406A0 /* SpaceLensBubbleView.swift */; };
 		C75E96295ED70F91F6B2A0F1 /* SectionTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA1ADE2572F4772B89B1B1 /* SectionTheme.swift */; };
+		C789001CAAACBF6DE4388751 /* ManagerContentTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C763E0DB99A67C5F869339C6 /* ManagerContentTokenTests.swift */; };
 		C7CC2B5E09E8E3A89C39815E /* MacHealthStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BF07D3C75C31A0EA7E9037 /* MacHealthStatus.swift */; };
 		C848FD080F1DED2282ADC12E /* LocalSnapshotCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */; };
 		C882EE0A16D160B09E59AC50 /* TrashSizeMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4578EA7CB74F883F99837D /* TrashSizeMonitor.swift */; };
@@ -458,6 +461,7 @@
 		1A3DE098197EC0362C64AEF7 /* CleanupGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupGroup.swift; sourceTree = "<group>"; };
 		1A69F8127A8C664B222B5691 /* DeviceBatteryMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBatteryMonitorTests.swift; sourceTree = "<group>"; };
 		1B0FF6808EEAB9104DCC8D61 /* MyClutterDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterDashboardView.swift; sourceTree = "<group>"; };
+		1BDD31CBAF12D911B31F6A0D /* LRUCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LRUCache.swift; sourceTree = "<group>"; };
 		1BED81B0628BEACAB6B965B9 /* MyClutterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterViewModelTests.swift; sourceTree = "<group>"; };
 		1C116D07B8F84B3D4F4307F6 /* SimilarImageScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarImageScanner.swift; sourceTree = "<group>"; };
 		1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionComparatorTests.swift; sourceTree = "<group>"; };
@@ -695,6 +699,7 @@
 		C56CC459E92A0C13A19DF2AE /* DiskScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScanner.swift; sourceTree = "<group>"; };
 		C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C5FD7F60311101E723D73E11 /* ApplicationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsUITests.swift; sourceTree = "<group>"; };
+		C763E0DB99A67C5F869339C6 /* ManagerContentTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagerContentTokenTests.swift; sourceTree = "<group>"; };
 		C7CD16572ECF164A186523BD /* ExclusionsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStoreTests.swift; sourceTree = "<group>"; };
 		C8565FBD4555B1398F2752F8 /* CleanupManagerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupManagerModelTests.swift; sourceTree = "<group>"; };
 		C889492FDFBDFBFC410FF577 /* DuplicateScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateScannerTests.swift; sourceTree = "<group>"; };
@@ -763,6 +768,7 @@
 		F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunnerTests.swift; sourceTree = "<group>"; };
 		F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManagerTests.swift; sourceTree = "<group>"; };
 		F0CE1F46BB605C6493C886C4 /* ProtectionSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectionSettingsStore.swift; sourceTree = "<group>"; };
+		F144C596261D524E3C0C40D0 /* LRUCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LRUCacheTests.swift; sourceTree = "<group>"; };
 		F1BA4607C3FFC174E84354A9 /* SpaceLensChildren.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensChildren.swift; sourceTree = "<group>"; };
 		F2C612F641A894AE10ADDA8F /* InstallationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFile.swift; sourceTree = "<group>"; };
 		F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDeleterTests.swift; sourceTree = "<group>"; };
@@ -916,6 +922,7 @@
 				82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */,
 				27F1DC062C52C51730548216 /* LoginItem.swift */,
 				5227D2DEB458CBF8DF1DE944 /* LoginItemManager.swift */,
+				1BDD31CBAF12D911B31F6A0D /* LRUCache.swift */,
 				32BF07D3C75C31A0EA7E9037 /* MacHealthStatus.swift */,
 				E2017911CF02D2B89E8BF865 /* MailReindexer.swift */,
 				FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */,
@@ -1159,6 +1166,7 @@
 				C19C886F966A9E160780D16F /* LocalSnapshotCounterTests.swift */,
 				1E020B5C72CBAE8A7A11630C /* LoginItemManagerTests.swift */,
 				5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */,
+				F144C596261D524E3C0C40D0 /* LRUCacheTests.swift */,
 				02E49583606C1454E9F0AF2C /* MachOHeaderReaderTests.swift */,
 				933E3B42C683C14A7398939F /* MailReindexerTests.swift */,
 				DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */,
@@ -1169,6 +1177,7 @@
 				A4D6F0A78035CA4C2F5D58C4 /* MalwareThreatRemoverTests.swift */,
 				EB9EFA17ABC7865841D10F28 /* MalwareThreatTests.swift */,
 				D2A9C2E47C91B66B79030BE7 /* MalwareViewModelTests.swift */,
+				C763E0DB99A67C5F869339C6 /* ManagerContentTokenTests.swift */,
 				CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */,
 				CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */,
 				175A6E5DE9F8C11D0560DB04 /* MyClutterScanScopeStoreTests.swift */,
@@ -1487,6 +1496,7 @@
 				17B03ADF49ECF79F5C4CC38D /* HelperProtocolTests.swift in Sources */,
 				667CDB738F03027C97828C68 /* HungAppMonitorTests.swift in Sources */,
 				B86DA7DFDECF401C5BCCAC24 /* InstallationFileScannerTests.swift in Sources */,
+				BEC40738A60C102ECB8CA1C6 /* LRUCacheTests.swift in Sources */,
 				57C68CCCE577CE52AC3F0DE2 /* LanguageFileLocatorTests.swift in Sources */,
 				50B0458DB3351E7011490C1D /* LargeOldFilesScannerTests.swift in Sources */,
 				250889E632F3F3F6E0C37E2B /* LargeOldFilesSummaryTests.swift in Sources */,
@@ -1504,6 +1514,7 @@
 				70D8E3251176A02F51CB78FD /* MalwareThreatRemoverTests.swift in Sources */,
 				20A0A0A414E0D919060C99D2 /* MalwareThreatTests.swift in Sources */,
 				710F2D2D1D68AEDE1A9462CD /* MalwareViewModelTests.swift in Sources */,
+				C789001CAAACBF6DE4388751 /* ManagerContentTokenTests.swift in Sources */,
 				C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */,
 				688FEF65720EAF3D51754EC6 /* MyClutterManagerModelTests.swift in Sources */,
 				BDAF9DD5414C50F4546C239B /* MyClutterScanScopeStoreTests.swift in Sources */,
@@ -1671,6 +1682,7 @@
 				96D6310BF326A52494BCEB42 /* HungAppMonitor.swift in Sources */,
 				03E56C4EFC8903CA9291A959 /* InstallationFile.swift in Sources */,
 				55B6AD3998807918EE9FD2AF /* InstallationFileScanner.swift in Sources */,
+				1EE29E50BDE662F5B4BB4F61 /* LRUCache.swift in Sources */,
 				D52B7FA3A74CF841E602953E /* LanguageFileLocator.swift in Sources */,
 				1082FF9550D57C1252211933 /* LargeOldFilesScanner.swift in Sources */,
 				483CE4B8CB180C13FC0934A6 /* LargeOldFilesViewSubviews.swift in Sources */,

--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -115,6 +115,17 @@ struct ApplicationsManagerView: View {
             if extensionsManagerViewModel.phase == .idle { await extensionsManagerViewModel.refresh() }
         }
         .task(id: uninstallerViewModel.apps.map(\.id)) { await uninstallerViewModel.loadListMetrics() }
+        // Warm the shared icon cache for every roster this manager renders.
+        // The cache never loads on a miss — `icon(for:)` returns the generic
+        // placeholder until a preload lands — so without these the rows only
+        // show real icons for apps some other card happened to preload.
+        // `preloadIcons` skips URLs already cached, so re-runs cost nothing.
+        .task(id: uninstallerViewModel.apps.map(\.id)) {
+            await iconCache.preloadIcons(for: uninstallerViewModel.apps.map(\.bundleURL))
+        }
+        .task(id: updaterViewModel.availableUpdates.map(\.bundleID)) {
+            await iconCache.preloadIcons(for: updaterViewModel.availableUpdates.map(\.bundleURL))
+        }
         .alert(uninstallConfirmationTitle, isPresented: $showUninstallConfirmation) {
             Button(String(localized: "Cancel", comment: "Cancel button on the uninstall confirmation."), role: .cancel) {}
             Button(String(localized: "Uninstall", comment: "Confirm batch uninstall."), role: .destructive) {

--- a/VaderCleaner/DuplicateScanner.swift
+++ b/VaderCleaner/DuplicateScanner.swift
@@ -1,5 +1,5 @@
 // DuplicateScanner.swift
-// Finds byte-identical files under ~/Downloads by bucketing on size then confirming with a streamed SHA-256 content hash, returning groups of duplicates.
+// Finds byte-identical files under ~/Downloads by bucketing on size, pre-filtering size collisions with a cheap prefix hash, then confirming with a streamed SHA-256 content hash, returning groups of duplicates.
 
 import Foundation
 import CryptoKit
@@ -10,6 +10,18 @@ import CryptoKit
 /// content-hashes only the size collisions with a streamed SHA-256 to confirm
 /// true byte-for-byte duplicates.
 struct DuplicateScanner {
+
+    /// Bytes covered by the cheap first-pass hash tier. Files whose first
+    /// `prefixHashByteLimit` bytes differ cannot be identical, so only prefix
+    /// collisions pay a full-content read — the expensive step when a size
+    /// bucket holds large files that diverge early. Internal so tests can
+    /// build fixtures on either side of the boundary.
+    static let prefixHashByteLimit = 64 * 1024
+
+    /// Most content hashes in flight at once. Hashing is I/O-bound; a small
+    /// bound overlaps reads across files without saturating the disk or
+    /// holding more cooperative-pool threads than the work needs.
+    private static let maxConcurrentHashes = 4
 
     private let fileScanner: FileScanning
     private let roots: [URL]
@@ -58,17 +70,29 @@ struct DuplicateScanner {
 
         // Only size collisions can be duplicates — hash just those to confirm.
         // iCloud placeholders are skipped so confirming a duplicate never forces
-        // a slow on-demand download.
+        // a slow on-demand download. Confirmation runs in two tiers: a cheap
+        // prefix hash first (files diverging in their first bytes never pay a
+        // full read), then a full-content hash over the surviving prefix
+        // collisions.
         var groups: [DuplicateGroup] = []
-        for (_, candidates) in bySize where candidates.count > 1 {
+        for (size, candidates) in bySize where candidates.count > 1 {
             try Task.checkCancellation()
-            var byHash: [String: [ScannedFile]] = [:]
-            for file in candidates where CloudFileAvailability.isLocallyAvailable(file.url) {
-                guard let hash = Self.sha256Hex(of: file.url) else { continue }
-                byHash[hash, default: []].append(file)
-            }
-            for (_, identical) in byHash where identical.count > 1 {
-                groups.append(DuplicateGroup(files: Self.sortedKeepingOriginalFirst(identical)))
+            let local = candidates.filter { CloudFileAvailability.isLocallyAvailable($0.url) }
+            guard local.count > 1 else { continue }
+
+            let byPrefix = try await Self.groupedByContentHash(local, readingUpTo: Self.prefixHashByteLimit)
+            for prefixMatches in byPrefix.values where prefixMatches.count > 1 {
+                // A file no longer than the prefix tier is fully covered by
+                // it — the prefix hash *is* the content hash, so these files
+                // are already confirmed identical without a second read.
+                if size <= Int64(Self.prefixHashByteLimit) {
+                    groups.append(DuplicateGroup(files: Self.sortedKeepingOriginalFirst(prefixMatches)))
+                    continue
+                }
+                let byHash = try await Self.groupedByContentHash(prefixMatches, readingUpTo: nil)
+                for (_, identical) in byHash where identical.count > 1 {
+                    groups.append(DuplicateGroup(files: Self.sortedKeepingOriginalFirst(identical)))
+                }
             }
         }
 
@@ -87,23 +111,62 @@ struct DuplicateScanner {
         }
     }
 
+    /// Buckets `files` by their content hash, reading at most `byteLimit`
+    /// bytes per file (`nil` hashes the whole file). Hashes run with bounded
+    /// concurrency (`maxConcurrentHashes`) so a big size bucket overlaps its
+    /// file reads instead of paying them serially. Unreadable files are
+    /// dropped, matching the single-hash behaviour.
+    private static func groupedByContentHash(
+        _ files: [ScannedFile],
+        readingUpTo byteLimit: Int?
+    ) async throws -> [String: [ScannedFile]] {
+        let hashes = try await withThrowingTaskGroup(of: (Int, String?).self) { group -> [String?] in
+            var results = [String?](repeating: nil, count: files.count)
+            var nextIndex = 0
+            func addTaskIfNeeded() {
+                guard nextIndex < files.count else { return }
+                let index = nextIndex
+                let url = files[index].url
+                nextIndex += 1
+                group.addTask { (index, Self.sha256Hex(of: url, readingUpTo: byteLimit)) }
+            }
+            for _ in 0..<maxConcurrentHashes { addTaskIfNeeded() }
+            while let (index, hash) = try await group.next() {
+                results[index] = hash
+                try Task.checkCancellation()
+                addTaskIfNeeded()
+            }
+            return results
+        }
+        var byHash: [String: [ScannedFile]] = [:]
+        for (file, hash) in zip(files, hashes) {
+            guard let hash else { continue }
+            byHash[hash, default: []].append(file)
+        }
+        return byHash
+    }
+
     /// Streams the file through SHA-256 in 1 MB chunks so a large file never
-    /// loads into memory at once. Returns `nil` if the file can't be read, so an
-    /// unreadable candidate is simply dropped rather than failing the scan.
-    private static func sha256Hex(of url: URL) -> String? {
+    /// loads into memory at once. `readingUpTo` caps the bytes hashed (the
+    /// prefix tier); `nil` hashes the whole file. Returns `nil` if the file
+    /// can't be read, so an unreadable candidate is simply dropped rather than
+    /// failing the scan.
+    private static func sha256Hex(of url: URL, readingUpTo byteLimit: Int?) -> String? {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         var hasher = SHA256()
         let chunkSize = 1024 * 1024
-        while true {
+        var remaining = byteLimit ?? Int.max
+        while remaining > 0 {
             let chunk: Data
             do {
-                chunk = try handle.read(upToCount: chunkSize) ?? Data()
+                chunk = try handle.read(upToCount: min(chunkSize, remaining)) ?? Data()
             } catch {
                 return nil
             }
             if chunk.isEmpty { break }
             hasher.update(data: chunk)
+            remaining -= chunk.count
         }
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }

--- a/VaderCleaner/LRUCache.swift
+++ b/VaderCleaner/LRUCache.swift
@@ -1,0 +1,55 @@
+// LRUCache.swift
+// Minimal least-recently-used cache — a capacity-bounded dictionary that evicts the stalest entries, used by row-level icon caches so very large scans can't grow them without bound.
+
+import Foundation
+
+/// A small in-memory cache that holds at most `capacity` entries and evicts
+/// the least-recently-used ones when full. Recency is tracked with a monotonic
+/// tick stamped on every read and write; eviction removes the oldest quarter
+/// in one pass so the sort cost is amortized rather than paid per insert at
+/// the boundary. Not thread-safe — callers confine it to one actor/thread
+/// (the icon caches are main-thread only).
+struct LRUCache<Key: Hashable, Value> {
+
+    private struct Entry {
+        var value: Value
+        var tick: UInt64
+    }
+
+    private var entries: [Key: Entry] = [:]
+    private var tick: UInt64 = 0
+    let capacity: Int
+
+    init(capacity: Int) {
+        self.capacity = max(1, capacity)
+    }
+
+    var count: Int { entries.count }
+
+    /// Returns the cached value and marks it most-recently-used.
+    mutating func value(forKey key: Key) -> Value? {
+        guard var entry = entries[key] else { return nil }
+        tick &+= 1
+        entry.tick = tick
+        entries[key] = entry
+        return entry.value
+    }
+
+    /// Stores (or replaces) a value, evicting the least-recently-used entries
+    /// if the cache would exceed its capacity.
+    mutating func setValue(_ value: Value, forKey key: Key) {
+        tick &+= 1
+        entries[key] = Entry(value: value, tick: tick)
+        evictIfNeeded()
+    }
+
+    private mutating func evictIfNeeded() {
+        guard entries.count > capacity else { return }
+        // Shrink to 75% of capacity so the next few inserts are eviction-free.
+        let target = capacity - capacity / 4
+        let staleFirst = entries.sorted { $0.value.tick < $1.value.tick }
+        for (key, _) in staleFirst.prefix(entries.count - target) {
+            entries.removeValue(forKey: key)
+        }
+    }
+}

--- a/VaderCleaner/ManagerItemTable.swift
+++ b/VaderCleaner/ManagerItemTable.swift
@@ -35,6 +35,19 @@ struct ManagerItemTable: NSViewRepresentable {
     /// Toggle an expandable row's disclosure (chevron tap).
     var onToggleExpand: (String) -> Void = { _ in }
 
+    /// Builds the reload token for a displayed row set: the row count, an
+    /// order-sensitive hash of every row id, and the sort/search inputs. Any
+    /// change to the rows or their order changes the token, so the bridge
+    /// reloads exactly when the content differs — including a swap in the
+    /// middle of the list that a count/first/last heuristic can't see. O(n)
+    /// over the ids, so callers with large lists compute it when the row set
+    /// changes rather than per render; tiny lists may build it inline.
+    static func contentToken(items: [ManagerItem], sort: String, search: String) -> String {
+        var hasher = Hasher()
+        for item in items { hasher.combine(item.id) }
+        return "\(items.count)|\(hasher.finalize())|\(sort)|\(search)"
+    }
+
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -501,15 +514,18 @@ private enum ManagerCheckboxImage {
 /// Caches the real Finder icons the Cleanup Manager rows show, keyed by path.
 /// `NSWorkspace.icon(forFile:)` is reasonably fast and OS-cached, but caching
 /// the sized `NSImage` here keeps scrolling smooth for large categories.
-/// Main-thread only (cells are configured on the main actor).
+/// LRU-bounded so scrolling a category of tens of thousands of files can't
+/// grow the cache without limit — evicted icons just re-fetch from
+/// `NSWorkspace` on the next pass. Main-thread only (cells are configured on
+/// the main actor).
 private enum ManagerFileIconCache {
-    private static var cache: [String: NSImage] = [:]
+    private static var cache = LRUCache<String, NSImage>(capacity: 1024)
 
     static func icon(forPath path: String) -> NSImage {
-        if let cached = cache[path] { return cached }
+        if let cached = cache.value(forKey: path) { return cached }
         let image = NSWorkspace.shared.icon(forFile: path)
         image.size = NSSize(width: 28, height: 28)
-        cache[path] = image
+        cache.setValue(image, forKey: path)
         return image
     }
 }

--- a/VaderCleaner/MyClutterManagerModel.swift
+++ b/VaderCleaner/MyClutterManagerModel.swift
@@ -136,6 +136,28 @@ enum MyClutterManagerModel {
         files.reduce(0) { $0 + $1.size }
     }
 
+    /// The rows the manager's right pane actually renders: the search filter
+    /// (case-insensitive, on the file name), an optional name sort, and a cap
+    /// on the rendered row count. Size-sorted lists arrive pre-sorted from the
+    /// facet cache, so `sortByName == false` passes the input order through.
+    /// Pure and `Sendable`-friendly so the view can recompute it off the main
+    /// actor only when an input changes — never per render.
+    static func display(
+        _ files: [ScannedFile],
+        search: String,
+        sortByName: Bool,
+        limit: Int
+    ) -> [ScannedFile] {
+        var result = files
+        if !search.isEmpty {
+            result = result.filter { $0.url.lastPathComponent.localizedCaseInsensitiveContains(search) }
+        }
+        if sortByName {
+            result = result.sorted { $0.url.lastPathComponent.localizedCaseInsensitiveCompare($1.url.lastPathComponent) == .orderedAscending }
+        }
+        return Array(result.prefix(limit))
+    }
+
     /// Downloads grouped by their source app, ordered by total bytes (largest
     /// first). Files with no recorded source fall into an "Other" bucket.
     static func downloadsBySource(_ items: [DownloadItem]) -> [MyClutterDownloadGroup] {

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -42,6 +42,13 @@ struct MyClutterManagerView: View {
     /// panes show a loader instead of a momentarily-empty list.
     @State private var isLoadingCache = false
 
+    /// The right pane's rendered file rows, memoized so a selection toggle
+    /// re-renders the checkboxes without re-running the search filter (and,
+    /// under name sort, the O(n log n) re-sort) over the whole facet on every
+    /// render. Rebuilt off the main actor only when a real input changes —
+    /// see `DisplayInputs`.
+    @State private var displayedFiles: [ScannedFile] = []
+
     /// Most file rows rendered at once. The lists are pre-sorted, so the capped
     /// slice is the meaningful top; the rest is reached by clearing and re-scanning.
     private static let displayRowLimit = 1000
@@ -81,6 +88,87 @@ struct MyClutterManagerView: View {
         // changes (and on first appearance). Selection toggles bump nothing
         // here, so they no longer trigger an O(N) recompute.
         .task(id: viewModel.resultsVersion) { await rebuildCaches() }
+        // Rebuild the right pane's rows only when a display input changes.
+        // The selection stamp participates only under the "Selected" facet,
+        // so an ordinary checkbox toggle repaints rows without recomputing
+        // the list.
+        .task(id: displayInputs) { await rebuildDisplayedFiles() }
+    }
+
+    /// The complete set of inputs the right pane's file rows derive from. The
+    /// rebuild task keys on this value, so any change reruns it and everything
+    /// else (notably a selection toggle outside the "Selected" facet) does not.
+    private struct DisplayInputs: Equatable {
+        let category: MyClutterCategory
+        let facet: MyClutterLargeOldFacet
+        let browser: String?
+        let search: String
+        let sort: ManagerSort
+        let resultsVersion: Int
+        let cacheLoading: Bool
+        /// Selected-file count in Large & Old — an O(1) read that changes on
+        /// every relevant toggle. Pinned to 0 outside the "Selected" facet so
+        /// toggles there don't retrigger the rebuild.
+        let selectionStamp: Int
+    }
+
+    private var displayInputs: DisplayInputs {
+        DisplayInputs(
+            category: category,
+            facet: largeOldFacet,
+            browser: selectedBrowser,
+            search: search,
+            sort: sort,
+            resultsVersion: viewModel.resultsVersion,
+            cacheLoading: isLoadingCache,
+            selectionStamp: (category == .largeOld && largeOldFacet == .selected)
+                ? viewModel.selectedCount(in: .largeOld)
+                : 0
+        )
+    }
+
+    /// Recomputes `displayedFiles` off the main actor: picks the pre-sorted
+    /// base list for the active category/facet, applies the "Selected" filter
+    /// when that facet is active, then runs the shared search/sort/cap pass.
+    private func rebuildDisplayedFiles() async {
+        let base: [ScannedFile]
+        var selection: Set<URL>? = nil
+        switch category {
+        case .largeOld:
+            switch largeOldFacet {
+            case .all:
+                base = largeOldCache.allSorted
+            case .selected:
+                base = largeOldCache.allSorted
+                selection = viewModel.selectedURLs
+            case .kind(let kind):
+                base = largeOldCache.byKind[kind] ?? []
+            case .size(let bucket):
+                base = largeOldCache.bySize[bucket] ?? []
+            }
+        case .downloads:
+            let group = downloadCache.first(where: { $0.source == selectedBrowser }) ?? downloadCache.first
+            base = group?.items.map(\.file) ?? []
+        case .duplicates, .similar:
+            // The image categories render the preview pane, not a file list.
+            displayedFiles = []
+            return
+        }
+        let search = self.search
+        let sortByName = sort == .name
+        let limit = Self.displayRowLimit
+        let selectionFilter = selection
+        let rows = await Task.detached(priority: .userInitiated) {
+            var files = base
+            if let selectionFilter {
+                files = files.filter { selectionFilter.contains($0.url) }
+            }
+            return MyClutterManagerModel.display(files, search: search, sortByName: sortByName, limit: limit)
+        }.value
+        // A superseded rebuild (its `.task` id changed mid-flight) must not
+        // overwrite the newer task's rows.
+        guard !Task.isCancelled else { return }
+        displayedFiles = rows
     }
 
     private func rebuildCaches() async {
@@ -348,7 +436,7 @@ struct MyClutterManagerView: View {
     private var rightPaneContent: some View {
         switch category {
         case .largeOld:
-            if isLoadingCache { loadingPane } else { fileList(display(largeOldBase)) }
+            if isLoadingCache { loadingPane } else { fileList(displayedFiles) }
         case .duplicates:
             if let group = viewModel.duplicateGroups.first(where: { $0.id == (selectedGroupID ?? viewModel.duplicateGroups.first?.id) }) {
                 imagePreviewPane(files: group.files, original: group.original, showsBestBadge: false)
@@ -360,11 +448,10 @@ struct MyClutterManagerView: View {
         case .downloads:
             if isLoadingCache {
                 loadingPane
+            } else if downloadCache.isEmpty {
+                emptyRightPane
             } else {
-                let group = downloadCache.first(where: { $0.source == selectedBrowser }) ?? downloadCache.first
-                if let group {
-                    fileList(display(group.items.map(\.file)))
-                } else { emptyRightPane }
+                fileList(displayedFiles)
             }
         }
     }
@@ -379,31 +466,6 @@ struct MyClutterManagerView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    /// The cached, pre-sorted base list for the active Large & Old facet. The
-    /// "Selected" facet filters the (in-memory) cached list; the rest are O(1).
-    private var largeOldBase: [ScannedFile] {
-        switch largeOldFacet {
-        case .all: return largeOldCache.allSorted
-        case .selected: return largeOldCache.allSorted.filter { viewModel.isSelected($0.url) }
-        case .kind(let kind): return largeOldCache.byKind[kind] ?? []
-        case .size(let bucket): return largeOldCache.bySize[bucket] ?? []
-        }
-    }
-
-    /// Applies the search filter and (only for name sort) re-sorts, then caps
-    /// the rendered rows. Size-sorted lists arrive pre-sorted from the cache, so
-    /// the default view does no per-render sort.
-    private func display(_ files: [ScannedFile]) -> [ScannedFile] {
-        var result = files
-        if !search.isEmpty {
-            result = result.filter { $0.url.lastPathComponent.localizedCaseInsensitiveContains(search) }
-        }
-        if sort == .name {
-            result = result.sorted { $0.url.lastPathComponent.localizedCaseInsensitiveCompare($1.url.lastPathComponent) == .orderedAscending }
-        }
-        return Array(result.prefix(Self.displayRowLimit))
     }
 
     private var emptyRightPane: some View {
@@ -675,13 +737,16 @@ struct MyClutterManagerView: View {
         focusedURL = nil
     }
 
+    /// Home path and name resolved once for the process — `breadcrumbText`
+    /// runs per visible row, so it must not re-derive them on every call.
+    private static let homePath = FileManager.default.homeDirectoryForCurrentUser.path
+    private static let homeName = FileManager.default.homeDirectoryForCurrentUser.lastPathComponent
+
     private func breadcrumbText(_ url: URL) -> String {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
         var path = url.deletingLastPathComponent().path
-        if path.hasPrefix(home) { path = String(path.dropFirst(home.count)) }
+        if path.hasPrefix(Self.homePath) { path = String(path.dropFirst(Self.homePath.count)) }
         let components = path.split(separator: "/").map(String.init)
-        let homeName = FileManager.default.homeDirectoryForCurrentUser.lastPathComponent
-        return ([homeName] + components).joined(separator: " › ")
+        return ([Self.homeName] + components).joined(separator: " › ")
     }
 
     private func dateText(_ date: Date?) -> String {

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -547,7 +547,10 @@ struct PerformanceTaskCatalogView: View {
                     onToggle: { toggle($0, in: selection) },
                     accent: ManagerChrome.accent,
                     rowHeight: 44,
-                    contentToken: "\(paneKey)|\(displayed.count)|\(displayed.first?.id ?? "")|\(sort.rawValue)|\(search)",
+                    // These panes hold at most a few dozen rows, so building
+                    // the order-sensitive token inline per render is cheap;
+                    // large-list managers precompute it instead.
+                    contentToken: "\(paneKey)|\(ManagerItemTable.contentToken(items: displayed, sort: sort.rawValue, search: search))",
                     accessibilityPrefix: "performance.manager.\(paneKey)",
                     forcesLightAppearance: true,
                     showsSparkle: true
@@ -588,9 +591,6 @@ struct PerformanceTaskCatalogView: View {
             Text(String(localized: "Select:", comment: "Label before the bulk-select menu on the Performance Manager."))
                 .foregroundStyle(.secondary)
             Menu {
-                Button(String(localized: "Smartly", comment: "Bulk-select the recommended items.")) {
-                    selection.wrappedValue.formUnion(allIDs)
-                }
                 Button(String(localized: "Select All", comment: "Bulk-select every item in the pane.")) {
                     selection.wrappedValue.formUnion(allIDs)
                 }

--- a/VaderCleaner/SmartScanReviewManager.swift
+++ b/VaderCleaner/SmartScanReviewManager.swift
@@ -219,11 +219,22 @@ struct SmartScanReviewManager: View {
     /// include the children of any expanded row. Recomputed when the category,
     /// sort, search, or expansion changes — never on a selection toggle.
     @State private var displayedItems: [ManagerItem] = []
+    /// Reload token for `displayedItems`, rebuilt alongside it (see
+    /// `ManagerItemTable.contentToken`) so the O(n) id hash runs once per
+    /// content change instead of once per render.
+    @State private var displayedToken = ""
     /// Lazily-loaded rows per category id (when `loadItems` is set), cached for
     /// this manager session.
     @State private var lazyItemsByCategory: [String: [ManagerItem]] = [:]
-    /// True while the selected category's rows are being loaded lazily.
-    @State private var isLoadingItems = false
+    /// Category id whose rows are being loaded lazily right now. Tracked by id
+    /// (not a plain flag) so a load superseded by a category switch can't
+    /// clear — or leave stuck — the newer load's spinner.
+    @State private var loadingCategoryID: String?
+
+    /// True while the *selected* category's rows are being loaded lazily.
+    private var isLoadingItems: Bool {
+        loadingCategoryID != nil && loadingCategoryID == selectedCategoryID
+    }
 
     private var loadedSections: [ManagerSection] { sections ?? [] }
 
@@ -278,11 +289,13 @@ struct SmartScanReviewManager: View {
     /// caching them for this session. No-op for eager managers.
     private func loadSelectedCategoryIfNeeded() async {
         guard let loadItems, let id = selectedCategoryID, lazyItemsByCategory[id] == nil else { return }
-        isLoadingItems = true
+        loadingCategoryID = id
         let built = await loadItems(id)
-        // Guard against the category having changed while loading.
-        if selectedCategoryID == id { lazyItemsByCategory[id] = built }
-        isLoadingItems = false
+        // Guard against the category having changed while loading: the cache
+        // still accepts the stale build (it's valid for its category), but
+        // only the load that is still current may clear the loading marker.
+        lazyItemsByCategory[id] = built
+        if loadingCategoryID == id { loadingCategoryID = nil }
     }
 
     // MARK: - Header
@@ -444,9 +457,6 @@ struct SmartScanReviewManager: View {
                         Text(String(localized: "Select:", comment: "Label before the bulk-select menu on a Smart Scan Manager."))
                             .foregroundStyle(.secondary)
                         Menu {
-                            Button(String(localized: "Smartly", comment: "Bulk-select the recommended items in the category.")) {
-                                onSetCategory(category, true)
-                            }
                             Button(String(localized: "Select All", comment: "Bulk-select every item in the category.")) {
                                 onSetCategory(category, true)
                             }
@@ -487,8 +497,10 @@ struct SmartScanReviewManager: View {
                         // `displayedItems` is recomputed, so an input-based token
                         // would reload with the previous category's row count and
                         // then skip the reload once the real rows arrive — leaving
-                        // stale, unconfigured cells.
-                        contentToken: "\(displayedItems.count)|\(displayedItems.first?.id ?? "")|\(displayedItems.last?.id ?? "")|\(sort.rawValue)|\(search)",
+                        // stale, unconfigured cells. The token is precomputed in
+                        // `refreshDisplayedItems` so its O(n) id hash never runs
+                        // per render.
+                        contentToken: displayedToken,
                         accessibilityPrefix: accessibilityPrefix,
                         forcesLightAppearance: lightSurface,
                         showsSparkle: showsSparkle,
@@ -610,7 +622,11 @@ struct SmartScanReviewManager: View {
     /// needs no top-level sort. Expanded rows are followed by their (already
     /// size-sorted) children.
     private func refreshDisplayedItems() {
-        guard selectedCategory != nil else { displayedItems = []; return }
+        guard selectedCategory != nil else {
+            displayedItems = []
+            displayedToken = ManagerItemTable.contentToken(items: [], sort: sort.rawValue, search: search)
+            return
+        }
         let categoryItems = currentCategoryItems
         let filtered = search.isEmpty
             ? categoryItems
@@ -630,6 +646,7 @@ struct SmartScanReviewManager: View {
             }
         }
         displayedItems = rows
+        displayedToken = ManagerItemTable.contentToken(items: rows, sort: sort.rawValue, search: search)
     }
 
     /// Toggle a top-level row's disclosure and rebuild the visible list.

--- a/VaderCleanerTests/DuplicateScannerTests.swift
+++ b/VaderCleanerTests/DuplicateScannerTests.swift
@@ -96,4 +96,32 @@ final class DuplicateScannerTests: XCTestCase {
                              "Groups must be ordered by reclaimable bytes, largest first")
         XCTAssertEqual(groups[0].reclaimableBytes, 5000, "One redundant 5000-byte copy is reclaimable")
     }
+
+    func test_identicalFilesLargerThanPrefixTierAreGrouped() async throws {
+        // Bigger than the prefix-hash tier, so grouping must fall through to
+        // the full-content hash and still confirm the match.
+        let bytes = Data((0..<(DuplicateScanner.prefixHashByteLimit + 4096)).map { UInt8(truncatingIfNeeded: $0) })
+        try bytes.write(to: root.appendingPathComponent("big-a.bin"))
+        try bytes.write(to: root.appendingPathComponent("big-b.bin"))
+
+        let groups = try await scan()
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(Set(groups[0].files.map { $0.url.lastPathComponent }), ["big-a.bin", "big-b.bin"])
+    }
+
+    func test_samePrefixDifferentTailIsNotGrouped() async throws {
+        // Identical through the whole prefix tier, differing only in the final
+        // byte — the cheap prefix pass must not be trusted as confirmation.
+        var a = Data((0..<(DuplicateScanner.prefixHashByteLimit + 4096)).map { UInt8(truncatingIfNeeded: $0) })
+        var b = a
+        a[a.count - 1] = 0x00
+        b[b.count - 1] = 0xFF
+        try a.write(to: root.appendingPathComponent("tail-a.bin"))
+        try b.write(to: root.appendingPathComponent("tail-b.bin"))
+
+        let groups = try await scan()
+
+        XCTAssertTrue(groups.isEmpty, "Files sharing only a prefix must not be reported as duplicates")
+    }
 }

--- a/VaderCleanerTests/LRUCacheTests.swift
+++ b/VaderCleanerTests/LRUCacheTests.swift
@@ -1,0 +1,56 @@
+// LRUCacheTests.swift
+// Pins the LRUCache contract: capacity-bounded storage, least-recently-used eviction, and read-refreshed recency.
+
+import XCTest
+@testable import VaderCleaner
+
+final class LRUCacheTests: XCTestCase {
+
+    func test_storesAndRetrievesValues() {
+        var cache = LRUCache<String, Int>(capacity: 4)
+        cache.setValue(1, forKey: "a")
+        cache.setValue(2, forKey: "b")
+
+        XCTAssertEqual(cache.value(forKey: "a"), 1)
+        XCTAssertEqual(cache.value(forKey: "b"), 2)
+        XCTAssertNil(cache.value(forKey: "missing"))
+    }
+
+    func test_countNeverExceedsCapacity() {
+        var cache = LRUCache<Int, Int>(capacity: 8)
+        for i in 0..<100 { cache.setValue(i, forKey: i) }
+
+        XCTAssertLessThanOrEqual(cache.count, 8)
+        XCTAssertEqual(cache.value(forKey: 99), 99, "The newest entry always survives")
+    }
+
+    func test_evictsLeastRecentlyUsedFirst() {
+        var cache = LRUCache<String, Int>(capacity: 2)
+        cache.setValue(1, forKey: "old")
+        cache.setValue(2, forKey: "new")
+        cache.setValue(3, forKey: "newest") // over capacity → evicts "old"
+
+        XCTAssertNil(cache.value(forKey: "old"))
+        XCTAssertEqual(cache.value(forKey: "newest"), 3)
+    }
+
+    func test_readRefreshesRecency() {
+        var cache = LRUCache<String, Int>(capacity: 2)
+        cache.setValue(1, forKey: "a")
+        cache.setValue(2, forKey: "b")
+        _ = cache.value(forKey: "a")   // "a" is now more recent than "b"
+        cache.setValue(3, forKey: "c") // over capacity → evicts "b", not "a"
+
+        XCTAssertEqual(cache.value(forKey: "a"), 1)
+        XCTAssertNil(cache.value(forKey: "b"))
+    }
+
+    func test_updatingExistingKeyDoesNotGrowCount() {
+        var cache = LRUCache<String, Int>(capacity: 2)
+        cache.setValue(1, forKey: "a")
+        cache.setValue(2, forKey: "a")
+
+        XCTAssertEqual(cache.count, 1)
+        XCTAssertEqual(cache.value(forKey: "a"), 2)
+    }
+}

--- a/VaderCleanerTests/ManagerContentTokenTests.swift
+++ b/VaderCleanerTests/ManagerContentTokenTests.swift
@@ -1,0 +1,64 @@
+// ManagerContentTokenTests.swift
+// Pins the ManagerItemTable content-token builder: any change to the displayed rows, their order, the sort, or the search must yield a different token so the table bridge reloads.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ManagerContentTokenTests: XCTestCase {
+
+    private func item(_ id: String) -> ManagerItem {
+        ManagerItem(
+            id: id,
+            title: id,
+            subtitle: nil,
+            size: nil,
+            sizeText: nil,
+            systemImage: "doc",
+            tint: .secondary
+        )
+    }
+
+    func test_sameRowsProduceSameToken() {
+        let items = [item("a"), item("b"), item("c")]
+
+        XCTAssertEqual(
+            ManagerItemTable.contentToken(items: items, sort: "size", search: ""),
+            ManagerItemTable.contentToken(items: items, sort: "size", search: "")
+        )
+    }
+
+    func test_middleRowChangeChangesToken_evenWithSameCountAndEndpoints() {
+        // Same count, same first id, same last id — only the middle differs.
+        // The old count|first|last heuristic could not tell these apart.
+        let before = [item("a"), item("m1"), item("z")]
+        let after = [item("a"), item("m2"), item("z")]
+
+        XCTAssertNotEqual(
+            ManagerItemTable.contentToken(items: before, sort: "size", search: ""),
+            ManagerItemTable.contentToken(items: after, sort: "size", search: "")
+        )
+    }
+
+    func test_rowOrderChangesToken() {
+        let forward = [item("a"), item("b")]
+        let reversed = [item("b"), item("a")]
+
+        XCTAssertNotEqual(
+            ManagerItemTable.contentToken(items: forward, sort: "size", search: ""),
+            ManagerItemTable.contentToken(items: reversed, sort: "size", search: "")
+        )
+    }
+
+    func test_sortAndSearchChangeToken() {
+        let items = [item("a")]
+
+        XCTAssertNotEqual(
+            ManagerItemTable.contentToken(items: items, sort: "size", search: ""),
+            ManagerItemTable.contentToken(items: items, sort: "name", search: "")
+        )
+        XCTAssertNotEqual(
+            ManagerItemTable.contentToken(items: items, sort: "size", search: ""),
+            ManagerItemTable.contentToken(items: items, sort: "size", search: "q")
+        )
+    }
+}

--- a/VaderCleanerTests/MyClutterManagerModelTests.swift
+++ b/VaderCleanerTests/MyClutterManagerModelTests.swift
@@ -39,6 +39,53 @@ final class MyClutterManagerModelTests: XCTestCase {
                        [URL(fileURLWithPath: "/a/big.mov")])
     }
 
+    func test_displayFiltersBySearchCaseInsensitively() {
+        let files = [
+            file("/a/Holiday.mov", size: 300),
+            file("/a/report.pdf", size: 200),
+            file("/a/holiday-2.mov", size: 100),
+        ]
+
+        let shown = MyClutterManagerModel.display(files, search: "HOLIDAY", sortByName: false, limit: 100)
+
+        XCTAssertEqual(shown.map(\.url.lastPathComponent), ["Holiday.mov", "holiday-2.mov"])
+    }
+
+    func test_displayPreservesInputOrderForSizeSort() {
+        let files = [
+            file("/a/b.mov", size: 300),
+            file("/a/a.mov", size: 200),
+            file("/a/c.mov", size: 100),
+        ]
+
+        let shown = MyClutterManagerModel.display(files, search: "", sortByName: false, limit: 100)
+
+        XCTAssertEqual(shown.map(\.url.lastPathComponent), ["b.mov", "a.mov", "c.mov"],
+                       "Size-sorted input arrives pre-sorted and must pass through untouched")
+    }
+
+    func test_displaySortsByNameWhenAsked() {
+        let files = [
+            file("/a/beta.mov", size: 300),
+            file("/a/Alpha.mov", size: 200),
+            file("/a/gamma.mov", size: 100),
+        ]
+
+        let shown = MyClutterManagerModel.display(files, search: "", sortByName: true, limit: 100)
+
+        XCTAssertEqual(shown.map(\.url.lastPathComponent), ["Alpha.mov", "beta.mov", "gamma.mov"])
+    }
+
+    func test_displayCapsRowsAtLimit() {
+        let files = (0..<10).map { file("/a/f\($0).mov", size: Int64(10 - $0)) }
+
+        let shown = MyClutterManagerModel.display(files, search: "", sortByName: false, limit: 3)
+
+        XCTAssertEqual(shown.count, 3)
+        XCTAssertEqual(shown.map(\.url.lastPathComponent), ["f0.mov", "f1.mov", "f2.mov"],
+                       "The cap keeps the head of the pre-sorted list")
+    }
+
     func test_downloadsGroupedBySourceOrderedByBytes() {
         let items = [
             DownloadItem(file: file("/d/a.dmg", size: 100), sourceApp: "Safari"),


### PR DESCRIPTION
## What changed

Fixes for every finding from a SwiftUI performance audit of the scan pipelines, section dashboards, and selection-bearing list surfaces, plus the missing Applications Manager icon preload spotted afterward.

- **My Clutter Manager** — the right pane's file rows are now memoized in `@State` and rebuilt off the main actor only when a real input changes (category, facet, search, sort, results version, or — only under the Selected facet — an O(1) selection stamp). A checkbox toggle previously re-ran the O(N) search filter (and under name sort, an O(N log N) re-sort) on every render. The filter/sort/cap pass moved to a pure helper, `MyClutterManagerModel.display(_:search:sortByName:limit:)`.
- **DuplicateScanner** — size collisions are confirmed in two tiers: a cheap 64 KB prefix hash first (files diverging early never pay a full read; files no larger than the prefix are confirmed by it outright), then a full-content hash over surviving prefix collisions. Both tiers run with bounded concurrency (4 hashes in flight).
- **ManagerItemTable** — the reload token is now an order-sensitive hash over every row id (`contentToken`), replacing the count/first/last heuristic that could miss a mid-list change. The Finder-icon cache is bounded by a new `LRUCache` (1,024 entries) so scrolling a huge category can't grow it without limit.
- **SmartScanReviewManager** — the token is precomputed alongside `displayedItems` (never per render, including the empty branch), and the lazy-load spinner is tracked by category id so a load superseded by a category switch can't clear or wedge the newer load's spinner.
- **Applications Manager** — preloads app icons for the Uninstaller and Updater rosters. `AppIconCache.icon(for:)` never loads on a miss, so rows only showed real icons for apps another card (e.g. the dashboard's Unused card) happened to preload first.
- **Cleanups** — removed the "Smartly" bulk-select menu items that were exact duplicates of "Select All" (Smart Scan review + Performance manager); the My Clutter breadcrumb resolves the home path once per process instead of twice per visible row.

## Why

A code-first performance audit found these as the remaining per-toggle/per-render costs and unbounded caches in otherwise well-optimized list surfaces; the icon issue made most Applications Manager rows render the generic placeholder indefinitely.

## Notes for review

- `junkCategorySelection`'s O(N) facade was also audited and deliberately left alone — it has no production callers (only tests pin its semantics).
- New tests (all passing, written before the implementations): `LRUCacheTests`, `ManagerContentTokenTests`, prefix-tier cases in `DuplicateScannerTests`, and display-pass cases in `MyClutterManagerModelTests`. Full unit suite passes on a clean build (`xcodebuild test` with `CODE_SIGNING_ALLOWED=NO`).
- `project.pbxproj` changes are from `xcodegen generate` registering the three new files.
- The view-layer pieces (memoized rows, loading marker, icon preload) aren't unit-testable directly; their extracted logic is what the new tests cover. Worth a quick manual pass over the My Clutter Manager, a Smart Scan review screen, and the Applications Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file and app lists now refresh more reliably when search, sorting, or selection changes.
  * Duplicate scanning is faster and more responsive on large file sets.

* **Bug Fixes**
  * Fixed stale loading indicators when switching categories during background loading.
  * Icon loading is now more efficient, reducing repeated work and memory growth.
  * Bulk selection menus were simplified to the available actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->