### PR TITLE
Prevent sleep during scans; fix Space Lens per-bubble tooltip

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B017EBC3CA11CE939B3362 /* ScannedFile.swift */; };
 		4A3FEBEBF48CA7078F98EA17 /* BrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F6A5DF7364E1886699488B /* BrowserTests.swift */; };
 		4AFD7481F468F9E06DF1A2DE /* AppUpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B3B6F431DB972DC6427E55 /* AppUpdaterViewModel.swift */; };
+		4BAEAB536AEF8709ECBF6658 /* ScanActivityAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273BF54E38EC3C41D2DB5466 /* ScanActivityAssertion.swift */; };
 		4E43B8F6DFA386900DC8CA24 /* com.personal.VaderCleaner.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36FD121EC3D77731E8032A96 /* com.personal.VaderCleaner.helper.plist */; };
 		4ED4E093FE7E2ADB381708F4 /* ScanDiscWindowFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75515819550B2B92260F57B /* ScanDiscWindowFrame.swift */; };
 		4EF8BA012B966F984D9569E7 /* CleanupManagerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DC35796A9897B1CE0113EC /* CleanupManagerStoreTests.swift */; };
@@ -166,6 +167,7 @@
 		688FEF65720EAF3D51754EC6 /* MyClutterManagerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */; };
 		6A34CA9DF4F4B0D1326A965C /* performance.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B51321F0F77F5813E6777822 /* performance.usdz */; };
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
+		6C7604F02241E2806956F887 /* ScanActivityAssertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF7C998C60CFE1A00C4549C /* ScanActivityAssertionTests.swift */; };
 		6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */; };
 		6D2476F58F6EDCF6C12C844D /* UnusedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */; };
 		6DD186684E701C06ABA8B3AB /* SystemJunkDeleterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3079940CD9C1E2D47837ED8 /* SystemJunkDeleterTests.swift */; };
@@ -471,6 +473,7 @@
 		2605C9D00F82838A6A9D11A3 /* SystemJunkDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDashboardSubviews.swift; sourceTree = "<group>"; };
 		2617BC26104D5196DEDB3589 /* UpdateInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInfo.swift; sourceTree = "<group>"; };
 		2659D57635179FE36BEC0366 /* WebDevScanFolderPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDevScanFolderPicker.swift; sourceTree = "<group>"; };
+		273BF54E38EC3C41D2DB5466 /* ScanActivityAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanActivityAssertion.swift; sourceTree = "<group>"; };
 		27F1DC062C52C51730548216 /* LoginItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItem.swift; sourceTree = "<group>"; };
 		2825A3B9ECD210BE8B10276D /* PrivacyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewModelTests.swift; sourceTree = "<group>"; };
 		2A12359DD9127DB0C1D5EDC3 /* PermissionOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModel.swift; sourceTree = "<group>"; };
@@ -522,6 +525,7 @@
 		48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDiscWindowController.swift; sourceTree = "<group>"; };
 		49D62624319B764770F02292 /* AppUninstallerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModel.swift; sourceTree = "<group>"; };
 		4ABAC3D4E20AD9AB7265338D /* AppVendor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVendor.swift; sourceTree = "<group>"; };
+		4AF7C998C60CFE1A00C4549C /* ScanActivityAssertionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanActivityAssertionTests.swift; sourceTree = "<group>"; };
 		4B3FB5D1E4E24DA8CD36F774 /* ClamAVScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamAVScanner.swift; sourceTree = "<group>"; };
 		4C0A3D2497CF28388945BB57 /* SystemJunkUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkUITests.swift; sourceTree = "<group>"; };
 		4D92F45290B56030CBFA83D3 /* Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
@@ -594,7 +598,6 @@
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
 		82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotCounter.swift; sourceTree = "<group>"; };
-		869E8D8A460A998AA0E6B854 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		86CB0FF38AA0C4E58C4ADFF8 /* SpaceLensProtectionMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensProtectionMessageTests.swift; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
 		88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanOverlay.swift; sourceTree = "<group>"; };
@@ -724,6 +727,7 @@
 		D9E9C1B2D0698E37C9F9E385 /* BrowserDataCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataCounter.swift; sourceTree = "<group>"; };
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
 		DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewSubviews.swift; sourceTree = "<group>"; };
+		DC7D808F11B63AFD691F0979 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceRunLogTests.swift; sourceTree = "<group>"; };
 		DEA948F9A1557934D6C51A6B /* ScanCompletionNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCompletionNotifier.swift; sourceTree = "<group>"; };
 		DEAFBD23ECABA75AF3D1F33B /* BrowserPrivacyInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrivacyInspector.swift; sourceTree = "<group>"; };
@@ -799,9 +803,9 @@
 		60EC9332AD3B6CA565B9AB47 = {
 			isa = PBXGroup;
 			children = (
+				B8F4254E5522527A3379D1BF /* recursing-torvalds-86010c */,
 				E64E279A077DB78FF7F39BDD /* Shared */,
 				82214E451FF2D64A74A4B196 /* VaderCleaner */,
