### PR TITLE
Add Tahoe-style motion: manager zoom, control springs, hero loaders

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		40BB821EAD9CD6628F9B0069 /* SpaceLensHoverCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B22856A47E87BF9A84172B2 /* SpaceLensHoverCardTests.swift */; };
 		4136425911121661B4C7774F /* SpaceLensVolumeUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44EE14A680D5C81A7BA681DD /* SpaceLensVolumeUsageTests.swift */; };
 		4156DAE09EB7579F22FA6959 /* MalwareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */; };
+		42A3B1422BEFF1E49B5EBDCE /* RailCollapseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0229FBE733B06D6302D5497 /* RailCollapseTests.swift */; };
 		432BC8C050B5B2A703CBA01A /* ApplicationsManagerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D4F328EFA6BEB382624507 /* ApplicationsManagerModelTests.swift */; };
 		4368849EA97B0EC0AF5C63E0 /* ProtectionPrivacyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D5840FAF0F143B4E943E0F /* ProtectionPrivacyModel.swift */; };
 		4453CD1C9BEA6DFD3C62E054 /* FloatingRunOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */; };
@@ -773,6 +774,7 @@
 		EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedApp.swift; sourceTree = "<group>"; };
 		EE225F3A130C0DDEE2E31DBF /* PerformanceDashboardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceDashboardSubviews.swift; sourceTree = "<group>"; };
 		EF58D340F13A253CAAB153AC /* UnsupportedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedApp.swift; sourceTree = "<group>"; };
+		F0229FBE733B06D6302D5497 /* RailCollapseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RailCollapseTests.swift; sourceTree = "<group>"; };
 		F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceScriptRunnerTests.swift; sourceTree = "<group>"; };
 		F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesManagerTests.swift; sourceTree = "<group>"; };
 		F0CE1F46BB605C6493C886C4 /* ProtectionSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectionSettingsStore.swift; sourceTree = "<group>"; };
@@ -1206,6 +1208,7 @@
 				4711C27CA5034F55665CC611 /* ProtectionDashboardViewModelTests.swift */,
 				2A836556BF25E11501EEE128 /* ProtectionPrivacyModelTests.swift */,
 				E32AF01DCEB8B6FC9C071426 /* ProtectionSettingsStoreTests.swift */,
+				F0229FBE733B06D6302D5497 /* RailCollapseTests.swift */,
 				78BB283D2312DE0FFBF3C04D /* RAMManagerTests.swift */,
 				F03D812C509D828B9543F898 /* RecentFilesManagerTests.swift */,
 				F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */,
@@ -1550,6 +1553,7 @@
 				87193C2089A602109732C183 /* ProtectionPrivacyModelTests.swift in Sources */,
 				ACC1444F40554C741F4742A4 /* ProtectionSettingsStoreTests.swift in Sources */,
 				3759AFDF2D0E46B1B1921F42 /* RAMManagerTests.swift in Sources */,
+				42A3B1422BEFF1E49B5EBDCE /* RailCollapseTests.swift in Sources */,
 				F08230836A44B9D015B78632 /* RecentFilesManagerTests.swift in Sources */,
 				3D65654B589EFF2972927ED7 /* ScanAccessPopoverTests.swift in Sources */,
 				6C7604F02241E2806956F887 /* ScanActivityAssertionTests.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */; };
 		1EA7A31BB3F6DBFD47A46FF1 /* MaintenanceScriptRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F029C41A438769EC30C69A0D /* MaintenanceScriptRunnerTests.swift */; };
 		1EE29E50BDE662F5B4BB4F61 /* LRUCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDD31CBAF12D911B31F6A0D /* LRUCache.swift */; };
+		1EFC3005FB3738519FCB871C /* TriggerAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6232E30181C53E844AC03226 /* TriggerAnchorTests.swift */; };
 		1F7B67D271BC88E4A13A1AE8 /* MaintenanceTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */; };
 		1F88CDFF1571AB8A8DCB3F7D /* MailReindexerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933E3B42C683C14A7398939F /* MailReindexerTests.swift */; };
 		2094AB11AA0400630E413C6F /* BrowserPrivacyRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2BB8E9DD31E37B171CC32D /* BrowserPrivacyRemover.swift */; };
@@ -94,6 +95,7 @@
 		3B8C348DB1DCBFB89771ADDC /* PrivacyPermissionCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B67D6CC3702F50AFF5F060 /* PrivacyPermissionCheckerTests.swift */; };
 		3C5FEDACD30210E5D23F3ABB /* SimilarImageScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C116D07B8F84B3D4F4307F6 /* SimilarImageScanner.swift */; };
 		3D65654B589EFF2972927ED7 /* ScanAccessPopoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8529ADBAF106E09B22B5866 /* ScanAccessPopoverTests.swift */; };
+		3E3E4054A22FDAF85B9844F8 /* VaderMotionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62087FF6D324B53E3ECD7747 /* VaderMotionTests.swift */; };
 		3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */; };
 		3FEA0B80571D0DF965503D2E /* AppUninstallerViewModelMultiSelectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E800D4E6E10B7B99B2D1170 /* AppUninstallerViewModelMultiSelectTests.swift */; };
 		406255CE86E2384C52557DB1 /* LoginItemsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8471EE937FF43BBE01CD61 /* LoginItemsManagerTests.swift */; };
@@ -334,7 +336,9 @@
 		E39551732C1E81A0418FF7EE /* MalwareOnboardingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C425A233C540203282273D7 /* MalwareOnboardingViewModelTests.swift */; };
 		E5548C91729D71FDA8D8ADC8 /* MalwareOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882E6C32BC5FC5028D921546 /* MalwareOnboardingView.swift */; };
 		E575F22107FEE2D723F7787D /* SpaceLensBottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DFE86EF01367F598551A8B /* SpaceLensBottomBar.swift */; };
+		E593DA64025CAC2160110497 /* TriggerAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF2C4CE1BE29B227FEB57CA /* TriggerAnchor.swift */; };
 		E5E7952A56BA88D9CA86A1B5 /* HTTPFetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8C7457CFE216106F15EDAA /* HTTPFetching.swift */; };
+		E77456FD775F682539451AFA /* ScanProgressIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F0F84AC9D6DC3F18F29AD5 /* ScanProgressIndicatorTests.swift */; };
 		E7B7C87B22F9328A45CC6A4B /* AppStoreUpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F67F7A443777AD4D4640457 /* AppStoreUpdateCheckerTests.swift */; };
 		EA293A7C8A48ED66CD98270E /* CleanupGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3DE098197EC0362C64AEF7 /* CleanupGroup.swift */; };
 		EAB0FCCF743586CB4273368C /* AssociatedFileFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3E0FC7C1A4A1AA750255FF /* AssociatedFileFinder.swift */; };
@@ -359,6 +363,7 @@
 		F6161C632AB8AA90DD7B9A36 /* UpdateProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3508580ADD1F5DD0DB60EE01 /* UpdateProbe.swift */; };
 		F6B3DE5619346F9E64977C47 /* ExtensionDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DACFA81A1696DEB67B7E6B7 /* ExtensionDiscoveryTests.swift */; };
 		F7CA4D7A9B843507613DEEBE /* BundledClamAVRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282664DFAA58CB5A5C87FFE /* BundledClamAVRuntime.swift */; };
+		F87B7EB25504B2F1CD3937C3 /* VaderMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FEB4611D6F3F7DC16E0029 /* VaderMotion.swift */; };
 		F8C8660BC76604FE849D6F5F /* WebDevScanScopeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6EA6E0EC8BFB813F89FAAE /* WebDevScanScopeStoreTests.swift */; };
 		F94ECD82ABC16F6465EEDA6C /* PerformanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935433C10308C1F2DDF51097 /* PerformanceView.swift */; };
 		F984A638A120B2D104F597EA /* BrowserDataClearerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9630D8D32B6A2B680E43B46 /* BrowserDataClearerTests.swift */; };
@@ -521,6 +526,7 @@
 		43596249B222D18142F961E2 /* HelperConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperConnectionManager.swift; sourceTree = "<group>"; };
 		448786867041AFF7B9206B86 /* VolumeMountMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeMountMonitorTests.swift; sourceTree = "<group>"; };
 		44EE14A680D5C81A7BA681DD /* SpaceLensVolumeUsageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensVolumeUsageTests.swift; sourceTree = "<group>"; };
+		45FEB4611D6F3F7DC16E0029 /* VaderMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderMotion.swift; sourceTree = "<group>"; };
 		462B37702C713BE1630DC992 /* ObservationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationRecording.swift; sourceTree = "<group>"; };
 		46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpersTests.swift; sourceTree = "<group>"; };
 		4711C27CA5034F55665CC611 /* ProtectionDashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectionDashboardViewModelTests.swift; sourceTree = "<group>"; };
@@ -563,6 +569,8 @@
 		603E7AED5C7A32BB0FE282B8 /* LargeOldFilesScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeOldFilesScannerTests.swift; sourceTree = "<group>"; };
 		6085B6A39985DFF334821551 /* ExclusionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExclusionsStore.swift; sourceTree = "<group>"; };
 		613035D3B46AA30DBD14381C /* DiskScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModel.swift; sourceTree = "<group>"; };
+		62087FF6D324B53E3ECD7747 /* VaderMotionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderMotionTests.swift; sourceTree = "<group>"; };
+		6232E30181C53E844AC03226 /* TriggerAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerAnchorTests.swift; sourceTree = "<group>"; };
 		62451B3F2460A961CA621D73 /* DownloadSourceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadSourceResolverTests.swift; sourceTree = "<group>"; };
 		6298096AACFE956ABD8B9C36 /* MyClutterScanScopeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClutterScanScopeStore.swift; sourceTree = "<group>"; };
 		62DC35796A9897B1CE0113EC /* CleanupManagerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupManagerStoreTests.swift; sourceTree = "<group>"; };
@@ -648,6 +656,7 @@
 		9EEBFFC9D55D324022C24CDE /* ApplicationsManagerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationsManagerModel.swift; sourceTree = "<group>"; };
 		9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionIntroView.swift; sourceTree = "<group>"; };
 		9F2BB8E9DD31E37B171CC32D /* BrowserPrivacyRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrivacyRemover.swift; sourceTree = "<group>"; };
+		9FF2C4CE1BE29B227FEB57CA /* TriggerAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerAnchor.swift; sourceTree = "<group>"; };
 		A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareUITests.swift; sourceTree = "<group>"; };
 		A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerApp.swift; sourceTree = "<group>"; };
 		A3852658DC221FB8B03631D1 /* HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocol.swift; sourceTree = "<group>"; };
@@ -658,6 +667,7 @@
 		A75EF6CEA94213CDD0564C48 /* SpaceLensSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensSelectionTests.swift; sourceTree = "<group>"; };
 		A77073103E6F462B0726CFD5 /* BrowserDataPathProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDataPathProviderTests.swift; sourceTree = "<group>"; };
 		A7D017D911C5C3674F2A6ECD /* SystemJunkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemJunkView.swift; sourceTree = "<group>"; };
+		A9F0F84AC9D6DC3F18F29AD5 /* ScanProgressIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanProgressIndicatorTests.swift; sourceTree = "<group>"; };
 		AB34A5999662EB913D47219A /* MaintenanceTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTaskTests.swift; sourceTree = "<group>"; };
 		ABD71B02544D13F9E3A36014 /* SmartScanMalwareReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanMalwareReview.swift; sourceTree = "<group>"; };
 		ABEC9B327E4ABAF6A05D6A7D /* DeveloperProjectScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperProjectScanner.swift; sourceTree = "<group>"; };
@@ -1025,6 +1035,7 @@
 				4736E8C36A9E9F2ACADEE5EB /* SystemStatsService.swift */,
 				944FFBC8E11AA4D85C33A981 /* TrashedAppMonitor.swift */,
 				FC4578EA7CB74F883F99837D /* TrashSizeMonitor.swift */,
+				9FF2C4CE1BE29B227FEB57CA /* TriggerAnchor.swift */,
 				EF58D340F13A253CAAB153AC /* UnsupportedApp.swift */,
 				0976ECD3B6F65080DAE55EF5 /* UnsupportedAppScanner.swift */,
 				EDF85D42AE611D1F64E6B4C6 /* UnusedApp.swift */,
@@ -1034,6 +1045,7 @@
 				9DDDE766D46D79E2C23FB557 /* UserFilesPathProviding.swift */,
 				FA2CB51CBEC832FDDDFB7D89 /* VaderCleaner.entitlements */,
 				A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */,
+				45FEB4611D6F3F7DC16E0029 /* VaderMotion.swift */,
 				F47916A68DDCAD9D0B7272B9 /* VaderTheme.swift */,
 				CEAF96E747AD4C1378B4043D /* VersionComparator.swift */,
 				D7F3D78EB1ABBA9055137FCC /* VolumeMountMonitor.swift */,
@@ -1203,6 +1215,7 @@
 				3796DD772CDFBB89B773ED8F /* ScanCoordinatingConformanceTests.swift */,
 				2E60EAC4A5C2C229B5304C87 /* ScanCoordinatingTests.swift */,
 				BC72C9CBA70B1BBF45D6B8C1 /* ScanDiscWindowFrameTests.swift */,
+				A9F0F84AC9D6DC3F18F29AD5 /* ScanProgressIndicatorTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
 				6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
@@ -1227,10 +1240,12 @@
 				46A5D22AFD4CA9BC39AB7225 /* TestHelpersTests.swift */,
 				9421F25B9FC2D1162925F2E7 /* TrashedAppMonitorTests.swift */,
 				4001147A48C26B95F8DB07D8 /* TrashSizeMonitorTests.swift */,
+				6232E30181C53E844AC03226 /* TriggerAnchorTests.swift */,
 				1C87F03C4A172754EDFB75A0 /* UnsupportedAppScannerTests.swift */,
 				382745ACB652CA50CA393BD5 /* UnusedAppScannerTests.swift */,
 				B46943B264F72B3753075A8C /* UpdateInfoTests.swift */,
 				CE71FA16E4B413D837F097E2 /* UpdateProbeTests.swift */,
+				62087FF6D324B53E3ECD7747 /* VaderMotionTests.swift */,
 				1C63552C9C84BCD29A3DE1F5 /* VersionComparatorTests.swift */,
 				448786867041AFF7B9206B86 /* VolumeMountMonitorTests.swift */,
 				AF6EA6E0EC8BFB813F89FAAE /* WebDevScanScopeStoreTests.swift */,
@@ -1543,6 +1558,7 @@
 				1E293D15A978268B2E156C83 /* ScanCoordinatingConformanceTests.swift in Sources */,
 				102012265B908DDF367DE36A /* ScanCoordinatingTests.swift in Sources */,
 				F106EE57A074D89D42E2872B /* ScanDiscWindowFrameTests.swift in Sources */,
+				E77456FD775F682539451AFA /* ScanProgressIndicatorTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
 				A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
@@ -1568,10 +1584,12 @@
 				109F26F16AF9EF6EA786DA0A /* TestHelpersTests.swift in Sources */,
 				E18273F08878A4649BD2CE68 /* TrashSizeMonitorTests.swift in Sources */,
 				042E4D668BD6A77F841EF13A /* TrashedAppMonitorTests.swift in Sources */,
+				1EFC3005FB3738519FCB871C /* TriggerAnchorTests.swift in Sources */,
 				F4BF8822B044CE3445A144E7 /* UnsupportedAppScannerTests.swift in Sources */,
 				48EF0257049EE6954E00E936 /* UnusedAppScannerTests.swift in Sources */,
 				218D346DC005B993AFE18957 /* UpdateInfoTests.swift in Sources */,
 				D911FAA1B6067442C5D36F11 /* UpdateProbeTests.swift in Sources */,
