### PR TITLE
Speed up Cleanup Manager selection and stop middle-pane reflow

### DIFF
--- a/VaderCleaner/CleanupManagerStore.swift
+++ b/VaderCleaner/CleanupManagerStore.swift
@@ -133,4 +133,15 @@ final class CleanupManagerStore: @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         return filesByPath[path]
     }
+
+    /// The scanned files a row covers (a folder's whole subtree, or a single
+    /// file), resolved under a single lock. A folder toggle needs every
+    /// descendant file; resolving them one `file(forPath:)` call at a time
+    /// re-acquired the lock per path, so a big folder paid tens of thousands of
+    /// lock round-trips just to gather its files.
+    func files(forRowID id: String) -> [ScannedFile] {
+        lock.lock(); defer { lock.unlock() }
+        let paths = pathsByRowID[id] ?? [id]
+        return paths.compactMap { filesByPath[$0] }
+    }
 }

--- a/VaderCleaner/SmartScanReviewManager.swift
+++ b/VaderCleaner/SmartScanReviewManager.swift
@@ -162,6 +162,14 @@ struct SmartScanReviewManager: View {
     /// badge. Returns `nil` (no badge) when the caller doesn't track it or
     /// nothing in the category is selected.
     var categorySelectedBytes: (ManagerCategory) -> Int64? = { _ in nil }
+    /// Optional O(1) per-category selection tally — the number of leaf items
+    /// selected in a category and its total item count — so the bulk-select
+    /// menu's None/All/Some state needn't scan every row (and, for hierarchical
+    /// managers, every file beneath each folder row) on each render. `nil` falls
+    /// back to a per-row `isSelected` scan, which is fine for the small flat
+    /// managers but is the walk that delayed the Cleanup Manager's checkbox
+    /// repaint on large scans.
+    var categorySelectionTally: (ManagerCategory) -> (selected: Int, total: Int)? = { _ in nil }
     /// Builds the rows for one category on demand (by `ManagerCategory.id`). When
     /// set, `buildSections` only needs to return the lightweight shell and each
     /// category's rows are loaded lazily here. `nil` keeps the eager behavior
@@ -420,12 +428,19 @@ struct SmartScanReviewManager: View {
                 icon(category.systemImage, category.tint.color)
             }
             VStack(alignment: .leading, spacing: 2) {
+                // Pinned to one line each: when the selected-size badge appears
+                // it steals trailing width, and an unconstrained title would wrap
+                // to a second line — growing the row and reflowing the whole
+                // middle pane on every checkbox toggle.
                 Text(category.title).font(.body.weight(.medium))
+                    .lineLimit(1)
                 if let text = category.totalSizeText {
                     Text(text).font(.caption).foregroundStyle(.secondary)
+                        .lineLimit(1)
                 } else {
                     Text("\(category.items.count) item\(category.items.count == 1 ? "" : "s")")
                         .font(.caption).foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
             }
             Spacer(minLength: 8)
@@ -452,7 +467,7 @@ struct SmartScanReviewManager: View {
                     // Counts come from the visible (loaded) rows, not the shell
                     // category, which carries no items when loading is lazy.
                     let rows = currentCategoryItems
-                    let selectedCount = rows.reduce(0) { $0 + (isSelected($1.id) ? 1 : 0) }
+                    let state = bulkSelectionState(category: category, rows: rows)
                     HStack(spacing: 8) {
                         Text(String(localized: "Select:", comment: "Label before the bulk-select menu on a Smart Scan Manager."))
                             .foregroundStyle(.secondary)
@@ -460,13 +475,13 @@ struct SmartScanReviewManager: View {
                             Button(String(localized: "Select All", comment: "Bulk-select every item in the category.")) {
                                 onSetCategory(category, true)
                             }
-                            .disabled(selectedCount == rows.count)
+                            .disabled(state == .all)
                             Button(String(localized: "Deselect All", comment: "Bulk-deselect every item in the category.")) {
                                 onSetCategory(category, false)
                             }
-                            .disabled(selectedCount == 0)
+                            .disabled(state == .none)
                         } label: {
-                            Text(bulkSelectLabel(selected: selectedCount, total: rows.count))
+                            Text(state.label)
                                 .foregroundStyle(.tint)
                         }
                         .menuStyle(.borderlessButton)
@@ -686,15 +701,36 @@ struct SmartScanReviewManager: View {
             .frame(width: 28, height: 28)
     }
 
-    /// The bulk-select menu's trigger label, reflecting the visible category's
-    /// current selection: "None", "All", or "Some".
-    private func bulkSelectLabel(selected: Int, total: Int) -> String {
-        if selected == 0 || total == 0 {
-            return String(localized: "None", comment: "Bulk-select trigger when nothing in the category is selected.")
+    /// The visible category's bulk-selection state, driving both the menu's
+    /// trigger label and the Select All / Deselect All disabled states.
+    private enum BulkSelectionState {
+        case none, some, all
+
+        var label: String {
+            switch self {
+            case .none:
+                return String(localized: "None", comment: "Bulk-select trigger when nothing in the category is selected.")
+            case .all:
+                return String(localized: "All", comment: "Bulk-select trigger when everything in the category is selected.")
+            case .some:
+                return String(localized: "Some", comment: "Bulk-select trigger when part of the category is selected.")
+            }
         }
-        if selected == total {
-            return String(localized: "All", comment: "Bulk-select trigger when everything in the category is selected.")
+    }
+
+    /// Resolve the bulk-select state for `category`. Prefers the caller's O(1)
+    /// `categorySelectionTally` (leaf-level selected/total counts) when supplied;
+    /// otherwise falls back to a per-row `isSelected` scan over the visible
+    /// `rows` — fine for the small flat managers that don't provide a tally.
+    private func bulkSelectionState(category: ManagerCategory, rows: [ManagerItem]) -> BulkSelectionState {
+        if let tally = categorySelectionTally(category) {
+            if tally.selected == 0 { return .none }
+            if tally.total > 0 && tally.selected >= tally.total { return .all }
+            return .some
         }
-        return String(localized: "Some", comment: "Bulk-select trigger when part of the category is selected.")
+        let selectedCount = rows.reduce(0) { $0 + (isSelected($1.id) ? 1 : 0) }
+        if selectedCount == 0 || rows.isEmpty { return .none }
+        if selectedCount == rows.count { return .all }
+        return .some
     }
 }

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -167,26 +167,23 @@ struct SystemJunkView: View {
             // Cheap shell: sections + category sizes, no file trees.
             buildSections: { store.sections() },
             isSelected: { id in
-                let paths = store.selectionPaths(forRowID: id)
-                return !paths.isEmpty && paths.allSatisfy { store.file(forPath: $0).map(viewModel.isSelected) ?? false }
+                // Checked when every file beneath the row is selected. The files
+                // are gathered under one store lock, and `areAllSelected` short-
+                // circuits, so an unchecked folder is cheap to answer.
+                viewModel.areAllSelected(store.files(forRowID: id))
             },
             onToggle: { id in
-                let paths = store.selectionPaths(forRowID: id)
-                // Whole-folder toggle: if every descendant is selected, clear
-                // them; otherwise select them all.
-                let target = !paths.allSatisfy { store.file(forPath: $0).map(viewModel.isSelected) ?? false }
-                for path in paths {
-                    guard let file = store.file(forPath: path) else { continue }
-                    if viewModel.isSelected(file) != target { viewModel.toggleSelection(file) }
-                }
+                // Whole-folder toggle in one batched pass: gather the row's files
+                // under a single lock, then flip them together so a folder over
+                // tens of thousands of files fires one UI update, not one per
+                // file.
+                viewModel.toggleSelection(store.files(forRowID: id))
             },
             onSetCategory: { category, selected in
                 // Operate on the whole scan category (by id), independent of
-                // whether its rows are loaded yet.
+                // whether its rows are loaded yet — one batched selection pass.
                 guard let scanCategory = ScanCategory(rawValue: category.id) else { return }
-                for file in itemsByCategory[scanCategory] ?? [] {
-                    if viewModel.isSelected(file) != selected { viewModel.toggleSelection(file) }
-                }
+                viewModel.setSelection(itemsByCategory[scanCategory] ?? [], selected: selected)
             },
             categorySelectedBytes: { category in
                 // O(1) read of the view-model's incrementally-maintained
@@ -195,6 +192,16 @@ struct SystemJunkView: View {
                 // switching categories on large scans.
                 guard let scanCategory = ScanCategory(rawValue: category.id) else { return nil }
                 return viewModel.selectedBytes(in: scanCategory)
+            },
+            categorySelectionTally: { category in
+                // O(1) None/All/Some for the bulk-select menu: the view model's
+                // incrementally-maintained per-category selected count against
+                // the scan's file count for that category — instead of the
+                // folder-aggregate scan that walked every file (with a lock per
+                // path) on each render and delayed the checkbox repaint.
+                guard let scanCategory = ScanCategory(rawValue: category.id) else { return nil }
+                let total = itemsByCategory[scanCategory]?.count ?? 0
+                return (selected: viewModel.selectedCount(in: scanCategory), total: total)
             },
             loadItems: { id in
                 // Off-main: a cache hit (usually, thanks to the prebuild)

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -81,6 +81,13 @@ final class SystemJunkViewModel {
     /// large scans.
     private(set) var selectedBytesByCategory: [ScanCategory: Int64] = [:]
 
+    /// Per-category running count of selected files, maintained in lockstep with
+    /// `selectedBytesByCategory`. Lets the Cleanup Manager's "Select:
+    /// None/All/Some" bulk menu read its state in O(1) instead of scanning every
+    /// row (and every file beneath each folder row) on each render — the walk
+    /// that delayed the checkbox repaint on large scans.
+    private(set) var selectedCountByCategory: [ScanCategory: Int] = [:]
+
     /// Running count of filesystem items the in-flight scan has walked. Reset
     /// to 0 at the start of each scan and fed by the scanner's progress
     /// callback so the scanning screen can show "Scanned N items…" — proof the
@@ -121,6 +128,12 @@ final class SystemJunkViewModel {
         selectedBytesByCategory[category] ?? 0
     }
 
+    /// Selected file count in one category — an O(1) read backing the Cleanup
+    /// Manager's per-category bulk-select menu state.
+    func selectedCount(in category: ScanCategory) -> Int {
+        selectedCountByCategory[category] ?? 0
+    }
+
     /// Flip the selection state for `file` and adjust `totalSelectedSize` in
     /// lockstep. Idempotent in the sense that two calls in a row return the VM
     /// to its prior selection.
@@ -129,11 +142,61 @@ final class SystemJunkViewModel {
             selectedURLs.remove(file.url)
             totalSelectedSize -= file.size
             selectedBytesByCategory[file.category, default: 0] -= file.size
+            selectedCountByCategory[file.category, default: 0] -= 1
         } else {
             selectedURLs.insert(file.url)
             totalSelectedSize += file.size
             selectedBytesByCategory[file.category, default: 0] += file.size
+            selectedCountByCategory[file.category, default: 0] += 1
         }
+    }
+
+    /// Whether every file in `files` is currently selected. Short-circuits on
+    /// the first unselected file, so the common "nothing selected yet" case is
+    /// O(1). Backs the folder-row checkbox's checked state and its all-or-
+    /// nothing toggle target.
+    func areAllSelected(_ files: [ScannedFile]) -> Bool {
+        !files.isEmpty && files.allSatisfy { selectedURLs.contains($0.url) }
+    }
+
+    /// Toggle a whole group of files as one unit — the Cleanup Manager's
+    /// folder-row checkbox, which covers every file beneath a folder. If the
+    /// group is already fully selected it's cleared; otherwise the whole group
+    /// is selected (so a partially-selected folder fills in).
+    func toggleSelection(_ files: [ScannedFile]) {
+        setSelection(files, selected: !areAllSelected(files))
+    }
+
+    /// Select or clear a whole group of files in a single pass, writing each
+    /// observable property exactly once. Toggling a folder that covers tens of
+    /// thousands of files went through `toggleSelection(_ file:)` per file,
+    /// which re-acquired the store lock, re-hashed each URL several times, and
+    /// fired four observation mutations *per file* — the work that froze the UI
+    /// for seconds on large folders. Building the new values on local copies and
+    /// assigning once collapses that to four mutations total.
+    func setSelection(_ files: [ScannedFile], selected: Bool) {
+        guard !files.isEmpty else { return }
+        var urls = selectedURLs
+        var total = totalSelectedSize
+        var bytes = selectedBytesByCategory
+        var counts = selectedCountByCategory
+        for file in files {
+            if selected {
+                guard urls.insert(file.url).inserted else { continue }
+                total += file.size
+                bytes[file.category, default: 0] += file.size
+                counts[file.category, default: 0] += 1
+            } else {
+                guard urls.remove(file.url) != nil else { continue }
+                total -= file.size
+                bytes[file.category, default: 0] -= file.size
+                counts[file.category, default: 0] -= 1
+            }
+        }
+        selectedURLs = urls
+        totalSelectedSize = total
+        selectedBytesByCategory = bytes
+        selectedCountByCategory = counts
     }
 
     /// Replace the selection with every file in `categories` — backs a
@@ -145,14 +208,17 @@ final class SystemJunkViewModel {
         var urls: Set<URL> = []
         var total: Int64 = 0
         var bytesByCategory: [ScanCategory: Int64] = [:]
+        var countByCategory: [ScanCategory: Int] = [:]
         for file in result.items where categories.contains(file.category) {
             urls.insert(file.url)
             total += file.size
             bytesByCategory[file.category, default: 0] += file.size
+            countByCategory[file.category, default: 0] += 1
         }
         selectedURLs = urls
         totalSelectedSize = total
         selectedBytesByCategory = bytesByCategory
+        selectedCountByCategory = countByCategory
     }
 
     /// Run the injected scanner and land in `.preview` (or `.failed`).
@@ -186,6 +252,7 @@ final class SystemJunkViewModel {
             self.selectedURLs = []
             self.totalSelectedSize = 0
             self.selectedBytesByCategory = [:]
+            self.selectedCountByCategory = [:]
             self.phase = .preview(result)
         } catch {
             log.error("System Junk scan failed: \(String(describing: error), privacy: .public)")
@@ -193,6 +260,7 @@ final class SystemJunkViewModel {
             self.selectedURLs = []
             self.totalSelectedSize = 0
             self.selectedBytesByCategory = [:]
+            self.selectedCountByCategory = [:]
             self.phase = .failed(stage: .scanning, message: error.localizedDescription)
         }
     }
@@ -208,6 +276,7 @@ final class SystemJunkViewModel {
         selectedURLs = []
         totalSelectedSize = 0
         selectedBytesByCategory = [:]
+        selectedCountByCategory = [:]
         phase = .preview(result)
     }
 
@@ -253,6 +322,7 @@ final class SystemJunkViewModel {
         selectedURLs = []
         totalSelectedSize = 0
         selectedBytesByCategory = [:]
+        selectedCountByCategory = [:]
         scannedItemCount = 0
         phase = .idle
     }

--- a/VaderCleanerTests/SystemJunkViewModelTests.swift
+++ b/VaderCleanerTests/SystemJunkViewModelTests.swift
@@ -354,6 +354,154 @@ final class SystemJunkViewModelTests: XCTestCase {
         XCTAssertEqual(vm.selectedBytes(in: .userCache), 0)
     }
 
+    // MARK: - Per-category selected count (bulk-select menu)
+
+    /// The per-category selected *count* is maintained incrementally on every
+    /// toggle so the Cleanup Manager's "Select: None/All/Some" menu reads O(1)
+    /// instead of re-scanning every file in the category on each render.
+    func test_selectedCountPerCategory_tracksTogglesPerCategory() async {
+        let cacheA = makeFile(name: "a", size: 100, category: .userCache)
+        let cacheB = makeFile(name: "b", size: 30, category: .userCache)
+        let log = makeFile(name: "c", size: 250, category: .userLogs)
+        let result = makeResult((.userCache, [cacheA, cacheB]), (.userLogs, [log]))
+        let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
+        await vm.scan()
+
+        vm.toggleSelection(cacheA)
+        vm.toggleSelection(log)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 1)
+        XCTAssertEqual(vm.selectedCount(in: .userLogs), 1)
+        XCTAssertEqual(vm.selectedCount(in: .trash), 0, "Untouched categories read zero")
+
+        vm.toggleSelection(cacheB)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 2)
+
+        vm.toggleSelection(cacheA)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 1, "Deselecting subtracts only that file")
+        XCTAssertEqual(vm.selectedCount(in: .userLogs), 1, "A sibling category is unaffected")
+    }
+
+    /// `selectOnly` rebuilds the per-category counts to exactly the chosen
+    /// group's files, zeroing categories that fall outside the group.
+    func test_selectedCountPerCategory_afterSelectOnly() async {
+        let cacheA = makeFile(name: "a", size: 100, category: .userCache)
+        let cacheB = makeFile(name: "b", size: 200, category: .systemCache)
+        let trash = makeFile(name: "t", size: 400, category: .trash)
+        let result = makeResult((.userCache, [cacheA]), (.systemCache, [cacheB]), (.trash, [trash]))
+        let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
+        await vm.scan()
+        vm.toggleSelection(trash) // a pre-existing selection outside the group
+
+        vm.selectOnly(categories: [.userCache, .systemCache])
+
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 1)
+        XCTAssertEqual(vm.selectedCount(in: .systemCache), 1)
+        XCTAssertEqual(vm.selectedCount(in: .trash), 0, "selectOnly clears categories outside the group")
+    }
+
+    /// A fresh scan and `scanAgain()` must drop the per-category counts so the
+    /// menu never carries a previous run's selection forward.
+    func test_selectedCountPerCategory_clearedOnScanAndScanAgain() async {
+        let file = makeFile(name: "a", size: 100, category: .userCache)
+        let result = makeResult((.userCache, [file]))
+        let vm = makeViewModel(scanner: { result }, deleter: { _ in 100 })
+
+        await vm.scan()
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 0, "A fresh scan selects nothing")
+
+        vm.toggleSelection(file)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 1)
+
+        vm.scanAgain()
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 0)
+    }
+
+    // MARK: - Bulk selection (folder-row / category toggle)
+
+    /// `setSelection(_:selected:)` selects a whole group in one pass, updating
+    /// the URL set and every running total. This backs the Cleanup Manager's
+    /// folder-row and category toggles, which cover thousands of files — doing
+    /// the work per file (and firing observation per file) is what froze the UI.
+    func test_setSelection_selectsGroupAndUpdatesTotals() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 30, category: .userCache)
+        let c = makeFile(name: "c", size: 250, category: .userLogs)
+        let vm = makeViewModel(scanner: { self.makeResult((.userCache, [a, b]), (.userLogs, [c])) }, deleter: noopDeleter)
+        await vm.scan()
+
+        vm.setSelection([a, b, c], selected: true)
+
+        XCTAssertEqual(vm.selectedURLs, [a.url, b.url, c.url])
+        XCTAssertEqual(vm.totalSelectedSize, 380)
+        XCTAssertEqual(vm.selectedBytes(in: .userCache), 130)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 2)
+        XCTAssertEqual(vm.selectedBytes(in: .userLogs), 250)
+        XCTAssertEqual(vm.selectedCount(in: .userLogs), 1)
+    }
+
+    /// Deselecting a group removes exactly those files and no others.
+    func test_setSelection_deselectsOnlyGivenFiles() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 30, category: .userCache)
+        let vm = makeViewModel(scanner: { self.makeResult((.userCache, [a, b])) }, deleter: noopDeleter)
+        await vm.scan()
+        vm.setSelection([a, b], selected: true)
+
+        vm.setSelection([a], selected: false)
+
+        XCTAssertEqual(vm.selectedURLs, [b.url])
+        XCTAssertEqual(vm.totalSelectedSize, 30)
+        XCTAssertEqual(vm.selectedBytes(in: .userCache), 30)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 1)
+    }
+
+    /// Re-selecting already-selected files (or clearing unselected ones) must
+    /// not double-count the totals — the bulk pass is idempotent per file.
+    func test_setSelection_isIdempotentPerFile() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let vm = makeViewModel(scanner: { self.makeResult((.userCache, [a])) }, deleter: noopDeleter)
+        await vm.scan()
+
+        vm.setSelection([a], selected: true)
+        vm.setSelection([a], selected: true) // repeat — must be a no-op
+
+        XCTAssertEqual(vm.selectedURLs, [a.url])
+        XCTAssertEqual(vm.totalSelectedSize, 100)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 1)
+    }
+
+    /// `toggleSelection(_ files:)` selects the group when it isn't already fully
+    /// selected, and clears it when every file is selected — the folder-row
+    /// checkbox's all-or-nothing behavior.
+    func test_toggleSelectionGroup_selectsThenClears() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 30, category: .userCache)
+        let vm = makeViewModel(scanner: { self.makeResult((.userCache, [a, b])) }, deleter: noopDeleter)
+        await vm.scan()
+
+        vm.toggleSelection([a, b]) // nothing selected → select all
+        XCTAssertTrue(vm.areAllSelected([a, b]))
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 2)
+
+        vm.toggleSelection([a, b]) // all selected → clear all
+        XCTAssertTrue(vm.selectedURLs.isEmpty)
+        XCTAssertEqual(vm.selectedCount(in: .userCache), 0)
+    }
+
+    /// A partially-selected group toggles to fully selected (not cleared), so a
+    /// folder with one checked child fills in rather than emptying.
+    func test_toggleSelectionGroup_partialSelectsRest() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 30, category: .userCache)
+        let vm = makeViewModel(scanner: { self.makeResult((.userCache, [a, b])) }, deleter: noopDeleter)
+        await vm.scan()
+        vm.setSelection([a], selected: true) // only one of two selected
+
+        vm.toggleSelection([a, b])
+
+        XCTAssertTrue(vm.areAllSelected([a, b]), "A partial group toggles to fully selected")
+    }
+
     // MARK: - Clean by category (dashboard card "Clean")
 
     /// `clean(categories:)` backs a dashboard card's Clean button: it must