-				89BDE2EE038F8B5544BF44FE /* VaderCleaner */,
 				DD23DA844162EC496E4C0C1D /* VaderCleanerHelper */,
 				E90D4526947C1F261F963425 /* VaderCleanerTests */,
 				6A2D96C9C63AD506553F0BE0 /* VaderCleanerUITests */,
@@ -959,6 +963,7 @@
 				C91F61D9C54461DBA18D930E /* ReassuranceCard.swift */,
 				2A932AAC115A2ADB167D59F8 /* RecentFilesManager.swift */,
 				2BB5681FA35AB3189E0143A5 /* ScanAccessPopover.swift */,
+				273BF54E38EC3C41D2DB5466 /* ScanActivityAssertion.swift */,
 				33EC67B639248BC5EA1F5473 /* ScanCategory.swift */,
 				DEA948F9A1557934D6C51A6B /* ScanCompletionNotifier.swift */,
 				AC931DDB859DD0025BB352EA /* ScanCoordinating.swift */,
@@ -1035,12 +1040,12 @@
 			path = VaderCleaner;
 			sourceTree = "<group>";
 		};
-		89BDE2EE038F8B5544BF44FE /* VaderCleaner */ = {
+		B8F4254E5522527A3379D1BF /* recursing-torvalds-86010c */ = {
 			isa = PBXGroup;
 			children = (
-				869E8D8A460A998AA0E6B854 /* Signing.xcconfig */,
+				DC7D808F11B63AFD691F0979 /* Signing.xcconfig */,
 			);
-			name = VaderCleaner;
+			name = "recursing-torvalds-86010c";
 			path = .;
 			sourceTree = "<group>";
 		};
@@ -1183,6 +1188,7 @@
 				78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */,
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */,
+				4AF7C998C60CFE1A00C4549C /* ScanActivityAssertionTests.swift */,
 				5CC50A90E584320709971BCB /* ScanCategoryTests.swift */,
 				B6E174B0BDF4FBEE8C025626 /* ScanCompletionNotifierTests.swift */,
 				3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */,
@@ -1520,6 +1526,7 @@
 				3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */,
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				3D65654B589EFF2972927ED7 /* ScanAccessPopoverTests.swift in Sources */,
+				6C7604F02241E2806956F887 /* ScanActivityAssertionTests.swift in Sources */,
 				99F54E1F93D8E812416A441B /* ScanCategoryTests.swift in Sources */,
 				FC5355702BCBC1A1C4DD43AC /* ScanCompletionNotifierTests.swift in Sources */,
 				1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */,
@@ -1721,6 +1728,7 @@
 				567D2B366B03261E808DA1B2 /* RecentFilesManager.swift in Sources */,
 				56E0A50749CEFC070968439D /* SMCReader.swift in Sources */,
 				45FB850A603BCEE6C2B1CFF6 /* ScanAccessPopover.swift in Sources */,
+				4BAEAB536AEF8709ECBF6658 /* ScanActivityAssertion.swift in Sources */,
 				AE5197BEDDDB0C8855A59B3A /* ScanCategory.swift in Sources */,
 				76E3EEE8D1DA95B2FCA60B93 /* ScanCompletionNotifier.swift in Sources */,
 				9465DF6DC888BECC125DCF01 /* ScanCoordinating.swift in Sources */,
@@ -1902,7 +1910,7 @@
 		};
 		6FC5B4C07B6F4D2470E81C20 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 869E8D8A460A998AA0E6B854 /* Signing.xcconfig */;
+			baseConfigurationReference = DC7D808F11B63AFD691F0979 /* Signing.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1968,7 +1976,7 @@
 		};
 		7AC507F3249F5A68448657EF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 869E8D8A460A998AA0E6B854 /* Signing.xcconfig */;
+			baseConfigurationReference = DC7D808F11B63AFD691F0979 /* Signing.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		AF573F2D6363CF0CDA72E5A4 /* ApplicationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5334403C48811B372CBEB19A /* ApplicationsView.swift */; };
 		AFE3EC8473F0D6BC1141FD07 /* SimilarImageGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331110971EA8F8690773FE88 /* SimilarImageGroup.swift */; };
 		B04E252C6875D95BB275CBA3 /* ExtensionsManagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF12BC1A8516C109492FA5B /* ExtensionsManagerViewModelTests.swift */; };
