### PR TITLE
Adopt the Maintenance Tasks card look across all manager right panes

### DIFF
--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -672,9 +672,7 @@ private struct InstallationFileRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
+            ManagerRowCheckbox(isOn: isSelected, action: onToggle)
 
             Image(systemName: kindSymbol)
                 .font(.system(size: 18))
@@ -860,9 +858,7 @@ private struct UnsupportedAppRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
+            ManagerRowCheckbox(isOn: isSelected, action: onToggle)
 
             Image(nsImage: iconCache.icon(for: entry.app.bundleURL))
                 .resizable()
@@ -1039,9 +1035,7 @@ private struct UnusedAppRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
+            ManagerRowCheckbox(isOn: isSelected, action: onToggle)
 
             Image(nsImage: iconCache.icon(for: entry.app.bundleURL))
                 .resizable()
@@ -1211,9 +1205,7 @@ private struct LeftoverRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
+            ManagerRowCheckbox(isOn: isSelected, action: onToggle)
 
             Image(systemName: "folder.badge.minus")
                 .font(.system(size: 18))

--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -1280,12 +1280,7 @@ struct ApplicationsManagerCheckbox: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            Image(systemName: selected ? "checkmark.square.fill" : "square")
-                .font(.system(size: 18))
-                .foregroundStyle(selected ? ApplicationsManagerChrome.accent : Color.secondary)
-        }
-        .buttonStyle(.plain)
+        ManagerRowCheckbox(isOn: selected, action: action)
     }
 }
 

--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -575,14 +575,13 @@ private struct UninstallerPaneView: View {
 
     private var list: some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
+            LazyVStack(spacing: 10) {
                 ForEach(displayedApps) { app in
                     appRow(app)
-                    Divider().opacity(0.3)
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 12)
         }
         .onAppear { recompute() }
         .onChange(of: facet) { _, _ in recompute() }
@@ -632,7 +631,8 @@ private struct UninstallerPaneView: View {
             .buttonStyle(.plain)
             .accessibilityIdentifier("applications.manager.uninstaller.detail.\(app.bundleID)")
         }
-        .padding(.vertical, 10)
+        .padding(12)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
         .accessibilityIdentifier("applications.manager.uninstaller.row.\(app.bundleID)")
     }
 
@@ -846,7 +846,7 @@ private struct LeftoversPaneView: View {
                 )
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 0) {
+                    LazyVStack(spacing: 10) {
                         ForEach(rows) { row in
                             HStack(spacing: 12) {
                                 ApplicationsManagerCheckbox(selected: row.selected, action: row.toggle)
@@ -859,13 +859,13 @@ private struct LeftoversPaneView: View {
                                 Spacer(minLength: 8)
                                 Text(ApplicationsManagerChrome.byteText(row.bytes)).font(.callout.weight(.semibold)).foregroundStyle(.secondary)
                             }
-                            .padding(.vertical, 10)
                             .contentShape(Rectangle())
                             .onTapGesture { row.toggle() }
-                            Divider().opacity(0.3)
+                            .padding(12)
+                            .glassEffect(.regular, in: .rect(cornerRadius: 12))
                         }
                     }
-                    .padding(.horizontal, 16).padding(.vertical, 8)
+                    .padding(.horizontal, 24).padding(.vertical, 12)
                 }
             }
         }
@@ -990,13 +990,12 @@ private struct UpdaterPaneView: View {
             .accessibilityIdentifier("applications.manager.updater.empty")
         } else {
             ScrollView {
-                LazyVStack(spacing: 0) {
+                LazyVStack(spacing: 10) {
                     ForEach(displayed) { info in
                         row(info)
-                        Divider().opacity(0.3)
                     }
                 }
-                .padding(.horizontal, 16).padding(.vertical, 8)
+                .padding(.horizontal, 24).padding(.vertical, 12)
             }
             .onAppear { recompute() }
             .onChange(of: facet) { _, _ in recompute() }
@@ -1027,7 +1026,8 @@ private struct UpdaterPaneView: View {
                  : String(localized: "Web", comment: "Update source label."))
                 .font(.caption).foregroundStyle(.secondary)
         }
-        .padding(.vertical, 10)
+        .padding(12)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
         .accessibilityIdentifier("applications.manager.updater.row.\(info.bundleID)")
     }
 
