### PR TITLE
Unify manager pane active/hover states to the magenta accent

### DIFF
--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -1422,11 +1422,10 @@ private struct ExtensionsPaneView: View {
 // MARK: - Shared chrome
 
 /// Constants and helpers shared by the Applications Manager and its pane
-/// subviews. The accent is the standalone Manager magenta; the selection fill is
-/// this manager's own quieter purple pill (distinct from `NavRow`'s accent fill).
+/// subviews. The accent is the standalone Manager magenta shared across the
+/// manager screens.
 enum ApplicationsManagerChrome {
     static let accent = ManagerChrome.accent
-    static let selectionFill = Color(red: 0.45, green: 0.30, blue: 0.85).opacity(0.14)
 
     static func byteText(_ bytes: Int64) -> String {
         smartScanByteFormatter.string(fromByteCount: bytes)
@@ -1449,11 +1448,15 @@ struct ApplicationsManagerPaneHeader: View {
     }
 }
 
-/// A nav / facet / section row with the manager's selection pill.
+/// A nav / facet / section row with the manager's selection pill and a quieter
+/// hover fill — the magenta `ManagerChrome.accent` active/hover states every
+/// manager's left and middle panes share (active fill plus a border, hover a
+/// lighter fill with no border).
 struct ApplicationsManagerSelectableRow<Content: View>: View {
     let selected: Bool
     let action: () -> Void
     @ViewBuilder let content: () -> Content
+    @State private var hovered = false
 
     var body: some View {
         Button(action: action) {
@@ -1462,11 +1465,16 @@ struct ApplicationsManagerSelectableRow<Content: View>: View {
                 .padding(.horizontal, 12).padding(.vertical, 10)
                 .background(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(selected ? ApplicationsManagerChrome.selectionFill : .clear)
+                        .fill(selected ? ManagerChrome.accent.opacity(0.22) : (hovered ? ManagerChrome.accent.opacity(0.08) : .clear))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(selected ? ManagerChrome.accent.opacity(0.40) : .clear, lineWidth: 1)
                 )
                 .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         .buttonStyle(.plain)
+        .onHover { hovered = $0 }
     }
 }
 

--- a/VaderCleaner/ManagerChrome.swift
+++ b/VaderCleaner/ManagerChrome.swift
@@ -8,17 +8,22 @@ import SwiftUI
 /// the footer action so every Manager card reads with one identity.
 enum ManagerChrome {
     static let accent = Color(red: 0.81, green: 0.10, blue: 0.55)
+    /// The AppKit twin of `accent`, for the recycled item-table row views that
+    /// draw their card and hover highlight with `NSColor`.
+    static let nsAccent = NSColor(srgbRed: 0.81, green: 0.10, blue: 0.55, alpha: 1)
 }
 
-/// A selectable section/category row with the section-accent selection pill and
-/// a quieter hover fill. Its own view with local hover `@State`, so moving the
-/// pointer between rows re-renders only the rows involved — never the whole
-/// manager (whose body recomputes per-category sizes and the item table).
+/// A selectable section/category row with the magenta manager selection pill
+/// and a quieter hover fill. Every manager's left and middle panes share the one
+/// `ManagerChrome.accent` for these active/hover states so they read with a
+/// single identity regardless of the section's own hue. Its own view with local
+/// hover `@State`, so moving the pointer between rows re-renders only the rows
+/// involved — never the whole manager (whose body recomputes per-category sizes
+/// and the item table).
 struct NavRow<Content: View>: View {
     let selected: Bool
     let action: () -> Void
     let content: Content
-    @Environment(\.sectionAccent) private var accent
     @State private var hovered = false
 
     init(selected: Bool, action: @escaping () -> Void, @ViewBuilder content: () -> Content) {
@@ -35,11 +40,11 @@ struct NavRow<Content: View>: View {
                 .padding(.vertical, 8)
                 .background(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(selected ? accent.opacity(0.22) : (hovered ? accent.opacity(0.08) : .clear))
+                        .fill(selected ? ManagerChrome.accent.opacity(0.22) : (hovered ? ManagerChrome.accent.opacity(0.08) : .clear))
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .strokeBorder(selected ? accent.opacity(0.40) : .clear, lineWidth: 1)
+                        .strokeBorder(selected ? ManagerChrome.accent.opacity(0.40) : .clear, lineWidth: 1)
                 )
                 .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
@@ -56,6 +61,8 @@ struct NavRow<Content: View>: View {
 /// and disclosure buttons unclickable. All the managers that use these rows
 /// force the light appearance, so the fixed white fill is safe.
 struct ManagerRowCard: ViewModifier {
+    @State private var hovered = false
+
     func body(content: Content) -> some View {
         content
             .background(
@@ -63,10 +70,19 @@ struct ManagerRowCard: ViewModifier {
                     .fill(Color.white)
                     .shadow(color: .black.opacity(0.10), radius: 3, y: 1)
             )
+            // A quieter magenta hover fill matching the left/middle nav rows, laid
+            // over the white card. Non-hit-testing so it never intercepts the
+            // row's checkbox or disclosure control.
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(ManagerChrome.accent.opacity(hovered ? 0.08 : 0))
+                    .allowsHitTesting(false)
+            )
             .overlay(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .strokeBorder(Color.black.opacity(0.06), lineWidth: 1)
             )
+            .onHover { hovered = $0 }
     }
 }
 

--- a/VaderCleaner/ManagerItemTable.swift
+++ b/VaderCleaner/ManagerItemTable.swift
@@ -262,7 +262,10 @@ final class HoverTableRowView: NSTableRowView {
             path.stroke()
         }
         guard isHovered else { return }
-        (isLight ? NSColor.black.withAlphaComponent(0.03) : NSColor.white.withAlphaComponent(0.05)).setFill()
+        // A quieter magenta hover fill matching the manager nav rows and the
+        // SwiftUI row cards, a touch stronger over the dark card so it stays
+        // visible there.
+        ManagerChrome.nsAccent.withAlphaComponent(isLight ? 0.08 : 0.16).setFill()
         path.fill()
     }
 }

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -18,8 +18,6 @@ struct MyClutterManagerView: View {
     /// The reference Manager uses a magenta accent on a white surface — the same
     /// one the Cleanup Manager adopts — independent of the section's teal.
     static let accent = Color(red: 0.81, green: 0.10, blue: 0.55)
-    /// Soft lavender selection fill for the left and middle panes.
-    private static let selectionFill = Color(red: 0.45, green: 0.30, blue: 0.85).opacity(0.14)
 
     @State private var category: MyClutterCategory
     @State private var search = ""
@@ -234,7 +232,7 @@ struct MyClutterManagerView: View {
         ScrollView {
             VStack(spacing: 4) {
                 ForEach(MyClutterCategory.allCases) { item in
-                    selectableRow(selected: item == category) {
+                    NavRow(selected: item == category) {
                         category = item
                         resetMiddleSelection()
                     } content: {
@@ -290,7 +288,7 @@ struct MyClutterManagerView: View {
     }
 
     private func facetRow(_ facet: MyClutterLargeOldFacet, label: String, bytes: Int64) -> some View {
-        selectableRow(selected: largeOldFacet == facet) {
+        NavRow(selected: largeOldFacet == facet) {
             largeOldFacet = facet
         } content: {
             HStack {
@@ -317,7 +315,7 @@ struct MyClutterManagerView: View {
     private func groupList(_ groups: [(id: String, original: ScannedFile, files: [ScannedFile])]) -> some View {
         LazyVStack(spacing: 4) {
             ForEach(groups, id: \.id) { group in
-                selectableRow(selected: selectedGroupID == group.id) {
+                NavRow(selected: selectedGroupID == group.id) {
                     selectedGroupID = group.id
                     focusedURL = group.files.first?.url
                 } content: {
@@ -347,7 +345,7 @@ struct MyClutterManagerView: View {
     private var browserList: some View {
         LazyVStack(spacing: 4) {
             ForEach(downloadCache) { group in
-                selectableRow(selected: selectedBrowser == group.source) {
+                NavRow(selected: selectedBrowser == group.source) {
                     selectedBrowser = group.source
                 } content: {
                     HStack(spacing: 12) {
@@ -686,24 +684,6 @@ struct MyClutterManagerView: View {
     private func breadcrumb(_ url: URL) -> some View {
         Text(breadcrumbText(url))
             .font(.caption).foregroundStyle(.secondary).lineLimit(1).truncationMode(.head)
-    }
-
-    private func selectableRow<Content: View>(
-        selected: Bool,
-        action: @escaping () -> Void,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        Button(action: action) {
-            content()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 12).padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(selected ? Self.selectionFill : .clear)
-                )
-                .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        }
-        .buttonStyle(.plain)
     }
 
     private func browserIcon(for group: MyClutterDownloadGroup) -> some View {


### PR DESCRIPTION
## What

Makes every Manager screen (Cleanup, Smart Scan, Protection, Performance, My Clutter, Applications) share one visual identity for its **left, middle, and right** panes: the magenta `ManagerChrome.accent` for both **active** and **hover** states — matching the Cleanup Manager reference.

The pattern, applied everywhere:
- **Active**: accent fill at 22% + accent border at 40%.
- **Hover**: lighter accent fill at 8%, no border.

## Why

Sections previously diverged: nav rows tinted with each section's own hue, My Clutter and Applications used a one-off purple selection fill with no hover, and the right-pane list rows either had no hover or a neutral one. This unifies them so all panes read consistently.

## Changes

- **`NavRow`** — active/hover fill and border pinned to `ManagerChrome.accent` instead of `\.sectionAccent`, so all sections' left/middle nav rows match.
- **My Clutter** — removed its divergent purple `selectableRow`/`selectionFill`; reuses the shared `NavRow`.
- **Applications** — `ApplicationsManagerSelectableRow` now uses the accent fill/border and gains the previously-missing hover state; removed its purple `selectionFill`.
- **Right panes** — `managerRowCard()` gains a non-hit-testing accent hover overlay (so it never blocks a row's checkbox/disclosure control); the recycled `HoverTableRowView` switches its neutral hover tint to the accent (8% light / 16% dark). Added `ManagerChrome.nsAccent` as the AppKit twin of the accent.

## Reviewer notes

- No behavior/logic changes — purely the active/hover styling of manager pane rows.
- The right-pane hover uses a slightly stronger alpha (16%) on the dark Smart Scan card so it stays visible over the dark gradient.
- Builds clean (`xcodebuild ... BUILD SUCCEEDED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover highlighting for selectable rows and cards, making navigation states more responsive and easier to see.
  * Updated the app’s accent color usage so selected and hovered items now share a more consistent visual style.

* **Bug Fixes**
  * Improved row and table hover visuals for clearer feedback in light and dark appearances.
  * Simplified selection rendering across multiple views for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->