+		B099D858DA5FA94630094FFC /* MyClutterThumbnailStripItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24633693DA0109BA4809355D /* MyClutterThumbnailStripItemTests.swift */; };
 		B139E21F16EA44AC362A028F /* CloudFileAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CE7DCEB93C1AFD8F68F8DC /* CloudFileAvailability.swift */; };
 		B189206CD9318968B0D685B6 /* WebDevScanFolderPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2659D57635179FE36BEC0366 /* WebDevScanFolderPicker.swift */; };
 		B1AB0F08BC3A704E2F413AF5 /* DiskNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39407E2EA6D045893F1BA4B /* DiskNode.swift */; };
@@ -274,6 +275,7 @@
 		BA3D489D48265F806CC468A2 /* MenuBarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C2B92863509818189F46CD /* MenuBarContent.swift */; };
 		BA47B242AAAE6EAD08CC7D23 /* ScanDiscWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F552ABB8AD311ED03743D9 /* ScanDiscWindowController.swift */; };
 		BABEDA3326E05DC3A8356E3D /* AppStoreUpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65311CF9EE5FEA6F23FF3552 /* AppStoreUpdateChecker.swift */; };
+		BACC269ED04FA26D7003F449 /* MyClutterThumbnailStripItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB9080DB9E32168E1AA98AB /* MyClutterThumbnailStripItem.swift */; };
 		BB6D9635C62A1D0635E2799F /* AppUpdaterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76CE861C998A697164C552 /* AppUpdaterError.swift */; };
 		BB9A4CF2FD2F04CD567D4F4F /* PerformanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C485B2B12D9A5E260323AB89 /* PerformanceViewModel.swift */; };
 		BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */; };
@@ -468,6 +470,7 @@
 		226E0F0A1BF7247823980DE5 /* AppVendorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVendorTests.swift; sourceTree = "<group>"; };
 		22DEDDB1C46A745F0896DB18 /* SparkleUpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateCheckerTests.swift; sourceTree = "<group>"; };
 		232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseUpdater.swift; sourceTree = "<group>"; };
+		24633693DA0109BA4809355D /* MyClutterThumbnailStripItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterThumbnailStripItemTests.swift; sourceTree = "<group>"; };
 		256F4BD04C334D03B15EC600 /* DownloadsScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsScanner.swift; sourceTree = "<group>"; };
 		25BF7F8FE4811CE7663B96F8 /* ActivationPolicyDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationPolicyDecisionTests.swift; sourceTree = "<group>"; };
 		2605C9D00F82838A6A9D11A3 /* SystemJunkDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkDashboardSubviews.swift; sourceTree = "<group>"; };
@@ -591,6 +594,7 @@
 		785EECE3C6B84ECB7D0A3384 /* spaceLens.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = spaceLens.usdz; sourceTree = "<group>"; };
 		78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManagerTests.swift; sourceTree = "<group>"; };
 		7E800D4E6E10B7B99B2D1170 /* AppUninstallerViewModelMultiSelectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUninstallerViewModelMultiSelectTests.swift; sourceTree = "<group>"; };
+		7EB9080DB9E32168E1AA98AB /* MyClutterThumbnailStripItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterThumbnailStripItem.swift; sourceTree = "<group>"; };
 		7ECD89431BD47AB75E415D87 /* PermissionOnboardingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOnboardingViewModelTests.swift; sourceTree = "<group>"; };
 		7F08CF19441CB25F982CDCD2 /* MaintenanceTaskRunnersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTaskRunnersTests.swift; sourceTree = "<group>"; };
 		7F30A757E0739FCBD68B3EE8 /* AppIconCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconCache.swift; sourceTree = "<group>"; };
@@ -932,6 +936,7 @@
 				558B0A2338BD9E61BDB7CE68 /* MyClutterManagerModel.swift */,
 				03DA725A728374ADDA906C40 /* MyClutterManagerView.swift */,
 				6298096AACFE956ABD8B9C36 /* MyClutterScanScopeStore.swift */,
+				7EB9080DB9E32168E1AA98AB /* MyClutterThumbnailStripItem.swift */,
 				8B4703AF41629FA4FA05F270 /* MyClutterView.swift */,
 				973FCD99A18392D82D543907 /* MyClutterViewModel.swift */,
 				D7D76FC5B20F88179DF40523 /* NavigationRailView.swift */,
@@ -1168,6 +1173,7 @@
 				CFCB5B73D26EDB0E1FB96805 /* MenuBarViewModelTests.swift */,
 				CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */,
 				175A6E5DE9F8C11D0560DB04 /* MyClutterScanScopeStoreTests.swift */,