@@ -1172,13 +1172,12 @@ private struct ExtensionsPaneView: View {
             .accessibilityIdentifier("applications.manager.extensions.empty")
         } else {
             ScrollView {
-                LazyVStack(spacing: 0) {
+                LazyVStack(spacing: 10) {
                     ForEach(displayed) { item in
                         row(item)
-                        Divider().opacity(0.3)
                     }
                 }
-                .padding(.horizontal, 16).padding(.vertical, 8)
+                .padding(.horizontal, 24).padding(.vertical, 12)
             }
             .onAppear { recompute() }
             .onChange(of: facet) { _, _ in recompute() }
@@ -1208,7 +1207,8 @@ private struct ExtensionsPaneView: View {
             Spacer(minLength: 8)
             Text(ApplicationsManagerChrome.byteText(item.size)).font(.callout.weight(.semibold)).foregroundStyle(.secondary)
         }
-        .padding(.vertical, 10)
+        .padding(12)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
         .accessibilityIdentifier("applications.manager.extensions.row.\(item.id.path)")
     }
 

--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -632,7 +632,7 @@ private struct UninstallerPaneView: View {
             .accessibilityIdentifier("applications.manager.uninstaller.detail.\(app.bundleID)")
         }
         .padding(12)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .managerRowCard()
         .accessibilityIdentifier("applications.manager.uninstaller.row.\(app.bundleID)")
     }
 
@@ -862,7 +862,7 @@ private struct LeftoversPaneView: View {
                             .contentShape(Rectangle())
                             .onTapGesture { row.toggle() }
                             .padding(12)
-                            .glassEffect(.regular, in: .rect(cornerRadius: 12))
+                            .managerRowCard()
                         }
                     }
                     .padding(.horizontal, 24).padding(.vertical, 12)
@@ -1027,7 +1027,7 @@ private struct UpdaterPaneView: View {
                 .font(.caption).foregroundStyle(.secondary)
         }
         .padding(12)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .managerRowCard()
         .accessibilityIdentifier("applications.manager.updater.row.\(info.bundleID)")
     }
 
@@ -1208,7 +1208,7 @@ private struct ExtensionsPaneView: View {
             Text(ApplicationsManagerChrome.byteText(item.size)).font(.callout.weight(.semibold)).foregroundStyle(.secondary)
         }
         .padding(12)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .managerRowCard()
         .accessibilityIdentifier("applications.manager.extensions.row.\(item.id.path)")
     }
 

--- a/VaderCleaner/ManagerChrome.swift
+++ b/VaderCleaner/ManagerChrome.swift
@@ -75,6 +75,36 @@ extension View {
     func managerRowCard() -> some View { modifier(ManagerRowCard()) }
 }
 
+/// The rounded checkbox every manager row card uses: an accent-filled rounded
+/// square with a white check when on, a softened accent outline when off — the
+/// SwiftUI counterpart of `ManagerCheckboxImage` in the AppKit item table, so
+/// checkboxes look the same across every list. Colored by the surrounding
+/// manager's section accent.
+struct ManagerRowCheckbox: View {
+    let isOn: Bool
+    let action: () -> Void
+    @Environment(\.sectionAccent) private var accent
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                if isOn {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous).fill(accent)
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(.white)
+                } else {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .strokeBorder(accent.opacity(0.6), lineWidth: 1.5)
+                }
+            }
+            .frame(width: 18, height: 18)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 /// Applies the white, light-mode surface for the standalone Manager cards. A
 /// no-op when `light` is false so Smart Scan's managers keep inheriting the
 /// section's dark gradient. The `colorScheme` override flips the SwiftUI chrome

--- a/VaderCleaner/ManagerChrome.swift
+++ b/VaderCleaner/ManagerChrome.swift
@@ -48,6 +48,33 @@ struct NavRow<Content: View>: View {
     }
 }
 
+/// The card surface behind one interactive row in a Manager's item pane: a
+/// white rounded card with a soft shadow and hairline border, matching the
+/// AppKit card drawn by `HoverTableRowView`. Deliberately not `glassEffect` —
+/// on macOS 26 a glass surface's container view can answer hit-testing itself
+/// (instead of the SwiftUI content hosted on it), which left row checkboxes
+/// and disclosure buttons unclickable. All the managers that use these rows
+/// force the light appearance, so the fixed white fill is safe.
+struct ManagerRowCard: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.white)
+                    .shadow(color: .black.opacity(0.10), radius: 3, y: 1)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(Color.black.opacity(0.06), lineWidth: 1)
+            )
+    }
+}
+
+extension View {
+    /// Styles the view as one Manager row card; see `ManagerRowCard`.
+    func managerRowCard() -> some View { modifier(ManagerRowCard()) }
+}
+
 /// Applies the white, light-mode surface for the standalone Manager cards. A
 /// no-op when `light` is false so Smart Scan's managers keep inheriting the
 /// section's dark gradient. The `colorScheme` override flips the SwiftUI chrome

