### PR TITLE
Add a traveling-light border to the Smart Scan hero card

### DIFF
--- a/VaderCleaner/SmartScanScanningView.swift
+++ b/VaderCleaner/SmartScanScanningView.swift
@@ -83,6 +83,10 @@ private struct SmartScanScanHero: View {
             .clipShape(RoundedRectangle(cornerRadius: 24))
         )
         .vaderTileGlass()
+        // A light travels the card's edge for as long as this module is the
+        // one being collected, so the hero reads as actively working even when
+        // its counter is momentarily still.
+        .overlay(SmartScanScanBorder(tint: module.scanTileTint))
     }
 
     /// Live progress line for the hero, from the sub-scan's own counters.
@@ -111,6 +115,70 @@ private struct SmartScanScanHero: View {
                     comment: "Hero progress line while the update probe has not yet reported a count."
                 )
         }
+    }
+}
+
+/// An animated stroke around the hero card that signals the module is still
+/// being scanned: a soft segment of the module's accent glides smoothly
+/// around the tile's edge over a steady dim ring of the same tint. The
+/// segment travels along the rounded-rect path itself — an animated dash
+/// phase — so it keeps a constant speed through the corners instead of
+/// whipping across them the way a centre-based sweep does. Reduce Motion
+/// drops the travel and holds the steady edge so the "still working" read
+/// survives without movement.
+private struct SmartScanScanBorder: View {
+    let tint: Color
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var phase = 0.0
+
+    private let cornerRadius: CGFloat = 24
+    private let lineWidth: CGFloat = 2
+
+    var body: some View {
+        if reduceMotion {
+            // No travel: a steady tinted edge still reads as "active".
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .strokeBorder(tint.opacity(0.6), lineWidth: lineWidth)
+        } else {
+            GeometryReader { proxy in
+                let perimeter = perimeter(of: proxy.size)
+                // One soft segment (~a third of the edge) with a matching gap,
+                // so a single band travels the whole path and wraps through the
+                // start seam without a jump.
+                let segment = perimeter / 3
+                ZStack {
+                    // Steady dim ring so the edge is never dark.
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .strokeBorder(tint.opacity(0.3), lineWidth: lineWidth)
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .inset(by: lineWidth / 2)
+                        .stroke(
+                            tint,
+                            style: StrokeStyle(
+                                lineWidth: lineWidth,
+                                lineCap: .round,
+                                dash: [segment, perimeter - segment],
+                                dashPhase: phase
+                            )
+                        )
+                        .blur(radius: 2)
+                }
+                .onAppear {
+                    withAnimation(.linear(duration: 4).repeatForever(autoreverses: false)) {
+                        phase = perimeter
+                    }
+                }
+            }
+        }
+    }
+
+    /// Length of the rounded-rect edge: the four straight runs plus the four
+    /// quarter-circle corners. Drives the dash pattern so exactly one segment
+    /// is visible and the phase animation loops seamlessly.
+    private func perimeter(of size: CGSize) -> CGFloat {
+        let straight = 2 * (size.width - 2 * cornerRadius) + 2 * (size.height - 2 * cornerRadius)
+        let corners = 2 * .pi * cornerRadius
+        return straight + corners
     }
 }
 


### PR DESCRIPTION
## What

Adds an animated border to the Smart Scan **scanning** hero card — the large card for the module being collected right now. A soft, accent-tinted segment glides continuously around the card's edge for as long as that module owns the hero.

## Why

The hero's only live "still working" cue was its item counter, which can sit still between the sub-scan's checkpoints. During those pauses the screen looked stalled. The traveling border keeps a clear sign of activity even when the counter is momentarily quiet.

## How

- New private `SmartScanScanBorder` view, overlaid on the hero in `SmartScanScanningView.swift`, tinted to the active module's accent (`scanTileTint`) so it re-colours on every hand-off.
- The highlight travels along the **rounded-rect path itself** via an animated `dashPhase`, so it keeps a constant speed through the corners. An earlier angular-gradient approach was replaced because a centre-based sweep whips through the corners at uneven speed on a wide card.
- The dash pattern length equals the measured perimeter (straights + the four quarter-circle corners, via `GeometryReader`), so exactly one segment shows and the loop wraps seamlessly through the start seam.
- A steady dim ring keeps the edge lit under the moving band; round caps + a light blur keep the segment soft.
- **Reduce Motion** holds the steady tinted ring with no travel.

## Reviewer notes

- Purely additive UI — no changes to scan logic, view models, or the strip tiles.
- Two tuning knobs if the motion needs adjusting: `segment = perimeter / 3` (band length) and `duration: 4` (lap time).
- Verified with `xcodebuild build -scheme VaderCleaner` (**BUILD SUCCEEDED**). I couldn't drive the GUI from the working session to watch the animation live, so a quick visual pass on the scanning screen is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)