+				24633693DA0109BA4809355D /* MyClutterThumbnailStripItemTests.swift */,
 				183D94243CDA9FABBF5A22E5 /* MyClutterTileKindTests.swift */,
 				1BED81B0628BEACAB6B965B9 /* MyClutterViewModelTests.swift */,
 				133467A06193C406B027D97C /* NavigationSectionTests.swift */,
@@ -1506,6 +1512,7 @@
 				C3F6768F9E7D9A36A7DA5801 /* MenuBarViewModelTests.swift in Sources */,
 				688FEF65720EAF3D51754EC6 /* MyClutterManagerModelTests.swift in Sources */,
 				BDAF9DD5414C50F4546C239B /* MyClutterScanScopeStoreTests.swift in Sources */,
+				B099D858DA5FA94630094FFC /* MyClutterThumbnailStripItemTests.swift in Sources */,
 				8B988F3F94B085674B032A7B /* MyClutterTileKindTests.swift in Sources */,
 				AD3DF5C0E560EB93A7D89410 /* MyClutterViewModelTests.swift in Sources */,
 				BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */,
@@ -1696,6 +1703,7 @@
 				65B572321C38997952E456EF /* MyClutterManagerModel.swift in Sources */,
 				B810AA29ADEFD684916D89A8 /* MyClutterManagerView.swift in Sources */,
 				F3EF226A59824AE175B8B40F /* MyClutterScanScopeStore.swift in Sources */,
+				BACC269ED04FA26D7003F449 /* MyClutterThumbnailStripItem.swift in Sources */,
 				5505910EB98B1A0B51410171 /* MyClutterView.swift in Sources */,
 				EB09514D96CA8746124FFBE9 /* MyClutterViewModel.swift in Sources */,
 				5325F2401AF35C69086E2056 /* NavigationRailView.swift in Sources */,

--- a/VaderCleaner/ApplicationsViewModel.swift
+++ b/VaderCleaner/ApplicationsViewModel.swift
@@ -634,6 +634,6 @@ extension ApplicationsViewModel: ScanCoordinating {
     }
 
     func beginScan() {
-        Task { await scan() }
+        runScanActivity { await self.scan() }
     }
 }

--- a/VaderCleaner/DiskScannerViewModel.swift
+++ b/VaderCleaner/DiskScannerViewModel.swift
@@ -537,7 +537,7 @@ extension DiskScannerViewModel: ScanCoordinating {
         // Space Lens scans the volume chosen in the intro picker (the boot
         // volume by default), so the explorer starts at that volume's root and
         // the breadcrumb matches its tree, the way a disk-usage map reads.
-        Task { await startScan(root: selectedVolumeURL) }
+        runScanActivity { await self.startScan(root: self.selectedVolumeURL) }
     }
 
     /// The boot volume's mount point — the default Space Lens scan root.

