### PR TITLE
Fix Space Lens list checkbox not toggling on

### DIFF
--- a/VaderCleaner/SpaceLensListPanel.swift
+++ b/VaderCleaner/SpaceLensListPanel.swift
@@ -180,10 +180,23 @@ struct SpaceLensListPanel: View {
             Button {
                 viewModel.selection.toggle(child)
             } label: {
+                // Keep the tap target confined to the box itself so only the
+                // checkbox toggles selection — clicking elsewhere on the row is
+                // reserved for drilling into a folder.
+                //
+                // An unchecked box fills with `Color.clear`, which draws nothing,
+                // and a plain button derives its hit region from the label's
+                // drawn pixels — so an unchecked box has no surface to click and
+                // only checking-off (opaque accent fill) registered. The
+                // near-transparent background gives the label a real, hittable
+                // surface over its full 22×22 frame in both states, and the
+                // content shape makes that whole square the tap region.
                 checkbox(isOn: selected)
+                    .frame(width: 22, height: 22)
+                    .background(Color.black.opacity(0.001))
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .frame(width: 22)
             .accessibilityIdentifier("space-lens.checkbox.\(child.name)")
         }
     }


### PR DESCRIPTION
## What

Fixes a bug where the Space Lens list-panel removal checkbox could be **unchecked** but never **checked**: clicking an empty box did nothing, while clicking a filled box cleared it.

## Why

The checkbox is a plain `Button` whose label is the custom `checkbox(isOn:)` shape. When unchecked, that shape fills with `Color.clear`, which draws nothing — and a `.buttonStyle(.plain)` button derives its hit region from the label's *drawn* pixels. So an unchecked box had no surface to register the click on, while a checked box (opaque accent fill) was hittable. Hence the asymmetry.

## How

Give the button label a real, hittable surface without changing the checkbox's appearance:

- explicit `22×22` frame on the label,
- a near-transparent `Color.black.opacity(0.001)` background (visually imperceptible, but a genuine hit-testable view), and
- a `Rectangle` content shape.

The tap now lands whether the box is checked or not, and the target stays confined to the box — clicking the row's icon/name/size still drills into a folder via its separate `.onTapGesture`, matching the intended behavior that only the checkbox toggles selection.

## Notes for reviewer

- Change is isolated to `SpaceLensListPanel.leadingControl` in `VaderCleaner/SpaceLensListPanel.swift`.
- The checkbox's visual (`checkbox(isOn:)`) is untouched.
- Verified the Swift compiles; full app build in this worktree is blocked only by the unrelated `Stage bundled ClamAV` phase (`Vendor/clamav` not staged), so please build from a checkout with ClamAV staged to click-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the selection checkbox in the list panel so its tap area is now consistent and easier to use.
  * Made the unchecked checkbox state more reliably tappable, reducing missed taps on smaller hit targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->