+				3E3E4054A22FDAF85B9844F8 /* VaderMotionTests.swift in Sources */,
 				3FE9EA6ED869EDC70CA3241B /* VersionComparatorTests.swift in Sources */,
 				8970C68164C01FF10E15F906 /* VolumeMountMonitorTests.swift in Sources */,
 				F8C8660BC76604FE849D6F5F /* WebDevScanScopeStoreTests.swift in Sources */,
@@ -1794,6 +1812,7 @@
 				094E458AFC6976D25693B106 /* SystemStatsService.swift in Sources */,
 				C882EE0A16D160B09E59AC50 /* TrashSizeMonitor.swift in Sources */,
 				090CB8BE2FE82898922C54D4 /* TrashedAppMonitor.swift in Sources */,
+				E593DA64025CAC2160110497 /* TriggerAnchor.swift in Sources */,
 				09F3933E9C2A8A09E3E8BAEB /* UnsupportedApp.swift in Sources */,
 				533BAE450469983F721BF936 /* UnsupportedAppScanner.swift in Sources */,
 				6D2476F58F6EDCF6C12C844D /* UnusedApp.swift in Sources */,
@@ -1802,6 +1821,7 @@
 				F6161C632AB8AA90DD7B9A36 /* UpdateProbe.swift in Sources */,
 				6CAE5BEE91E8F09DDB87590F /* UserFilesPathProviding.swift in Sources */,
 				BD7CE0EE2AA543E528587A90 /* VaderCleanerApp.swift in Sources */,
+				F87B7EB25504B2F1CD3937C3 /* VaderMotion.swift in Sources */,
 				A2B88722EF3A609E7898FE48 /* VaderTheme.swift in Sources */,
 				B51203EFD0B1E0734609E427 /* VersionComparator.swift in Sources */,
 				7A3F6FF5FA5DC9E2E74C568B /* VolumeMountMonitor.swift in Sources */,

--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		42A3B1422BEFF1E49B5EBDCE /* RailCollapseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0229FBE733B06D6302D5497 /* RailCollapseTests.swift */; };
 		432BC8C050B5B2A703CBA01A /* ApplicationsManagerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D4F328EFA6BEB382624507 /* ApplicationsManagerModelTests.swift */; };
 		4368849EA97B0EC0AF5C63E0 /* ProtectionPrivacyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D5840FAF0F143B4E943E0F /* ProtectionPrivacyModel.swift */; };
+		4383D2D6F605D8F7D65B9738 /* SmartScanScanningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED9F943D2B14BA444B06B60 /* SmartScanScanningView.swift */; };
 		4453CD1C9BEA6DFD3C62E054 /* FloatingRunOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BBF737C8160E8BA9C847B /* FloatingRunOverlay.swift */; };
 		4536F93FC837F56C61CDD236 /* spaceLens.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 785EECE3C6B84ECB7D0A3384 /* spaceLens.usdz */; };
 		45825BEE32AC83FC8B685E28 /* ScanProgressFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A3AE9EED81844B80CF3A1A /* ScanProgressFormatting.swift */; };
@@ -442,6 +443,7 @@
 		0C9CCEAC7D02D3629B18BC5B /* NotificationThresholdMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationThresholdMonitor.swift; sourceTree = "<group>"; };
 		0D4E92A146A223EA836C156D /* ScanResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanResultTests.swift; sourceTree = "<group>"; };
 		0D83104C36AA0A0E85DB7698 /* MaintenanceTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceTask.swift; sourceTree = "<group>"; };
+		0ED9F943D2B14BA444B06B60 /* SmartScanScanningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanScanningView.swift; sourceTree = "<group>"; };
 		0FB23D6F3B48857BDEB6DF3A /* SpaceLensUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceLensUITests.swift; sourceTree = "<group>"; };
 		0FDFA9AEE80D49DAD57BC670 /* MalwareViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareViewModel.swift; sourceTree = "<group>"; };
 		1071E99E2EFBE2C48C528D41 /* ConnectedDevicesMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedDevicesMonitorTests.swift; sourceTree = "<group>"; };
@@ -1009,6 +1011,7 @@
 				5F498579A77E1DAED6AC00AF /* SmartScanMyClutterReview.swift */,
 				952CFA79F6F0E89198DED8E3 /* SmartScanPerformanceReview.swift */,
 				963F8A6735414A3746D68C0F /* SmartScanReviewManager.swift */,
+				0ED9F943D2B14BA444B06B60 /* SmartScanScanningView.swift */,
 				8A791BBD75807EE466740BD0 /* SmartScanSettingsStore.swift */,
 				3D034A83ED3EF29EA3A00669 /* SmartScanView.swift */,
 				D24DCDF404CBFA38E2A703F3 /* SmartScanViewModel.swift */,
@@ -1789,6 +1792,7 @@
 				BEFCD2F309C985449A2901F5 /* SmartScanMyClutterReview.swift in Sources */,
 				CFF959AB010953129DB8B8D0 /* SmartScanPerformanceReview.swift in Sources */,
 				17EC5A02C885E96D7115CFC3 /* SmartScanReviewManager.swift in Sources */,
+				4383D2D6F605D8F7D65B9738 /* SmartScanScanningView.swift in Sources */,
 				9FCF64A2D2BAF68FC256007B /* SmartScanSettingsStore.swift in Sources */,
 				FFA343C50E64EF6C36B01D3C /* SmartScanView.swift in Sources */,
 				9E6129DCBC5B79B5E84A5904 /* SmartScanViewModel.swift in Sources */,

