### PR TITLE
Remove medium-confidence dead code (member-level)

### DIFF
--- a/VaderCleaner/AppStoreUpdateChecker.swift
+++ b/VaderCleaner/AppStoreUpdateChecker.swift
@@ -2,7 +2,6 @@
 // Mac App Store update lookup via the public iTunes Search API — returns the latest released version and the apps.apple.com URL for an installed App Store bundle ID.
 
 import Foundation
-import os.log
 
 /// Reduced view of the iTunes Search API response that the App Updater
 /// actually consumes — version and the App Store URL we hand to
@@ -19,8 +18,6 @@ struct DefaultAppStoreUpdateChecker: Sendable {
 
     private let httpFetcher: HTTPFetching
     private let baseURL: URL
-    private let log = Logger(subsystem: "com.personal.VaderCleaner",
-                             category: "AppStoreUpdateChecker")
 
     init(
         httpFetcher: HTTPFetching = URLSession.shared,

--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -29,7 +29,6 @@ struct ApplicationsManagerView: View {
     /// one the My Clutter / Cleanup Managers adopt — independent of the
     /// Applications section's own hue.
     private static let accent = ApplicationsManagerChrome.accent
-    private static let selectionFill = ApplicationsManagerChrome.selectionFill
 
     @State private var pane: Pane
     @State private var search = ""

--- a/VaderCleaner/AssociatedFileFinder.swift
+++ b/VaderCleaner/AssociatedFileFinder.swift
@@ -2,7 +2,6 @@
 // Locates on-disk artifacts (preferences, caches, logs, containers, launch agents, …) that belong to a given app bundle so the App Uninstaller can review and Trash them alongside the .app bundle.
 
 import Foundation
-import os.log
 
 /// Production finder — looks under `~/Library/...` and `/Library/...`
 /// for files and directories whose names match the given bundle ID.
@@ -24,8 +23,6 @@ struct DefaultAssociatedFileFinder: Sendable {
     /// leave alone. Injected (like `homeDirectory`) so the production
     /// wiring can snapshot the live `ExclusionsStore` per uninstall.
     private let canonicalExclusions: [String]
-    private let log = Logger(subsystem: "com.personal.VaderCleaner",
-                             category: "AssociatedFileFinder")
 
     init(
         fileManager: FileManager = .default,

--- a/VaderCleaner/BrowserDataCounter.swift
+++ b/VaderCleaner/BrowserDataCounter.swift
@@ -3,7 +3,6 @@
 
 import Foundation
 import SQLite3
-import os.log
 
 /// Reads item counts for the Privacy feature, the count analogue of
 /// `BrowserDataClearer`'s size preview. Cache categories count files on disk;
@@ -37,8 +36,6 @@ private actor BrowserDataCountWorker {
 
     private let pathProvider: BrowserDataPathProviding
     private let fileManager: FileManager
-    private let log = Logger(subsystem: "com.personal.VaderCleaner",
-                             category: "BrowserDataCounter")
 
     init(pathProvider: BrowserDataPathProviding, fileManager: FileManager) {
         self.pathProvider = pathProvider

--- a/VaderCleaner/DeviceBatteryMonitor.swift
+++ b/VaderCleaner/DeviceBatteryMonitor.swift
@@ -64,7 +64,7 @@ final class DeviceBatteryMonitor {
     }
 
     func start() {
-        timer?.invalidate()
+        stop()
         let timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated { self?.poll() }
         }

--- a/VaderCleaner/FileScanner.swift
+++ b/VaderCleaner/FileScanner.swift
@@ -130,20 +130,6 @@ extension FileScanning {
         return results
     }
 
-    func scan(
-        roots: [ScanRoot],
-        excluding: [URL],
-        batchSize: Int,
-        onBatch: ([ScannedFile]) async throws -> Void
-    ) async throws {
-        try await scan(
-            roots: roots,
-            excluding: excluding,
-            options: .default,
-            batchSize: batchSize,
-            onBatch: onBatch
-        )
-    }
 }
 
 enum PathExclusionMatcher {
@@ -262,18 +248,6 @@ enum PackageDirectorySizer {
     ]
 
     private static let resourceKeySet = Set(resourceKeys)
-
-    static func recursiveSize(
-        of packageURL: URL,
-        excluding canonicalExclusions: [String] = [],
-        progress: (() -> Void)? = nil
-    ) async throws -> Int64 {
-        try await recursiveSizeResult(
-            of: packageURL,
-            excluding: canonicalExclusions,
-            progress: progress
-        ).size
-    }
 
     static func recursiveSizeResult(
         of packageURL: URL,

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -586,19 +586,6 @@ private struct PressureBadge: View {
     }
 }
 
-extension StatusColor {
-    /// Maps the SwiftUI-free `StatusColor` to a `Color` at the leaf, keeping
-    /// the view-model and its tests free of SwiftUI imports.
-    var color: Color {
-        switch self {
-        case .green: return .green
-        case .yellow: return .yellow
-        case .red: return .red
-        case .gray: return .secondary
-        }
-    }
-}
-
 #Preview("Health Monitor") {
     HealthMonitorView(service: SystemStatsService(autostart: false))
         .frame(width: 900, height: 600)

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -42,28 +42,22 @@ final class HealthMonitorViewModel {
 
     var cpuPercent: String { Self.cpuPercentString(service.cpuUsage) }
     var cpuRatio: Double { Self.cpuRatio(service.cpuUsage) }
-    var cpuColor: StatusColor { Self.cpuColor(for: service.cpuUsage) }
 
     var ramUsage: String { Self.ramUsageString(service.ramUsage) }
     var ramPressureLevel: MemoryPressureLevel { service.ramUsage.pressureLevel }
     var ramPressureLabel: String { Self.pressureLabel(for: ramPressureLevel) }
-    var ramPressureColor: StatusColor { Self.pressureColor(for: ramPressureLevel) }
 
     var diskUsage: String { Self.diskSpaceString(service.diskSpace) }
     var diskRatio: Double { Self.diskUsageRatio(service.diskSpace) }
-    var diskColor: StatusColor { Self.diskColor(for: service.diskSpace) }
 
     var batteryAvailability: BatteryAvailability { service.batteryAvailability }
-    var batteryColor: StatusColor { Self.batteryColor(for: batteryAvailability) }
 
     var smartStatus: SMARTStatus { service.diskSMARTStatus }
     var smartLabel: String { Self.smartLabel(for: smartStatus) }
-    var smartColor: StatusColor { Self.smartColor(for: smartStatus) }
 
     var fileVaultState: FileVaultState { service.fileVaultState }
     var fileVaultIconName: String { Self.fileVaultIconName(for: fileVaultState) }
     var fileVaultLabel: String { Self.fileVaultLabel(for: fileVaultState) }
-    var fileVaultColor: StatusColor { Self.fileVaultColor(for: fileVaultState) }
 
     // MARK: - Mac Health hero verdict
 

--- a/VaderCleaner/HungAppMonitor.swift
+++ b/VaderCleaner/HungAppMonitor.swift
@@ -76,7 +76,7 @@ final class HungAppMonitor {
     }
 
     func start() {
-        timer?.invalidate()
+        stop()
         let timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated { self?.evaluate() }
         }

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -11,26 +11,6 @@ enum LargeOldFilesFormatting {
         f.countStyle = .file
         return f
     }()
-
-    private static let dateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateStyle = .medium
-        f.timeStyle = .none
-        return f
-    }()
-
-    static func accessDate(_ date: Date?) -> String {
-        guard let date else { return "—" }
-        return dateFormatter.string(from: date)
-    }
-
-    static func selectionLabel(for file: ScannedFile) -> String {
-        let format = String(
-            localized: "Select %@",
-            comment: "Accessibility label for selecting a file in the Large & Old Files table."
-        )
-        return String.localizedStringWithFormat(format, file.url.lastPathComponent)
-    }
 }
 
 /// Pure strings for the results header above the file list: a headline file

--- a/VaderCleaner/MailReindexer.swift
+++ b/VaderCleaner/MailReindexer.swift
@@ -2,7 +2,6 @@
 // Rebuilds the Mail "Envelope Index" SQLite databases (VACUUM; REINDEX) to speed up Mail search. Runs at user level — no privileged helper — and distinguishes "no Full Disk Access" from "no Mail data" so the UI can guide the user.
 
 import Foundation
-import os.log
 
 /// Speeds up Mail by compacting and reindexing its envelope-index databases.
 /// The index locator and the per-database vacuum are injected so unit tests
@@ -16,8 +15,6 @@ struct MailReindexer {
 
     private let locateIndexes: LocateIndexes
     private let vacuumIndex: VacuumIndex
-    private let log = Logger(subsystem: "com.personal.VaderCleaner",
-                             category: "MailReindexer")
 
     init(
         locateIndexes: @escaping LocateIndexes = MailReindexer.defaultLocateIndexes,

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -65,9 +65,6 @@ final class MenuBarViewModel {
     /// Free space on the boot volume — the storage tile's headline number.
     var availableDiskSpace: String { Self.availableDiskString(service.diskSpace) }
 
-    /// Memory in use as a whole percentage — the memory tile's headline number.
-    var memoryUsedPercent: String { Self.memoryUsedPercentString(service.ramUsage) }
-
     /// Live charge snapshot for the battery tile, or `nil` when there is no
     /// internal battery.
     var batteryCharge: BatteryCharge? { service.batteryCharge }

--- a/VaderCleaner/MyClutterManagerModel.swift
+++ b/VaderCleaner/MyClutterManagerModel.swift
@@ -131,11 +131,6 @@ enum MyClutterManagerModel {
         }
     }
 
-    /// Total bytes of the files in a facet.
-    static func bytes(of files: [ScannedFile]) -> Int64 {
-        files.reduce(0) { $0 + $1.size }
-    }
-
     /// The rows the manager's right pane actually renders: the search filter
     /// (case-insensitive, on the file name), an optional name sort, and a cap
     /// on the rendered row count. Size-sorted lists arrive pre-sorted from the

--- a/VaderCleaner/MyClutterViewModel.swift
+++ b/VaderCleaner/MyClutterViewModel.swift
@@ -149,11 +149,6 @@ final class MyClutterViewModel {
         }
     }
 
-    /// Toggle by path string — the id the review manager passes back.
-    func toggleSelection(path: String) {
-        toggleSelection(url: URL(fileURLWithPath: path))
-    }
-
     func toggleSelection(url: URL) {
         if selectedURLs.contains(url) {
             selectedURLs.remove(url)

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -510,27 +510,6 @@ final class PrivacyViewModel {
         isClearRecentsChecked.toggle()
     }
 
-    // MARK: - Bulk selection (Protection Manager)
-
-    /// Clear every selection. The Protection Manager opens with nothing
-    /// selected, so it calls this on appear. Cached sizes/counts/paths stay.
-    func deselectAll() {
-        checkedSelections = []
-        isClearRecentsChecked = false
-    }
-
-    /// Set a single `(browser, category)` cell's checked state — used by the
-    /// Protection Manager's per-pane Select All / Deselect All.
-    func setChecked(_ value: Bool, browser: Browser, category: PrivacyCategory) {
-        let selection = Selection(browser: browser, category: category)
-        if value { checkedSelections.insert(selection) } else { checkedSelections.remove(selection) }
-    }
-
-    /// Set the recent-items toggle directly (Protection Manager Select menu).
-    func setClearRecents(_ value: Bool) {
-        isClearRecentsChecked = value
-    }
-
     /// Reset to `.idle`, dropping cached preview state.
     func scanAgain() {
         cancelCurrentOperation()

--- a/VaderCleaner/RecentFilesManager.swift
+++ b/VaderCleaner/RecentFilesManager.swift
@@ -3,7 +3,6 @@
 
 import AppKit
 import Foundation
-import os.log
 
 /// Clears the user's recently-opened files list.
 ///
@@ -29,8 +28,6 @@ struct RecentFilesManager {
     private let homeDirectory: URL
     private let fileManager: FileManager
     private let clearAppRecentDocuments: @MainActor () -> Void
-    private let log = Logger(subsystem: "com.personal.VaderCleaner",
-                             category: "RecentFilesManager")
 
     init(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,

--- a/VaderCleaner/ScanProgressFormatting.swift
+++ b/VaderCleaner/ScanProgressFormatting.swift
@@ -61,21 +61,4 @@ enum ScanProgressFormatting {
         return String.localizedStringWithFormat(template, checkedFormatted, totalFormatted)
     }
 
-    /// "12,431 files" — the Malware variant, where each counted unit is a file
-    /// ClamAV reported on rather than a generic filesystem item.
-    static func filesScanned(_ count: Int) -> String {
-        let formatted = count.formatted()
-        // Malware counts one file per ClamAV line, so the very first tick is
-        // count == 1 — use the singular template there.
-        let template = count == 1
-            ? String(
-                localized: "%@ file",
-                comment: "Live progress count, singular, shown under the Scanning label while the malware scanner checks files; %@ is a localized file count of one."
-            )
-            : String(
-                localized: "%@ files",
-                comment: "Live progress count shown under the Scanning label while the malware scanner checks files; %@ is a localized file count."
-            )
-        return String.localizedStringWithFormat(template, formatted)
-    }
 }

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -881,11 +881,6 @@ final class SmartScanViewModel {
         SmartScanModule.allCases.contains { willExecute($0) }
     }
 
-    /// Whether the system maintenance scripts can run on this macOS — false on
-    /// macOS 26+, where Apple removed `periodic`. Exposed so the Performance
-    /// Review can phrase its explainer accurately.
-    var maintenanceScriptsSupported: Bool { maintenanceScriptsAvailable }
-
     /// Default tile-selection seed for a freshly-landed `.results` payload.
     /// A module starts checked iff it has actionable work for Run. Performance
     /// always starts on because its DNS-cache flush always has work (the

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -359,14 +359,6 @@ struct SmartScanResultsState: View {
             .staggeredEntrance(index: index, appeared: appeared)
     }
 
-    /// Whether the given module would actually produce work if Run were
-    /// pressed right now. Delegates to `SmartScanViewModel.willExecute(_:)`
-    /// so per-tile caption decisions and the floating Run disc's visibility
-    /// gate share one source of truth.
-    private func willExecute(_ module: SmartScanModule) -> Bool {
-        viewModel.willExecute(module)
-    }
-
     @ViewBuilder
     private func tile(for module: SmartScanModule) -> some View {
         if !settings.isModuleEnabled(module) {

--- a/VaderCleaner/SparkleUpdateChecker.swift
+++ b/VaderCleaner/SparkleUpdateChecker.swift
@@ -2,7 +2,6 @@
 // Sparkle appcast pipeline — reads SUFeedURL from an .app bundle, fetches the appcast XML, and parses out the newest <item> with a downloadable enclosure.
 
 import Foundation
-import os.log
 
 /// Single appcast `<item>` reduced to the fields the App Updater consumes.
 /// `shortVersion` is the user-facing version string ("2.0.0"); `version`
@@ -21,8 +20,6 @@ struct SparkleAppcastItem: Hashable, Sendable {
 struct DefaultSparkleUpdateChecker: Sendable {
 
     private let httpFetcher: HTTPFetching
-    private let log = Logger(subsystem: "com.personal.VaderCleaner",
-                             category: "SparkleUpdateChecker")
 
     init(httpFetcher: HTTPFetching = URLSession.shared) {
         self.httpFetcher = httpFetcher

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -109,12 +109,6 @@ final class SystemJunkViewModel {
 
     // MARK: - Public surface
 
-    /// Convenience for the view layer — formatting once on the VM keeps the
-    /// "human-readable size" rule in one place across cards and totals.
-    var formattedTotalSelectedSize: String {
-        Self.byteFormatter.string(fromByteCount: totalSelectedSize)
-    }
-
     /// Whether `file` is currently selected. The view binds each review row's
     /// `Toggle` to `Binding(get:set:)` over `isSelected` + `toggleSelection`.
     func isSelected(_ file: ScannedFile) -> Bool {
@@ -263,18 +257,6 @@ final class SystemJunkViewModel {
         phase = .idle
     }
 
-    // MARK: - Formatters
-
-    /// Shared `ByteCountFormatter` for the human-readable total. Constructed
-    /// once because the formatter allocates measurable internal state per
-    /// instance and `formattedTotalSelectedSize` is read on every keystroke /
-    /// toggle while the preview list is on screen.
-    private static let byteFormatter: ByteCountFormatter = {
-        let f = ByteCountFormatter()
-        f.allowedUnits = .useAll
-        f.countStyle = .file
-        return f
-    }()
 }
 
 // MARK: - Production wiring

--- a/VaderCleaner/TrashSizeMonitor.swift
+++ b/VaderCleaner/TrashSizeMonitor.swift
@@ -55,7 +55,7 @@ final class TrashSizeMonitor {
 
     /// Begins polling the Trash size on a timer.
     func start() {
-        timer?.invalidate()
+        stop()
         let timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in await self?.poll() }
         }

--- a/VaderCleaner/TrashedAppMonitor.swift
+++ b/VaderCleaner/TrashedAppMonitor.swift
@@ -20,7 +20,6 @@ final class TrashedAppMonitor {
     /// Apps already seen in the Trash, so only *newly* trashed apps notify.
     private var seen: Set<String> = []
     private var source: DispatchSourceFileSystemObject?
-    private var watchedDescriptor: Int32 = -1
 
     init(
         preferences: PreferencesStore,
@@ -45,13 +44,13 @@ final class TrashedAppMonitor {
     }
 
     func start() {
+        stop()
         // Prime the baseline so apps already in the Trash don't notify on launch.
         seen = Set(appLister())
 
         let trash = Self.trashURL()
         let descriptor = open(trash.path, O_EVTONLY)
         guard descriptor >= 0 else { return }
-        watchedDescriptor = descriptor
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: descriptor,
@@ -61,9 +60,11 @@ final class TrashedAppMonitor {
         source.setEventHandler { [weak self] in
             MainActor.assumeIsolated { self?.poll() }
         }
-        source.setCancelHandler { [weak self] in
-            if let fd = self?.watchedDescriptor, fd >= 0 { close(fd) }
-            self?.watchedDescriptor = -1
+        // Close the descriptor this source owns — captured locally so a
+        // stop()/restart closes the right fd rather than a shared field a
+        // newer start() may have overwritten.
+        source.setCancelHandler {
+            close(descriptor)
         }
         self.source = source
         source.resume()


### PR DESCRIPTION
Stacked on #165. Base is `chore/remove-dead-code` so this diff shows only the member-level cleanup plus one lifecycle fix.

## What & why

Follows the high-confidence file/struct pass with **member-level** removals. Every item was verified individually against a **test-inclusive** Periphery scan — confirmed unreferenced by both app and test code, and confirmed *not* a protocol witness — before removal.

Verification during this pass caught that roughly **half of Periphery's raw "medium" flags were not actually deletable** (protocol seams, C-interop, lifecycle, intentional state). Those were left in place; see "Deliberately kept" below.

## Removed (30 members, −166 lines, 19 files)

**Unused `os.Logger` properties** (+ now-unused `import os`)
`AppStoreUpdateChecker`, `AssociatedFileFinder`, `BrowserDataCounter`, `MailReindexer`, `RecentFilesManager`, `SparkleUpdateChecker`

**Unused functions**
- `FileScanner` — the no-`options:` `scan` convenience wrapper and the `recursiveSize` wrapper around the used `recursiveSizeResult`
- `MyClutterManagerModel.bytes(of:)`, `MyClutterViewModel.toggleSelection(path:)`
- `ScanProgressFormatting.filesScanned(_:)`
- `LargeOldFiles` `accessDate(_:)` / `selectionLabel(for:)`
- `SmartScanViewSubviews` — a dead local `willExecute` wrapper (nothing called it; tiles call the view model directly)
- `PrivacyViewModel.deselectAll` / `setChecked` / `setClearRecents` — the live callers are on the **separate** `ProtectionPrivacyModel` class; `PrivacyViewModel`'s copies were dead with stale comments

**Unused properties**
- `HealthMonitorViewModel` — 6 instance color accessors + the dead `StatusColor → Color` leaf mapping
- `MenuBarViewModel.memoryUsedPercent`, `SmartScanViewModel.maintenanceScriptsSupported`
- `ApplicationsManagerView` — redundant `selectionFill` alias
- `SystemJunkViewModel.formattedTotalSelectedSize` + its private `byteFormatter` (stale "read on every keystroke" comment; no readers)
- `LargeOldFiles.dateFormatter`

## Lifecycle fix (the four monitor `stop()` methods)

Periphery flagged `DeviceBatteryMonitor` / `HungAppMonitor` / `TrashSizeMonitor` / `TrashedAppMonitor` `stop()` as unused. Investigation showed this was a **start()-without-stop() asymmetry**, not dead code: `NotificationMonitors` starts each monitor once and never tears them down. `VolumeMountMonitor` already establishes the intended pattern (`start()` calls `stop()` first, making it idempotent and self-cleaning); the other four didn't follow it.

- The three timer monitors: replaced the inline `timer?.invalidate()` at the top of `start()` with `stop()`, matching `VolumeMountMonitor` and giving each `stop()` a caller.
- `TrashedAppMonitor`: `start()` now calls `stop()` first (previously a second `start()` leaked the first dispatch source), and the cancel handler now closes a **locally-captured** descriptor instead of a shared `watchedDescriptor` field a newer `start()` could overwrite — removing that field and the restart race it created.

## Deliberately kept (documented in `docs/dead-code-report.md`)
- **Protocol DI seams** flagged as "redundant" (`AppDiscovering.installedApps`, `ExtensionDiscovering.extensions`, `UnsupportedAppScanning.scan`, `BrowserDetecting`, `DiskScanning`) — called polymorphically; Periphery's existential-use heuristic misfires.
- **`SMCReader` C-interop struct fields** (required for IOKit memory layout), **`VaderTheme` palette tokens**, the **unwired `LargeOldFilesFailureStage.deleting` state**, and **assign-only properties**.

## Testing
- Clean build: no compile errors, no new warnings
- `VaderCleanerTests`: **1322 tests, 0 failures** (after each change)
- Follow-up Periphery scan confirms **no new dead code introduced** (93 → 63 findings; remaining findings are all in the kept categories, minus the four `stop()` now that they have callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)