--- a/VaderCleaner/MalwareViewModel.swift
+++ b/VaderCleaner/MalwareViewModel.swift
@@ -449,6 +449,6 @@ extension MalwareViewModel: ScanCoordinating {
     }
 
     func beginScan() {
-        Task { await scan(mode: configuredScanMode) }
+        runScanActivity { await self.scan(mode: self.configuredScanMode) }
     }
 }

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -555,26 +555,16 @@ struct MyClutterManagerView: View {
     }
 
     private func thumbnailStripItem(_ file: ScannedFile, isOriginal: Bool, showsBestBadge: Bool) -> some View {
-        let isFocused = (focusedURL ?? file.url) == file.url
-        return Button {
-            focusedURL = file.url
-        } label: {
-            ClutterThumbnailView(url: file.url, fallbackSymbol: "photo")
-                .frame(width: 64, height: 64)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .strokeBorder(isFocused ? Self.accent : Color.secondary.opacity(0.25), lineWidth: isFocused ? 2 : 1)
-                )
-                .overlay(alignment: .topTrailing) {
-                    if showsBestBadge && isOriginal {
-                        Circle().fill(.green).frame(width: 12, height: 12)
-                            .overlay(Circle().strokeBorder(.white, lineWidth: 2))
-                            .padding(4)
-                    }
-                }
-        }
-        .buttonStyle(.plain)
+        ClutterThumbnailStripItem(
+            url: file.url,
+            isOriginal: isOriginal,
+            showsBestBadge: showsBestBadge,
+            isSelected: viewModel.isSelected(file.url),
+            isFocused: (focusedURL ?? file.url) == file.url,
+            accent: Self.accent,
+            onToggleSelect: { viewModel.toggleSelection(url: file.url) },
+            onFocus: { focusedURL = file.url }
+        )
     }
 
     private func metadata(for file: ScannedFile) -> some View {

--- a/VaderCleaner/MyClutterThumbnailStripItem.swift
+++ b/VaderCleaner/MyClutterThumbnailStripItem.swift
@@ -1,0 +1,105 @@
+// MyClutterThumbnailStripItem.swift
+// One selectable image in the Duplicates / Similar Images thumbnail strip: a removal checkbox, the kept-original badge, and magenta active/hover states.
+
+import SwiftUI
+
+/// Which emphasis a thumbnail draws, highest priority first: a selected image
+/// (marked for removal) always shows the active magenta border, then the
+/// focused image (the one shown in the large preview), then a hovered one, then
+/// idle. Pure so the precedence stays unit-testable without rendering.
+enum ClutterThumbnailEmphasis {
+    case selected
+    case focused
+    case hovered
+    case idle
+
+    static func resolve(isSelected: Bool, isFocused: Bool, hovered: Bool) -> ClutterThumbnailEmphasis {
+        if isSelected { return .selected }
+        if isFocused { return .focused }
+        if hovered { return .hovered }
+        return .idle
+    }
+}
+
+/// One image in the Duplicates / Similar Images thumbnail strip: a selectable
+/// card with a removal checkbox (top-left), the kept-original badge (top-right),
+/// a magenta border when selected (active), and a light-magenta hover tint. Its
+/// own view with local hover state so moving the pointer repaints only the
+/// hovered thumbnail, not the whole preview pane. The checkbox toggles removal
+/// selection; tapping elsewhere on the image focuses it in the large preview.
+struct ClutterThumbnailStripItem: View {
+    let url: URL
+    let isOriginal: Bool
+    let showsBestBadge: Bool
+    let isSelected: Bool
+    let isFocused: Bool
+    let accent: Color
+    let onToggleSelect: () -> Void
+    let onFocus: () -> Void
+
+    @State private var hovered = false
+
+    private var emphasis: ClutterThumbnailEmphasis {
+        ClutterThumbnailEmphasis.resolve(isSelected: isSelected, isFocused: isFocused, hovered: hovered)
+    }
+
+    var body: some View {
+        ClutterThumbnailView(url: url, fallbackSymbol: "photo")
+            .frame(width: 72, height: 72)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            // Light-magenta hover tint, non-hit-testing so it never intercepts
+            // the checkbox tap or the focus tap beneath it.
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(accent.opacity(hovered ? 0.14 : 0))
+                    .allowsHitTesting(false)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(borderColor, lineWidth: borderWidth)
+            )
+            .overlay(alignment: .topLeading) { checkbox }
+            .overlay(alignment: .topTrailing) { badge }
+            .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .onTapGesture(perform: onFocus)
+            .onHover { hovered = $0 }
+    }
+
+    // A white chip behind the shared manager checkbox keeps it legible over a
+    // busy photo, matching the checkbox used by the file-list rows.
+    private var checkbox: some View {
+        ManagerRowCheckbox(isOn: isSelected, action: onToggleSelect)
+            .padding(3)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.white.opacity(0.85))
+            )
+            .padding(4)
+    }
+
+    @ViewBuilder
+    private var badge: some View {
+        if showsBestBadge && isOriginal {
+            Circle().fill(.green).frame(width: 12, height: 12)
+                .overlay(Circle().strokeBorder(.white, lineWidth: 2))
+                .padding(5)
+        }
+    }
+
+    private var borderColor: Color {
+        switch emphasis {
+        case .selected: return accent
+        case .focused:  return accent.opacity(0.55)
+        case .hovered:  return accent.opacity(0.40)
+        case .idle:     return Color.secondary.opacity(0.25)
+        }
+    }
+
+    private var borderWidth: CGFloat {
+        switch emphasis {
+        case .selected:         return 2.5
+        case .focused:          return 1.5
+        case .hovered, .idle:   return 1
+        }
+    }
+}

--- a/VaderCleaner/MyClutterViewModel.swift
+++ b/VaderCleaner/MyClutterViewModel.swift
@@ -375,7 +375,7 @@ extension MyClutterViewModel: ScanCoordinating {
 
     func beginScan() {
         guard phase != .scanning else { return }
-        Task { await scan() }
+        runScanActivity { await self.scan() }
     }
 }
 

--- a/VaderCleaner/PerformanceViewModel.swift
+++ b/VaderCleaner/PerformanceViewModel.swift
@@ -690,6 +690,6 @@ extension PerformanceViewModel: ScanCoordinating {
         // redundant work, so skip kicking off another load while one (or
         // an action in `.working`) is already in flight.
         guard phase != .loading, phase != .working else { return }
-        Task { await refresh() }
+        runScanActivity { await self.refresh() }
     }
 }

