### PR TITLE
Add centered empty states to manager right panes

### DIFF
--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -631,15 +631,31 @@ private struct UninstallerPaneView: View {
         )
     }
 
+    @ViewBuilder
     private var list: some View {
-        ScrollView {
-            LazyVStack(spacing: 10) {
-                ForEach(displayedApps) { app in
-                    appRow(app)
+        // The recompute hooks stay attached to the outer Group so they fire in
+        // both branches — otherwise an initially empty `displayedApps` would
+        // pin the empty state and never recompute into the list.
+        Group {
+            if displayedApps.isEmpty {
+                ApplicationsManagerEmptyState(
+                    icon: "checkmark.seal.fill",
+                    title: String(localized: "Uninstaller", comment: "Uninstaller empty-state title."),
+                    detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Uninstaller empty-state detail.")
+                )
+                .accessibilityIdentifier("applications.manager.uninstaller.empty")
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 10) {
+                        ForEach(displayedApps) { app in
+                            appRow(app)
+                        }
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
                 }
+                .accessibilityIdentifier("applications.manager.uninstaller.list")
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 12)
         }
         .onAppear { recompute() }
         .onChange(of: facet) { _, _ in recompute() }
@@ -655,7 +671,6 @@ private struct UninstallerPaneView: View {
         .onChange(of: uninstallerViewModel.uninstallSelection) { _, _ in
             if facet == .selected { recompute() }
         }
-        .accessibilityIdentifier("applications.manager.uninstaller.list")
     }
 
     private func appRow(_ app: AppInfo) -> some View {
@@ -1177,31 +1192,36 @@ private struct UpdaterPaneView: View {
 
     @ViewBuilder
     private var list: some View {
-        if updaterViewModel.availableUpdates.isEmpty {
-            ApplicationsManagerEmptyState(
-                icon: "arrow.down.circle",
-                title: String(localized: "Updater", comment: "Updater empty-state title."),
-                detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Updater empty-state detail.")
-            )
-            .accessibilityIdentifier("applications.manager.updater.empty")
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 10) {
-                    ForEach(displayed) { info in
-                        row(info)
+        // The recompute hooks stay attached to the outer Group so they fire in
+        // both branches — otherwise an initially empty `displayed` would pin the
+        // empty state and never recompute into the list.
+        Group {
+            if displayed.isEmpty {
+                ApplicationsManagerEmptyState(
+                    icon: "arrow.down.circle",
+                    title: String(localized: "Updater", comment: "Updater empty-state title."),
+                    detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Updater empty-state detail.")
+                )
+                .accessibilityIdentifier("applications.manager.updater.empty")
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 10) {
+                        ForEach(displayed) { info in
+                            row(info)
+                        }
                     }
+                    .padding(.horizontal, 24).padding(.vertical, 12)
                 }
-                .padding(.horizontal, 24).padding(.vertical, 12)
+                .accessibilityIdentifier("applications.manager.updater.list")
             }
-            .onAppear { recompute() }
-            .onChange(of: facet) { _, _ in recompute() }
-            .onChange(of: search) { _, _ in recompute() }
-            .onChange(of: updaterViewModel.availableUpdates.map(\.id)) { _, _ in recompute() }
-            // The selection only changes the visible list under the Selected facet.
-            .onChange(of: selection) { _, _ in
-                if facet == .selected { recompute() }
-            }
-            .accessibilityIdentifier("applications.manager.updater.list")
+        }
+        .onAppear { recompute() }
+        .onChange(of: facet) { _, _ in recompute() }
+        .onChange(of: search) { _, _ in recompute() }
+        .onChange(of: updaterViewModel.availableUpdates.map(\.id)) { _, _ in recompute() }
+        // The selection only changes the visible list under the Selected facet.
+        .onChange(of: selection) { _, _ in
+            if facet == .selected { recompute() }
         }
     }
 
@@ -1359,31 +1379,36 @@ private struct ExtensionsPaneView: View {
 
     @ViewBuilder
     private var list: some View {
-        if extensionsManagerViewModel.items.isEmpty {
-            ApplicationsManagerEmptyState(
-                icon: "puzzlepiece.extension",
-                title: String(localized: "Extensions", comment: "Extensions empty-state title."),
-                detail: String(localized: "No browser extensions or plug-ins were found.", comment: "Extensions empty-state detail.")
-            )
-            .accessibilityIdentifier("applications.manager.extensions.empty")
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 10) {
-                    ForEach(displayed) { item in
-                        row(item)
+        // The recompute hooks stay attached to the outer Group so they fire in
+        // both branches — otherwise an initially empty `displayed` would pin the
+        // empty state and never recompute into the list.
+        Group {
+            if displayed.isEmpty {
+                ApplicationsManagerEmptyState(
+                    icon: "puzzlepiece.extension",
+                    title: String(localized: "Extensions", comment: "Extensions empty-state title."),
+                    detail: String(localized: "No browser extensions or plug-ins were found.", comment: "Extensions empty-state detail.")
+                )
+                .accessibilityIdentifier("applications.manager.extensions.empty")
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 10) {
+                        ForEach(displayed) { item in
+                            row(item)
+                        }
                     }
+                    .padding(.horizontal, 24).padding(.vertical, 12)
                 }
-                .padding(.horizontal, 24).padding(.vertical, 12)
+                .accessibilityIdentifier("applications.manager.extensions.list")
             }
-            .onAppear { recompute() }
-            .onChange(of: facet) { _, _ in recompute() }
-            .onChange(of: search) { _, _ in recompute() }
-            .onChange(of: extensionsManagerViewModel.items.map(\.id)) { _, _ in recompute() }
-            // The selection only changes the visible list under the Selected facet.
-            .onChange(of: selection) { _, _ in
-                if facet == .selected { recompute() }
-            }
-            .accessibilityIdentifier("applications.manager.extensions.list")
+        }
+        .onAppear { recompute() }
+        .onChange(of: facet) { _, _ in recompute() }
+        .onChange(of: search) { _, _ in recompute() }
+        .onChange(of: extensionsManagerViewModel.items.map(\.id)) { _, _ in recompute() }
+        // The selection only changes the visible list under the Selected facet.
+        .onChange(of: selection) { _, _ in
+            if facet == .selected { recompute() }
         }
     }
 

--- a/VaderCleaner/ManagerChrome.swift
+++ b/VaderCleaner/ManagerChrome.swift
@@ -148,3 +148,21 @@ struct ManagerSurfaceModifier: ViewModifier {
         }
     }
 }
+
+/// Centered icon + title + detail empty state for a Manager right pane with no
+/// items. Shared across the Cleanup, My Clutter, and Smart Scan managers so an
+/// empty pane reads the same everywhere instead of a bare line of text.
+struct ManagerEmptyState: View {
+    let icon: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: icon).font(.system(size: 44)).foregroundStyle(.tint.opacity(0.7))
+            Text(title).font(.title2.weight(.semibold))
+            Text(detail).font(.callout).foregroundStyle(.secondary).multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -434,7 +434,13 @@ struct MyClutterManagerView: View {
     private var rightPaneContent: some View {
         switch category {
         case .largeOld:
-            if isLoadingCache { loadingPane } else { fileList(displayedFiles) }
+            if isLoadingCache {
+                loadingPane
+            } else if displayedFiles.isEmpty {
+                emptyRightPane
+            } else {
+                fileList(displayedFiles)
+            }
         case .duplicates:
             if let group = viewModel.duplicateGroups.first(where: { $0.id == (selectedGroupID ?? viewModel.duplicateGroups.first?.id) }) {
                 imagePreviewPane(files: group.files, original: group.original, showsBestBadge: false)
@@ -467,9 +473,11 @@ struct MyClutterManagerView: View {
     }
 
     private var emptyRightPane: some View {
-        VStack { Spacer(); Text(String(localized: "Nothing to review", comment: "Empty manager pane."))
-            .foregroundStyle(.secondary); Spacer() }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ManagerEmptyState(
+            icon: "checkmark.seal.fill",
+            title: String(localized: "Nothing to review", comment: "Empty manager pane title."),
+            detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Empty manager pane detail.")
+        )
     }
 
     /// A scrollable list of file rows with a checkbox, thumbnail, name,

--- a/VaderCleaner/SmartScanReviewManager.swift
+++ b/VaderCleaner/SmartScanReviewManager.swift
@@ -499,6 +499,13 @@ struct SmartScanReviewManager: View {
                     ProgressView()
                         .controlSize(.large)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if displayedItems.isEmpty {
+                    ManagerEmptyState(
+                        icon: "checkmark.seal.fill",
+                        title: String(localized: "Nothing to review", comment: "Empty state title in a Smart Scan Manager's detail pane."),
+                        detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Empty state detail in a Smart Scan Manager's detail pane.")
+                    )
+                    .accessibilityIdentifier("\(accessibilityPrefix).empty")
                 } else {
                     ManagerItemTable(
                         items: displayedItems,
@@ -527,11 +534,11 @@ struct SmartScanReviewManager: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             } else {
-                Spacer()
-                Text(String(localized: "Nothing to review", comment: "Empty state in a Smart Scan Manager's detail pane."))
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity)
-                Spacer()
+                ManagerEmptyState(
+                    icon: "checkmark.seal.fill",
+                    title: String(localized: "Nothing to review", comment: "Empty state in a Smart Scan Manager's detail pane."),
+                    detail: String(localized: "There are no items to clean or fix in this area.\nEverything is in order.", comment: "Empty state detail when no category is selected in a Smart Scan Manager.")
+                )
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)


### PR DESCRIPTION
## What

Ensure every Manager right pane shows the centered **icon + title + detail** empty state (matching the Applications Manager reference in the screenshot) whenever a pane has no items — instead of a blank list or a bare line of text.

## Why

Several manager panes rendered nothing (or a stray line) when empty, which reads as "you did something wrong" rather than "there's nothing to do here." This makes the empty experience consistent across the app.

## Changes

**Applications Manager** (`ApplicationsManagerView.swift`)
- The **Uninstaller** pane had no empty state at all — an empty facet rendered a blank `ScrollView`.
- **Updater** and **Extensions** only showed an empty state when the *entire* section was empty, so a facet with no visible rows (e.g. Updater → Selected with nothing selected, or a search that matched nothing) still rendered blank.
- All three now key on the *displayed* list, with the `recompute()` hooks moved to the outer container so the empty→list transition still fires (otherwise an initially-empty list would pin the empty state).

**My Clutter Manager** (`MyClutterManagerView.swift`)
- The **Large & Old Files** case rendered a blank `ScrollView` when empty — fixed.
- All empty branches (Duplicates / Similar / Downloads / Large & Old) now use the shared centered empty state instead of a bare "Nothing to review" line.

**Cleanup / Smart Scan Manager** (`SmartScanReviewManager.swift`)
- A selected category with zero displayed rows rendered an empty table with no message — fixed.
- Both the empty-category and no-category-selected states now use the shared centered empty state.

**Shared** (`ManagerChrome.swift`)
- Added a reusable `ManagerEmptyState` view so these panes read consistently.

## Notes for reviewers

- **Protection Manager** was reviewed and left as-is: the Privacy pane always renders a fixed set of categories (never empty), and the Malware pane already shows "No threats were found" (as a header-attached line, not centered). Happy to align the malware pane to the centered style too if desired.
- **Verification:** Swift compiles cleanly. A full app build can't complete in this worktree because the `Vendor/clamav` blob isn't populated (the post-compile ClamAV staging phase fails), which also blocks launching the app for a visual check — unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)