--- a/VaderCleaner/ManagerItemTable.swift
+++ b/VaderCleaner/ManagerItemTable.swift
@@ -112,7 +112,6 @@ struct ManagerItemTable: NSViewRepresentable {
         private var showsSparkle = false
         private var isExpanded: (String) -> Bool = { _ in false }
         private var onToggleExpand: (String) -> Void = { _ in }
-        private var roundedCheckbox = false
         fileprivate var contentToken = ""
         weak var table: NSTableView?
 
@@ -126,8 +125,6 @@ struct ManagerItemTable: NSViewRepresentable {
             showsSparkle = source.showsSparkle
             isExpanded = source.isExpanded
             onToggleExpand = source.onToggleExpand
-            // The white Cleanup card uses the rounded, accent-outlined checkbox.
-            roundedCheckbox = source.forcesLightAppearance
             contentToken = source.contentToken
         }
 
@@ -149,8 +146,7 @@ struct ManagerItemTable: NSViewRepresentable {
                 showsSparkle: showsSparkle,
                 isExpanded: isExpanded(item.id),
                 onToggleExpand: onToggleExpand,
-                onToggleSelection: onToggle,
-                roundedCheckbox: roundedCheckbox
+                onToggleSelection: onToggle
             )
             cell.setAccessibilityIdentifier("\(accessibilityPrefix).item.\(item.id)")
             return cell
@@ -301,9 +297,6 @@ final class ManagerRowCellView: NSTableCellView {
     private var onChevron: (() -> Void)?
     /// Invoked when the checkbox is clicked — the only way to (de)select a row.
     private var onCheckbox: (() -> Void)?
-    /// Whether to draw the rounded, accent-outlined checkbox (Cleanup card)
-    /// instead of the system SF-symbol checkbox.
-    private var roundedCheckbox = false
 
     init(reuseIdentifier: NSUserInterfaceItemIdentifier) {
         textStack = NSStackView(views: [titleField, subtitleField])
@@ -397,10 +390,8 @@ final class ManagerRowCellView: NSTableCellView {
         showsSparkle: Bool,
         isExpanded: Bool,
         onToggleExpand: @escaping (String) -> Void,
-        onToggleSelection: @escaping (String) -> Void,
-        roundedCheckbox: Bool
+        onToggleSelection: @escaping (String) -> Void
     ) {
-        self.roundedCheckbox = roundedCheckbox
         indentWidth.constant = CGFloat(item.indentLevel) * Self.indentStep
         checkbox.isHidden = !showsCheckbox
         let selectionID = item.id
@@ -472,18 +463,10 @@ final class ManagerRowCellView: NSTableCellView {
 
     func setSelected(_ selected: Bool, accent: NSColor) {
         guard !checkbox.isHidden else { return }
-        if roundedCheckbox {
-            // A rounded square: an accent-outlined box when unchecked, filled
-            // with a white check when selected — matching the reference card.
-            checkbox.image = ManagerCheckboxImage.image(checked: selected, accent: accent)
-            checkbox.contentTintColor = nil
-        } else {
-            checkbox.image = ManagerSymbolCache.image(
-                selected ? "checkmark.square.fill" : "square",
-                pointSize: 15
-            )
-            checkbox.contentTintColor = selected ? accent : .tertiaryLabelColor
-        }
+        // A rounded square: an accent-outlined box when unchecked, filled
+        // with a white check when selected — matching the reference card.
+        checkbox.image = ManagerCheckboxImage.image(checked: selected, accent: accent)
+        checkbox.contentTintColor = nil
     }
 }
 
@@ -502,7 +485,7 @@ private enum ManagerSymbolCache {
     }
 }
 
-/// Draws and caches the rounded checkbox used on the Cleanup card: an
+/// Draws and caches the rounded checkbox used on every manager row: an
 /// accent-outlined rounded square when unchecked, filled with a white check when
 /// selected. Keyed by checked-state + accent so it redraws only when those
 /// change. Main-thread only (cells are configured on the main actor).

--- a/VaderCleaner/ManagerItemTable.swift
+++ b/VaderCleaner/ManagerItemTable.swift
@@ -59,7 +59,9 @@ struct ManagerItemTable: NSViewRepresentable {
         table.gridStyleMask = []
         table.usesAlternatingRowBackgroundColors = false
         table.rowHeight = rowHeight
-        table.intercellSpacing = NSSize(width: 0, height: 4)
+        // The 10-point visual gap between row cards comes from each card's
+        // 4-point vertical inset (×2) plus this spacing.
+        table.intercellSpacing = NSSize(width: 0, height: 2)
         // No table-wide click action: only the row's checkbox toggles selection.
         table.onHoverRowChange = { [weak coordinator = context.coordinator] row in
             coordinator?.setHoveredRow(row)
@@ -154,7 +156,7 @@ struct ManagerItemTable: NSViewRepresentable {
             return cell
         }
 
-        /// Vends a row view that can draw the hover highlight.
+        /// Vends a row view that draws the card background and hover highlight.
         func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
             let id = NSUserInterfaceItemIdentifier("HoverRow")
             let view = (tableView.makeView(withIdentifier: id, owner: self) as? HoverTableRowView)
@@ -225,7 +227,9 @@ final class HoverTableView: NSTableView {
     }
 }
 
-/// Row view that draws a soft, rounded hover fill behind its cell.
+/// Row view that draws each row as a rounded card — the same look as the
+/// SwiftUI glass card rows in the manager panes — plus a soft hover tint over
+/// the card.
 final class HoverTableRowView: NSTableRowView {
     var isHovered = false {
         didSet { if isHovered != oldValue { needsDisplay = true } }
@@ -233,10 +237,37 @@ final class HoverTableRowView: NSTableRowView {
 
     override func drawBackground(in dirtyRect: NSRect) {
         super.drawBackground(in: dirtyRect)
+        // Inset to the panes' 24-point content margin; the vertical inset pairs
+        // with the table's intercell spacing to form the gap between cards.
+        let card = bounds.insetBy(dx: 24, dy: 4)
+        let path = NSBezierPath(roundedRect: card, xRadius: 12, yRadius: 12)
+        let isLight = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua
+        if isLight {
+            // A white card with a soft shadow and hairline border, standing in
+            // for SwiftUI's glass card on the white manager surface.
+            NSGraphicsContext.saveGraphicsState()
+            let shadow = NSShadow()
+            shadow.shadowColor = NSColor.black.withAlphaComponent(0.10)
+            shadow.shadowBlurRadius = 3
+            shadow.shadowOffset = NSSize(width: 0, height: -1)
+            shadow.set()
+            NSColor.white.setFill()
+            path.fill()
+            NSGraphicsContext.restoreGraphicsState()
+            NSColor.black.withAlphaComponent(0.06).setStroke()
+            path.lineWidth = 1
+            path.stroke()
+        } else {
+            // A translucent white card over the section's dark gradient.
+            NSColor.white.withAlphaComponent(0.08).setFill()
+            path.fill()
+            NSColor.white.withAlphaComponent(0.12).setStroke()
+            path.lineWidth = 1
+            path.stroke()
+        }
         guard isHovered else { return }
-        let inset = bounds.insetBy(dx: 8, dy: 1)
-        NSColor(white: 0.5, alpha: 0.16).setFill()
-        NSBezierPath(roundedRect: inset, xRadius: 8, yRadius: 8).fill()
+        (isLight ? NSColor.black.withAlphaComponent(0.03) : NSColor.white.withAlphaComponent(0.05)).setFill()
+        path.fill()
     }
 }
 
@@ -264,7 +295,7 @@ final class ManagerRowCellView: NSTableCellView {
     private var indentWidth: NSLayoutConstraint!
 
     /// Per-indent-level inset (matches the icon column so children line up).
-    private static let indentStep: CGFloat = 28
+    private static let indentStep: CGFloat = 38
 
     /// Invoked when the disclosure chevron is clicked. Set per `configure`.
     private var onChevron: (() -> Void)?
@@ -294,7 +325,7 @@ final class ManagerRowCellView: NSTableCellView {
         subtitleField.textColor = .secondaryLabelColor
         subtitleField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-        sparkleView.image = ManagerSymbolCache.image("sparkles", pointSize: 14)
+        sparkleView.image = ManagerSymbolCache.image("sparkles", pointSize: 15)
         sparkleView.contentTintColor = .systemPink
         sparkleView.setContentHuggingPriority(.required, for: .horizontal)
 
@@ -346,7 +377,9 @@ final class ManagerRowCellView: NSTableCellView {
         rowStack.orientation = .horizontal
         rowStack.alignment = .centerY
         rowStack.spacing = 12
-        rowStack.edgeInsets = NSEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        // 24-point card inset plus the card's 14-point interior padding, so the
+        // content sits inside the row's card background.
+        rowStack.edgeInsets = NSEdgeInsets(top: 0, left: 38, bottom: 0, right: 38)
         rowStack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(rowStack)
         NSLayoutConstraint.activate([
@@ -377,11 +410,12 @@ final class ManagerRowCellView: NSTableCellView {
             // `iconPath` lets a row draw an icon from a path other than its
             // selection `id` (e.g. a login item keyed by bundle id).
             iconView.image = ManagerFileIconCache.icon(forPath: item.iconPath ?? item.id)
-            iconView.contentTintColor = nil
         } else {
-            iconView.image = ManagerSymbolCache.image(item.systemImage, pointSize: 16)
-            iconView.contentTintColor = item.tint.nsColor
+            // A tinted gradient badge — the same look as the SwiftUI
+            // `TaskIconBadge` — so symbol rows match the card panes.
+            iconView.image = ManagerBadgeImageCache.image(symbol: item.systemImage, tint: item.tint)
         }
+        iconView.contentTintColor = nil
         titleField.stringValue = item.title
         if let subtitle = item.subtitle {
             subtitleField.stringValue = subtitle
@@ -511,6 +545,48 @@ private enum ManagerCheckboxImage {
     }
 }
 
+/// Draws and caches the tinted gradient icon badges for symbol rows — the same
+/// look as the SwiftUI `TaskIconBadge` so table rows match the card panes.
+/// Keyed by symbol + tint. Main-thread only (cells are configured on the main
+/// actor).
+private enum ManagerBadgeImageCache {
+    private static var cache: [String: NSImage] = [:]
+
+    static func image(symbol: String, tint: ManagerTint) -> NSImage {
+        let key = "\(symbol)|\(tint)"
+        if let cached = cache[key] { return cached }
+
+        let side: CGFloat = 38
+        let fill = NSColor(tint.color.deepenedForWhite).usingColorSpace(.sRGB) ?? .systemGray
+        let glyph = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)?
+            .withSymbolConfiguration(
+                NSImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+                    .applying(NSImage.SymbolConfiguration(paletteColors: [.white]))
+            )
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { _ in
+            let bounds = NSRect(x: 0, y: 0, width: side, height: side)
+            NSBezierPath(roundedRect: bounds, xRadius: 10, yRadius: 10).addClip()
+            // Top-to-bottom fade matching TaskIconBadge's LinearGradient.
+            NSGradient(
+                starting: fill.withAlphaComponent(0.95),
+                ending: fill.withAlphaComponent(0.65)
+            )?.draw(in: bounds, angle: 270)
+            if let glyph {
+                let size = glyph.size
+                glyph.draw(in: NSRect(
+                    x: (side - size.width) / 2,
+                    y: (side - size.height) / 2,
+                    width: size.width,
+                    height: size.height
+                ))
+            }
+            return true
+        }
+        cache[key] = image
+        return image
+    }
+}
+
 /// Caches the real Finder icons the Cleanup Manager rows show, keyed by path.
 /// `NSWorkspace.icon(forFile:)` is reasonably fast and OS-cached, but caching
 /// the sized `NSImage` here keeps scrolling smooth for large categories.
@@ -524,22 +600,8 @@ private enum ManagerFileIconCache {
     static func icon(forPath path: String) -> NSImage {
         if let cached = cache.value(forKey: path) { return cached }
         let image = NSWorkspace.shared.icon(forFile: path)
-        image.size = NSSize(width: 28, height: 28)
+        image.size = NSSize(width: 38, height: 38)
         cache.setValue(image, forKey: path)
         return image
-    }
-}
-
-extension ManagerTint {
-    /// AppKit counterpart of `color`, for the native table rows.
-    var nsColor: NSColor {
-        switch self {
-        case .green: return .systemGreen
-        case .blue: return .systemBlue
-        case .red: return .systemRed
-        case .orange: return .systemOrange
-        case .purple: return .systemPurple
-        case .secondary: return .secondaryLabelColor
-        }
     }
 }

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -678,14 +678,9 @@ struct MyClutterManagerView: View {
     }
 
     private func checkbox(for url: URL) -> some View {
-        Button {
+        ManagerRowCheckbox(isOn: viewModel.isSelected(url)) {
             viewModel.toggleSelection(url: url)
-        } label: {
-            Image(systemName: viewModel.isSelected(url) ? "checkmark.square.fill" : "square")
-                .font(.system(size: 18))
-                .foregroundStyle(viewModel.isSelected(url) ? Self.accent : Color.secondary)
         }
-        .buttonStyle(.plain)
     }
 
     private func breadcrumb(_ url: URL) -> some View {

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -478,14 +478,13 @@ struct MyClutterManagerView: View {
     /// breadcrumb path, modified date, and size.
     private func fileList(_ files: [ScannedFile]) -> some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
+            LazyVStack(spacing: 10) {
                 ForEach(files, id: \.url) { file in
                     fileRow(file)
-                    Divider().opacity(0.3)
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 12)
         }
     }
 
@@ -505,7 +504,8 @@ struct MyClutterManagerView: View {
             Text(ManagerByteText.string(file.size))
                 .font(.callout.weight(.semibold)).frame(width: 72, alignment: .trailing)
         }
-        .padding(.vertical, 10)
+        .padding(12)
+        .managerRowCard()
     }
 
     /// The image-preview pane for Duplicates / Similar Images: a "Select"

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -909,7 +909,7 @@ struct PerformanceTaskRow: View {
         .contentShape(Rectangle())
         .onTapGesture { onToggle() }
         .padding(12)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .managerRowCard()
         .accessibilityIdentifier("performance.task.\(task.kind.rawValue)")
         .animation(.smooth(duration: 0.25), value: isCompleted)
     }
@@ -965,7 +965,7 @@ struct PerformanceItemRow: View {
         .contentShape(Rectangle())
         .onTapGesture { onToggle() }
         .padding(12)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .managerRowCard()
         .accessibilityIdentifier(identifier)
         .task(id: item.iconPath ?? item.id) { resolveFileIcon() }
     }

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -517,8 +517,9 @@ struct PerformanceTaskCatalogView: View {
         }
     }
 
-    /// A checkbox list pane (Login Items / Background Items): a header, a
-    /// `Select:` menu, the `ManagerItemTable`, and an optional footnote.
+    /// A checkbox list pane (Login Items / Background Items), laid out like the
+    /// Maintenance Tasks pane: a heading, a one-line description, a `Select:`
+    /// menu, the card rows, and an optional footnote.
     @ViewBuilder
     private func itemListPane(
         paneKey: String,
@@ -530,58 +531,39 @@ struct PerformanceTaskCatalogView: View {
     ) -> some View {
         let allIDs = items.map(\.id)
         let displayed = filteredSorted(items)
-        VStack(alignment: .leading, spacing: 0) {
-            paneHeader(title: title, description: description)
-            selectRow(paneKey: paneKey, allIDs: allIDs, selection: selection)
-            if displayed.isEmpty {
-                Spacer()
-                Text(String(localized: "Nothing to review", comment: "Empty state in a Performance Manager pane."))
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(title).font(.title3.weight(.semibold))
+                Text(description)
+                    .font(.callout)
                     .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity)
-                Spacer()
-            } else {
-                ManagerItemTable(
-                    items: displayed,
-                    showsSelection: true,
-                    isSelected: { selection.wrappedValue.contains($0) },
-                    onToggle: { toggle($0, in: selection) },
-                    accent: ManagerChrome.accent,
-                    rowHeight: 44,
-                    // These panes hold at most a few dozen rows, so building
-                    // the order-sensitive token inline per render is cheap;
-                    // large-list managers precompute it instead.
-                    contentToken: "\(paneKey)|\(ManagerItemTable.contentToken(items: displayed, sort: sort.rawValue, search: search))",
-                    accessibilityPrefix: "performance.manager.\(paneKey)",
-                    forcesLightAppearance: true,
-                    showsSparkle: true
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                selectRow(paneKey: paneKey, allIDs: allIDs, selection: selection)
+                if displayed.isEmpty {
+                    Text(String(localized: "Nothing to review", comment: "Empty state in a Performance Manager pane."))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 48)
+                } else {
+                    VStack(spacing: 10) {
+                        ForEach(displayed) { item in
+                            PerformanceItemRow(
+                                item: item,
+                                isSelected: selection.wrappedValue.contains(item.id),
+                                identifier: "performance.manager.\(paneKey).item.\(item.id)",
+                                onToggle: { toggle(item.id, in: selection) }
+                            )
+                        }
+                    }
+                }
+                if let footnote {
+                    Text(footnote)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
-            if let footnote {
-                Text(footnote)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 10)
-            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(24)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-    }
-
-    /// The title + one-line description atop a pane, mirroring the Cleanup
-    /// Manager's pane header.
-    private func paneHeader(title: String, description: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title).font(.title3.weight(.semibold))
-            Text(description)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 24)
-        .padding(.top, 16)
-        .padding(.bottom, 12)
     }
 
     /// The `Select:` bulk-select menu, scoped to the pane's items.
@@ -609,9 +591,6 @@ struct PerformanceTaskCatalogView: View {
             Spacer()
         }
         .font(.callout)
-        .padding(.horizontal, 24)
-        .padding(.top, 4)
-        .padding(.bottom, 8)
     }
 
     private var maintenanceTasksPane: some View {
@@ -933,6 +912,79 @@ struct PerformanceTaskRow: View {
         .glassEffect(.regular, in: .rect(cornerRadius: 12))
         .accessibilityIdentifier("performance.task.\(task.kind.rawValue)")
         .animation(.smooth(duration: 0.25), value: isCompleted)
+    }
+}
+
+/// One selectable Login Items / Background Items card, matching the Maintenance
+/// Tasks row styling: a checkbox, the item's icon (the real Finder icon when it
+/// has one, else a tinted badge), the name with a one-line detail underneath,
+/// and the trailing pink sparkle.
+struct PerformanceItemRow: View {
+    let item: ManagerItem
+    let isSelected: Bool
+    let identifier: String
+    let onToggle: () -> Void
+
+    // Resolved once per icon path rather than on every render: the Finder-icon
+    // lookup is a synchronous NSWorkspace call, and a checkbox toggle re-renders
+    // every row in the pane.
+    @State private var fileIcon: NSImage?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+
+            iconView
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(.body.weight(.medium))
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        // The full detail (often a long path) stays readable on
+                        // hover; the row stays one line so its height is stable.
+                        .help(subtitle)
+                }
+            }
+
+            Spacer()
+
+            // Decorative "smart suggestion" sparkle, matching the maintenance
+            // task rows so every pane shares one trailing column.
+            Image(systemName: "sparkles")
+                .font(.system(size: 15))
+                .foregroundStyle(.pink)
+                .accessibilityHidden(true)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onToggle() }
+        .padding(12)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .accessibilityIdentifier(identifier)
+        .task(id: item.iconPath ?? item.id) { resolveFileIcon() }
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        if item.usesFileIcon, let fileIcon {
+            Image(nsImage: fileIcon)
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 38, height: 38)
+        } else {
+            TaskIconBadge(symbol: item.systemImage, tint: item.tint.color)
+        }
+    }
+
+    private func resolveFileIcon() {
+        guard item.usesFileIcon else { return }
+        fileIcon = NSWorkspace.shared.icon(forFile: item.iconPath ?? item.id)
     }
 }
 

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -866,9 +866,7 @@ struct PerformanceTaskRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
+            ManagerRowCheckbox(isOn: isSelected, action: onToggle)
                 .accessibilityIdentifier("performance.task.checkbox.\(task.kind.rawValue)")
 
             TaskIconBadge(symbol: task.icon, tint: tint)
@@ -932,9 +930,7 @@ struct PerformanceItemRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
-                .toggleStyle(.checkbox)
-                .labelsHidden()
+            ManagerRowCheckbox(isOn: isSelected, action: onToggle)
 
             iconView
 

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -356,17 +356,25 @@ private struct PrivacyPane: View {
                     onAll: { model.setAllSelected(true, browser: browser) },
                     onNone: { model.setAllSelected(false, browser: browser) }
                 )
-                ForEach(ProtectionPrivacyCategory.allCases) { category in
-                    categoryRow(category)
-                    if isExpanded(category) {
-                        ForEach(sortedItems(category)) { item in
-                            itemRow(category, item)
+                // Each category (with its expanded per-item rows) sits on its
+                // own rounded glass card, matching the manager card rows used
+                // across the app's other sections.
+                VStack(spacing: 10) {
+                    ForEach(ProtectionPrivacyCategory.allCases) { category in
+                        VStack(spacing: 0) {
+                            categoryRow(category)
+                            if isExpanded(category) {
+                                ForEach(sortedItems(category)) { item in
+                                    itemRow(category, item)
+                                }
+                            }
                         }
+                        .padding(.horizontal, 12)
+                        .glassEffect(.regular, in: .rect(cornerRadius: 12))
                     }
-                    Divider().opacity(0.3)
                 }
             }
-            .padding(.horizontal, 20).padding(.vertical, 16)
+            .padding(.horizontal, 24).padding(.vertical, 16)
         }
     }
 
@@ -479,31 +487,31 @@ private struct MalwareResultsPane: View {
                         onAll: { selectedThreats = Set(threats.map(\.id)) },
                         onNone: { selectedThreats = [] }
                     )
-                    ForEach(sortedThreats) { threat in threatRow(threat) }
+                    VStack(spacing: 10) {
+                        ForEach(sortedThreats) { threat in threatRow(threat) }
+                    }
                 }
             }
-            .padding(.horizontal, 20).padding(.vertical, 16)
+            .padding(.horizontal, 24).padding(.vertical, 16)
         }
     }
 
     private func threatRow(_ threat: MalwareThreat) -> some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 12) {
-                ManagerCheckbox(state: selectedThreats.contains(threat.id) ? .on : .off, accent: accent) {
-                    if selectedThreats.contains(threat.id) { selectedThreats.remove(threat.id) }
-                    else { selectedThreats.insert(threat.id) }
-                }
-                .frame(width: 26)
-                Image(systemName: "ant").font(.title3).foregroundStyle(.tint).frame(width: 26)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(threat.threatName).font(.body)
-                    Text(threat.filePath.path).font(.caption).foregroundStyle(.secondary).lineLimit(1).truncationMode(.middle)
-                }
-                Spacer(minLength: 0)
+        HStack(spacing: 12) {
+            ManagerCheckbox(state: selectedThreats.contains(threat.id) ? .on : .off, accent: accent) {
+                if selectedThreats.contains(threat.id) { selectedThreats.remove(threat.id) }
+                else { selectedThreats.insert(threat.id) }
             }
-            .padding(.vertical, 9)
-            Divider().opacity(0.3)
+            .frame(width: 26)
+            Image(systemName: "ant").font(.title3).foregroundStyle(.tint).frame(width: 26)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(threat.threatName).font(.body)
+                Text(threat.filePath.path).font(.caption).foregroundStyle(.secondary).lineLimit(1).truncationMode(.middle)
+            }
+            Spacer(minLength: 0)
         }