### PR DESCRIPTION
## What & why

The Cleanup Manager's right-pane checkboxes were painfully slow — clicking a large folder row (e.g. `.npm` at ~30 GB / 100k+ files) froze the UI for **~5 seconds** before the check appeared — and the middle-pane category rows visibly **reflowed on every toggle**. This fixes both, in three parts.

### 1. Per-render bulk-select scan (O(N) → O(1))
The "Select: None/All/Some" menu recomputed its state by scanning every row on each render. For the Cleanup Manager that meant a folder-aggregate `isSelected` doing a **lock-per-descendant** walk over the whole category — re-run on every checkbox toggle.

- Added `SystemJunkViewModel.selectedCountByCategory`, maintained incrementally alongside the existing `selectedBytesByCategory`.
- Added an optional `SmartScanReviewManager.categorySelectionTally` closure. When `nil`, the manager falls back to the original per-row scan, so the small flat managers (Junk / My Clutter / Malware / Applications reviews) are **unchanged**.

### 2. Folder toggle — the multi-second freeze
`onToggle` looped every descendant file, re-acquiring the store lock per path (twice), re-hashing each `URL` several times, and firing **four `@Observable` mutations per file**.

- Added batched `SystemJunkViewModel.setSelection(_:selected:)` / `toggleSelection(_ files:)` that work on local copies and write each observable property **once** (4 mutations total, not 4×N).
- Added a single-lock `CleanupManagerStore.files(forRowID:)` that resolves a folder's whole subtree in **one** lock acquisition; `areAllSelected(_:)` short-circuits.