--- a/VaderCleaner/ApplicationsDashboardSubviews.swift
+++ b/VaderCleaner/ApplicationsDashboardSubviews.swift
@@ -488,14 +488,14 @@ struct ApplicationsDashboardCard: View {
 /// Centered spinner shown while the Applications scan runs.
 struct ApplicationsProgressState: View {
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 28) {
             ScanProgressIndicator()
-            Text(String(
+            // The shared status view, so this loader's type matches every
+            // other section's scan screen.
+            ScanningStatusView(phrases: [String(
                 localized: "Scanning your applications…",
                 comment: "Progress label shown while the Applications scan runs."
-            ))
-            .font(.callout)
-            .foregroundStyle(.secondary)
+            )])
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("applications.loading")

--- a/VaderCleaner/ApplicationsManagerView.swift
+++ b/VaderCleaner/ApplicationsManagerView.swift
@@ -133,7 +133,8 @@ struct ApplicationsManagerView: View {
         .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .shadow(color: .black.opacity(0.18), radius: 16, y: 6)
         .padding(14)
-        .ignoresSafeArea(.container, edges: .top)
+        // The title-bar safe-area extension is applied by ApplicationsView,
+        // outside the manager zoom transition — see ManagerSurfaceModifier.
         .tint(Self.accent)
         .environment(\.sectionAccent, Self.accent)
         .accessibilityIdentifier("applications.manager")

--- a/VaderCleaner/ApplicationsView.swift
+++ b/VaderCleaner/ApplicationsView.swift
@@ -22,17 +22,30 @@ struct ApplicationsView: View {
     /// app's real icon instead of a generic glyph. Pre-loaded off the main
     /// thread by the review screens when they appear.
     @State private var iconCache = AppIconCache()
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Which screen the results surface is showing — the dashboard grid, or one
     /// of the pushed detail screens. Owned here so the selection survives the
     /// brief remount when the underlying detail view loads.
     @State private var detail: Detail = .dashboard
+    /// Where the manager zoom anchors: the button that opened it, resolved
+    /// by `openManager`. Also the point Back zooms the manager back into.
+    @State private var managerAnchor: UnitPoint = .center
+    /// The transition host's frame in global space, for mapping the opening
+    /// click to `managerAnchor`.
+    @State private var paneFrame: CGRect = .zero
+    /// The title-bar safe-area inset the transition host permanently claims;
+    /// handed back to the dashboard as top padding so only the manager
+    /// extends under the title bar.
+    @State private var paneTopInset: CGFloat = 0
 
     /// The results surface's screens: the dashboard grid, or the full Manager
     /// opened on a specific destination. Every card's Review button deep-links
     /// into the Manager rather than pushing its own review screen, so the Manage
     /// button and the cards share one manager surface.
-    private enum Detail {
+    /// Equatable so the dashboard ↔ manager swap can key its transition
+    /// animation on the current screen.
+    private enum Detail: Equatable {
         case dashboard
         case manage(ApplicationsManagerView.Destination)
     }
@@ -76,51 +89,81 @@ struct ApplicationsView: View {
         }
     }
 
+    /// The dashboard and the manager exchange inside a ZStack (a stable
+    /// transition host) with the shared manager motion: the manager zooms up
+    /// from the button that opened it over the receding dashboard, and zooms
+    /// back into it on Back.
     @ViewBuilder
     private func resultsContent(_ result: ApplicationsScanResult) -> some View {
-        switch detail {
-        case .dashboard:
-            // The dashboard divides the pane height into a hero banner and a
-            // grid of equal-height tiles, so it fills the detail area without a
-            // scroll view.
-            ApplicationsDashboardView(
-                result: result,
-                iconCache: iconCache,
-                accent: NavigationSection.applications.theme.accent,
-                onOpenManage: { detail = .manage(.uninstaller) },
-                onOpenInstallationFiles: { detail = .manage(.installationFiles) },
-                onOpenUnsupported: { detail = .manage(.unsupported) },
-                onOpenUnused: { detail = .manage(.unused) },
-                onOpenUpdates: { detail = .manage(.updater) },
-                onOpenLeftovers: { detail = .manage(.leftovers) },
-                onRemoveLeftovers: {
-                    viewModel.selectAllLeftovers()
-                    Task { await viewModel.deleteSelectedLeftovers() }
-                }
-            )
-            // Generous top and bottom insets so the section breathes above the
-            // hero and below the cards rather than running into the window edges.
-            .padding(.horizontal, 24)
-            .padding(.top, 44)
-            .padding(.bottom, 48)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        case .manage(let destination):
-            // Full multi-pane manager (Uninstaller / Updater / Extensions /
-            // Leftovers / Unsupported), styled like the Performance "View All
-            // Tasks" catalog — it owns its own header. Opens on `destination` so
-            // each card's Review deep-links straight to the pane and facet where
-            // its finding lives.
-            ApplicationsManagerView(
-                viewModel: viewModel,
-                uninstallerViewModel: uninstallerViewModel,
-                updaterViewModel: updaterViewModel,
-                extensionsManagerViewModel: extensionsManagerViewModel,
-                result: result,
-                iconCache: iconCache,
-                destination: destination,
-                onBack: { detail = .dashboard }
-            )
+        ZStack {
+            switch detail {
+            case .dashboard:
+                // The dashboard divides the pane height into a hero banner and a
+                // grid of equal-height tiles, so it fills the detail area without a
+                // scroll view.
+                ApplicationsDashboardView(
+                    result: result,
+                    iconCache: iconCache,
+                    accent: NavigationSection.applications.theme.accent,
+                    onOpenManage: { openManager(.uninstaller) },
+                    onOpenInstallationFiles: { openManager(.installationFiles) },
+                    onOpenUnsupported: { openManager(.unsupported) },
+                    onOpenUnused: { openManager(.unused) },
+                    onOpenUpdates: { openManager(.updater) },
+                    onOpenLeftovers: { openManager(.leftovers) },
+                    onRemoveLeftovers: {
+                        viewModel.selectAllLeftovers()
+                        Task { await viewModel.deleteSelectedLeftovers() }
+                    }
+                )
+                // Generous top and bottom insets so the section breathes above the
+                // hero and below the cards rather than running into the window edges.
+                .padding(.horizontal, 24)
+                .padding(.top, 44)
+                .padding(.bottom, 48)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // The dashboard keeps its usual place below the title bar:
+                // the host ZStack claims that inset permanently, so it is
+                // handed back here as explicit padding.
+                .padding(.top, paneTopInset)
+                .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
+            case .manage(let destination):
+                // Full multi-pane manager (Uninstaller / Updater / Extensions /
+                // Leftovers / Unsupported), styled like the Performance "View All
+                // Tasks" catalog — it owns its own header. Opens on `destination` so
+                // each card's Review deep-links straight to the pane and facet where
+                // its finding lives.
+                ApplicationsManagerView(
+                    viewModel: viewModel,
+                    uninstallerViewModel: uninstallerViewModel,
+                    updaterViewModel: updaterViewModel,
+                    extensionsManagerViewModel: extensionsManagerViewModel,
+                    result: result,
+                    iconCache: iconCache,
+                    destination: destination,
+                    onBack: { detail = .dashboard }
+                )
+                .transition(VaderMotion.managerTransition(anchor: managerAnchor, reduceMotion: reduceMotion))
+                // Draw over the dashboard while the two overlap mid-swap.
+                .zIndex(1)
+            }
         }
+        // Claim the title-bar safe area on this stable container, never on a
+        // transitioning branch: safe-area changes anywhere inside a freshly
+        // inserted transition subtree are deferred until its spring fully
+        // settles, which read as the manager stuck below a title-bar-height
+        // gap for a beat after opening.
+        .ignoresSafeArea(.container, edges: .top)
+        .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { paneFrame = $0 })
+        .onGeometryChange(for: CGFloat.self, of: { $0.safeAreaInsets.top }, action: { paneTopInset = $0 })
+        .animation(VaderMotion.managerZoom, value: detail)
+    }
+
+    /// Anchors the zoom to the button (or failing that, the click) being
+    /// handled, then raises the manager on `destination`.
+    private func openManager(_ destination: ApplicationsManagerView.Destination) {
+        managerAnchor = TriggerAnchor.resolve(in: paneFrame)
+        detail = .manage(destination)
     }
 }
 

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -46,10 +46,16 @@ struct ContentView: View {
     /// Width of the rail when collapsed to icons only — narrow enough to read as
     /// a glyph rail while still fitting the selection pill around each icon.
     private let collapsedRailWidth: CGFloat = 76
+    /// Latched the first time any section collapses the rail. Once set, the
+    /// rail stays icons-only for the rest of the session instead of
+    /// re-expanding when the user returns to an intro or a non-scannable
+    /// section — the expanded rail is a landing layout, not a state worth
+    /// bouncing back to mid-session.
+    @State private var railCollapsedOnceThisSession = false
     /// Current rail width. Shared by the rail's own frame and the Scan disc
     /// panel so the disc centers over the detail content area (not the full
     /// window) without the two drifting apart. Collapses once the selected
-    /// section leaves its intro.
+    /// section leaves its intro, and stays collapsed for the session.
     private var railWidth: CGFloat { isRailCollapsed ? collapsedRailWidth : expandedRailWidth }
 
     /// The coarse scan phase of the section currently on screen, or `nil` for a
@@ -68,11 +74,27 @@ struct ContentView: View {
     }
 
     /// The rail collapses to icons only once the selected section leaves its
-    /// intro — i.e. right after the user taps Scan — and re-expands when it
-    /// returns to the intro (Start Over). Non-scannable sections keep the
+    /// intro — i.e. right after the user taps Scan — and then stays collapsed
+    /// for the rest of the session (see `railCollapsedOnceThisSession`).
+    /// Before that first collapse, intros and non-scannable sections keep the
     /// expanded rail.
     private var isRailCollapsed: Bool {
-        guard let presentation = activeScanPresentation else { return false }
+        Self.railCollapsed(
+            activePresentation: activeScanPresentation,
+            collapsedOnceThisSession: railCollapsedOnceThisSession
+        )
+    }
+
+    /// Pure rail-collapse rule, testable without rendering: collapsed while
+    /// the active scannable section is out of its intro, and latched
+    /// collapsed for the rest of the session once that has happened even
+    /// once.
+    static func railCollapsed(
+        activePresentation: ScanPresentation?,
+        collapsedOnceThisSession: Bool
+    ) -> Bool {
+        if collapsedOnceThisSession { return true }
+        guard let presentation = activePresentation else { return false }
         return presentation != .intro
     }
     /// Owns the borderless child panel that hosts the floating Scan disc so it
@@ -232,6 +254,13 @@ struct ContentView: View {
         // collapses/expands — its placement is computed from the rail width.
         .onChange(of: railWidth) { _, newWidth in
             scanDiscController.setRailWidth(newWidth)
+        }
+        // Latch the first collapse so the rail stays icons-only for the rest
+        // of the session. Setting the latch while the rail is already
+        // collapsed causes no visual change; it only stops later intros from
+        // re-expanding it.
+        .onChange(of: isRailCollapsed) { _, collapsed in
+            if collapsed { railCollapsedOnceThisSession = true }
         }
         // Animates the rail's section-change motion — chiefly the selection
         // pill sliding between rows. The detail pane and the backdrop each

--- a/VaderCleaner/DeveloperProjectScanner.swift
+++ b/VaderCleaner/DeveloperProjectScanner.swift
@@ -49,14 +49,27 @@ struct DeveloperProjectScanner {
         self.fileManager = fileManager
     }
 
+    /// Cadence of progress ticks during the walk, matching `FileScanner`'s
+    /// interval so the count advances smoothly without a closure call per
+    /// visited file.
+    private static let progressTickInterval = 512
+
     /// Runs the discovery walk and returns one rolled-up `ScannedFile` per
     /// matched project folder. Non-throwing so it merges into `SystemJunkScanner`
-    /// alongside the other supplementary enumerators.
-    func scan() async -> [ScannedFile] {
+    /// alongside the other supplementary enumerators. `onProgress` receives the
+    /// walk's cumulative visited-item count — directory entries walked plus
+    /// every file sized inside a matched artifact folder — so the scanning
+    /// screen's tally keeps moving through what can be a long crawl over big
+    /// `node_modules` trees.
+    func scan(onProgress: (@Sendable (Int) -> Void)? = nil) async -> [ScannedFile] {
         var results: [ScannedFile] = []
+        var visited = 0
         for root in roots {
-            collect(in: root, depth: 0, into: &results)
+            collect(in: root, depth: 0, into: &results, visited: &visited, onProgress: onProgress)
         }
+        // Final tick so a short walk still reports a count, and a long one
+        // ends on its true total rather than the last interval boundary.
+        onProgress?(visited)
         return results
     }
 
@@ -64,7 +77,13 @@ struct DeveloperProjectScanner {
     /// whose name is a known artifact folder and recursing into the rest until
     /// `maxDepth` is reached. A match is never descended into, so its whole
     /// subtree — including nested matches — folds into its single rolled-up size.
-    private func collect(in directory: URL, depth: Int, into results: inout [ScannedFile]) {
+    private func collect(
+        in directory: URL,
+        depth: Int,
+        into results: inout [ScannedFile],
+        visited: inout Int,
+        onProgress: (@Sendable (Int) -> Void)?
+    ) {
         if Task.isCancelled { return }
         guard let entries = try? fileManager.contentsOfDirectory(
             at: directory,
@@ -74,25 +93,39 @@ struct DeveloperProjectScanner {
             return
         }
         for entry in entries {
+            visit(&visited, onProgress: onProgress)
             let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
             guard isDirectory else { continue }
 
             if Self.junkFolderNames.contains(entry.lastPathComponent) {
-                results.append(rolledUpFile(for: entry))
+                results.append(rolledUpFile(for: entry, visited: &visited, onProgress: onProgress))
             } else if depth < maxDepth {
-                collect(in: entry, depth: depth + 1, into: &results)
+                collect(in: entry, depth: depth + 1, into: &results, visited: &visited, onProgress: onProgress)
             }
+        }
+    }
+
+    /// Counts one visited filesystem item, ticking `onProgress` on the shared
+    /// interval.
+    private func visit(_ visited: inout Int, onProgress: (@Sendable (Int) -> Void)?) {
+        visited += 1
+        if visited.isMultiple(of: Self.progressTickInterval) {
+            onProgress?(visited)
         }
     }
 
     /// Builds the single `ScannedFile` representing a matched folder: the folder
     /// URL, its recursive byte total, and the folder's own timestamps so the
     /// Cleanup Manager can sort and age it like any other entry.
-    private func rolledUpFile(for folder: URL) -> ScannedFile {
+    private func rolledUpFile(
+        for folder: URL,
+        visited: inout Int,
+        onProgress: (@Sendable (Int) -> Void)?
+    ) -> ScannedFile {
         let timestamps = try? folder.resourceValues(forKeys: [.contentAccessDateKey, .contentModificationDateKey])
         return ScannedFile(
             url: folder,
-            size: directorySize(folder),
+            size: directorySize(folder, visited: &visited, onProgress: onProgress),
             lastAccessDate: timestamps?.contentAccessDate,
             lastModifiedDate: timestamps?.contentModificationDate,
             category: .webDevJunk
@@ -100,8 +133,14 @@ struct DeveloperProjectScanner {
     }
 
     /// Sums the byte size of every regular file under `folder`. Unreadable
-    /// descendants are skipped rather than aborting the walk.
-    private func directorySize(_ folder: URL) -> Int64 {
+    /// descendants are skipped rather than aborting the walk. This is where
+    /// the bulk of a big artifact folder's items are visited, so each
+    /// enumerated descendant counts toward the progress tally.
+    private func directorySize(
+        _ folder: URL,
+        visited: inout Int,
+        onProgress: (@Sendable (Int) -> Void)?
+    ) -> Int64 {
         guard let enumerator = fileManager.enumerator(
             at: folder,
             includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
@@ -111,6 +150,7 @@ struct DeveloperProjectScanner {
         }
         var total: Int64 = 0
         for case let url as URL in enumerator {
+            visit(&visited, onProgress: onProgress)
             let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
             if values?.isRegularFile == true {
                 total += Int64(values?.fileSize ?? 0)

--- a/VaderCleaner/LargeOldFilesViewSubviews.swift
+++ b/VaderCleaner/LargeOldFilesViewSubviews.swift
@@ -75,7 +75,7 @@ struct LargeOldFilesProgressState: View {
     var phrases: [String]? = nil
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 28) {
             ScanProgressIndicator()
             ScanningStatusView(
                 phrases: phrases ?? [label],

--- a/VaderCleaner/MalwareViewSubviews.swift
+++ b/VaderCleaner/MalwareViewSubviews.swift
@@ -12,7 +12,7 @@ struct MalwareProgressState: View {
     var phrases: [String]? = nil
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 28) {
             ScanProgressIndicator()
             ScanningStatusView(phrases: phrases ?? [label])
         }

--- a/VaderCleaner/ManagerChrome.swift
+++ b/VaderCleaner/ManagerChrome.swift
@@ -50,6 +50,10 @@ struct NavRow<Content: View>: View {
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
+        // Ease the hover and selection fills in and out instead of snapping,
+        // so pointing along the pane reads as a soft glide.
+        .animation(VaderMotion.hover, value: hovered)
+        .animation(VaderMotion.hover, value: selected)
     }
 }
 
@@ -83,6 +87,9 @@ struct ManagerRowCard: ViewModifier {
                     .strokeBorder(Color.black.opacity(0.06), lineWidth: 1)
             )
             .onHover { hovered = $0 }
+            // Fade the hover fill in and out so rows light up softly as the
+            // pointer travels the list.
+            .animation(VaderMotion.hover, value: hovered)
     }
 }
 
@@ -100,6 +107,7 @@ struct ManagerRowCheckbox: View {
     let isOn: Bool
     let action: () -> Void
     @Environment(\.sectionAccent) private var accent
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Button(action: action) {
@@ -109,6 +117,10 @@ struct ManagerRowCheckbox: View {
                     Image(systemName: "checkmark")
                         .font(.system(size: 11, weight: .bold))
                         .foregroundStyle(.white)
+                        // The check pops in from a smaller scale with the
+                        // control spring, so ticking a row answers with a
+                        // little bounce; Reduce Motion keeps a plain fade.
+                        .transition(reduceMotion ? .opacity : .scale(scale: 0.5).combined(with: .opacity))
                 } else {
                     RoundedRectangle(cornerRadius: 5, style: .continuous)
                         .strokeBorder(accent.opacity(0.6), lineWidth: 1.5)
@@ -116,6 +128,7 @@ struct ManagerRowCheckbox: View {
             }
             .frame(width: 18, height: 18)
             .contentShape(Rectangle())
+            .animation(VaderMotion.control, value: isOn)
         }
         .buttonStyle(.plain)
     }
@@ -139,10 +152,11 @@ struct ManagerSurfaceModifier: ViewModifier {
                 .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .shadow(color: .black.opacity(0.18), radius: 16, y: 6)
                 .padding(14)
-                // Extend up under the title-bar safe area so the top margin is
-                // as thin as the sides instead of leaving the toolbar's tall
-                // gradient band above the card.
-                .ignoresSafeArea(.container, edges: .top)
+                // The extension up under the title-bar safe area (so the top
+                // margin is as thin as the sides) is applied by the hosting
+                // section, outside the manager zoom transition — expansion
+                // requested from inside an in-flight transition is deferred
+                // until the spring settles, which read as a stuck top margin.
         } else {
             content
         }

--- a/VaderCleaner/MyClutterManagerView.swift
+++ b/VaderCleaner/MyClutterManagerView.swift
@@ -78,7 +78,8 @@ struct MyClutterManagerView: View {
         .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .shadow(color: .black.opacity(0.18), radius: 16, y: 6)
         .padding(14)
-        .ignoresSafeArea(.container, edges: .top)
+        // The title-bar safe-area extension is applied by MyClutterView,
+        // outside the manager zoom transition — see ManagerSurfaceModifier.
         .tint(Self.accent)
         .environment(\.sectionAccent, Self.accent)
         .accessibilityIdentifier("myClutter.manager")

--- a/VaderCleaner/MyClutterView.swift
+++ b/VaderCleaner/MyClutterView.swift
@@ -9,11 +9,22 @@ import SwiftUI
 struct MyClutterView: View {
     @Bindable var viewModel: MyClutterViewModel
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let accent = NavigationSection.largeOldFiles.theme.accent
 
     /// Which review screen is up, or `nil` for the dashboard.
     @State private var review: ReviewTarget?
+    /// Where the manager zoom anchors: the button that opened it, resolved
+    /// by `openReview`. Also the point Back zooms the manager back into.
+    @State private var managerAnchor: UnitPoint = .center
+    /// The transition host's frame in global space, for mapping the opening
+    /// click to `managerAnchor`.
+    @State private var paneFrame: CGRect = .zero
+    /// The title-bar safe-area inset the transition host permanently claims;
+    /// handed back to the dashboard as top padding so only the manager
+    /// extends under the title bar.
+    @State private var paneTopInset: CGFloat = 0
 
     /// A review destination: one card's category, or every category at once.
     enum ReviewTarget: Equatable {
@@ -58,27 +69,57 @@ struct MyClutterView: View {
         case .failed(let message):
             LargeOldFilesFailedState(stage: .scanning, message: message, onTryAgain: viewModel.scanAgain)
         case .results:
-            if let review {
-                MyClutterManagerView(
-                    viewModel: viewModel,
-                    initialCategory: Self.category(for: review),
-                    onBack: { self.review = nil }
-                )
-            } else {
-                dashboard
+            // The dashboard and the review manager exchange inside a ZStack
+            // (a stable transition host) with the shared manager motion: the
+            // manager zooms up from the button that opened it over the
+            // receding dashboard, and zooms back into it on Back.
+            ZStack {
+                if let review {
+                    MyClutterManagerView(
+                        viewModel: viewModel,
+                        initialCategory: Self.category(for: review),
+                        onBack: { self.review = nil }
+                    )
+                    .transition(VaderMotion.managerTransition(anchor: managerAnchor, reduceMotion: reduceMotion))
+                    // Draw over the dashboard while the two overlap mid-swap.
+                    .zIndex(1)
+                } else {
+                    dashboard
+                        // The dashboard keeps its usual place below the title
+                        // bar: the host ZStack claims that inset permanently,
+                        // so it is handed back here as explicit padding.
+                        .padding(.top, paneTopInset)
+                        .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
+                }
             }
+            // Claim the title-bar safe area on this stable container, never
+            // on a transitioning branch: safe-area changes anywhere inside a
+            // freshly inserted transition subtree are deferred until its
+            // spring fully settles, which read as the manager stuck below a
+            // title-bar-height gap for a beat after opening.
+            .ignoresSafeArea(.container, edges: .top)
+            .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { paneFrame = $0 })
+            .onGeometryChange(for: CGFloat.self, of: { $0.safeAreaInsets.top }, action: { paneTopInset = $0 })
+            .animation(VaderMotion.managerZoom, value: review)
         }
+    }
+
+    /// Anchors the zoom to the button (or failing that, the click) being
+    /// handled, then raises the review.
+    private func openReview(_ target: ReviewTarget) {
+        managerAnchor = TriggerAnchor.resolve(in: paneFrame)
+        review = target
     }
 
     private var dashboard: some View {
         MyClutterDashboardView(
             viewModel: viewModel,
             accent: accent,
-            onReviewAll: { review = .all },
-            onReviewDuplicates: { review = .duplicates },
-            onReviewSimilar: { review = .similar },
-            onReviewLargeOld: { review = .largeOld },
-            onReviewDownloads: { review = .downloads },
+            onReviewAll: { openReview(.all) },
+            onReviewDuplicates: { openReview(.duplicates) },
+            onReviewSimilar: { openReview(.similar) },
+            onReviewLargeOld: { openReview(.largeOld) },
+            onReviewDownloads: { openReview(.downloads) },
             onStartOver: viewModel.scanAgain
         )
     }

--- a/VaderCleaner/PerformanceView.swift
+++ b/VaderCleaner/PerformanceView.swift
@@ -10,6 +10,7 @@ struct PerformanceView: View {
 
     private var viewModel: PerformanceViewModel
     @Environment(\.openURL) private var openURL
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Toggles the ready surface between the summary dashboard and the full
     /// "View All Tasks" Performance Manager.
     @State private var showAllTasks = false
@@ -20,6 +21,16 @@ struct PerformanceView: View {
     /// Selected task ids for the catalog's multi-select Run. Owned here so the
     /// selection persists across the progress screen and a completed run.
     @State private var selectedTaskIDs: Set<String> = []
+    /// Where the manager zoom anchors: the button that opened it, resolved
+    /// by `openCatalog`. Also the point Back zooms the manager back into.
+    @State private var managerAnchor: UnitPoint = .center
+    /// The transition host's frame in global space, for mapping the opening
+    /// click to `managerAnchor`.
+    @State private var paneFrame: CGRect = .zero
+    /// The title-bar safe-area inset the transition host permanently claims;
+    /// handed back to the dashboard as top padding so only the manager
+    /// extends under the title bar.
+    @State private var paneTopInset: CGFloat = 0
 
     init(viewModel: PerformanceViewModel) {
         self.viewModel = viewModel
@@ -95,53 +106,72 @@ struct PerformanceView: View {
         )
     }
 
+    /// The dashboard and the task catalog exchange inside a ZStack (a stable
+    /// transition host) with the shared manager motion: the catalog zooms up
+    /// from the button that opened it over the receding dashboard, and zooms
+    /// back into it on Back.
     @ViewBuilder
     private var readyContent: some View {
-        if showAllTasks {
-            // The manager owns its full-height card layout (header + nav + pane +
-            // footer), so it replaces the dashboard entirely rather than
-            // rendering inside it.
-            PerformanceTaskCatalogView(
-                pane: $catalogPane,
-                selectedTaskIDs: $selectedTaskIDs,
-                tasks: viewModel.tasks,
-                results: viewModel.taskResults,
-                loginItems: viewModel.loginItems,
-                userAgents: viewModel.userAgents,
-                systemAgents: viewModel.systemAgents,
-                onRunSelected: { tasks in Task { await viewModel.run(tasks) } },
-                onRemoveSelected: { loginIDs, agentIDs in
-                    Task { await viewModel.removeSelected(loginItemIDs: loginIDs, agentIDs: agentIDs) }
-                },
-                onBack: { showAllTasks = false }
-            )
-        } else {
-            PerformanceDashboardView(
-                loginItemCount: viewModel.loginItems.count,
-                loginItemBundleIDs: viewModel.loginItems.map(\.id),
-                backgroundItemCount: viewModel.userAgents.count + viewModel.systemAgents.count,
-                maintenanceTasksDue: viewModel.maintenanceTasksDue,
-                accent: NavigationSection.performance.theme.accent,
-                onViewAllTasks: {
-                    catalogPane = .maintenanceTasks
-                    showAllTasks = true
-                },
-                onReviewLoginItems: {
-                    catalogPane = .loginItems
-                    showAllTasks = true
-                },
-                onReviewBackgroundItems: {
-                    catalogPane = .backgroundItems
-                    showAllTasks = true
-                },
-                onReviewMaintenance: {
-                    catalogPane = .maintenanceTasks
-                    showAllTasks = true
-                }
-            )
-            .padding(24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ZStack {
+            if showAllTasks {
+                // The manager owns its full-height card layout (header + nav + pane +
+                // footer), so it replaces the dashboard entirely rather than
+                // rendering inside it.
+                PerformanceTaskCatalogView(
+                    pane: $catalogPane,
+                    selectedTaskIDs: $selectedTaskIDs,
+                    tasks: viewModel.tasks,
+                    results: viewModel.taskResults,
+                    loginItems: viewModel.loginItems,
+                    userAgents: viewModel.userAgents,
+                    systemAgents: viewModel.systemAgents,
+                    onRunSelected: { tasks in Task { await viewModel.run(tasks) } },
+                    onRemoveSelected: { loginIDs, agentIDs in
+                        Task { await viewModel.removeSelected(loginItemIDs: loginIDs, agentIDs: agentIDs) }
+                    },
+                    onBack: { showAllTasks = false }
+                )
+                .transition(VaderMotion.managerTransition(anchor: managerAnchor, reduceMotion: reduceMotion))
+                // Draw over the dashboard while the two overlap mid-swap.
+                .zIndex(1)
+            } else {
+                PerformanceDashboardView(
+                    loginItemCount: viewModel.loginItems.count,
+                    loginItemBundleIDs: viewModel.loginItems.map(\.id),
+                    backgroundItemCount: viewModel.userAgents.count + viewModel.systemAgents.count,
+                    maintenanceTasksDue: viewModel.maintenanceTasksDue,
+                    accent: NavigationSection.performance.theme.accent,
+                    onViewAllTasks: { openCatalog(pane: .maintenanceTasks) },
+                    onReviewLoginItems: { openCatalog(pane: .loginItems) },
+                    onReviewBackgroundItems: { openCatalog(pane: .backgroundItems) },
+                    onReviewMaintenance: { openCatalog(pane: .maintenanceTasks) }
+                )
+                .padding(24)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // The dashboard keeps its usual place below the title bar:
+                // the host ZStack claims that inset permanently, so it is
+                // handed back here as explicit padding.
+                .padding(.top, paneTopInset)
+                .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
+            }
         }
+        // Claim the title-bar safe area on this stable container, never on a
+        // transitioning branch: safe-area changes anywhere inside a freshly
+        // inserted transition subtree are deferred until its spring fully
+        // settles, which read as the manager stuck below a title-bar-height
+        // gap for a beat after opening.
+        .ignoresSafeArea(.container, edges: .top)
+        .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { paneFrame = $0 })
+        .onGeometryChange(for: CGFloat.self, of: { $0.safeAreaInsets.top }, action: { paneTopInset = $0 })
+        .animation(VaderMotion.managerZoom, value: showAllTasks)
+    }
+
+    /// Anchors the zoom to the button (or failing that, the click) being
+    /// handled, then raises the catalog on `pane`.
+    private func openCatalog(pane: PerformanceTaskCatalogView.Pane) {
+        managerAnchor = TriggerAnchor.resolve(in: paneFrame)
+        catalogPane = pane
+        showAllTasks = true
     }
 }
 

--- a/VaderCleaner/PerformanceViewSubviews.swift
+++ b/VaderCleaner/PerformanceViewSubviews.swift
@@ -10,11 +10,11 @@ struct PerformanceProgressState: View {
     let identifier: String
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 28) {
             ScanProgressIndicator()
-            Text(label)
-                .font(.callout)
-                .foregroundStyle(.secondary)
+            // The shared status view, so this loader's type matches every
+            // other section's scan screen.
+            ScanningStatusView(phrases: [label])
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier(identifier)

--- a/VaderCleaner/ProtectionDashboardView.swift
+++ b/VaderCleaner/ProtectionDashboardView.swift
@@ -29,13 +29,28 @@ struct ProtectionDashboardView: View {
     /// through the shared `AppIconCache`.
     @State private var iconCache = AppIconCache()
     @State private var browserBundleURLs: [Browser: URL] = [:]
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Where the manager zoom anchors: the button that opened it, resolved
+    /// by `openManager`. Also the point Back zooms the manager back into.
+    @State private var managerAnchor: UnitPoint = .center
+    /// The transition host's frame in global space, for mapping the opening
+    /// click to `managerAnchor`.
+    @State private var paneFrame: CGRect = .zero
+    /// The title-bar safe-area inset the transition host permanently claims;
+    /// handed back to the dashboard as top padding so only the manager
+    /// extends under the title bar.
+    @State private var paneTopInset: CGFloat = 0
 
     private var malware: MalwareViewModel { viewModel.malware }
     private var privacy: PrivacyViewModel { viewModel.privacy }
     private let accent = NavigationSection.malwareRemoval.theme.accent
 
     var body: some View {
-        Group {
+        // The dashboard and the Protection Manager exchange inside a ZStack
+        // (a stable transition host) with the shared manager motion: the
+        // manager zooms up from the button that opened it over the receding
+        // dashboard, and zooms back into it on Back.
+        ZStack {
             if detail == .manager {
                 ProtectionManagerView(
                     malware: malware,
@@ -44,10 +59,27 @@ struct ProtectionDashboardView: View {
                     bundleURL: { browserBundleURLs[$0] },
                     onBack: { detail = .dashboard }
                 )
+                .transition(VaderMotion.managerTransition(anchor: managerAnchor, reduceMotion: reduceMotion))
+                // Draw over the dashboard while the two overlap mid-swap.
+                .zIndex(1)
             } else {
                 dashboardSurface
+                    // The dashboard keeps its usual place below the title
+                    // bar: the host ZStack claims that inset permanently, so
+                    // it is handed back here as explicit padding.
+                    .padding(.top, paneTopInset)
+                    .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
             }
         }
+        // Claim the title-bar safe area on this stable container, never on a
+        // transitioning branch: safe-area changes anywhere inside a freshly
+        // inserted transition subtree are deferred until its spring fully
+        // settles, which read as the manager stuck below a title-bar-height
+        // gap for a beat after opening.
+        .ignoresSafeArea(.container, edges: .top)
+        .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { paneFrame = $0 })
+        .onGeometryChange(for: CGFloat.self, of: { $0.safeAreaInsets.top }, action: { paneTopInset = $0 })
+        .animation(VaderMotion.managerZoom, value: detail)
         // The dashboard appears once a scan has begun. Ensure the privacy
         // preview is running too — covers the Smart Scan seed path, where
         // the dashboard shows without this view's own beginScan.
@@ -57,6 +89,13 @@ struct ProtectionDashboardView: View {
         // Resolve each detected browser's bundle URL + warm the icon cache for
         // the manager's rows.
         .task(id: privacy.detectedBrowsers) { await loadBrowserIcons() }
+    }
+
+    /// Anchors the zoom to the button (or failing that, the click) being
+    /// handled, then raises the manager.
+    private func openManager() {
+        managerAnchor = TriggerAnchor.resolve(in: paneFrame)
+        detail = .manager
     }
 
     private var dashboardSurface: some View {
@@ -198,7 +237,7 @@ struct ProtectionDashboardView: View {
                     .foregroundStyle(.white.opacity(0.7))
                     .multilineTextAlignment(.center)
             }
-            Button(action: { detail = .manager }) {
+            Button(action: openManager) {
                 Text(String(
                     localized: "Manage Privacy Items",
                     comment: "Protection dashboard button that opens the Privacy manager."
@@ -348,7 +387,7 @@ struct ProtectionDashboardView: View {
             metric: tile.metric,
             caption: tile.caption,
             systemImage: tile.systemImage,
-            onReview: { detail = .manager },
+            onReview: openManager,
             onRemove: { pendingPrivacyRemoval = tile.removal }
         )
         .accessibilityIdentifier("protection.privacyTile.\(tile.id)")

--- a/VaderCleaner/ProtectionManagerView.swift
+++ b/VaderCleaner/ProtectionManagerView.swift
@@ -100,10 +100,9 @@ struct ProtectionManagerView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .shadow(color: .black.opacity(0.18), radius: 16, y: 6)
                 .padding(14)
-                // Extend up under the title-bar safe area so the top margin is
-                // as thin as the sides instead of leaving the toolbar's tall
-                // gradient band above the card.
-                .ignoresSafeArea(.container, edges: .top)
+                // The title-bar safe-area extension is applied by
+                // ProtectionDashboardView, outside the manager zoom
+                // transition — see ManagerSurfaceModifier.
                 .tint(accent)
                 .environment(\.sectionAccent, accent)
         }

--- a/VaderCleaner/ScanProgressIndicator.swift
+++ b/VaderCleaner/ScanProgressIndicator.swift
@@ -14,8 +14,10 @@ import SwiftUI
 /// per-call wiring. Honors Reduce Motion: the spin and sonar drop to a calm,
 /// static glowing emblem.
 struct ScanProgressIndicator: View {
-    /// Overall diameter; every element scales from this.
-    var size: CGFloat = 132
+    /// Overall diameter; every element scales from this. Sized as a hero
+    /// element — the loader is the screen's sole occupant while a scan runs,
+    /// so it carries the space rather than floating in it.
+    var size: CGFloat = 220
     /// Explicit tint override. `nil` uses the active section accent so the
     /// loader matches the backdrop it sits on.
     var accent: Color? = nil
@@ -143,21 +145,23 @@ struct ScanningStatusView: View {
     }
 
     var body: some View {
-        VStack(spacing: 8) {
+        // Type is scaled to pair with the hero-sized indicator above: a
+        // title-weight phrase with the accent count a step below it.
+        VStack(spacing: 10) {
             ZStack {
                 Text(phrase)
                     .id(phrase)
                     .transition(.opacity)
             }
-            .font(.callout.weight(.medium))
+            .font(.title2.weight(.medium))
             .foregroundStyle(.primary)
             .multilineTextAlignment(.center)
-            .frame(maxWidth: 460)
+            .frame(maxWidth: 560)
             .animation(.smooth(duration: 0.5), value: phrase)
 
             if let count {
                 Text(count)
-                    .font(.callout.monospacedDigit().weight(.semibold))
+                    .font(.title3.monospacedDigit().weight(.semibold))
                     .foregroundStyle(accent)
                     .contentTransition(.numericText())
                     .accessibilityIdentifier(countIdentifier ?? "")
@@ -292,7 +296,7 @@ enum ScanPhrases {
             count: "12,431 items"
         )
     }
-    .frame(width: 320, height: 360)
+    .frame(width: 520, height: 560)
     .environment(\.sectionAccent, Color(red: 0.13, green: 0.90, blue: 0.21))
     .background(Color.black)
 }

--- a/VaderCleaner/SmartScanScanningView.swift
+++ b/VaderCleaner/SmartScanScanningView.swift
@@ -1,0 +1,229 @@
+// SmartScanScanningView.swift
+// Smart Scan's staged loading screen — a hero card for the module being collected right now above a strip of compact module tiles that flip to their result summaries as each sub-scan lands.
+
+import SwiftUI
+
+/// The `.scanning` surface for Smart Scan: one module at a time takes the
+/// hero card (headline, artwork in the module's accent wash, live progress
+/// line) while the other modules wait as compact tiles that fill in with
+/// result summaries the moment their sub-scan is collected. The five
+/// sub-scans actually run concurrently — the staging follows the real
+/// collection checkpoints in `SmartScanViewModel.scan()`, so every hand-off
+/// the user sees corresponds to results genuinely landing.
+struct SmartScanScanningView: View {
+    var viewModel: SmartScanViewModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 16) {
+                ForEach(stripModules, id: \.self) { module in
+                    SmartScanScanTile(
+                        module: module,
+                        state: viewModel.moduleScanStates[module] ?? .pending
+                    )
+                }
+            }
+            .frame(height: 132)
+
+            if let active = viewModel.activeScanModule {
+                SmartScanScanHero(module: active, viewModel: viewModel)
+                    // Fresh identity per module so the hand-off crossfades
+                    // between hero cards instead of morphing text in place.
+                    .id(active)
+                    .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(VaderMotion.surface, value: viewModel.activeScanModule)
+        .accessibilityIdentifier("smartScan.scanning")
+    }
+
+    /// Every module except the hero, in collection order, so the strip reads
+    /// as the queue the scan is working through.
+    private var stripModules: [SmartScanModule] {
+        SmartScanViewModel.scanCollectionOrder.filter { $0 != viewModel.activeScanModule }
+    }
+}
+
+/// The large card for the module being collected right now: headline, the
+/// module's dashboard artwork over its accent wash, and a live progress line
+/// fed by the sub-scan's own counters.
+private struct SmartScanScanHero: View {
+    let module: SmartScanModule
+    var viewModel: SmartScanViewModel
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text(module.scanningHeadline)
+                .font(.system(size: 34, weight: .bold))
+                .foregroundStyle(.white)
+            Image(module.scanTileAsset)
+                .resizable()
+                .scaledToFit()
+                .frame(maxHeight: 220)
+            Text(detail)
+                .font(.title3)
+                .foregroundStyle(.white.opacity(0.75))
+                .contentTransition(.numericText())
+                .animation(.default, value: detail)
+                .accessibilityIdentifier("smartScan.scanning.detail")
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // The module's accent washes the card so each hand-off recolours the
+        // hero, clipped to the tile shape the glass beneath uses.
+        .background(
+            LinearGradient(
+                colors: [module.scanTileTint.opacity(0.45), module.scanTileTint.opacity(0.08)],
+                startPoint: .bottom,
+                endPoint: .top
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+        )
+        .vaderTileGlass()
+    }
+
+    /// Live progress line for the hero, from the sub-scan's own counters.
+    private var detail: String {
+        switch module {
+        case .systemJunk, .myClutter:
+            // The two file walks share one combined walked-items tally.
+            return ScanProgressFormatting.itemsScanned(viewModel.scannedItemCount)
+        case .malware:
+            return viewModel.malwareFilesScanned > 0
+                ? ScanProgressFormatting.threatsScanned(viewModel.malwareFilesScanned)
+                : String(
+                    localized: "Matching against known signatures…",
+                    comment: "Hero progress line while the malware scan has not yet reported a count."
+                )
+        case .performance:
+            return String(
+                localized: "Collecting login items and launch agents…",
+                comment: "Hero progress line while the Performance sub-scan is collected."
+            )
+        case .applications:
+            return viewModel.appsTotal > 0
+                ? ScanProgressFormatting.appsChecked(viewModel.appsChecked, of: viewModel.appsTotal)
+                : String(
+                    localized: "Comparing app versions with new releases…",
+                    comment: "Hero progress line while the update probe has not yet reported a count."
+                )
+        }
+    }
+}
+
+/// One compact module tile in the strip above the hero: title and dimmed
+/// artwork while the module waits its turn, the result summary once its
+/// sub-scan lands, or a quiet "Skipped" for modules excluded from this run.
+private struct SmartScanScanTile: View {
+    let module: SmartScanModule
+    let state: SmartScanModuleScanState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .top) {
+                Text(module.scanTileTitle)
+                    .font(.headline)
+                    .foregroundStyle(.white.opacity(0.9))
+                Spacer()
+                Image(module.scanTileAsset)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 40, height: 40)
+                    .opacity(isFinished ? 1 : 0.5)
+            }
+            Spacer(minLength: 0)
+            switch state {
+            case .finished(let metric, let caption):
+                Text(metric)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.7)
+                Text(caption)
+                    .font(.callout)
+                    .foregroundStyle(.white.opacity(0.7))
+            case .skipped:
+                Text(String(
+                    localized: "Skipped",
+                    comment: "Compact scanning-screen tile label for a module excluded from this run."
+                ))
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.55))
+            case .pending, .running:
+                // Title-only while the module waits its turn; the dimmed tile
+                // itself reads as "queued".
+                EmptyView()
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .vaderTileGlass()
+        .opacity(state == .pending ? 0.6 : 1)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("smartScan.scanning.tile.\(module.rawValue)")
+    }
+
+    private var isFinished: Bool {
+        if case .finished = state { return true }
+        return false
+    }
+}
+
+/// Per-module art, accent, title, and hero headline for the scanning screen —
+/// mirroring the dashboard tiles' metadata in
+/// `SmartScanResultsState.tileMeta` so both screens speak with one visual
+/// identity per module.
+private extension SmartScanModule {
+    var scanTileAsset: String {
+        switch self {
+        case .systemJunk: return "systemJunk"
+        case .malware: return "malwareRemoval"
+        case .performance: return "performance"
+        case .applications: return "applications"
+        case .myClutter: return "largeOldFiles"
+        }
+    }
+
+    var scanTileTint: Color {
+        switch self {
+        case .systemJunk: return NavigationSection.systemJunk.theme.accent
+        case .malware: return NavigationSection.malwareRemoval.theme.accent
+        case .performance: return NavigationSection.performance.theme.accent
+        case .applications: return NavigationSection.applications.theme.accent
+        case .myClutter: return NavigationSection.largeOldFiles.theme.accent
+        }
+    }
+
+    var scanTileTitle: String {
+        switch self {
+        case .systemJunk:
+            return String(localized: "Cleanup", comment: "Scanning-screen tile title for the System Junk module.")
+        case .malware:
+            return String(localized: "Protection", comment: "Scanning-screen tile title for the Malware module.")
+        case .performance:
+            return String(localized: "Performance", comment: "Scanning-screen tile title for the Performance module.")
+        case .applications:
+            return String(localized: "Applications", comment: "Scanning-screen tile title for the Applications module.")
+        case .myClutter:
+            return String(localized: "My Clutter", comment: "Scanning-screen tile title for the My Clutter module.")
+        }
+    }
+
+    var scanningHeadline: String {
+        switch self {
+        case .systemJunk:
+            return String(localized: "Looking for junk…", comment: "Hero headline while the System Junk sub-scan is collected.")
+        case .malware:
+            return String(localized: "Looking for threats…", comment: "Hero headline while the malware sub-scan is collected.")
+        case .performance:
+            return String(localized: "Examining your system…", comment: "Hero headline while the Performance sub-scan is collected.")
+        case .applications:
+            return String(localized: "Checking for updates…", comment: "Hero headline while the app-update sub-scan is collected.")
+        case .myClutter:
+            return String(localized: "Analyzing your storage…", comment: "Hero headline while the My Clutter sub-scan is collected.")
+        }
+    }
+}

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -19,6 +19,13 @@ struct SmartScanView: View {
     /// dashboard is visible. State is local because Review is a transient
     /// UI mode, not a persisted part of the scan model.
     @State private var review: SmartScanModule?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Where the manager zoom anchors: the button that opened it, resolved
+    /// by `openReview`. Also the point Back zooms the manager back into.
+    @State private var managerAnchor: UnitPoint = .center
+    /// The transition host's frame in global space, for mapping the opening
+    /// click to `managerAnchor`.
+    @State private var paneFrame: CGRect = .zero
 
     init(
         viewModel: SmartScanViewModel,
@@ -32,8 +39,13 @@ struct SmartScanView: View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .id(phaseTransitionID)
-            .transition(.opacity)
-            .animation(.smooth(duration: 0.35), value: phaseTransitionID)
+            // The subtle scale-and-fade phase changes share: the incoming
+            // surface settles forward from 97% while the outgoing recedes.
+            // Review pushes are not phase changes — they swap inside
+            // `resultsContent` with the manager zoom motion. Reduce Motion
+            // keeps the plain crossfade.
+            .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
+            .animation(VaderMotion.surface, value: phaseTransitionID)
             .navigationTitle(NavigationSection.smartScan.title)
             // Every transition out of `.results` clears any in-flight Review
             // (e.g. Start Over → idle, Run → cleaning, an external reset).
@@ -51,17 +63,17 @@ struct SmartScanView: View {
     }
 
     /// Stable per-phase token so moving between scan phases crossfades
-    /// instead of hard-cutting. Distinct phases (and the Review-vs-dashboard
-    /// split within `.results`) map to distinct strings; associated values
-    /// are intentionally ignored — only the phase identity drives the
-    /// transition.
+    /// instead of hard-cutting. Distinct phases map to distinct strings;
+    /// associated values are intentionally ignored — only the phase identity
+    /// drives the transition. The Review-vs-dashboard split within `.results`
+    /// is deliberately not part of the token: Review swaps animate with the
+    /// manager zoom motion inside `resultsContent`, and folding them into
+    /// this identity would replace that with the phase crossfade.
     private var phaseTransitionID: String {
         switch viewModel.phase {
         case .idle:     return "idle"
         case .scanning: return "scanning"
-        case .results:
-            if let review { return "review.\(review)" }
-            return "results"
+        case .results:  return "results"
         case .cleaning: return "cleaning"
         case .done:     return "done"
         case .failed:   return "failed"
@@ -113,47 +125,72 @@ struct SmartScanView: View {
 
     /// Within `.results`, route to the dashboard or to the active Review
     /// screen. Each Review pops back to the dashboard via `review = nil`.
+    /// The two surfaces exchange inside a ZStack (a stable transition host)
+    /// with the shared manager motion: the Review zooms up from the button
+    /// that opened it over the receding dashboard, and zooms back into it on
+    /// Back.
     @ViewBuilder
     private func resultsContent(result: SmartScanResult) -> some View {
-        if let review {
-            switch review {
-            case .systemJunk:
-                SmartScanJunkReview(
+        ZStack {
+            if let review {
+                reviewScreen(for: review, result: result)
+                    .transition(VaderMotion.managerTransition(anchor: managerAnchor, reduceMotion: reduceMotion))
+                    // Draw over the dashboard while the two overlap mid-swap.
+                    .zIndex(1)
+            } else {
+                SmartScanResultsState(
                     viewModel: viewModel,
                     result: result,
-                    onBack: { self.review = nil }
+                    onRequestReview: openReview,
+                    onStartOver: { viewModel.reset() }
                 )
-            case .malware:
-                SmartScanMalwareReview(
-                    viewModel: viewModel,
-                    result: result,
-                    onBack: { self.review = nil }
-                )
-            case .performance:
-                SmartScanPerformanceReview(
-                    result: result,
-                    onBack: { self.review = nil },
-                    onOpenPerformance: onOpenPerformance
-                )
-            case .applications:
-                SmartScanApplicationsReview(
-                    viewModel: viewModel,
-                    result: result,
-                    onBack: { self.review = nil }
-                )
-            case .myClutter:
-                SmartScanMyClutterReview(
-                    viewModel: viewModel,
-                    result: result,
-                    onBack: { self.review = nil }
-                )
+                .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
             }
-        } else {
-            SmartScanResultsState(
+        }
+        .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { paneFrame = $0 })
+        .animation(VaderMotion.managerZoom, value: review)
+    }
+
+    /// Anchors the zoom to the button (or failing that, the click) being
+    /// handled, then raises the module's Review screen.
+    private func openReview(_ module: SmartScanModule) {
+        managerAnchor = TriggerAnchor.resolve(in: paneFrame)
+        review = module
+    }
+
+    /// The tile-specific Review screen for one Smart Scan module.
+    @ViewBuilder
+    private func reviewScreen(for review: SmartScanModule, result: SmartScanResult) -> some View {
+        switch review {
+        case .systemJunk:
+            SmartScanJunkReview(
                 viewModel: viewModel,
                 result: result,
-                onRequestReview: { module in self.review = module },
-                onStartOver: { viewModel.reset() }
+                onBack: { self.review = nil }
+            )
+        case .malware:
+            SmartScanMalwareReview(
+                viewModel: viewModel,
+                result: result,
+                onBack: { self.review = nil }
+            )
+        case .performance:
+            SmartScanPerformanceReview(
+                result: result,
+                onBack: { self.review = nil },
+                onOpenPerformance: onOpenPerformance
+            )
+        case .applications:
+            SmartScanApplicationsReview(
+                viewModel: viewModel,
+                result: result,
+                onBack: { self.review = nil }
+            )
+        case .myClutter:
+            SmartScanMyClutterReview(
+                viewModel: viewModel,
+                result: result,
+                onBack: { self.review = nil }
             )
         }
     }

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -89,18 +89,11 @@ struct SmartScanView: View {
             // so the detail view is never built in this phase. The arm stays
             // only to keep the switch exhaustive over `Phase`.
             EmptyView()
-        case .scanning(let phase):
-            // Key the progress view on the current stage so a stage change
-            // rebuilds ScanningStatusView with the new phrase set — it shuffles
-            // its phrases once at init, so a fresh identity is what swaps the
-            // voice from the broad sweep to threats to the app check.
-            SmartScanProgressState(
-                label: phase,
-                identifier: "smartScan.scanning",
-                detail: viewModel.scanProgressDetail,
-                phrases: ScanPhrases.smartScanStage(viewModel.currentStage)
-            )
-            .id(viewModel.currentStage)
+        case .scanning:
+            // The staged scanning screen: one module heroes at a time while
+            // the others fill in with result summaries as their sub-scans
+            // are collected.
+            SmartScanScanningView(viewModel: viewModel)
         case .results(let result):
             resultsContent(result: result)
         case .cleaning:

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -39,6 +39,17 @@ enum SmartScanStage: Hashable {
     case checkingApps
 }
 
+/// One module's presentation state on the staged scanning screen: waiting its
+/// turn, the one whose results are being collected right now (the hero),
+/// finished with a short result summary, or skipped entirely (disabled in
+/// Customize Smart Care, or ClamAV absent for Malware).
+enum SmartScanModuleScanState: Equatable {
+    case pending
+    case running
+    case finished(metric: String, caption: String)
+    case skipped
+}
+
 /// One aggregated Smart Scan result, holding each sub-module's findings so the
 /// results screen can render a card per module. `clamAVAvailable` lets the
 /// Malware card hide its remove action when ClamAV is absent (the scan was
@@ -229,6 +240,72 @@ final class SmartScanViewModel {
     private(set) var junkWalkComplete = false
     private(set) var clutterWalkComplete = false
     private(set) var malwareScanComplete = false
+
+    /// Per-module presentation state for the staged scanning screen. Rebuilt
+    /// at the start of every scan; modules flip `.running` → `.finished` in
+    /// `Self.scanCollectionOrder` as `scan()` collects each sub-scan's
+    /// results, so the "one at a time" read tracks real checkpoints even
+    /// though the sub-scans run concurrently.
+    private(set) var moduleScanStates: [SmartScanModule: SmartScanModuleScanState] = [:]
+
+    /// The order the scanning screen walks the modules — the same order
+    /// `scan()` awaits the concurrently-running sub-scans.
+    static let scanCollectionOrder: [SmartScanModule] = [
+        .systemJunk, .myClutter, .performance, .malware, .applications,
+    ]
+
+    /// The module the scanning screen shows as its hero: the first still
+    /// running in collection order, or `nil` outside a scan.
+    var activeScanModule: SmartScanModule? {
+        Self.scanCollectionOrder.first { moduleScanStates[$0] == .running }
+    }
+
+    /// The staged screen's starting line-up: every module that will actually
+    /// run is `.pending` (Malware additionally requires ClamAV), the rest are
+    /// `.skipped`, and the first runnable module takes the hero slot.
+    static func startingModuleStates(
+        enabled: Set<SmartScanModule>,
+        clamAVAvailable: Bool
+    ) -> [SmartScanModule: SmartScanModuleScanState] {
+        var states: [SmartScanModule: SmartScanModuleScanState] = [:]
+        for module in scanCollectionOrder {
+            let runs = enabled.contains(module) && (module != .malware || clamAVAvailable)
+            states[module] = runs ? .pending : .skipped
+        }
+        if let first = scanCollectionOrder.first(where: { states[$0] == .pending }) {
+            states[first] = .running
+        }
+        return states
+    }
+
+    /// Records `module`'s result summary and hands the hero slot to the next
+    /// pending module in collection order. A skipped module's collection
+    /// point changes nothing — it never ran, so it must not surface a
+    /// summary or steal the hero.
+    static func finishing(
+        _ module: SmartScanModule,
+        in states: [SmartScanModule: SmartScanModuleScanState],
+        metric: String,
+        caption: String
+    ) -> [SmartScanModule: SmartScanModuleScanState] {
+        var updated = states
+        guard updated[module] == .running || updated[module] == .pending else { return updated }
+        updated[module] = .finished(metric: metric, caption: caption)
+        if let next = scanCollectionOrder.first(where: { updated[$0] == .pending }) {
+            updated[next] = .running
+        }
+        return updated
+    }
+
+    /// Shared `ByteCountFormatter` for the scanning screen's result
+    /// summaries ("33.4 GB of junk"). Static so the allocation happens once,
+    /// not per collection point.
+    private static let summaryByteFormatter: ByteCountFormatter = {
+        let f = ByteCountFormatter()
+        f.allowedUnits = .useAll
+        f.countStyle = .file
+        return f
+    }()
 
     /// Both file walks have finished enumerating the disk.
     private var fileWalksComplete: Bool { junkWalkComplete && clutterWalkComplete }
@@ -479,6 +556,10 @@ final class SmartScanViewModel {
         let mods = enabledModules()
         let cats = enabledJunkCategories()
 
+        // Line up the staged scanning screen: skipped modules are marked up
+        // front, and the first runnable module takes the hero slot.
+        moduleScanStates = Self.startingModuleStates(enabled: mods, clamAVAvailable: clamAVAvailable)
+
         async let junk = scanJunkIfEnabled(mods.contains(.systemJunk), onProgress: onJunkProgress)
         async let threats = scanForThreatsIfPossible(
             clamAVAvailable: clamAVAvailable && mods.contains(.malware),
@@ -500,14 +581,65 @@ final class SmartScanViewModel {
             // kept enabled in the Cleanup sub-tree. Done here (rather than in the
             // scanner) so the scanner stays category-agnostic and the same walk
             // serves every caller.
+            // Each collection point below also advances the staged scanning
+            // screen: the collected module flips to its result summary and
+            // the next runnable module takes the hero slot.
             let junkResult = Self.filteringJunkCategories(try await junk, to: cats)
             junkWalkComplete = true
+            moduleScanStates = Self.finishing(
+                .systemJunk, in: moduleScanStates,
+                metric: junkResult.totalSize > 0
+                    ? String(
+                        localized: "\(Self.summaryByteFormatter.string(fromByteCount: junkResult.totalSize)) of junk",
+                        comment: "Scanning-screen summary on the Cleanup tile; the interpolation is a byte count like '33.4 GB'."
+                    )
+                    : String(localized: "No junk", comment: "Zero-work scanning-screen summary on the Cleanup tile."),
+                caption: String(localized: "to clean", comment: "Caption under the Cleanup tile's scanning-screen summary.")
+            )
             let duplicates = await large
             clutterWalkComplete = true
+            let reclaimable = duplicates.reduce(Int64(0)) { $0 + $1.reclaimableBytes }
+            moduleScanStates = Self.finishing(
+                .myClutter, in: moduleScanStates,
+                metric: reclaimable > 0
+                    ? String(
+                        localized: "\(Self.summaryByteFormatter.string(fromByteCount: reclaimable)) of duplicates",
+                        comment: "Scanning-screen summary on the My Clutter tile; the interpolation is a byte count like '1.2 GB'."
+                    )
+                    : String(localized: "No duplicates", comment: "Zero-work scanning-screen summary on the My Clutter tile."),
+                caption: String(localized: "to review", comment: "Caption under the My Clutter tile's scanning-screen summary.")
+            )
             let loginItems = await login
+            moduleScanStates = Self.finishing(
+                .performance, in: moduleScanStates,
+                metric: loginItems.isEmpty
+                    ? String(localized: "No items", comment: "Zero-work scanning-screen summary on the Performance tile.")
+                    : loginItems.count == 1
+                        ? String(localized: "1 item", comment: "Singular scanning-screen summary on the Performance tile.")
+                        : String(localized: "\(loginItems.count) items", comment: "Plural scanning-screen summary on the Performance tile."),
+                caption: String(localized: "to review", comment: "Caption under the Performance tile's scanning-screen summary.")
+            )
             let foundThreats = await threats
             malwareScanComplete = true
+            moduleScanStates = Self.finishing(
+                .malware, in: moduleScanStates,
+                metric: foundThreats.isEmpty
+                    ? String(localized: "No threats", comment: "Zero-work scanning-screen summary on the Protection tile.")
+                    : foundThreats.count == 1
+                        ? String(localized: "1 threat", comment: "Singular scanning-screen summary on the Protection tile.")
+                        : String(localized: "\(foundThreats.count) threats", comment: "Plural scanning-screen summary on the Protection tile."),
+                caption: String(localized: "to remove", comment: "Caption under the Protection tile's scanning-screen summary.")
+            )
             let foundUpdates = await updates
+            moduleScanStates = Self.finishing(
+                .applications, in: moduleScanStates,
+                metric: foundUpdates.isEmpty
+                    ? String(localized: "No vital updates", comment: "Zero-work scanning-screen summary on the Applications tile.")
+                    : foundUpdates.count == 1
+                        ? String(localized: "1 update", comment: "Singular scanning-screen summary on the Applications tile.")
+                        : String(localized: "\(foundUpdates.count) updates", comment: "Plural scanning-screen summary on the Applications tile."),
+                caption: String(localized: "to install", comment: "Caption under the Applications tile's scanning-screen summary.")
+            )
 
             let result = SmartScanResult(
                 junkResult: junkResult,
@@ -917,6 +1049,7 @@ final class SmartScanViewModel {
         junkWalkComplete = false
         clutterWalkComplete = false
         malwareScanComplete = false
+        moduleScanStates = [:]
     }
 }
 

--- a/VaderCleaner/SmartScanViewSubviews.swift
+++ b/VaderCleaner/SmartScanViewSubviews.swift
@@ -15,7 +15,7 @@ struct SmartScanProgressState: View {
     var phrases: [String]? = nil
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 28) {
             ScanProgressIndicator()
             ScanningStatusView(
                 phrases: phrases ?? [label],

--- a/VaderCleaner/SpaceLensView.swift
+++ b/VaderCleaner/SpaceLensView.swift
@@ -56,7 +56,7 @@ struct SpaceLensView: View {
     // MARK: - Scanning / error
 
     private var scanningState: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 28) {
             ScanProgressIndicator()
             ScanningStatusView(
                 phrases: ScanPhrases.scanning(for: .spaceLens),

--- a/VaderCleaner/SystemJunkScanner.swift
+++ b/VaderCleaner/SystemJunkScanner.swift
@@ -25,8 +25,12 @@ struct SystemJunkScanner {
     /// `FileScanner` and must come from the privileged helper — currently the
     /// root-owned Document Versions store. Async + `@Sendable` so production can
     /// wrap `DocumentVersionsScanner`; the default is a no-op so unit tests stay
-    /// hermetic (no XPC) unless they wire one in.
-    typealias PrivilegedEnumerator = @Sendable () async -> [ScannedFile]
+    /// hermetic (no XPC) unless they wire one in. `reportVisited` receives the
+    /// enumerator's own cumulative visited-item count so the scanning screen's
+    /// tally keeps climbing through these phases (see `PhaseProgressRelay`).
+    /// Optional rather than bare so implementations can forward it into other
+    /// escaping `onProgress` parameters.
+    typealias PrivilegedEnumerator = @Sendable (_ reportVisited: (@Sendable (Int) -> Void)?) async -> [ScannedFile]
 
     private let fileScanner: FileScanning
     private let pathProvider: SystemPathProviding
@@ -36,8 +40,8 @@ struct SystemJunkScanner {
     init(
         fileScanner: FileScanning = FileScanner(),
         pathProvider: SystemPathProviding = DefaultSystemPathProvider(),
-        documentVersionsEnumerator: @escaping PrivilegedEnumerator = { [] },
-        developerProjectEnumerator: @escaping PrivilegedEnumerator = { [] }
+        documentVersionsEnumerator: @escaping PrivilegedEnumerator = { _ in [] },
+        developerProjectEnumerator: @escaping PrivilegedEnumerator = { _ in [] }
     ) {
         self.fileScanner = fileScanner
         self.pathProvider = pathProvider
@@ -57,8 +61,17 @@ struct SystemJunkScanner {
     static func live(projectScanRoots: [URL]? = nil) -> SystemJunkScanner {
         let roots = projectScanRoots ?? WebDevScanScopeStore().scanRoots
         return SystemJunkScanner(
-            documentVersionsEnumerator: { await DocumentVersionsScanner().scan() },
-            developerProjectEnumerator: { await DeveloperProjectScanner(roots: roots).scan() }
+            // The store is enumerated in one privileged XPC round trip, so
+            // the best available progress is a single bump by the returned
+            // count once it lands.
+            documentVersionsEnumerator: { reportVisited in
+                let files = await DocumentVersionsScanner().scan()
+                reportVisited?(files.count)
+                return files
+            },
+            developerProjectEnumerator: { reportVisited in
+                await DeveloperProjectScanner(roots: roots).scan(onProgress: reportVisited)
+            }
         )
     }
 
@@ -72,18 +85,66 @@ struct SystemJunkScanner {
         onProgress: (@Sendable (Int) -> Void)? = nil
     ) async throws -> ScanResult {
         let roots = pathProvider.roots()
-        let files = try await fileScanner.scan(roots: roots, excluding: excluding, onProgress: onProgress)
+        // One walked-count spans all three phases: the relay stacks each
+        // phase's own tally onto the finished phases' totals, so the count
+        // the scanning screen shows keeps climbing through the supplementary
+        // enumerations instead of freezing when the main walk completes.
+        let progress = PhaseProgressRelay(onProgress)
+        let files = try await fileScanner.scan(
+            roots: roots,
+            excluding: excluding,
+            onProgress: { progress.report($0) }
+        )
+        progress.finishPhase()
         // Document Versions live in a root-owned store the in-process walk can't
         // read, so they come from the privileged enumerator and are merged in.
         // The default enumerator returns nothing, so this is a no-op unless the
         // production scanner wired one in.
-        let documentVersions = await documentVersionsEnumerator()
+        let documentVersions = await documentVersionsEnumerator { progress.report($0) }
+        progress.finishPhase()
         // Scattered web/dev project artifacts (node_modules, dist, …) live at
         // arbitrary depths under the user's code directories, so they come from
         // the developer-project enumerator rather than a fixed scan root. The
         // default enumerator returns nothing, so this is a no-op unless the
         // production scanner wired one in.
-        let developerProjects = await developerProjectEnumerator()
+        let developerProjects = await developerProjectEnumerator { progress.report($0) }
         return ScanResult(items: files + documentVersions + developerProjects)
+    }
+}
+
+/// Stacks each scan phase's own cumulative walked-count onto the totals of
+/// the phases already finished, forwarding one ever-climbing number to the
+/// caller's `onProgress`. Each phase counts from zero in its own terms;
+/// without the relay, the hand-off from the main walk to the supplementary
+/// enumerators would reset (or freeze) the count the scanning screen shows.
+/// Thread-safe because phases report from their own tasks.
+private final class PhaseProgressRelay: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completedPhasesTotal = 0
+    private var currentPhaseCount = 0
+    private let onProgress: (@Sendable (Int) -> Void)?
+
+    init(_ onProgress: (@Sendable (Int) -> Void)?) {
+        self.onProgress = onProgress
+    }
+
+    /// Reports the running phase's own cumulative count, forwarding the
+    /// all-phases total. Kept monotonic within the phase so an out-of-order
+    /// tick can't move the number backwards.
+    func report(_ count: Int) {
+        lock.lock()
+        currentPhaseCount = max(currentPhaseCount, count)
+        let total = completedPhasesTotal + currentPhaseCount
+        lock.unlock()
+        onProgress?(total)
+    }
+
+    /// Seals the finished phase's tally into the running base before the next
+    /// phase starts its own count from zero.
+    func finishPhase() {
+        lock.lock()
+        completedPhasesTotal += currentPhaseCount
+        currentPhaseCount = 0
+        lock.unlock()
     }
 }

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -18,6 +18,7 @@ struct SystemJunkView: View {
 
     private var viewModel: SystemJunkViewModel
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Whether the Cleanup Manager (the three-pane Review) is showing over the
     /// dashboard. Pure navigation state held on the view; reset to the dashboard
@@ -27,6 +28,16 @@ struct SystemJunkView: View {
     /// Deep-link target for the manager when opened from a card's Review.
     @State private var managerInitialSection: String?
     @State private var managerInitialCategory: String?
+    /// Where the manager zoom anchors: the button that opened it, resolved
+    /// by `openManager`. Also the point Back zooms the manager back into.
+    @State private var managerAnchor: UnitPoint = .center
+    /// The transition host's frame in global space, for mapping the opening
+    /// click to `managerAnchor`.
+    @State private var paneFrame: CGRect = .zero
+    /// The title-bar safe-area inset the transition host permanently claims;
+    /// handed back to the dashboard as top padding so only the manager
+    /// extends under the title bar.
+    @State private var paneTopInset: CGFloat = 0
 
     /// Persistent, prebuilt model for the Cleanup Manager. Warmed in the
     /// background as soon as a scan finishes so opening Review paints instantly,
@@ -83,7 +94,7 @@ struct SystemJunkView: View {
     // MARK: - States
 
     private func progressState(label: String, identifier: String, detail: String? = nil, phrases: [String]? = nil) -> some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 28) {
             ScanProgressIndicator()
             ScanningStatusView(
                 phrases: phrases ?? [label],
@@ -114,43 +125,77 @@ struct SystemJunkView: View {
     }
 
     /// The results surface: the category dashboard, or the three-pane Cleanup
-    /// Manager when the user taps Review / Review All Junk.
+    /// Manager when the user taps Review / Review All Junk. The two surfaces
+    /// exchange inside a ZStack (a stable transition host) with the shared
+    /// manager motion: the manager zooms up from the button that opened it
+    /// over the receding dashboard, and zooms back into it on Back.
     @ViewBuilder
     private func resultsContent(result: ScanResult) -> some View {
-        if showingManager {
-            managerScreen(result: result)
-        } else {
-            // No scroll view: the dashboard fills the detail pane and divides
-            // the available height between the header and the tile grid, like
-            // the Large & Old Files section.
-            SystemJunkDashboardView(
-                totalBytes: result.totalSize,
-                tiles: CleanupDashboardTile.recommended(from: result),
-                accent: NavigationSection.systemJunk.theme.accent,
-                onReview: { group in
-                    // Pre-select this card's whole group so the right pane opens
-                    // all-checked and the selected total matches the card's size.
-                    viewModel.selectOnly(categories: Set(group.categories))
-                    // Deep link: open the manager at this card's section and the
-                    // sub-category the card maps to.
-                    let category = group.managerCategory
-                    managerInitialSection = category.flatMap(CleanupManagerModel.sectionID(containing:))
-                        ?? CleanupManagerModel.groups.first?.id
-                    managerInitialCategory = category?.rawValue
-                    showingManager = true
-                },
-                onClean: { group in
-                    Task { await viewModel.clean(categories: Set(group.categories)) }
-                },
-                onReviewAll: {
-                    // The full manager, default first section/category.
-                    managerInitialSection = nil
-                    managerInitialCategory = nil
-                    showingManager = true
-                },
-                onStartOver: viewModel.scanAgain
-            )
+        ZStack {
+            if showingManager {
+                managerScreen(result: result)
+                    .transition(VaderMotion.managerTransition(anchor: managerAnchor, reduceMotion: reduceMotion))
+                    // Draw over the dashboard while the two overlap mid-swap.
+                    .zIndex(1)
+            } else {
+                dashboard(result: result)
+                    // The dashboard keeps its usual place below the title
+                    // bar: the host ZStack claims that inset permanently, so
+                    // it is handed back here as explicit padding.
+                    .padding(.top, paneTopInset)
+                    .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
+            }
         }
+        // Claim the title-bar safe area on this stable container, never on a
+        // transitioning branch: safe-area changes anywhere inside a freshly
+        // inserted transition subtree are deferred until its spring fully
+        // settles, which read as the manager stuck below a title-bar-height
+        // gap for a beat after opening.
+        .ignoresSafeArea(.container, edges: .top)
+        .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { paneFrame = $0 })
+        .onGeometryChange(for: CGFloat.self, of: { $0.safeAreaInsets.top }, action: { paneTopInset = $0 })
+        .animation(VaderMotion.managerZoom, value: showingManager)
+    }
+
+    /// Anchors the zoom to the button (or failing that, the click) being
+    /// handled, then raises the manager.
+    private func openManager() {
+        managerAnchor = TriggerAnchor.resolve(in: paneFrame)
+        showingManager = true
+    }
+
+    /// The post-scan category dashboard grid.
+    private func dashboard(result: ScanResult) -> some View {
+        // No scroll view: the dashboard fills the detail pane and divides
+        // the available height between the header and the tile grid, like
+        // the Large & Old Files section.
+        SystemJunkDashboardView(
+            totalBytes: result.totalSize,
+            tiles: CleanupDashboardTile.recommended(from: result),
+            accent: NavigationSection.systemJunk.theme.accent,
+            onReview: { group in
+                // Pre-select this card's whole group so the right pane opens
+                // all-checked and the selected total matches the card's size.
+                viewModel.selectOnly(categories: Set(group.categories))
+                // Deep link: open the manager at this card's section and the
+                // sub-category the card maps to.
+                let category = group.managerCategory
+                managerInitialSection = category.flatMap(CleanupManagerModel.sectionID(containing:))
+                    ?? CleanupManagerModel.groups.first?.id
+                managerInitialCategory = category?.rawValue
+                openManager()
+            },
+            onClean: { group in
+                Task { await viewModel.clean(categories: Set(group.categories)) }
+            },
+            onReviewAll: {
+                // The full manager, default first section/category.
+                managerInitialSection = nil
+                managerInitialCategory = nil
+                openManager()
+            },
+            onStartOver: viewModel.scanAgain
+        )
     }
 
     /// The shared three-pane Cleanup Manager (sections → categories → files),

--- a/VaderCleaner/TriggerAnchor.swift
+++ b/VaderCleaner/TriggerAnchor.swift
@@ -1,0 +1,111 @@
+// TriggerAnchor.swift
+// Resolves where the manager zoom anchors: the button (or click) that opened the manager, mapped into the transition host's unit space.
+
+import SwiftUI
+import AppKit
+
+/// Maps the interaction that opens a manager to the zoom's anchor point, so
+/// the manager scales up out of the control that was pressed and back into
+/// it on Back. Prefers the pressed button's center (recorded by the Vader
+/// button styles via `TriggerPressRegistry`), then the raw click location,
+/// then the pane's center for pointer-less opens.
+enum TriggerAnchor {
+
+    /// The anchor for the open currently being handled.
+    @MainActor
+    static func resolve(in paneFrame: CGRect) -> UnitPoint {
+        if let press = TriggerPressRegistry.shared.consumeRecentPress() {
+            return unitPoint(for: CGPoint(x: press.midX, y: press.midY), in: paneFrame)
+        }
+        return click(in: paneFrame)
+    }
+
+    /// The current mouse event's location mapped into `paneFrame` (the
+    /// transition host's frame in SwiftUI's global space). Falls back to the
+    /// center when there is no usable pointer event — e.g. keyboard
+    /// activation or a programmatic open.
+    @MainActor
+    static func click(in paneFrame: CGRect) -> UnitPoint {
+        guard let event = NSApp.currentEvent,
+              let contentView = event.window?.contentView else {
+            return .center
+        }
+        // Window base coords → content-view coords, then into the top-left
+        // origin SwiftUI's global space uses (NSHostingView is flipped, but
+        // guard on it rather than assume).
+        let inContent = contentView.convert(event.locationInWindow, from: nil)
+        let point = contentView.isFlipped
+            ? inContent
+            : CGPoint(x: inContent.x, y: contentView.bounds.height - inContent.y)
+        return unitPoint(for: point, in: paneFrame)
+    }
+
+    /// `point` mapped into `pane`'s unit space, clamped to the pane's edges.
+    /// A degenerate pane (not yet laid out) yields the center instead of
+    /// dividing by zero.
+    static func unitPoint(for point: CGPoint, in pane: CGRect) -> UnitPoint {
+        guard pane.width > 0, pane.height > 0 else { return .center }
+        return UnitPoint(
+            x: min(max((point.x - pane.minX) / pane.width, 0), 1),
+            y: min(max((point.y - pane.minY) / pane.height, 0), 1)
+        )
+    }
+}
+
+/// Records the frame of the most recently pressed styled button, so a
+/// manager-opening action (which runs on the same click's mouse-up) can
+/// anchor the zoom on the exact button that triggered it. The Vader button
+/// styles feed this on every press; consumers take the press at most once,
+/// and presses older than `freshness` are discarded — a manager opened by
+/// keyboard or deep link should not anchor to some long-ago click.
+@MainActor
+final class TriggerPressRegistry {
+    static let shared = TriggerPressRegistry()
+    /// How long a press stays claimable. Generous enough for a slow click
+    /// (mouse-down … mouse-up), far too short to survive between unrelated
+    /// interactions.
+    static let freshness: TimeInterval = 10
+
+    private var lastPress: (frame: CGRect, at: Date)?
+
+    /// Called by the button styles on mouse-down with the button's frame in
+    /// SwiftUI's global space.
+    func recordPress(frame: CGRect, at date: Date = Date()) {
+        lastPress = (frame, date)
+    }
+
+    /// The pressed button's frame if one was recorded within `freshness`,
+    /// cleared on read so it anchors at most one open.
+    func consumeRecentPress(at date: Date = Date()) -> CGRect? {
+        defer { lastPress = nil }
+        guard let lastPress, date.timeIntervalSince(lastPress.at) < Self.freshness else {
+            return nil
+        }
+        return lastPress.frame
+    }
+}
+
+/// Tracks its view's global frame and reports it to `TriggerPressRegistry`
+/// whenever the press begins, so every styled button can anchor a manager
+/// zoom with zero call-site wiring. Attached inside the Vader button styles,
+/// which already know the press state.
+private struct TriggerPressRecorder: ViewModifier {
+    let isPressed: Bool
+    @State private var frame: CGRect = .zero
+
+    func body(content: Content) -> some View {
+        content
+            .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { frame = $0 })
+            .onChange(of: isPressed) { _, pressed in
+                if pressed { TriggerPressRegistry.shared.recordPress(frame: frame) }
+            }
+    }
+}
+
+extension View {
+    /// Reports this view's frame to `TriggerPressRegistry` when `isPressed`
+    /// flips on; see `TriggerPressRecorder`.
+    func recordsTriggerPress(isPressed: Bool) -> some View {
+        modifier(TriggerPressRecorder(isPressed: isPressed))
+    }
+}

--- a/VaderCleaner/VaderMotion.swift
+++ b/VaderCleaner/VaderMotion.swift
@@ -1,0 +1,58 @@
+// VaderMotion.swift
+// Shared motion vocabulary: the springs and surface transitions that give every control press, hover fill, and manager push the same macOS Tahoe-style response.
+
+import SwiftUI
+
+/// The app-wide motion vocabulary. Controls answer a click with a quick
+/// springy press, hover fills fade rather than snap, and full-screen
+/// surfaces (a manager zooming over its dashboard) exchange with a soft
+/// scale-and-fade that reads as depth — the way macOS Tahoe's Liquid Glass
+/// surfaces respond. Centralised so every screen speaks with one motion
+/// accent instead of per-view one-off curves.
+enum VaderMotion {
+    /// Quick spring for direct-manipulation feedback: button presses and
+    /// checkbox flips. Snappy enough to track the pointer, with a touch of
+    /// bounce on the release so controls feel elastic rather than mechanical.
+    static let control: Animation = .snappy(duration: 0.22, extraBounce: 0.06)
+    /// Short fade for hover fills and selection pills — pointer feedback
+    /// should ease in, not blink, and carries no bounce.
+    static let hover: Animation = .easeOut(duration: 0.18)
+    /// Soft spring for full-surface exchanges — the sections' scan-phase
+    /// swaps and the dashboard recede.
+    static let surface: Animation = .smooth(duration: 0.45)
+    /// The manager zoom's clock: a quick snappy spring — fast enough to stay
+    /// out of the way on the hundredth open, with just enough bounce to feel
+    /// alive.
+    static let managerZoom: Animation = .snappy(duration: 0.4)
+
+    /// How far a pressed control shrinks: 96% reads as the Tahoe glass press
+    /// dip without making the label swim.
+    static let pressedScale: CGFloat = 0.96
+
+    /// Scale a control should render at for a given press state. Reduce
+    /// Motion pins the control at full size — the press still reads through
+    /// each style's opacity dip.
+    static func pressScale(isPressed: Bool, reduceMotion: Bool) -> CGFloat {
+        guard isPressed, !reduceMotion else { return 1 }
+        return pressedScale
+    }
+
+    /// Transition for a manager surface: an anchored zoom in the platform
+    /// idiom — the manager scales up from 90% at `anchor` (the button that
+    /// triggered it, resolved via `TriggerAnchor`) while fading in, and
+    /// zooms back into the same point on Back. One uniform scale, no
+    /// distortion — calm enough to survive constant use, anchored enough to
+    /// keep the "it came from here" read. Reduce Motion collapses it to a
+    /// plain crossfade.
+    static func managerTransition(anchor: UnitPoint = .center, reduceMotion: Bool) -> AnyTransition {
+        reduceMotion ? .opacity : .scale(scale: 0.9, anchor: anchor).combined(with: .opacity)
+    }
+
+    /// Transition for the dashboard beneath a manager: a subtler recede to
+    /// 97% and fade while the manager covers it, returning forward when the
+    /// manager closes. Reduce Motion collapses it to a plain crossfade.
+    static func dashboardTransition(reduceMotion: Bool) -> AnyTransition {
+        reduceMotion ? .opacity : .scale(scale: 0.97).combined(with: .opacity)
+    }
+}
+

--- a/VaderCleaner/VaderTheme.swift
+++ b/VaderCleaner/VaderTheme.swift
@@ -260,6 +260,7 @@ struct VaderProminentButtonStyle: ButtonStyle {
         @Environment(\.sectionAccent) private var accent
         @Environment(\.isEnabled) private var isEnabled
         @Environment(\.controlSize) private var controlSize
+        @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
         /// Large/extra-large controls get a taller capsule so the primary
         /// action bars keep the heft of a `.controlSize(.large)` button.
@@ -273,8 +274,10 @@ struct VaderProminentButtonStyle: ButtonStyle {
                 .padding(.vertical, isLarge ? 9 : 6)
                 .background(Capsule().fill(accent.deepenedForWhite))
                 .opacity(isEnabled ? (configuration.isPressed ? 0.82 : 1.0) : 0.45)
+                .scaleEffect(VaderMotion.pressScale(isPressed: configuration.isPressed, reduceMotion: reduceMotion))
                 .contentShape(Capsule())
-                .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+                .animation(VaderMotion.control, value: configuration.isPressed)
+                .recordsTriggerPress(isPressed: configuration.isPressed)
         }
     }
 }
@@ -309,6 +312,7 @@ struct VaderGlassButtonStyle: ButtonStyle {
         let configuration: Configuration
         let matchesTileSurface: Bool
         @Environment(\.controlSize) private var controlSize
+        @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
         /// Large/extra-large controls get the header pills' roomier capsule;
         /// the default size stays compact enough for two capsules to share a
@@ -329,8 +333,10 @@ struct VaderGlassButtonStyle: ButtonStyle {
                     in: .capsule
                 )
                 .opacity(configuration.isPressed ? 0.82 : 1.0)
+                .scaleEffect(VaderMotion.pressScale(isPressed: configuration.isPressed, reduceMotion: reduceMotion))
                 .contentShape(Capsule())
-                .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+                .animation(VaderMotion.control, value: configuration.isPressed)
+                .recordsTriggerPress(isPressed: configuration.isPressed)
         }
     }
 }
@@ -355,6 +361,7 @@ struct VaderWhiteButtonStyle: ButtonStyle {
     private struct WhiteLabel: View {
         let configuration: Configuration
         @Environment(\.controlSize) private var controlSize
+        @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
         private var isLarge: Bool { controlSize == .large || controlSize == .extraLarge }
 
@@ -369,8 +376,10 @@ struct VaderWhiteButtonStyle: ButtonStyle {
                 .padding(.vertical, isLarge ? 9 : 6)
                 .background(Capsule().fill(.white))
                 .opacity(configuration.isPressed ? 0.82 : 1.0)
+                .scaleEffect(VaderMotion.pressScale(isPressed: configuration.isPressed, reduceMotion: reduceMotion))
                 .contentShape(Capsule())
-                .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+                .animation(VaderMotion.control, value: configuration.isPressed)
+                .recordsTriggerPress(isPressed: configuration.isPressed)
         }
     }
 }

--- a/VaderCleanerTests/DeveloperProjectScannerTests.swift
+++ b/VaderCleanerTests/DeveloperProjectScannerTests.swift
@@ -130,4 +130,24 @@ final class DeveloperProjectScannerTests: XCTestCase {
         let results = await scanner.scan()
         XCTAssertTrue(results.isEmpty)
     }
+
+    // MARK: - Progress
+
+    /// The walk reports its cumulative visited tally — directory entries plus
+    /// every file sized inside matched artifact folders — so the Cleanup
+    /// scanning screen's count keeps moving through big `node_modules` trees.
+    func test_scan_reportsTheVisitedTallyThroughOnProgress() async throws {
+        let modules = try makeDir("app/node_modules/pkg")
+        try TestHelpers.createDummyFiles(count: 4, size: 8, in: modules)
+        let recorder = TestHelpers.ProgressRecorder()
+        let scanner = DeveloperProjectScanner(roots: [tempRoot])
+
+        _ = await scanner.scan(onProgress: { recorder.record($0) })
+
+        let values = recorder.snapshot
+        XCTAssertEqual(values, values.sorted(), "visited tally must be monotonic")
+        // At minimum the app dir, the node_modules match, and the four sized
+        // files inside it were visited; the final tick reports the total.
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(values.last), 6)
+    }
 }

--- a/VaderCleanerTests/RailCollapseTests.swift
+++ b/VaderCleanerTests/RailCollapseTests.swift
@@ -1,0 +1,45 @@
+// RailCollapseTests.swift
+// Pins the navigation rail's collapse rule: icons-only while the active section is out of its intro, and latched collapsed for the rest of the session once that has happened even once.
+
+import XCTest
+@testable import VaderCleaner
+
+final class RailCollapseTests: XCTestCase {
+
+    func testRailStaysExpandedOnAnIntroBeforeAnyCollapse() {
+        XCTAssertFalse(ContentView.railCollapsed(
+            activePresentation: .intro, collapsedOnceThisSession: false
+        ))
+    }
+
+    func testRailStaysExpandedOnANonScannableSectionBeforeAnyCollapse() {
+        // Health Monitor has no scan flow (nil presentation) and keeps the
+        // expanded rail until some section has collapsed it.
+        XCTAssertFalse(ContentView.railCollapsed(
+            activePresentation: nil, collapsedOnceThisSession: false
+        ))
+    }
+
+    func testRailCollapsesWhenTheActiveSectionLeavesItsIntro() {
+        XCTAssertTrue(ContentView.railCollapsed(
+            activePresentation: .working, collapsedOnceThisSession: false
+        ))
+        XCTAssertTrue(ContentView.railCollapsed(
+            activePresentation: .results, collapsedOnceThisSession: false
+        ))
+    }
+
+    func testRailStaysCollapsedForTheSessionOnceLatched() {
+        // Returning to an intro (Start Over) or a non-scannable section no
+        // longer re-expands the rail once any section has collapsed it.
+        XCTAssertTrue(ContentView.railCollapsed(
+            activePresentation: .intro, collapsedOnceThisSession: true
+        ))
+        XCTAssertTrue(ContentView.railCollapsed(
+            activePresentation: nil, collapsedOnceThisSession: true
+        ))
+        XCTAssertTrue(ContentView.railCollapsed(
+            activePresentation: .results, collapsedOnceThisSession: true
+        ))
+    }
+}

--- a/VaderCleanerTests/ScanProgressIndicatorTests.swift
+++ b/VaderCleanerTests/ScanProgressIndicatorTests.swift
@@ -1,0 +1,17 @@
+// ScanProgressIndicatorTests.swift
+// Pins the scan indicator's hero sizing: the default diameter every loading screen shares.
+
+import XCTest
+@testable import VaderCleaner
+
+final class ScanProgressIndicatorTests: XCTestCase {
+
+    func testDefaultDiameterIsTheSharedHeroSize() {
+        // Every scan/clean loading screen builds `ScanProgressIndicator()`
+        // with no explicit size, so this default is the single knob for how
+        // large the loader reads app-wide. Pinned so a stray per-screen
+        // override or an accidental default change can't quietly shrink the
+        // hero treatment back down.
+        XCTAssertEqual(ScanProgressIndicator().size, 220)
+    }
+}

--- a/VaderCleanerTests/SmartScanViewModelTests.swift
+++ b/VaderCleanerTests/SmartScanViewModelTests.swift
@@ -1541,6 +1541,100 @@ final class SmartScanViewModelTests: XCTestCase {
 
     // MARK: - Helpers
 
+    // MARK: - Staged scanning states
+
+    func test_startingModuleStates_runsTheFirstModuleAndQueuesTheRest() {
+        let states = SmartScanViewModel.startingModuleStates(
+            enabled: Set(SmartScanModule.allCases),
+            clamAVAvailable: true
+        )
+        XCTAssertEqual(states[.systemJunk], .running)
+        XCTAssertEqual(states[.myClutter], .pending)
+        XCTAssertEqual(states[.performance], .pending)
+        XCTAssertEqual(states[.malware], .pending)
+        XCTAssertEqual(states[.applications], .pending)
+    }
+
+    func test_startingModuleStates_skipsDisabledModulesAndMissingClamAV() {
+        let states = SmartScanViewModel.startingModuleStates(
+            enabled: [.malware, .performance],
+            clamAVAvailable: false
+        )
+        XCTAssertEqual(states[.systemJunk], .skipped)
+        XCTAssertEqual(states[.myClutter], .skipped)
+        // Malware is enabled but ClamAV is absent, so its sub-scan never runs.
+        XCTAssertEqual(states[.malware], .skipped)
+        // The first module that will actually run takes the hero slot.
+        XCTAssertEqual(states[.performance], .running)
+    }
+
+    func test_finishing_recordsTheSummaryAndPromotesTheNextPendingModule() {
+        var states = SmartScanViewModel.startingModuleStates(
+            enabled: Set(SmartScanModule.allCases),
+            clamAVAvailable: true
+        )
+        states = SmartScanViewModel.finishing(
+            .systemJunk, in: states, metric: "1.5 GB of junk", caption: "to clean"
+        )
+        XCTAssertEqual(states[.systemJunk], .finished(metric: "1.5 GB of junk", caption: "to clean"))
+        XCTAssertEqual(states[.myClutter], .running)
+        XCTAssertEqual(states[.performance], .pending)
+    }
+
+    func test_finishing_promotionSkipsOverSkippedModules() {
+        var states = SmartScanViewModel.startingModuleStates(
+            enabled: Set(SmartScanModule.allCases).subtracting([.myClutter, .performance]),
+            clamAVAvailable: true
+        )
+        states = SmartScanViewModel.finishing(
+            .systemJunk, in: states, metric: "No junk", caption: "to clean"
+        )
+        // My Clutter and Performance are skipped, so Malware runs next.
+        XCTAssertEqual(states[.myClutter], .skipped)
+        XCTAssertEqual(states[.performance], .skipped)
+        XCTAssertEqual(states[.malware], .running)
+    }
+
+    func test_finishing_aSkippedModulesCollectionPointChangesNothing() {
+        let states = SmartScanViewModel.startingModuleStates(
+            enabled: Set(SmartScanModule.allCases).subtracting([.myClutter]),
+            clamAVAvailable: true
+        )
+        let after = SmartScanViewModel.finishing(
+            .myClutter, in: states, metric: "No duplicates", caption: "to review"
+        )
+        XCTAssertEqual(after, states)
+    }
+
+    func test_scan_finishesEveryModuleWithItsSummary() async {
+        let junkFile = makeFile(name: "cache.db", size: 1_500_000_000, category: .userCache)
+        let vm = makeViewModel(
+            junkScanner: { [junkFile] in ScanResult(items: [junkFile]) },
+            malwareScanner: { [] },
+            loginItemsLoader: {
+                [LoginItem(id: "com.example.helper", name: "Helper", isEnabled: true)]
+            },
+            duplicatesScanner: { [] },
+            updatesChecker: { [] }
+        )
+
+        await vm.scan()
+
+        guard case .finished(let junkMetric, let junkCaption) = vm.moduleScanStates[.systemJunk] else {
+            return XCTFail("System Junk should finish with a summary")
+        }
+        XCTAssertTrue(junkMetric.hasSuffix("of junk"), "got \(junkMetric)")
+        XCTAssertEqual(junkCaption, "to clean")
+        XCTAssertEqual(vm.moduleScanStates[.malware], .finished(metric: "No threats", caption: "to remove"))
+        XCTAssertEqual(vm.moduleScanStates[.performance], .finished(metric: "1 item", caption: "to review"))
+        XCTAssertEqual(vm.moduleScanStates[.applications], .finished(metric: "No vital updates", caption: "to install"))
+        XCTAssertEqual(vm.moduleScanStates[.myClutter], .finished(metric: "No duplicates", caption: "to review"))
+        // Nothing is left running once the results are in.
+        XCTAssertNil(vm.activeScanModule)
+    }
+
+    // MARK: - Factory helpers
+
     private func makeViewModel(
         junkScanner: @escaping () async throws -> ScanResult = { ScanResult(items: []) },
         malwareInstalled: @escaping SmartScanViewModel.MalwareInstalled = { true },

--- a/VaderCleanerTests/SystemJunkScannerTests.swift
+++ b/VaderCleanerTests/SystemJunkScannerTests.swift
@@ -237,7 +237,7 @@ final class SystemJunkScannerTests: XCTestCase {
             pathProvider: StubSystemPathProvider(roots: [
                 ScanRoot(url: userCaches, category: .userCache)
             ]),
-            developerProjectEnumerator: { [nodeModules] }
+            developerProjectEnumerator: { _ in [nodeModules] }
         )
 
         let result = try await scanner.scan(excluding: [])
@@ -266,6 +266,35 @@ final class SystemJunkScannerTests: XCTestCase {
         _ = try await scanner.scan(excluding: [], onProgress: { recorder.record($0) })
 
         XCTAssertEqual(recorder.snapshot, [512, 1024, 2000])
+    }
+
+    /// The walked count must keep climbing through the supplementary
+    /// enumerators instead of freezing when the main file walk completes:
+    /// each phase reports its own tally, stacked on the finished phases'
+    /// totals. Without this the scanning screen's count froze while the
+    /// (potentially long) Document Versions and developer-project walks ran.
+    func test_scan_progressKeepsClimbingThroughSupplementaryEnumerators() async throws {
+        let scanner = SystemJunkScanner(
+            fileScanner: ProgressEmittingFakeFileScanner(progressTicks: [512, 1024]),
+            pathProvider: StubSystemPathProvider(roots: [
+                ScanRoot(url: tempRoot, category: .userCache)
+            ]),
+            documentVersionsEnumerator: { reportVisited in
+                reportVisited?(100)
+                return []
+            },
+            developerProjectEnumerator: { reportVisited in
+                reportVisited?(50)
+                return []
+            }
+        )
+        let recorder = TestHelpers.ProgressRecorder()
+
+        _ = try await scanner.scan(excluding: [], onProgress: { recorder.record($0) })
+
+        // 512, 1024 from the main walk; 1024 + 100 once Document Versions
+        // reports; 1024 + 100 + 50 once the developer-project walk reports.
+        XCTAssertEqual(recorder.snapshot, [512, 1024, 1124, 1174])
     }
 
     // MARK: - Helpers

--- a/VaderCleanerTests/TriggerAnchorTests.swift
+++ b/VaderCleanerTests/TriggerAnchorTests.swift
@@ -1,0 +1,77 @@
+// TriggerAnchorTests.swift
+// Pins the click-to-anchor mapping for the manager zoom (pane-relative unit coordinates, clamping, center fallback) and the press registry the button styles feed.
+
+import XCTest
+import SwiftUI
+@testable import VaderCleaner
+
+final class TriggerAnchorTests: XCTestCase {
+
+    /// A detail pane sitting to the right of the navigation rail, matching
+    /// how the transition host is framed in window space.
+    private let pane = CGRect(x: 240, y: 0, width: 900, height: 700)
+
+    func testPointAtPaneCenterMapsToCenterAnchor() {
+        let anchor = TriggerAnchor.unitPoint(for: CGPoint(x: 690, y: 350), in: pane)
+        XCTAssertEqual(anchor.x, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(anchor.y, 0.5, accuracy: 0.0001)
+    }
+
+    func testPointMapsRelativeToThePaneOriginNotTheWindow() {
+        // A click near the pane's top-leading corner is a small unit value
+        // even though its window x is large — the rail offset must not leak
+        // into the anchor.
+        let anchor = TriggerAnchor.unitPoint(for: CGPoint(x: 330, y: 70), in: pane)
+        XCTAssertEqual(anchor.x, 0.1, accuracy: 0.0001)
+        XCTAssertEqual(anchor.y, 0.1, accuracy: 0.0001)
+    }
+
+    func testCornersMapToUnitCorners() {
+        XCTAssertEqual(TriggerAnchor.unitPoint(for: CGPoint(x: 240, y: 0), in: pane), UnitPoint(x: 0, y: 0))
+        XCTAssertEqual(TriggerAnchor.unitPoint(for: CGPoint(x: 1140, y: 700), in: pane), UnitPoint(x: 1, y: 1))
+    }
+
+    func testPointsOutsideThePaneAreClampedToItsEdges() {
+        let outside = TriggerAnchor.unitPoint(for: CGPoint(x: 100, y: 900), in: pane)
+        XCTAssertEqual(outside.x, 0)
+        XCTAssertEqual(outside.y, 1)
+    }
+
+    func testDegeneratePaneFallsBackToTheCenterAnchor() {
+        let anchor = TriggerAnchor.unitPoint(for: CGPoint(x: 100, y: 100), in: .zero)
+        XCTAssertEqual(anchor, .center)
+    }
+}
+
+/// Pins the press registry the button styles feed: a fresh press is consumed
+/// exactly once, and stale presses are ignored.
+@MainActor
+final class TriggerPressRegistryTests: XCTestCase {
+
+    func testFreshPressIsConsumedExactlyOnce() {
+        let registry = TriggerPressRegistry()
+        let frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        let now = Date()
+        registry.recordPress(frame: frame, at: now)
+        XCTAssertEqual(registry.consumeRecentPress(at: now.addingTimeInterval(1)), frame)
+        XCTAssertNil(registry.consumeRecentPress(at: now.addingTimeInterval(1)))
+    }
+
+    func testStalePressIsIgnored() {
+        let registry = TriggerPressRegistry()
+        let now = Date()
+        registry.recordPress(frame: CGRect(x: 0, y: 0, width: 10, height: 10), at: now)
+        XCTAssertNil(registry.consumeRecentPress(
+            at: now.addingTimeInterval(TriggerPressRegistry.freshness + 1)
+        ))
+    }
+
+    func testLaterPressReplacesAnEarlierOne() {
+        let registry = TriggerPressRegistry()
+        let now = Date()
+        registry.recordPress(frame: CGRect(x: 0, y: 0, width: 10, height: 10), at: now)
+        let latest = CGRect(x: 5, y: 5, width: 20, height: 20)
+        registry.recordPress(frame: latest, at: now.addingTimeInterval(0.2))
+        XCTAssertEqual(registry.consumeRecentPress(at: now.addingTimeInterval(0.4)), latest)
+    }
+}

--- a/VaderCleanerTests/VaderMotionTests.swift
+++ b/VaderCleanerTests/VaderMotionTests.swift
@@ -1,0 +1,44 @@
+// VaderMotionTests.swift
+// Unit tests for VaderMotion's pure press-scale helper — the control-press shrink and its Reduce Motion opt-out.
+
+import XCTest
+import SwiftUI
+@testable import VaderCleaner
+
+final class VaderMotionTests: XCTestCase {
+
+    func testPressedControlShrinksToThePressedScale() {
+        XCTAssertEqual(
+            VaderMotion.pressScale(isPressed: true, reduceMotion: false),
+            VaderMotion.pressedScale
+        )
+    }
+
+    func testPressedScaleIsAGentleShrinkNotACollapse() {
+        // The Tahoe press reads as a subtle dip: visibly smaller than full
+        // size, but never below 90% where the label would swim.
+        XCTAssertLessThan(VaderMotion.pressedScale, 1)
+        XCTAssertGreaterThanOrEqual(VaderMotion.pressedScale, 0.9)
+    }
+
+    func testUnpressedControlStaysAtFullSize() {
+        XCTAssertEqual(VaderMotion.pressScale(isPressed: false, reduceMotion: false), 1)
+    }
+
+    func testReduceMotionPinsThePressedControlAtFullSize() {
+        XCTAssertEqual(VaderMotion.pressScale(isPressed: true, reduceMotion: true), 1)
+    }
+
+    func testReduceMotionAndUnpressedStaysAtFullSize() {
+        XCTAssertEqual(VaderMotion.pressScale(isPressed: false, reduceMotion: true), 1)
+    }
+
+    func testManagerZoomRunsOnItsOwnClock() {
+        // The manager zoom is a quick snappy spring — distinct from the
+        // general surface spring so opening a manager feels like a response,
+        // not choreography. Pinned so the two can't silently collapse back
+        // into one timing.
+        XCTAssertEqual(VaderMotion.managerZoom, .snappy(duration: 0.4))
+        XCTAssertNotEqual(VaderMotion.managerZoom, VaderMotion.surface)
+    }
+}


### PR DESCRIPTION
## What changed

This PR gives the whole app a coherent macOS Tahoe-style motion system, centralized in a new shared vocabulary (`VaderMotion`) instead of per-view one-off curves.

**Manager open/close (all six sections).** Opening a manager (Cleanup, My Clutter, Applications, Performance catalog, Protection, Smart Scan reviews) previously hard-cut. It now zooms up from 90% *anchored at the button that triggered it* while the dashboard recedes beneath, and zooms back into the same button on Back — the platform's zoom idiom, on a quick `.snappy(0.4)` spring. The anchor plumbing (`TriggerAnchor`) needs zero call-site wiring: the Vader button styles record their frame into a press registry on mouse-down, and each section's open helper consumes it, falling back to the raw click location, then center for keyboard opens.

**Control feedback.** The three hand-rolled capsule button styles dip to 96% with a springy release; manager nav rows and row cards ease their hover/selection fills; checkboxes pop their checkmark in with a bounce. Reduce Motion pins scales at 1 and collapses all transitions to plain crossfades.

**Hero loading screens.** The scan indicator's default diameter grows 132 → 220pt (everything scales from that one knob), status type steps up to title2/title3, and the two screens that had drifted to plain `.callout` labels (Performance, Applications) now use the shared `ScanningStatusView`, so all seven loaders read identically.

## Why the safe-area restructure

The title-bar extension (`ignoresSafeArea(.top)`) moved off the manager chrome onto each section's stable ZStack transition host, with the measured inset handed back to the dashboard as explicit padding. Safe-area changes anywhere inside a freshly inserted transition subtree are deferred until the spring fully settles — with the modifier inside the manager, cards sat below a title-bar-height gap for a beat after opening. Dashboards keep their exact resting geometry.

## Reviewer notes

- The zoom transition is pure transforms (`scale` + `opacity`) by design. Earlier iterations of this work tried a Metal `distortionEffect` genie warp: any shader/layer effect on these surfaces — even disabled — forces a rasterized mode that AppKit-backed content (search fields, `List`, the item tables) cannot render in, permanently blanking the managers. Do not reintroduce layer effects on manager surfaces.
- New pure logic is unit-tested (`VaderMotionTests`, `TriggerAnchorTests`, `ScanProgressIndicatorTests`): press-scale + Reduce Motion opt-out, click→anchor mapping and clamping, press-registry freshness/consumption, hero size pin, and the two motion clocks pinned apart.
- Full suite: 1,357 tests, 0 failures (`xcodebuild test` with the repo's codesign workaround). UI tests can't bootstrap from a terminal on this machine, so the motion itself was verified by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staged Smart Scan with module tiles plus a hero card that advances through results.
  * Implemented zoom-style dashboard↔manager and dashboard↔review transitions with consistent anchoring from the initiating control and improved motion choreography.
* **Improvements**
  * Updated shared scanning/status presentations (spacing, typography, and loader sizing) across multiple scan progress views.
  * Refined navigation rail to stay icons-only after the first intro-to-content switch per session.
  * Improved Reduce Motion behavior for hover/press/checkbox feedback.
* **Bug Fixes**
  * Improved title-bar safe-area handling during transitions for better alignment.
* **Tests**
  * Added/expanded unit tests for transition anchoring, motion helpers, progress defaults, staged scanning states, and rail-collapse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->