### PR TITLE
Fix Space Lens checkbox taps and tint manager Back/Search icons

### DIFF
--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -174,7 +174,7 @@ struct ApplicationsManagerView: View {
         HStack(spacing: 16) {
             Button(action: onBack) {
                 HStack(spacing: 4) {
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "chevron.left").foregroundStyle(.tint)
                     Text(String(localized: "Back", comment: "Back button on the Applications Manager."))
                 }
             }
@@ -187,7 +187,7 @@ struct ApplicationsManagerView: View {
             Spacer()
 
             HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                Image(systemName: "magnifyingglass").foregroundStyle(.tint)
                 TextField(String(localized: "Search", comment: "Manager search placeholder."), text: $search)
                     .textFieldStyle(.plain)
                     .frame(width: 130)
@@ -701,7 +701,7 @@ private struct UninstallerPaneView: View {
                     inspectingAppID = nil
                 } label: {
                     HStack(spacing: 4) {
-                        Image(systemName: "chevron.left")
+                        Image(systemName: "chevron.left").foregroundStyle(.tint)
                         Text(String(localized: "All Applications", comment: "Back to the full uninstaller list."))
                     }
                 }

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -192,7 +192,7 @@ struct MyClutterManagerView: View {
         HStack(spacing: 16) {
             Button(action: onBack) {
                 HStack(spacing: 4) {
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "chevron.left").foregroundStyle(.tint)
                     Text(String(localized: "Back", comment: "Back button on the My Clutter Manager."))
                 }
             }
@@ -205,7 +205,7 @@ struct MyClutterManagerView: View {
             Spacer()
 
             HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                Image(systemName: "magnifyingglass").foregroundStyle(.tint)
                 TextField(String(localized: "Search", comment: "Manager search placeholder."), text: $search)
                     .textFieldStyle(.plain)
                     .frame(width: 130)

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -404,7 +404,7 @@ struct PerformanceTaskCatalogView: View {
                 // HStack(Image, Text) rather than Label so the control surfaces
                 // reliably in XCUITest.
                 HStack(spacing: 4) {
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "chevron.left").foregroundStyle(.tint)
                     Text(String(localized: "Back", comment: "Back button returning from the Performance Manager to the dashboard."))
                 }
             }
@@ -418,7 +418,7 @@ struct PerformanceTaskCatalogView: View {
 
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.tint)
                 TextField(
                     String(localized: "Search", comment: "Placeholder in the Performance Manager search field."),
                     text: $search

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -115,7 +115,7 @@ struct ProtectionManagerView: View {
         HStack(spacing: 16) {
             Button(action: onBack) {
                 HStack(spacing: 4) {
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "chevron.left").foregroundStyle(.tint)
                     Text(String(localized: "Back", comment: "Back button on the Protection Manager."))
                 }
             }
@@ -125,7 +125,7 @@ struct ProtectionManagerView: View {
             Text(String(localized: "Protection Manager", comment: "Protection Manager screen title.")).font(.headline)
             Spacer()
             HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                Image(systemName: "magnifyingglass").foregroundStyle(.tint)
                 TextField(String(localized: "Search", comment: "Manager search placeholder."), text: $search)
                     .textFieldStyle(.plain).frame(width: 130)
                     .accessibilityIdentifier("protection.manager.search")

--- a/VaderCleaner/SmartScanReviewManager.swift
+++ b/VaderCleaner/SmartScanReviewManager.swift
@@ -312,7 +312,7 @@ struct SmartScanReviewManager: View {
         HStack(spacing: 16) {
             Button(action: onBack) {
                 HStack(spacing: 4) {
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "chevron.left").foregroundStyle(.tint)
                     Text(String(localized: "Back", comment: "Back button on a Smart Scan Manager screen."))
                 }
             }
@@ -327,7 +327,7 @@ struct SmartScanReviewManager: View {
 
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.tint)
                 TextField(
                     String(localized: "Search", comment: "Placeholder in a Smart Scan Manager search field."),
                     text: $search

--- a/VaderCleaner/SpaceLensListPanel.swift
+++ b/VaderCleaner/SpaceLensListPanel.swift
@@ -135,33 +135,38 @@ struct SpaceLensListPanel: View {
         let highlighted = viewModel.highlightedNodeID == child.id
         HStack(spacing: 10) {
             leadingControl(for: child, selected: selected)
-            Image(nsImage: iconCache.icon(for: child.url))
-                .resizable()
-                .interpolation(.high)
-                .frame(width: 22, height: 22)
-            Text(child.name)
-                .font(.callout)
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Text(child.formattedSize)
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.secondary)
+            // The drill-in tap is scoped to the icon/name/size content so it
+            // doesn't overlap the checkbox button; a container-wide tap gesture
+            // would swallow the checkbox click and drill in instead of toggling.
+            HStack(spacing: 10) {
+                Image(nsImage: iconCache.icon(for: child.url))
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: 22, height: 22)
+                Text(child.name)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text(child.formattedSize)
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                if child.isDirectory { viewModel.drillDown(into: child) }
+            }
         }
         .padding(.horizontal, 10)
         .frame(height: Self.rowHeight)
         .background(highlighted ? Color.white.opacity(0.08) : .clear,
                     in: RoundedRectangle(cornerRadius: 8))
-        .contentShape(Rectangle())
         // Hovering the row drives the shared highlight; the checkbox is a
         // separate control, so a row click drills in without toggling removal.
         .onHover { hovering in
             if hovering { viewModel.highlightedNodeID = child.id }
             else if viewModel.highlightedNodeID == child.id { viewModel.highlightedNodeID = nil }
-        }
-        .onTapGesture {
-            if child.isDirectory { viewModel.drillDown(into: child) }
         }
         .accessibilityIdentifier("space-lens.row.\(child.name)")
     }


### PR DESCRIPTION
## What changed

Two UI fixes for the manager screens:

### 1. Space Lens left-pane checkboxes were unclickable
In `SpaceLensListPanel`, each list row attached the drill-in `.onTapGesture` (plus `.contentShape(Rectangle())`) to the **entire** row `HStack`, with the checkbox `Button` nested inside it. On macOS the container-wide tap gesture intercepted the click before the plain-styled checkbox button, so clicking a checkbox drilled into the folder instead of toggling selection — exactly the reported bug. The row's own comment described the intended behavior ("the checkbox is a separate control, so a row click drills in without toggling removal"); the gesture layout just defeated it.

**Fix:** scope the drill-in `.onTapGesture`/`.contentShape` to only the icon/name/size content sub-`HStack`, leaving the checkbox button in its own hit region. The full-row hover highlight is preserved via `.onHover` on the outer frame.
- Clicking the checkbox → toggles selection
- Clicking the name/icon/size → drills into the folder

### 2. Manager Back/Search icons were neutral gray instead of the accent
The **Back** chevron (default dark label color) and **Search** magnifying-glass glyph (`.secondary` gray) didn't match the accent-colored "Sort by:" value and category glyphs already in the same headers. Changed both icons to `.foregroundStyle(.tint)` so they adopt each manager's accent — magenta in the light managers (My Clutter, Applications, Protection, Performance) and the section accent in Smart Scan. Only the icons are tinted; the "Back" text and search placeholder are unchanged.

Covered: My Clutter, Applications (header + "All Applications" uninstaller-detail back), Protection, Performance, and Smart Scan managers.

## Why `.tint` rather than a hardcoded magenta
`.tint` resolves to each manager's own accent, so every screen stays internally consistent with the accent icons already in its header. Hardcoding magenta would have clashed with Smart Scan's intentional purple theme.

## Reviewer notes
- Out of scope (left unchanged): the Space Lens breadcrumb back/forward (a different bordered-button style) and the Smart Scan "Start Over" dashboard button.
- **Not built/run locally:** the app build is blocked by a pre-existing, unrelated environment issue — `Scripts/bundle-clamav.sh` fails staging `json-c` due to a Homebrew bottle version mismatch. Both changes are pure SwiftUI view/modifier edits (no new symbols, standard API), verified by inspection and a syntax parse rather than at runtime. Worth a quick manual smoke-test of the Space Lens checkboxes and the manager header colors before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)