### 3. Middle-pane layout shift
`categoryRow`'s title had no line limit, so when the selected-size badge appeared it stole trailing width and the title **wrapped to a second line**, growing the row and reflowing the whole middle pane. Pinned the title and size/count text to one line. This row is shared by Cleanup **and every Smart Scan review**, so all affected sections are fixed at once.

## Reviewer notes
- **Behavior change (intentional):** the bulk-select menu's None/All/Some is now file-count based, so a partially-selected folder reads **"Some"** (Deselect All enabled) instead of the old **"None"**. This is arguably more correct.
- **Residual cost:** the repaint's "is this folder fully checked?" check (`refreshVisibleSelection` → `isSelected`) is still O(files) for the toggled folder — a fraction of a second, not a freeze. Making it O(1) would need per-folder selected-count tracking; deferred.
- No new test for the `.lineLimit(1)` layout fix — it's a pure SwiftUI layout constraint with no XCTest-able logic.

## Testing
- Added unit coverage for `selectedCountByCategory` (toggles, `selectOnly`, scan/scanAgain reset) and the bulk selection API (select/deselect group, idempotence, all-or-nothing and partial toggle).
- Full unit target: **1330 passing, 0 failures**.
- App build: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bulk selection controls with more accurate None/Some/All states.
  * Folder and category selections now update in larger batches for smoother interaction.
  * Category rows stay on a single line to reduce layout shifting.

* **Bug Fixes**
  * Selection counts now stay in sync when selecting, deselecting, or rescanning items.
  * Bulk actions now correctly reflect partially selected groups and reset cleanly after a new scan.

* **Tests**
  * Added coverage for per-category selection counts and bulk selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->