### PR TITLE
Restyle dashboard tiles and buttons with shared Liquid Glass treatment

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		667CDB738F03027C97828C68 /* HungAppMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603884BF695008972AC925C8 /* HungAppMonitorTests.swift */; };
 		67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */; };
 		688FEF65720EAF3D51754EC6 /* MyClutterManagerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */; };
+		6902C7298B34C1DD1DFABCCF /* CleanupCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1D0804B8FCB3DD9A50123 /* CleanupCardTests.swift */; };
 		6A34CA9DF4F4B0D1326A965C /* performance.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B51321F0F77F5813E6777822 /* performance.usdz */; };
 		6AC51485E23A7686B53833C9 /* ActivationPolicyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534E7E5B73EF84C82735B13 /* ActivationPolicyDecision.swift */; };
 		6C7604F02241E2806956F887 /* ScanActivityAssertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF7C998C60CFE1A00C4549C /* ScanActivityAssertionTests.swift */; };
@@ -602,6 +603,7 @@
 		811E341D8E122FCF1C9CF68C /* HelperProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocolTests.swift; sourceTree = "<group>"; };
 		8277A67975EF073283C98450 /* LargeOldFilesScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScanner.swift; sourceTree = "<group>"; };
 		82FFEBA3FB7EB4DCAC300B14 /* LocalSnapshotCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSnapshotCounter.swift; sourceTree = "<group>"; };
+		869E8D8A460A998AA0E6B854 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		86CB0FF38AA0C4E58C4ADFF8 /* SpaceLensProtectionMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensProtectionMessageTests.swift; sourceTree = "<group>"; };
 		882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareOnboardingView.swift; sourceTree = "<group>"; };
 		88A38D3CACCA30ED5C202225 /* FloatingScanOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingScanOverlay.swift; sourceTree = "<group>"; };
@@ -609,6 +611,7 @@
 		8A0F635D79B943130BAB15AE /* VaderCleaner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VaderCleaner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A65AFA27768AC34C413F69E /* ProtectionPrivacyCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectionPrivacyCategory.swift; sourceTree = "<group>"; };
 		8A791BBD75807EE466740BD0 /* SmartScanSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanSettingsStore.swift; sourceTree = "<group>"; };
+		8AE1D0804B8FCB3DD9A50123 /* CleanupCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupCardTests.swift; sourceTree = "<group>"; };
 		8AE3D70086A4D06A40C2A899 /* MenuBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarViewModel.swift; sourceTree = "<group>"; };
 		8B18E28D449EF4D5FB1D6E0B /* SmartScanUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanUITests.swift; sourceTree = "<group>"; };
 		8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFileFinder.swift; sourceTree = "<group>"; };
@@ -731,7 +734,6 @@
 		D9E9C1B2D0698E37C9F9E385 /* BrowserDataCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataCounter.swift; sourceTree = "<group>"; };
 		DB771A6C924CDDCC000BB3E6 /* SystemJunkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkViewModelTests.swift; sourceTree = "<group>"; };
 		DB9A2FDFC86DCAD4AF412E6E /* MalwareViewSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewSubviews.swift; sourceTree = "<group>"; };
-		DC7D808F11B63AFD691F0979 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		DCCBDF9F53F48AD9A9E0A70B /* MaintenanceRunLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceRunLogTests.swift; sourceTree = "<group>"; };
 		DEA948F9A1557934D6C51A6B /* ScanCompletionNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCompletionNotifier.swift; sourceTree = "<group>"; };
 		DEAFBD23ECABA75AF3D1F33B /* BrowserPrivacyInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrivacyInspector.swift; sourceTree = "<group>"; };
@@ -807,9 +809,9 @@
 		60EC9332AD3B6CA565B9AB47 = {
 			isa = PBXGroup;
 			children = (
-				B8F4254E5522527A3379D1BF /* recursing-torvalds-86010c */,
 				E64E279A077DB78FF7F39BDD /* Shared */,
 				82214E451FF2D64A74A4B196 /* VaderCleaner */,
+				89BDE2EE038F8B5544BF44FE /* VaderCleaner */,
 				DD23DA844162EC496E4C0C1D /* VaderCleanerHelper */,
 				E90D4526947C1F261F963425 /* VaderCleanerTests */,
 				6A2D96C9C63AD506553F0BE0 /* VaderCleanerUITests */,
@@ -1045,12 +1047,12 @@
 			path = VaderCleaner;
 			sourceTree = "<group>";
 		};
-		B8F4254E5522527A3379D1BF /* recursing-torvalds-86010c */ = {
+		89BDE2EE038F8B5544BF44FE /* VaderCleaner */ = {
 			isa = PBXGroup;
 			children = (
-				DC7D808F11B63AFD691F0979 /* Signing.xcconfig */,
+				869E8D8A460A998AA0E6B854 /* Signing.xcconfig */,
 			);
-			name = "recursing-torvalds-86010c";
+			name = VaderCleaner;
 			path = .;
 			sourceTree = "<group>";
 		};
@@ -1122,6 +1124,7 @@
 				E6E0615BF174E6CD7925C8C9 /* ClamAVDetectorTests.swift */,
 				CE0EA3955C85E769BBC3C895 /* ClamAVOutputParserTests.swift */,
 				C2B32284509BF497C570E2FA /* ClamAVScannerTests.swift */,
+				8AE1D0804B8FCB3DD9A50123 /* CleanupCardTests.swift */,
 				17630CA93451A0E1A29ED6A1 /* CleanupGroupTests.swift */,
 				C8565FBD4555B1398F2752F8 /* CleanupManagerModelTests.swift */,
 				62DC35796A9897B1CE0113EC /* CleanupManagerStoreTests.swift */,
@@ -1461,6 +1464,7 @@
 				8B4F6825901250C83DBA5941 /* ClamAVDetectorTests.swift in Sources */,
 				725D1A78CA0593CC3E1267AB /* ClamAVOutputParserTests.swift in Sources */,
 				DC099BEFD567C81EAA36519E /* ClamAVScannerTests.swift in Sources */,
+				6902C7298B34C1DD1DFABCCF /* CleanupCardTests.swift in Sources */,
 				B3289BEA17E2D156D19E8E71 /* CleanupGroupTests.swift in Sources */,
 				8C8A94A741DBC80FA3FB4DE2 /* CleanupManagerModelTests.swift in Sources */,
 				4EF8BA012B966F984D9569E7 /* CleanupManagerStoreTests.swift in Sources */,
@@ -1918,7 +1922,7 @@
 		};
 		6FC5B4C07B6F4D2470E81C20 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC7D808F11B63AFD691F0979 /* Signing.xcconfig */;