--- a/VaderCleaner/PrivacyViewModel.swift
+++ b/VaderCleaner/PrivacyViewModel.swift
@@ -584,6 +584,6 @@ extension PrivacyViewModel: ScanCoordinating {
         // work-in-flight phases keeps the behavior identical to the other
         // scannable view models.
         guard phase != .scanning, phase != .clearing else { return }
-        Task { await preview() }
+        runScanActivity { await self.preview() }
     }
 }

--- a/VaderCleaner/ScanActivityAssertion.swift
+++ b/VaderCleaner/ScanActivityAssertion.swift
@@ -1,0 +1,42 @@
+// ScanActivityAssertion.swift
+// Holds an idle-sleep-preventing power assertion around an async scan so an automatic system sleep doesn't suspend a scan that is still running.
+
+import Foundation
+
+/// Runs an async operation while holding a `ProcessInfo` activity that keeps the
+/// system awake, releasing the activity once the work finishes — including when
+/// the work suspends repeatedly or the task is cancelled.
+///
+/// The `begin`/`end` seams default to `ProcessInfo.beginActivity`/`endActivity`
+/// but are injectable so tests can verify the activity is taken for the whole
+/// duration of the work and always released, without a real power assertion.
+@MainActor
+struct ScanActivityAssertion {
+    /// Starts a system activity and returns an opaque token identifying it.
+    private let begin: (String) -> NSObjectProtocol
+    /// Releases the activity identified by a token previously returned by `begin`.
+    private let end: (NSObjectProtocol) -> Void
+
+    init(
+        begin: @escaping (String) -> NSObjectProtocol = { reason in
+            ProcessInfo.processInfo.beginActivity(
+                options: [.userInitiated, .idleSystemSleepDisabled],
+                reason: reason
+            )
+        },
+        end: @escaping (NSObjectProtocol) -> Void = { token in
+            ProcessInfo.processInfo.endActivity(token)
+        }
+    ) {
+        self.begin = begin
+        self.end = end
+    }
+
+    /// Runs `operation` with the activity held for its full duration. `defer`
+    /// guarantees the activity is released even if `operation` returns early.
+    func callAsFunction(reason: String, _ operation: () async -> Void) async {
+        let token = begin(reason)
+        defer { end(token) }
+        await operation()
+    }
+}

--- a/VaderCleaner/ScanCoordinating.swift
+++ b/VaderCleaner/ScanCoordinating.swift
@@ -38,3 +38,18 @@ protocol ScanCoordinating: AnyObject {
     /// Start the section's scan or load.
     func beginScan()
 }
+
+extension ScanCoordinating {
+    /// Spawns a section's async scan inside a power assertion so an automatic
+    /// system sleep can't suspend a scan that is still running. Conformers call
+    /// this from `beginScan()` in place of a bare `Task`; the assertion is held
+    /// for the scan's full duration and released when it finishes.
+    func runScanActivity(
+        reason: String = "VaderCleaner is scanning",
+        _ operation: @escaping () async -> Void
+    ) {
+        Task {
+            await ScanActivityAssertion()(reason: reason, operation)
+        }
+    }
+}

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -1130,6 +1130,6 @@ extension SmartScanViewModel: ScanCoordinating {
     }
 
     func beginScan() {
-        Task { await scan() }
+        runScanActivity { await self.scan() }
     }
 }

--- a/VaderCleaner/SpaceLensBubbleView.swift
+++ b/VaderCleaner/SpaceLensBubbleView.swift
@@ -238,7 +238,11 @@ struct SpaceLensBubbleView: View {
             let category = item.node.map {
                 SpaceLensProtection.category(url: $0.url, isDirectory: $0.isDirectory)
             }
-            let totals = viewModel.selection.totals
+            // Per-bubble: the "Selected:" line reflects only the hovered node's
+            // own selection, so an unselected bubble shows no such line.
+            let hoveredSelection = item.node.map {
+                viewModel.selection.selectionTotal(for: $0)
+            } ?? (count: 0, size: 0)
             SpaceLensHoverCard(
                 name: item.name,
                 category: category?.displayName ?? String(localized: "Group"),
@@ -248,8 +252,8 @@ struct SpaceLensBubbleView: View {
                 formattedSize: ByteCountFormatter.string(fromByteCount: item.size, countStyle: .binary),
                 itemCount: item.itemCount,
                 modificationDate: item.node?.modificationDate,
-                selectedCount: totals.count,
-                selectedSize: totals.size
+                selectedCount: hoveredSelection.count,
+                selectedSize: hoveredSelection.size
             )
             .frame(width: SpaceLensHoverCard.preferredWidth)
             .fixedSize(horizontal: false, vertical: true)

--- a/VaderCleaner/SpaceLensSelection.swift
+++ b/VaderCleaner/SpaceLensSelection.swift
@@ -111,4 +111,13 @@ final class SpaceLensSelection {
         }
         return (count, size)
     }
+
+    /// A single node's removal contribution *when it is selected*, else zero —
+    /// the count follows the same rule as `totals` (a folder reports its
+    /// contained `itemCount`, a file counts as one). Drives the hover card's
+    /// per-bubble "Selected:" line, which appears only for the hovered node.
+    func selectionTotal(for node: DiskNode) -> (count: Int, size: Int64) {
+        guard isSelected(node) else { return (0, 0) }
+        return (node.isDirectory ? node.itemCount : 1, node.size)
+    }
 }

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -393,6 +393,6 @@ extension SystemJunkViewModel: ScanCoordinating {
         // `latestResult` / `selectedURLs` writes interleave. Gate on the
         // in-flight phases, mirroring `SmartScanViewModel.scan()`.
         guard phase != .scanning, phase != .cleaning else { return }
-        Task { await scan() }
+        runScanActivity { await self.scan() }
     }
 }