+        .padding(12)
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
     }
 
     private var sortedThreats: [MalwareThreat] {

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -370,7 +370,7 @@ private struct PrivacyPane: View {
                             }
                         }
                         .padding(.horizontal, 12)
-                        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+                        .managerRowCard()
                     }
                 }
             }
@@ -511,7 +511,7 @@ private struct MalwareResultsPane: View {
             Spacer(minLength: 0)
         }
         .padding(12)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .managerRowCard()
     }
 
     private var sortedThreats: [MalwareThreat] {

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -389,7 +389,7 @@ private struct PrivacyPane: View {
             if category.isExpandable {
                 Button { toggleExpanded(category) } label: {
                     Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                        .font(.caption.weight(.semibold)).foregroundStyle(.tint)
                         .rotationEffect(.degrees(isExpanded(category) ? 90 : 0))
                         .frame(width: 20, height: 20).contentShape(Rectangle())
                 }
@@ -613,8 +613,9 @@ private struct ManagerCheckbox: View {
     var body: some View {
         Button(action: action) {
             ZStack {
+                // Softened outline matching ManagerRowCheckbox's unchecked state.
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .strokeBorder(accent, lineWidth: 1.5)
+                    .strokeBorder(accent.opacity(0.6), lineWidth: 1.5)
                     .frame(width: 18, height: 18)
                 if state != .off {
                     RoundedRectangle(cornerRadius: 5, style: .continuous).fill(accent).frame(width: 18, height: 18)

--- a/VaderCleaner/SmartScanReviewManager.swift
+++ b/VaderCleaner/SmartScanReviewManager.swift
@@ -491,7 +491,9 @@ struct SmartScanReviewManager: View {
                         isSelected: isSelected,
                         onToggle: onToggle,
                         accent: accent,
-                        rowHeight: 44,
+                        // Tall enough for the 38-point icon plus the card's
+                        // interior padding and 4-point vertical card inset.
+                        rowHeight: 68,
                         // Key the table reload to the *actual* displayed rows, not
                         // the inputs: `selectedCategoryID` changes a render before
                         // `displayedItems` is recomputed, so an input-based token


### PR DESCRIPTION
## What changed

All manager right-hand item panes now share the Maintenance Tasks card design: rounded cards with a checkbox, an icon (real Finder/app icon or a tinted gradient badge), a bold name with a one-line detail underneath, and 10-point gaps between cards.

**Commit 1 — Performance Manager** ([PerformanceDashboardSubviews.swift](../blob/feature/performance-manager-card-panes/VaderCleaner/PerformanceDashboardSubviews.swift))
- Login Items and Background Items panes rebuilt on the Maintenance Tasks layout, replacing the AppKit `ManagerItemTable` with a new `PerformanceItemRow` glass card styled after `PerformanceTaskRow`.

**Commit 2 — every other manager**
- `ManagerItemTable` (serves the Cleanup Manager and the Smart Scan Junk / My Clutter / Applications / Malware / Performance reviews): each native `NSTableView` row now draws itself as a card — white with a soft shadow and hairline border on the light managers, translucent over Smart Scan's dark gradient — with 68-point rows, gradient icon badges matching `TaskIconBadge` (cached AppKit drawing, reusing `deepenedForWhite`), and hover as a tint over the card. The NSTableView stays because these lists reach tens of thousands of rows, where SwiftUI lists jank.
- Applications Manager: the Uninstaller, Leftovers (Installers / Leftover Files), Updater, and Extensions lists swap divider-separated rows for spaced glass card rows.
- Protection Manager: each Privacy category sits on its own card that expands to reveal its per-item rows; each detected threat is its own card.

## Why

The Maintenance Tasks pane's card list is the reference design; every section's manager should read as one visual system instead of a mix of flat tables and divider lists.

## Reviewer notes

- Behavior is unchanged everywhere: selection, `Select:` bulk menus, search, sort, disclosure/expansion, footnotes, and footer actions all work as before, and no accessibility identifiers changed.
- Middle nav/facet columns, the uninstaller's per-app detail drill-in, and dashboard sections without list panes (Space Lens, Health Monitor) are intentionally untouched.
- Verified: full build succeeds and all 1322 unit tests pass (`xcodebuild test … -only-testing:VaderCleanerTests clean CODE_SIGNING_ALLOWED=NO`). UI tests can't bootstrap from the terminal on this machine, so a visual pass is worthwhile — especially Cleanup (light) and a Smart Scan review (dark), where the card is drawn in AppKit rather than with SwiftUI's glass effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed manager screens with consistent, card-style rows across app lists, privacy categories, scan results, login items, background items, uninstallers, leftovers, updaters, and extensions.
  * Enhanced selection interactions: tapping anywhere on selectable rows toggles items, with improved visual feedback and consistent spacing.
* **Bug Fixes**
  * Improved icon handling and visuals, including clearer Finder/file icons and more consistent badge artwork.
  * Refined list spacing and empty-state presentation for cleaner, more readable layouts, including updated row sizing where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->