+			baseConfigurationReference = 869E8D8A460A998AA0E6B854 /* Signing.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1984,7 +1988,7 @@
 		};
 		7AC507F3249F5A68448657EF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC7D808F11B63AFD691F0979 /* Signing.xcconfig */;
+			baseConfigurationReference = 869E8D8A460A998AA0E6B854 /* Signing.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -79,7 +79,7 @@ struct ApplicationsDashboardView: View {
                 ))
                 .padding(.horizontal, 8)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.vaderTileGlass)
             .controlSize(.large)
             .accessibilityIdentifier("applications.manageMyApplications")
         }
@@ -155,7 +155,8 @@ struct ApplicationsDashboardView: View {
                 card(only).frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         } else {
-            GlassEffectContainer(spacing: 16) {
+            // Spacing below the 16pt grid gap so adjacent tiles never blend.
+            GlassEffectContainer(spacing: 8) {
                 HStack(alignment: .top, spacing: 16) {
                     card(tiles[0])
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -398,8 +399,8 @@ enum ApplicationsCardIcon {
 /// A single Applications dashboard card in the reference layout: a title and
 /// detail at the top with a top-right illustration, and a bottom action row.
 /// The Unused card additionally shows a cluster of real app icons at the
-/// bottom-left; the App Leftovers card shows a bordered Review plus a prominent
-/// Remove.
+/// bottom-left; the App Leftovers card shows a glass Review capsule plus a
+/// white Remove capsule.
 struct ApplicationsDashboardCard: View {
     let title: String
     let detail: String
@@ -420,7 +421,7 @@ struct ApplicationsDashboardCard: View {
                         .fixedSize(horizontal: false, vertical: true)
                     Text(detail)
                         .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.white.opacity(0.75))
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 8)
@@ -439,17 +440,17 @@ struct ApplicationsDashboardCard: View {
                 Spacer()
                 if let secondaryLabel, let secondaryAction {
                     Button(secondaryLabel, action: secondaryAction)
-                        .buttonStyle(.bordered)
+                        .buttonStyle(.vaderGlass)
                         .accessibilityIdentifier(identifier + ".secondary")
                 }
                 Button(primaryLabel, action: primaryAction)
-                    .buttonStyle(.vaderProminent)
+                    .buttonStyle(.vaderWhite)
                     .accessibilityIdentifier(identifier)
             }
         }
-        .padding(18)
+        .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .vaderTileGlass()
     }
 
     @ViewBuilder

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -245,7 +245,7 @@ struct ContentView: View {
         // height (top inset + nine rows + gaps + bottom inset) so the last rail
         // icon always keeps a comfortable gap to the window's bottom edge, even
         // at the smallest allowed size.
-        .frame(minWidth: 1140, minHeight: 640)
+        .frame(minWidth: 1140, minHeight: 720)
         // Per-section gradient backdrop, keyed to the selection and crossfaded
         // on change so moving between sections recolours the whole window. The
         // toolbar background is hidden so the floating glass toolbar items sit

--- a/VaderCleaner/MyClutterDashboardView.swift
+++ b/VaderCleaner/MyClutterDashboardView.swift
@@ -160,7 +160,7 @@ struct MyClutterDashboardView: View {
                 Text(String(localized: "Review All Files", comment: "Opens the complete review across every My Clutter category."))
                     .padding(.horizontal, 8)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.vaderTileGlass)
             .controlSize(.large)
             .accessibilityIdentifier("myClutter.reviewAll")
         }
@@ -205,11 +205,16 @@ struct MyClutterDashboardView: View {
             card(tiles[0])
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         default:
-            HStack(alignment: .top, spacing: 16) {
-                card(tiles[0])
-                    .frame(width: heroColumnWidth)
-                    .frame(maxHeight: .infinity)
-                rightColumn(Array(tiles.dropFirst()))
+            // One container so the adjacent glass tiles sample each other and
+            // refract consistently; spacing stays below the 16pt grid gap so
+            // they never blend into one blob.
+            GlassEffectContainer(spacing: 8) {
+                HStack(alignment: .top, spacing: 16) {
+                    card(tiles[0])
+                        .frame(width: heroColumnWidth)
+                        .frame(maxHeight: .infinity)
+                    rightColumn(Array(tiles.dropFirst()))
+                }
             }
         }
     }
@@ -398,14 +403,7 @@ struct MyClutterCard: View {
         }
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(.white.opacity(0.08))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .strokeBorder(.white.opacity(0.10), lineWidth: 1)
-        )
+        .vaderTileGlass()
         .opacity(isEnabled ? 1 : 0.7)
         .accessibilityIdentifier(identifier)
     }
@@ -419,7 +417,7 @@ struct MyClutterCard: View {
             if let subtitle {
                 Text(subtitle)
                     .font(.callout)
-                    .foregroundStyle(.white.opacity(0.7))
+                    .foregroundStyle(.white.opacity(0.75))
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -431,9 +429,8 @@ struct MyClutterCard: View {
             if isEnabled {
                 Button(action: onReview) {
                     Text(String(localized: "Review", comment: "Opens the review screen for a My Clutter card."))
-                        .padding(.horizontal, 10)
                 }
-                .buttonStyle(.bordered)
+                .buttonStyle(.vaderGlass)
                 .accessibilityIdentifier("\(identifier).review")
             } else {
                 Text(String(localized: "All clear", comment: "Shown on a My Clutter card whose category found nothing."))

--- a/VaderCleaner/NavigationSection.swift
+++ b/VaderCleaner/NavigationSection.swift
@@ -3,14 +3,16 @@
 
 import Foundation
 
+// Declaration order is the rail's top-to-bottom order (`allCases`), pinned by
+// NavigationSectionTests. Space Lens sits directly above Health Monitor.
 enum NavigationSection: CaseIterable, Hashable, Identifiable {
     case smartScan
     case systemJunk
     case largeOldFiles
-    case spaceLens
     case malwareRemoval
     case performance
     case applications
+    case spaceLens
     case healthMonitor
 
     var id: Self { self }

--- a/VaderCleaner/PerformanceDashboardSubviews.swift
+++ b/VaderCleaner/PerformanceDashboardSubviews.swift
@@ -99,7 +99,7 @@ struct PerformanceDashboardView: View {
                 ))
                 .padding(.horizontal, 8)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.vaderTileGlass)
             .controlSize(.large)
             .accessibilityIdentifier("performance.viewAllTasks")
         }
@@ -108,7 +108,8 @@ struct PerformanceDashboardView: View {
     /// The ranked summary cards along the bottom, refracting together in one
     /// glass container so they read as a set.
     private var summaryCards: some View {
-        GlassEffectContainer(spacing: 16) {
+        // Spacing below the 16pt grid gap so adjacent tiles never blend.
+        GlassEffectContainer(spacing: 8) {
             HStack(spacing: 16) {
                 ForEach(tiles) { tile in
                     card(tile)
@@ -235,7 +236,7 @@ struct PerformanceSummaryCard: View {
             }
             Text(description)
                 .font(.callout)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.white.opacity(0.75))
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 8)
             HStack {
@@ -243,13 +244,13 @@ struct PerformanceSummaryCard: View {
                 Button(action: onReview) {
                     Text(String(localized: "Review", comment: "Summary card button that opens the manager at this card's items."))
                 }
-                .buttonStyle(.bordered)
+                .buttonStyle(.vaderGlass)
                 .accessibilityIdentifier(reviewIdentifier)
             }
         }
-        .padding(18)
+        .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .vaderTileGlass()
     }
 
     @ViewBuilder

--- a/VaderCleaner/ProtectionDashboardSubviews.swift
+++ b/VaderCleaner/ProtectionDashboardSubviews.swift
@@ -9,8 +9,8 @@ import SwiftUI
 /// it reproduces the reference: a "Looking for Threats…" heading, a biohazard
 /// hero, the current file being scanned, and a Stop button. When the scan
 /// finishes it updates in place — "No threats", a threats card with
-/// Review/Remove, or the removing/done/failed states. Shares the Applications
-/// dashboard card chrome (glass, corner radius 12).
+/// Review/Remove, or the removing/done/failed states. Shares the app-wide
+/// dashboard tile chrome (`vaderTileGlass`).
 struct ProtectionMalwareTile: View {
 
     let malware: MalwareViewModel
@@ -44,9 +44,9 @@ struct ProtectionMalwareTile: View {
                 controls
             }
         }
-        .padding(18)
+        .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .vaderTileGlass()
     }
 
     private var hero: some View {
@@ -85,21 +85,21 @@ struct ProtectionMalwareTile: View {
         case .checkingClamAV, .updatingDatabase, .scanning:
             Button(String(localized: "Stop", comment: "Stops the in-progress malware scan."),
                    action: onStop)
-                .buttonStyle(.bordered)
+                .buttonStyle(.vaderGlass)
                 .accessibilityIdentifier("protection.malwareTile.stop")
         case .results:
             Button(String(localized: "Review", comment: "Opens the detected-threats list."),
                    action: onReview)
-                .buttonStyle(.bordered)
+                .buttonStyle(.vaderGlass)
                 .accessibilityIdentifier("protection.malwareTile.review")
             Button(String(localized: "Remove", comment: "Removes all detected threats."),
                    action: onRemove)
-                .buttonStyle(.vaderProminent)
+                .buttonStyle(.vaderWhite)
                 .accessibilityIdentifier("protection.malwareTile.remove")
         case .idle, .failed:
             Button(String(localized: "Scan Again", comment: "Restarts the malware scan."),
                    action: onScanAgain)
-                .buttonStyle(.bordered)
+                .buttonStyle(.vaderGlass)
                 .accessibilityIdentifier("protection.malwareTile.scanAgain")
         case .clean, .removing, .done, .needsInstall:
             EmptyView()
@@ -203,17 +203,17 @@ struct ProtectionPrivacyTile: View {
                 if let onReview {
                     Button(String(localized: "Review", comment: "Opens the privacy manager for this group."),
                            action: onReview)
-                        .buttonStyle(.bordered)
+                        .buttonStyle(.vaderGlass)
                 }
                 if let onRemove {
                     Button(String(localized: "Remove", comment: "Clears this privacy group."),
                            action: onRemove)
-                        .buttonStyle(.vaderProminent)
+                        .buttonStyle(.vaderWhite)
                 }
             }
         }
-        .padding(18)
+        .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .vaderTileGlass()
     }
 }

--- a/VaderCleaner/ProtectionDashboardView.swift
+++ b/VaderCleaner/ProtectionDashboardView.swift
@@ -203,14 +203,10 @@ struct ProtectionDashboardView: View {
                     localized: "Manage Privacy Items",
                     comment: "Protection dashboard button that opens the Privacy manager."
                 ))
-                .font(.headline)
-                .foregroundStyle(.white)
-                .padding(.horizontal, 18)
-                .padding(.vertical, 9)
-                .background(.white.opacity(0.15), in: Capsule())
-                .overlay(Capsule().strokeBorder(.white.opacity(0.16), lineWidth: 1))
+                .padding(.horizontal, 8)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(.vaderTileGlass)
+            .controlSize(.large)
             .accessibilityIdentifier("protection.managePrivacy")
         }
         .padding(.top, 4)
@@ -270,7 +266,10 @@ struct ProtectionDashboardView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         } else {
-            GlassEffectContainer(spacing: 16) {
+            // Spacing below the 16pt grid gap: glass shapes closer than the
+            // container's spacing melt into one blob, and the tiles must stay
+            // discrete.
+            GlassEffectContainer(spacing: 8) {
                 HStack(alignment: .top, spacing: 16) {
                     tileView(tiles[0])
                         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/VaderCleaner/ReassuranceCard.swift
+++ b/VaderCleaner/ReassuranceCard.swift
@@ -24,14 +24,14 @@ struct ReassuranceCard: View {
                     .foregroundStyle(.white)
                 Text(content.detail)
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.white.opacity(0.75))
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(18)
+        .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .vaderTileGlass()
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("recommendation.reassurance.\(content.id)")
     }

--- a/VaderCleaner/SectionIntroView.swift
+++ b/VaderCleaner/SectionIntroView.swift
@@ -313,7 +313,12 @@ struct SectionIntroView: View {
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(.white)
                 }
-                .shadow(color: presentation.accent.opacity(0.4), radius: 7, y: 3)
+                // Shadow from the same deepened tone as the fill: the raw
+                // accent here made the bright-accent sections' badges (green
+                // Cleanup, teal My Clutter) cast a vivid halo that read as a
+                // bloom, while the deep-accent sections cast a normal dark
+                // drop shadow.
+                .shadow(color: presentation.accent.deepenedForWhite.opacity(0.4), radius: 7, y: 3)
             Text(feature.title)
                 .font(.system(size: 15, weight: .regular))
             Spacer(minLength: 0)

--- a/VaderCleaner/SpaceLensBubbleView.swift
+++ b/VaderCleaner/SpaceLensBubbleView.swift
@@ -1,5 +1,5 @@
 // SpaceLensBubbleView.swift
-// Space Lens bubble chart — packs the current folder's children into glassy purple bubbles sized by disk usage, drills in on tap, reflects the removal selection, and surfaces a details card on hover.
+// Space Lens bubble chart — packs the current folder's children into Liquid Glass bubbles sized by disk usage, drills in on tap, reflects the removal selection, and surfaces a details card on hover.
 
 import SwiftUI
 
@@ -94,18 +94,29 @@ struct SpaceLensBubbleView: View {
             : circle.radius * 0.92
 
         ZStack {
+            // Real Liquid Glass in the tiles' shade. Each bubble is its own
+            // glass shape, deliberately *not* grouped in a GlassEffectContainer:
+            // packed circles touch, and a container would fuse the touching
+            // shapes into one blob.
             Circle()
-                .fill(bubbleFill(isSelected: isSelected, isHovered: isHighlighted, radius: circle.radius))
+                .fill(.clear)
+                .glassEffect(bubbleGlass(isSelected: isSelected, isHovered: isHighlighted), in: .circle)
                 .overlay(
+                    // No resting ring: the tiles carry no border, so a bubble
+                    // at rest is delineated by the glass rim alone. The ring
+                    // appears only for the magenta selected/highlighted states.
                     Circle().strokeBorder(
                         isSelected ? Self.accent.opacity(0.85)
-                            : (isHighlighted ? Self.accent.opacity(0.9) : Color.white.opacity(0.28)),
-                        lineWidth: (isSelected || isHighlighted) ? 2 : 1
+                            : (isHighlighted ? Self.accent.opacity(0.9) : Color.clear),
+                        lineWidth: (isSelected || isHighlighted) ? 2 : 0
                     )
+                    // The glow rides the ring: the glass-filled circle beneath
+                    // is a clear view, so it can't cast the selection shadow
+                    // itself.
+                    .shadow(color: isSelected ? Self.accent.opacity(0.5)
+                                : (isHighlighted ? Self.accent.opacity(0.45) : .clear),
+                            radius: isSelected ? 22 : (isHighlighted ? 16 : 0))
                 )
-                .shadow(color: isSelected ? Self.accent.opacity(0.5)
-                            : (isHighlighted ? Self.accent.opacity(0.45) : .clear),
-                        radius: isSelected ? 22 : (isHighlighted ? 16 : 0))
 
             VStack(spacing: 6) {
                 bubbleIcon(item: item, size: iconSize)
@@ -171,36 +182,20 @@ struct SpaceLensBubbleView: View {
         .accessibilityIdentifier("space-lens.bubble.checkbox.\(node.name)")
     }
 
-    /// Radial fill for a bubble. Selected bubbles keep a purple center (so the
-    /// blue icon still reads) and bloom into bright magenta at the rim — a pink
-    /// rim glow, like the reference. Hovered bubbles lift brighter; at rest they
-    /// are soft lavender glass.
-    private func bubbleFill(isSelected: Bool, isHovered: Bool, radius: CGFloat) -> RadialGradient {
+    /// Liquid Glass for a bubble. At rest it is exactly the tiles' glass
+    /// (`Glass.vaderTile`) — no `interactive` treatment, which renders its own
+    /// darker button-like surface — so the chart's bubbles match the app's
+    /// tile color. Selected bubbles tint magenta (keeping the removal state's
+    /// color, like the reference's pink glow) and hovered bubbles lift a step
+    /// brighter, both with the interactive pointer response.
+    private func bubbleGlass(isSelected: Bool, isHovered: Bool) -> Glass {
         if isSelected {
-            return RadialGradient(
-                colors: [
-                    Color(red: 0.50, green: 0.36, blue: 0.74).opacity(0.34),
-                    Color(red: 0.74, green: 0.34, blue: 0.74).opacity(0.34),
-                    Color(red: 0.96, green: 0.38, blue: 0.80).opacity(0.55)
-                ],
-                center: .init(x: 0.45, y: 0.40),
-                startRadius: radius * 0.30,
-                endRadius: radius
-            )
+            return Glass.regular.tint(Self.accent.opacity(0.35)).interactive()
         }
-        let colors: [Color] = isHovered
-            ? [
-                Color.white.opacity(0.26),
-                Color(red: 0.55, green: 0.45, blue: 0.92).opacity(0.34),
-                Color(red: 0.34, green: 0.24, blue: 0.62).opacity(0.22)
-              ]
-            : [
-                Color(red: 0.62, green: 0.55, blue: 0.86).opacity(0.22),
-                Color(red: 0.46, green: 0.37, blue: 0.74).opacity(0.26),
-                Color(red: 0.30, green: 0.22, blue: 0.52).opacity(0.16)
-              ]
-        return RadialGradient(colors: colors, center: .init(x: 0.42, y: 0.34),
-                              startRadius: 0, endRadius: radius)
+        if isHovered {
+            return Glass.regular.tint(.white.opacity(0.2)).interactive()
+        }
+        return .vaderTile
     }
 
     @ViewBuilder

--- a/VaderCleaner/SpaceLensListPanel.swift
+++ b/VaderCleaner/SpaceLensListPanel.swift
@@ -48,7 +48,10 @@ struct SpaceLensListPanel: View {
         }
         .padding(16)
         .frame(maxHeight: .infinity, alignment: .top)
-        .background(.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 16))
+        // Plain (un-tinted) glass: the white tile tint reads as a muddy violet
+        // slab with a hard rim at this panel's size over the indigo backdrop,
+        // so the chrome keeps the quieter regular material.
+        .glassEffect(.regular, in: .rect(cornerRadius: 16))
         // Draw the protected-item tooltip at the panel level (above the
         // ScrollView) so it isn't clipped by the scrolling rows.
         .overlayPreferenceValue(ProtectedTooltipKey.self) { value in

--- a/VaderCleaner/SpaceLensReviewSheet.swift
+++ b/VaderCleaner/SpaceLensReviewSheet.swift
@@ -46,8 +46,10 @@ struct SpaceLensReviewSheet: View {
             .accessibilityIdentifier("space-lens.review.close")
         }
         .frame(maxWidth: 880, maxHeight: 540)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24))
-        .overlay(RoundedRectangle(cornerRadius: 24).strokeBorder(.white.opacity(0.08)))
+        // The shared dashboard tile surface (same 24pt radius the card already
+        // used), replacing the plain material + hairline so the review card
+        // matches the other sections' frosted glass tiles.
+        .vaderTileGlass()
         .shadow(radius: 30, y: 12)
         .padding(40)
         .accessibilityIdentifier("space-lens.review")

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -135,7 +135,7 @@ struct SpaceLensView: View {
                 bubbleArea(current: current, items: items)
             }
             .padding(.horizontal, 24)
-            .padding(.top, 4)
+            .padding(.top, 16)
             .padding(.bottom, 8)
             SpaceLensBottomBar(viewModel: viewModel)
         }
@@ -225,7 +225,10 @@ struct SpaceLensView: View {
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 12)
-        .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 12))
+        // Plain (un-tinted) glass on the bar's slimmer radius: the white tile
+        // tint made this wide strip read as a bright-rimmed slab, so the
+        // chrome keeps the quieter regular material.
+        .glassEffect(.regular, in: .rect(cornerRadius: 12))
         .padding(.horizontal, 24)
         .padding(.top, 8)
     }

--- a/VaderCleaner/SystemJunkDashboardSubviews.swift
+++ b/VaderCleaner/SystemJunkDashboardSubviews.swift
@@ -165,7 +165,7 @@ struct SystemJunkDashboardView: View {
                 ))
                 .padding(.horizontal, 8)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.vaderTileGlass)
             .controlSize(.large)
             .accessibilityIdentifier("system-junk.viewAll")
         }
@@ -206,7 +206,10 @@ struct SystemJunkDashboardView: View {
     /// flow in rows of two beneath it. Grouped in a `GlassEffectContainer` so the
     /// adjacent glass surfaces sample each other and refract consistently.
     private func rightColumn(_ rest: [CleanupDashboardTile]) -> some View {
-        GlassEffectContainer(spacing: 16) {
+        // Container spacing stays below the 16pt grid gap: glass shapes closer
+        // than the container's spacing melt into one blob, and the tiles must
+        // stay discrete.
+        GlassEffectContainer(spacing: 8) {
             VStack(spacing: 16) {
                 if let wide = rest.first {
                     card(wide, style: .wide)
@@ -277,9 +280,9 @@ enum CleanupCardStyle {
 }
 
 /// One Cleanup dashboard card: a size-led title, an optional description, a
-/// glossy 3D badge, and Review / Clean actions. Shares the glass surface and
-/// corner radius of the app's other dashboard cards so the surfaces stay
-/// consistent.
+/// glossy 3D badge, and Review / Clean actions. Wears the shared dashboard
+/// tile surface (`vaderTileGlass`) with a glass Review capsule and a white
+/// Clean capsule, matching the other sections' grid screens.
 struct CleanupCard: View {
     let title: String
     let blurb: String
@@ -297,11 +300,18 @@ struct CleanupCard: View {
     /// Compact cards drop the description, matching the reference's small cards.
     private var showsBlurb: Bool { style != .compact }
 
+    /// Title typography per card style: the hero and wide cards lead with the
+    /// reference's large bold size-led headline; compact cards keep the denser
+    /// headline so two-up rows don't wrap at the grid's narrowest widths.
+    static func titleFont(for style: CleanupCardStyle) -> Font {
+        style == .compact ? .headline : .title2.weight(.bold)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 10) {
                 Text(title)
-                    .font(isHero ? .title3.weight(.semibold) : .headline)
+                    .font(Self.titleFont(for: style))
                     .foregroundStyle(.white)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 8)
@@ -313,7 +323,10 @@ struct CleanupCard: View {
             if showsBlurb {
                 Text(blurb)
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    // Soft white rather than `.secondary`: the reference's
+                    // description text stays warm and legible over the green
+                    // glass instead of going gray.
+                    .foregroundStyle(.white.opacity(0.75))
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -334,7 +347,7 @@ struct CleanupCard: View {
                     localized: "Review",
                     comment: "Cleanup card action that opens the group's file list."
                 ), action: onReview)
-                .buttonStyle(.bordered)
+                .buttonStyle(.vaderGlass)
                 .accessibilityIdentifier("\(identifierBase).review")
 
                 if showsClean {
@@ -342,14 +355,14 @@ struct CleanupCard: View {
                         localized: "Clean",
                         comment: "Cleanup card action that removes the whole group directly."
                     ), action: onClean)
-                    .buttonStyle(.vaderProminent)
+                    .buttonStyle(.vaderWhite)
                     .accessibilityIdentifier("\(identifierBase).clean")
                 }
             }
         }
-        .padding(18)
+        .padding(20)
         .frame(maxWidth: .infinity, minHeight: isHero ? 320 : 150, alignment: .leading)
-        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        .vaderTileGlass()
     }
 
     /// The glossy 3D badge artwork. The baked PNG carries its own soft drop
@@ -364,3 +377,4 @@ struct CleanupCard: View {
             .accessibilityHidden(true)
     }
 }
+

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -157,3 +157,108 @@ extension ButtonStyle where Self == VaderProminentButtonStyle {
     /// Section-accent prominent button with a luminance-aware label.
     static var vaderProminent: VaderProminentButtonStyle { VaderProminentButtonStyle() }
 }
+
+extension Glass {
+    /// The white-tinted glass shared by the dashboard tiles and the header
+    /// pill buttons, lifting both a step brighter than the section backdrop
+    /// (plain `.regular` glass darkens over the dark gradients).
+    static var vaderTile: Glass { .regular.tint(.white.opacity(0.1)) }
+}
+
+/// Neutral Liquid Glass capsule with a white semibold label — the Review
+/// treatment on the dashboard tiles. Hand-rolled over `glassEffect` rather
+/// than `.buttonStyle(.glass)` because the system style fills with the
+/// window's control tint (the section accent), while the reference keeps
+/// these capsules free of it. On-tile capsules use the darker plain glass;
+/// `matchesTileSurface` swaps in the tiles' white-tinted shade for the
+/// dashboards' header pills.
+struct VaderGlassButtonStyle: ButtonStyle {
+    var matchesTileSurface = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        GlassLabel(configuration: configuration, matchesTileSurface: matchesTileSurface)
+    }
+
+    private struct GlassLabel: View {
+        let configuration: Configuration
+        let matchesTileSurface: Bool
+        @Environment(\.controlSize) private var controlSize
+
+        /// Large/extra-large controls get the header pills' roomier capsule;
+        /// the default size stays compact enough for two capsules to share a
+        /// narrow two-up tile.
+        private var isLarge: Bool { controlSize == .large || controlSize == .extraLarge }
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: isLarge ? 15 : 13, weight: .semibold))
+                .foregroundStyle(.white)
+                // A capsule label must never wrap mid-word on a narrow tile.
+                .lineLimit(1)
+                .fixedSize()
+                .padding(.horizontal, isLarge ? 20 : 14)
+                .padding(.vertical, isLarge ? 9 : 6)
+                .glassEffect(
+                    matchesTileSurface ? Glass.vaderTile.interactive() : Glass.regular.interactive(),
+                    in: .capsule
+                )
+                .opacity(configuration.isPressed ? 0.82 : 1.0)
+                .contentShape(Capsule())
+                .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+        }
+    }
+}
+
+extension ButtonStyle where Self == VaderGlassButtonStyle {
+    /// Tint-free glass capsule for the dashboards' Review-style actions.
+    static var vaderGlass: VaderGlassButtonStyle { VaderGlassButtonStyle() }
+    /// Glass capsule in the tiles' white-tinted shade — the dashboards'
+    /// "Review All / View All / Manage" header pills.
+    static var vaderTileGlass: VaderGlassButtonStyle { VaderGlassButtonStyle(matchesTileSurface: true) }
+}
+
+/// Solid white capsule with a black semibold label — the dashboards' direct
+/// Clean/Remove treatment, reading as the brightest element on the glass
+/// tiles. Metrics mirror the glass capsule beside it so the pair sits on one
+/// baseline at one height.
+struct VaderWhiteButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        WhiteLabel(configuration: configuration)
+    }
+
+    private struct WhiteLabel: View {
+        let configuration: Configuration
+        @Environment(\.controlSize) private var controlSize
+
+        private var isLarge: Bool { controlSize == .large || controlSize == .extraLarge }
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: isLarge ? 15 : 13, weight: .semibold))
+                .foregroundStyle(.black)
+                // A capsule label must never wrap mid-word on a narrow tile.
+                .lineLimit(1)
+                .fixedSize()
+                .padding(.horizontal, isLarge ? 20 : 14)
+                .padding(.vertical, isLarge ? 9 : 6)
+                .background(Capsule().fill(.white))
+                .opacity(configuration.isPressed ? 0.82 : 1.0)
+                .contentShape(Capsule())
+                .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+        }
+    }
+}
+
+extension ButtonStyle where Self == VaderWhiteButtonStyle {
+    /// White-filled capsule for the dashboard tiles' direct primary action.
+    static var vaderWhite: VaderWhiteButtonStyle { VaderWhiteButtonStyle() }
+}
+
+extension View {
+    /// The dashboard tile surface shared by every section's grid screen:
+    /// Liquid Glass under the reference's large corner radius, in the shared
+    /// white-tinted shade (`Glass.vaderTile`).
+    func vaderTileGlass() -> some View {
+        glassEffect(.vaderTile, in: .rect(cornerRadius: 24))
+    }
+}

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -18,13 +18,22 @@ extension Color {
 }
 
 /// Full-bleed branded backdrop: a vertical dark → rich gradient in the active
-/// section's hue, with a soft accent bloom centred low so the brightest part of
-/// the glow pools behind the hero cluster and the floating Scan disc. Driven by
-/// the section theme so navigating between sections recolours the whole window.
+/// section's hue, under a cluster of accent blooms that orbit at different
+/// radii, speeds, and directions with a slow brightness breathe — a lava-lamp
+/// motion that keeps the gradient visibly alive. The blooms anchor along the
+/// window edges so each shows only a partial arc — an atmospheric wash, not a
+/// travelling circle — with the primary low on the bottom edge where its glow
+/// still pools behind the floating Scan disc. Driven by the section theme so
+/// navigating between sections recolours the whole window.
 struct VaderBackground: View {
     /// The active section's colour identity. The whole backdrop is built from
     /// this, so the caller crossfades it as the selection changes.
     let theme: SectionTheme
+
+    /// Flipped once on appear into a repeat-forever pulse that breathes the
+    /// bloom cluster's brightness.
+    @State private var breathing = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ZStack {
@@ -33,17 +42,134 @@ struct VaderBackground: View {
                 startPoint: .top,
                 endPoint: .bottom
             )
-            RadialGradient(
-                colors: [theme.accent.opacity(0.5), .clear],
-                // y is biased well below centre so the bloom pools behind the
-                // hero/title cluster and the floating Scan disc rather than the
-                // empty middle of the window.
-                center: UnitPoint(x: 0.5, y: 0.74),
-                startRadius: 0,
-                endRadius: 760
-            )
+            GeometryReader { geo in
+                ZStack {
+                    // All three anchors hug (or overshoot) the window edges so
+                    // only a partial arc of each glow is ever visible — the
+                    // light reads as a wash coming in from the edge, never as
+                    // a travelling circle.
+                    //
+                    // Primary bloom — the section's classic glow, low on the
+                    // bottom edge where it still pools behind the floating
+                    // Scan disc.
+                    OrbitingBloom(
+                        color: theme.accent.opacity(0.45),
+                        falloff: 760,
+                        anchor: UnitPoint(x: 0.5, y: 0.9),
+                        orbitRadius: 160,
+                        period: 20,
+                        clockwise: true,
+                        animated: !reduceMotion,
+                        size: geo.size
+                    )
+                    // Secondary bloom — dimmer, wider orbit, counter-rotating
+                    // just past the left edge so it swells in and out of the
+                    // window as it circles.
+                    OrbitingBloom(
+                        color: theme.accent.opacity(0.26),
+                        falloff: 460,
+                        anchor: UnitPoint(x: -0.08, y: 0.3),
+                        orbitRadius: 220,
+                        period: 34,
+                        clockwise: false,
+                        animated: !reduceMotion,
+                        size: geo.size
+                    )
+                    // Tertiary bloom — small and faint in the upper-right
+                    // corner, on the fastest lap, adding a third phase.
+                    OrbitingBloom(
+                        color: theme.accent.opacity(0.2),
+                        falloff: 320,
+                        anchor: UnitPoint(x: 1.08, y: 0.08),
+                        orbitRadius: 140,
+                        period: 14,
+                        clockwise: true,
+                        animated: !reduceMotion,
+                        size: geo.size
+                    )
+                }
+                // A slow breathe over the whole cluster: brightness swells and
+                // relaxes on a cycle offset from every orbit period, so the
+                // combined motion never visibly repeats. Opacity is composited
+                // on the GPU like the orbits — no per-frame view redraws.
+                .opacity(breathing ? 0.86 : 1.0)
+                .animation(.easeInOut(duration: 8).repeatForever(autoreverses: true), value: breathing)
+            }
         }
         .ignoresSafeArea()
+        .onAppear {
+            // Honour Reduce Motion: the blooms stay put at their resting
+            // poses at full brightness.
+            guard !reduceMotion else { return }
+            breathing = true
+        }
+    }
+}
+
+/// One accent bloom on a circular path: a radial glow displaced off the pivot
+/// of an oversized square layer that spins forever — the orbit trick. The
+/// gradient is radially symmetric, so the rotation itself is invisible; only
+/// the circular travel shows. Rotation is a GPU-composited transform, no
+/// per-frame view redraws.
+private struct OrbitingBloom: View {
+    /// The bloom's colour, opacity included.
+    let color: Color
+    /// Radius at which the glow fades to fully clear.
+    let falloff: CGFloat
+    /// Resting pose in window space — the top of the orbit, and where the
+    /// bloom stays when the orbit is not animated (Reduce Motion).
+    let anchor: UnitPoint
+    /// Radius of the circular path.
+    let orbitRadius: CGFloat
+    /// Seconds per revolution.
+    let period: Double
+    /// Direction of travel around the circle.
+    let clockwise: Bool
+    /// Whether the orbit runs; false parks the bloom at its anchor.
+    let animated: Bool
+    /// The hosting window's size, from the caller's `GeometryReader`.
+    let size: CGSize
+
+    /// Flipped once on appear into the repeat-forever linear rotation that
+    /// carries the bloom around its path.
+    @State private var orbiting = false
+
+    /// Side of the square layer the bloom is drawn on. Must contain the whole
+    /// falloff plus the orbit displacement, so the layer's rectangular bounds
+    /// always sit in the gradient's fully-clear region — a bounds cut inside
+    /// the falloff shows up as a hard seam when the layer moves.
+    private var layerSide: CGFloat { 2 * (falloff + orbitRadius) + 100 }
+
+    var body: some View {
+        RadialGradient(
+            // A white-hot core inside the accent glow: on themes whose accent
+            // sits close to the backdrop hue (Health Monitor's blue on blue),
+            // a pure accent bloom moves almost invisibly — the bright core is
+            // what keeps the motion legible on every section's palette.
+            stops: [
+                .init(color: .white.opacity(0.07), location: 0),
+                .init(color: color, location: 0.3),
+                .init(color: .clear, location: 1),
+            ],
+            center: .center,
+            startRadius: 0,
+            endRadius: falloff
+        )
+        .frame(width: layerSide, height: layerSide)
+        .offset(y: -orbitRadius)
+        .rotationEffect(.degrees(orbiting ? (clockwise ? 360 : -360) : 0))
+        .animation(.linear(duration: period).repeatForever(autoreverses: false), value: orbiting)
+        // The orbit's centre sits one radius below the anchor, so the
+        // path's top — and the Reduce Motion resting pose — is exactly
+        // the anchor.
+        .position(
+            x: size.width * anchor.x,
+            y: size.height * anchor.y + orbitRadius
+        )
+        .onAppear {
+            guard animated else { return }
+            orbiting = true
+        }
     }
 }
 

--- a/VaderCleanerTests/CleanupCardTests.swift
+++ b/VaderCleanerTests/CleanupCardTests.swift
@@ -1,0 +1,22 @@
+// CleanupCardTests.swift
+// Pins the Cleanup card typography contract: hero and wide cards lead with the reference's large bold size-led title while compact cards keep the denser headline.
+
+import XCTest
+import SwiftUI
+@testable import VaderCleaner
+
+final class CleanupCardTests: XCTestCase {
+
+    func test_titleFont_isLargeAndBoldForHeroAndWideCards() {
+        // The reference tiles lead with a big bold "34.4 GB of System Junk
+        // Found" headline; both the hero and the wide card have room for it.
+        XCTAssertEqual(CleanupCard.titleFont(for: .hero), .title2.weight(.bold))
+        XCTAssertEqual(CleanupCard.titleFont(for: .wide), .title2.weight(.bold))
+    }
+
+    func test_titleFont_staysHeadlineForCompactCards() {
+        // Compact cards sit two-up in a row; the denser headline keeps their
+        // size-led titles from wrapping at the grid's narrowest widths.
+        XCTAssertEqual(CleanupCard.titleFont(for: .compact), .headline)
+    }
+}

--- a/VaderCleanerTests/NavigationSectionTests.swift
+++ b/VaderCleanerTests/NavigationSectionTests.swift
@@ -15,6 +15,15 @@ final class NavigationSectionTests: XCTestCase {
         XCTAssertEqual(NavigationSection.allCases.first, .smartScan)
     }
 
+    func test_railOrder_isPinned() {
+        // The rail renders `allCases` top to bottom. Space Lens sits directly
+        // above Health Monitor at the bottom of the rail.
+        XCTAssertEqual(NavigationSection.allCases, [
+            .smartScan, .systemJunk, .largeOldFiles, .malwareRemoval,
+            .performance, .applications, .spaceLens, .healthMonitor,
+        ])
+    }
+
     func test_eachSection_hasNonEmptyTitle() {
         for section in NavigationSection.allCases {
             XCTAssertFalse(


### PR DESCRIPTION
## What changed

One shared Liquid Glass tile language across every section's grid screen, matching the Cleanup reference design.

**Shared styles (VaderTheme.swift)**
- `Glass.vaderTile` — the single source for the tile shade: regular glass with a `white.opacity(0.1)` tint, lifting surfaces a step brighter than the dark section backdrops (plain `.regular` glass renders darker).
- `vaderTileGlass()` — the 24pt-radius tile surface used by every dashboard card.
- `.vaderGlass` / `.vaderTileGlass` — neutral glass capsule button styles, hand-rolled because the system `.buttonStyle(.glass)` fills with the window's control tint (the section accent) instead of staying neutral.
- `.vaderWhite` — the white capsule with black label for tiles' prominent actions (Clean/Remove).
- Button styles are controlSize-aware (compact on tiles, roomy at `.large` for header pills) with `lineLimit(1)` + `fixedSize()` so labels can never wrap mid-word on narrow tiles.

**Applied across** Cleanup, My Clutter, Applications, Performance, Protection, and the shared `ReassuranceCard`; the "Review All / View All / Manage" header pills share the tile shade.

**Grid fix** — `GlassEffectContainer` spacing dropped to 8 (below the 16pt grid gap) everywhere: with spacing equal to the gap, adjacent glass shapes sat at the blend threshold and melted into blobs (visible on the Protection grid once tiles got brighter).

**Space Lens** — list panel and breadcrumb bar on quiet un-tinted glass (the white tile tint read as a bright-rimmed slab at panel size), review card on the full tile surface, and the chart bubbles converted from painted radial gradients to real Liquid Glass in the tile shade — magenta tint/ring/glow only when selected or highlighted, and deliberately **no** container around the bubbles since packed circles touch and would fuse.

**Misc** — window minimum height 640 → 720; Space Lens moved directly above Health Monitor in the nav rail (declaration order drives the rail), with the order now pinned by `test_railOrder_isPinned`.

## Why

The Cleanup section was restyled to match a reference design (frosted glass tiles, glass Review capsules, white prominent buttons), then extended app-wide for consistency, with follow-up fixes for the rendering issues that surfaced (accent-tinted system glass buttons, tile blending, label wrapping).

## Reviewer notes

- All accessibility identifiers are unchanged, so existing UI-test locators still work.
- Unit suite: 1342 tests, 0 failures. New tests pin the Cleanup card typography and the rail order.
- Manager screens' footer buttons and the Smart Scan selectable tiles intentionally keep their existing styles.
- Visual verification was done by the author from screenshots; worth a quick click-through of each dashboard plus Space Lens hover/selection (bubble tap and on-bubble checkbox hit-testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared “vader” frosted-glass visual style for dashboard tiles and action buttons, including standardized tile glass surfaces.
  * Updated multiple dashboards and review panels with consistent spacing/padding and refreshed button treatments.
  * Refreshed the Space Lens bubble and list visuals with improved Liquid Glass rendering.
* **Bug Fixes**
  * Prevented adjacent tile blending by reducing grid container spacing in multiple dashboard layouts.
* **Tests**
  * Added unit tests for CleanupCard title typography rules and pinned navigation rail ordering.
* **Chores**
  * Updated signing configuration references for build configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up commit: animated backdrop

`VaderBackground` now hosts three lava-lamp accent blooms orbiting on GPU-composited transforms (offset + rotation on oversized layers, so layer bounds never show as seams) with an 8s brightness breathe — periods of 20/34/14/8s so the motion never visibly repeats. Anchors hug the window edges so only partial arcs show. Each bloom has a faint white core to stay legible on low-contrast themes (Health Monitor's blue-on-blue). Reduce Motion parks everything static. The same commit fixes the intro feature badges on bright-accent sections (Cleanup/My Clutter) casting a vivid halo — their shadow now derives from the same deepened tone as their fill.