--- a/VaderCleanerTests/MyClutterThumbnailStripItemTests.swift
+++ b/VaderCleanerTests/MyClutterThumbnailStripItemTests.swift
@@ -1,0 +1,40 @@
+// MyClutterThumbnailStripItemTests.swift
+// Verifies the emphasis precedence for a Duplicates/Similar-Images thumbnail: selected (active) outranks focused, focused outranks hover, hover outranks idle.
+
+import XCTest
+@testable import VaderCleaner
+
+final class MyClutterThumbnailStripItemTests: XCTestCase {
+
+    func test_selected_isActive_regardlessOfFocusOrHover() {
+        XCTAssertEqual(
+            ClutterThumbnailEmphasis.resolve(isSelected: true, isFocused: true, hovered: true),
+            .selected
+        )
+        XCTAssertEqual(
+            ClutterThumbnailEmphasis.resolve(isSelected: true, isFocused: false, hovered: false),
+            .selected
+        )
+    }
+
+    func test_focused_outranksHover_whenNotSelected() {
+        XCTAssertEqual(
+            ClutterThumbnailEmphasis.resolve(isSelected: false, isFocused: true, hovered: true),
+            .focused
+        )
+    }
+
+    func test_hovered_whenOnlyHovered() {
+        XCTAssertEqual(
+            ClutterThumbnailEmphasis.resolve(isSelected: false, isFocused: false, hovered: true),
+            .hovered
+        )
+    }
+
+    func test_idle_whenNoStateApplies() {
+        XCTAssertEqual(
+            ClutterThumbnailEmphasis.resolve(isSelected: false, isFocused: false, hovered: false),
+            .idle
+        )
+    }
+}

--- a/VaderCleanerTests/ScanActivityAssertionTests.swift
+++ b/VaderCleanerTests/ScanActivityAssertionTests.swift
@@ -1,0 +1,56 @@
+// ScanActivityAssertionTests.swift
+// Verifies ScanActivityAssertion holds a system activity for the full duration of an async scan and always releases it, so idle sleep can't suspend a running scan.
+
+import XCTest
+@testable import VaderCleaner
+
+@MainActor
+final class ScanActivityAssertionTests: XCTestCase {
+
+    /// Records begin/end calls so a test can assert on ordering and the token
+    /// round-trip without taking a real `ProcessInfo` activity.
+    private final class ActivityLog {
+        private(set) var beganReasons: [String] = []
+        private(set) var endedTokens: [ObjectIdentifier] = []
+        let token = NSObject()
+
+        func begin(_ reason: String) -> NSObjectProtocol {
+            beganReasons.append(reason)
+            return token
+        }
+
+        func end(_ token: NSObjectProtocol) {
+            endedTokens.append(ObjectIdentifier(token))
+        }
+    }
+
+    func test_holdsActivityForDurationOfOperationThenReleasesIt() async {
+        let log = ActivityLog()
+        let assertion = ScanActivityAssertion(begin: log.begin, end: log.end)
+
+        var beganCountDuringOperation = 0
+        var endedCountDuringOperation = 0
+        await assertion(reason: "scan") {
+            beganCountDuringOperation = log.beganReasons.count
+            endedCountDuringOperation = log.endedTokens.count
+        }
+
+        XCTAssertEqual(beganCountDuringOperation, 1, "activity must be held before the operation runs")
+        XCTAssertEqual(endedCountDuringOperation, 0, "activity must stay held while the operation runs")
+        XCTAssertEqual(log.endedTokens.count, 1, "activity must be released once the operation finishes")
+        XCTAssertEqual(log.endedTokens.first, ObjectIdentifier(log.token), "the token from begin must be the one released")
+        XCTAssertEqual(log.beganReasons, ["scan"], "the reason must be forwarded to begin")
+    }
+
+    func test_releasesActivityEvenWhenOperationSuspends() async {
+        let log = ActivityLog()
+        let assertion = ScanActivityAssertion(begin: log.begin, end: log.end)
+
+        await assertion(reason: "scan") {
+            await Task.yield() // the real scans suspend repeatedly; the assertion must survive that
+        }
+
+        XCTAssertEqual(log.beganReasons.count, 1)
+        XCTAssertEqual(log.endedTokens.count, 1, "a suspending operation must still release the activity exactly once")
+    }
+}

--- a/VaderCleanerTests/SpaceLensSelectionTests.swift
+++ b/VaderCleanerTests/SpaceLensSelectionTests.swift
@@ -63,6 +63,42 @@ final class SpaceLensSelectionTests: XCTestCase {
         XCTAssertEqual(Set(selection.selectedNodes().map(\.name)), ["docs", "big"])
     }
 
+    func test_selectionTotal_forSelectedFile_reportsItsOwnSizeAndCountsOne() {
+        let tree = sampleTree()
+        let big = tree.children.first { $0.name == "big" }!
+        let selection = SpaceLensSelection()
+
+        selection.toggle(big)
+        let total = selection.selectionTotal(for: big)
+        XCTAssertEqual(total.size, 500)
+        XCTAssertEqual(total.count, 1)
+    }
+
+    func test_selectionTotal_forSelectedFolder_reportsContainedItemCount() {
+        let tree = sampleTree()
+        let docs = tree.children.first { $0.name == "docs" }!
+        let selection = SpaceLensSelection()
+
+        selection.toggle(docs) // folder reports its contained items: itemCount 2
+        let total = selection.selectionTotal(for: docs)
+        XCTAssertEqual(total.size, 300)
+        XCTAssertEqual(total.count, 2)
+    }
+
+    func test_selectionTotal_forUnselectedNode_isZero() {
+        let tree = sampleTree()
+        let docs = tree.children.first { $0.name == "docs" }!
+        let big = tree.children.first { $0.name == "big" }!
+        let selection = SpaceLensSelection()
+
+        // Another node is selected, but `big` itself is not — its per-node total
+        // must stay zero so the hover card's "Selected:" line stays hidden.
+        selection.toggle(docs)
+        let total = selection.selectionTotal(for: big)
+        XCTAssertEqual(total.size, 0)
+        XCTAssertEqual(total.count, 0)
+    }
+
     func test_deselectAndClear() {
         let tree = sampleTree()
         let docs = tree.children.first { $0.name == "docs" }!


### PR DESCRIPTION
## What changed

Two related Space Lens / scanning improvements.

### 1. Keep the system awake while a scan is running
Scans run as in-app async `Task`s and nothing prevented idle sleep, so an automatic sleep would suspend an in-progress scan until wake.

- New `ScanActivityAssertion` holds a `ProcessInfo` activity (`[.userInitiated, .idleSystemSleepDisabled]`) for the full duration of an async operation, always releasing it via `defer`. `begin`/`end` are injectable so it's unit-testable without a real power assertion.
- Added `runScanActivity(reason:_:)` to the `ScanCoordinating` protocol; every `beginScan()` now calls it in place of a bare `Task`. `ProtectionDashboardViewModel` is covered via its delegation to `malware`/`privacy`.
- This does **not** override a manual lid-close/sleep — only idle sleep is deferred while a scan runs.

### 2. Space Lens hover "Selected:" line is now per-bubble
The hover card's `Selected:` footer was driven by the global selection total, so it appeared on **every** bubble once anything was selected — including unselected ones, where it read as if that bubble were selected.

- Added `SpaceLensSelection.selectionTotal(for:)`, returning a node's removal contribution (a folder's contained `itemCount`, a file's 1; its own size) only when that node is selected, else zero.
- The hover card now reads this per-hovered-node value instead of `selection.totals`, so the line appears only for a selected bubble and reflects its own size. Global `totals` (bottom bar / review sheet) is unchanged.

## Testing
- TDD: tests written first for both `ScanActivityAssertion` and `selectionTotal(for:)`.
- Full unit suite: **1335 tests, 0 failures**.

## Reviewer notes
- `xcodebuild test` in a local worktree can hit a `bundle format unrecognized` app-seal failure; run with `CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="skip-dev-seal"` so `sign-dev.sh` skips its seal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scans now keep the app’s activity state active while work is running, helping prevent system sleep during long scans.
  * Hover details in Space Lens now show selection totals for the item under the pointer, not the entire selection.

* **Bug Fixes**
  * Improved scan start behavior across multiple scan flows for more consistent execution.

* **Tests**
  * Added coverage for scan activity handling and per-item selection totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->