### PR TITLE
Make Smart Scan sequential and fix the hero scan border

### DIFF
--- a/VaderCleaner/SmartScanScanningView.swift
+++ b/VaderCleaner/SmartScanScanningView.swift
@@ -6,13 +6,17 @@ import SwiftUI
 /// The `.scanning` surface for Smart Scan: one module at a time takes the
 /// hero card (headline, artwork in the module's accent wash, live progress
 /// line) while the other modules wait as compact tiles that fill in with
-/// result summaries the moment their sub-scan is collected. The five
-/// sub-scans actually run concurrently — the staging follows the real
-/// collection checkpoints in `SmartScanViewModel.scan()`, so every hand-off
-/// the user sees corresponds to results genuinely landing.
+/// result summaries the moment their sub-scan is collected. The five sub-scans
+/// run one at a time in collection order, so the staging follows the work
+/// genuinely running: at each hand-off the finishing hero recedes into its
+/// strip slot and the next module's tile flies down into the hero slot, the
+/// two swapping in place via a shared `matchedGeometryEffect`.
 struct SmartScanScanningView: View {
     var viewModel: SmartScanViewModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Ties each module's compact strip tile to its hero card so the active
+    /// module's frame animates between the two slots instead of crossfading.
+    @Namespace private var heroNamespace
 
     var body: some View {
         VStack(spacing: 16) {
@@ -22,21 +26,26 @@ struct SmartScanScanningView: View {
                         module: module,
                         state: viewModel.moduleScanStates[module] ?? .pending
                     )
+                    .matchedGeometryEffect(id: module, in: heroNamespace)
                 }
             }
             .frame(height: 132)
 
             if let active = viewModel.activeScanModule {
                 SmartScanScanHero(module: active, viewModel: viewModel)
-                    // Fresh identity per module so the hand-off crossfades
-                    // between hero cards instead of morphing text in place.
+                    // Share the active module's identity with its strip tile so
+                    // the hero grows out of the tile's former slot; a fresh
+                    // `.id` per module makes each hand-off an insert/remove the
+                    // matched-geometry effect can fly rather than a text morph.
+                    .matchedGeometryEffect(id: active, in: heroNamespace)
                     .id(active)
-                    .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
+                    .transition(.opacity)
             }
         }
         .padding(24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(VaderMotion.surface, value: viewModel.activeScanModule)
+        // Reduce Motion drops the fly-into-place travel to a plain swap.
+        .animation(reduceMotion ? nil : VaderMotion.surface, value: viewModel.activeScanModule)
         .accessibilityIdentifier("smartScan.scanning")
     }
 
@@ -129,10 +138,11 @@ private struct SmartScanScanHero: View {
 private struct SmartScanScanBorder: View {
     let tint: Color
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var phase = 0.0
 
     private let cornerRadius: CGFloat = 24
     private let lineWidth: CGFloat = 2
+    /// Seconds for the moving segment to travel one full loop of the edge.
+    private let period: TimeInterval = 4
 
     var body: some View {
         if reduceMotion {
@@ -146,38 +156,68 @@ private struct SmartScanScanBorder: View {
                 // so a single band travels the whole path and wraps through the
                 // start seam without a jump.
                 let segment = perimeter / 3
-                ZStack {
-                    // Steady dim ring so the edge is never dark.
-                    RoundedRectangle(cornerRadius: cornerRadius)
-                        .strokeBorder(tint.opacity(0.3), lineWidth: lineWidth)
-                    RoundedRectangle(cornerRadius: cornerRadius)
-                        .inset(by: lineWidth / 2)
-                        .stroke(
-                            tint,
-                            style: StrokeStyle(
-                                lineWidth: lineWidth,
-                                lineCap: .round,
-                                dash: [segment, perimeter - segment],
-                                dashPhase: phase
+                // Drive the travel from the animation clock, not an animatable
+                // `@State`. A `repeatForever` animation restarts whenever the
+                // hero re-renders, and the malware sub-scan re-renders it many
+                // times a second (one tick per file clamscan checks), which
+                // snapped the segment back mid-loop. A clock-derived phase is
+                // immune to re-renders — it always completes full revolutions —
+                // and multiplying by the live perimeter keeps it smooth as the
+                // hero grows into place.
+                let dash = [segment, perimeter - segment]
+                TimelineView(.animation) { context in
+                    let dashPhase = context.date.timeIntervalSinceReferenceDate
+                        .truncatingRemainder(dividingBy: period) / period * perimeter
+                    ZStack {
+                        // Steady dim ring so the edge is never dark.
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .strokeBorder(tint.opacity(0.3), lineWidth: lineWidth)
+                        // Soft halo behind the travelling segment: a wide,
+                        // translucent stroke fakes the glow. It replaces a
+                        // per-frame `.blur`, whose full-card offscreen pass over
+                        // the glass material every frame dropped frames on the
+                        // longest scan (Malware) and read as a stutter.
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .inset(by: lineWidth / 2)
+                            .stroke(
+                                tint.opacity(0.35),
+                                style: StrokeStyle(
+                                    lineWidth: lineWidth * 4,
+                                    lineCap: .round,
+                                    dash: dash,
+                                    dashPhase: dashPhase
+                                )
                             )
-                        )
-                        .blur(radius: 2)
-                }
-                .onAppear {
-                    withAnimation(.linear(duration: 4).repeatForever(autoreverses: false)) {
-                        phase = perimeter
+                        // Crisp core of the travelling segment.
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .inset(by: lineWidth / 2)
+                            .stroke(
+                                tint,
+                                style: StrokeStyle(
+                                    lineWidth: lineWidth,
+                                    lineCap: .round,
+                                    dash: dash,
+                                    dashPhase: dashPhase
+                                )
+                            )
                     }
                 }
             }
         }
     }
 
-    /// Length of the rounded-rect edge: the four straight runs plus the four
-    /// quarter-circle corners. Drives the dash pattern so exactly one segment
-    /// is visible and the phase animation loops seamlessly.
+    /// Length of the *stroked* edge — the rounded rect inset by `lineWidth / 2`,
+    /// which is the path `.strokeBorder` and `.inset(by:)` actually trace — not
+    /// the outer bounds. Measuring the outer rect makes the dash pattern
+    /// ~`π · lineWidth` longer than the real path, so the single travelling
+    /// segment fails to tile the closed path and visibly snaps back each time it
+    /// crosses the rounded-rect's seam. The four straight runs are unchanged by
+    /// the inset; only the corner arc radius shrinks by `lineWidth / 2`.
     private func perimeter(of size: CGSize) -> CGFloat {
-        let straight = 2 * (size.width - 2 * cornerRadius) + 2 * (size.height - 2 * cornerRadius)
-        let corners = 2 * .pi * cornerRadius
+        let insetRadius = cornerRadius - lineWidth / 2
+        let straight = 2 * (size.width - lineWidth - 2 * insetRadius)
+            + 2 * (size.height - lineWidth - 2 * insetRadius)
+        let corners = 2 * .pi * insetRadius
         return straight + corners
     }
 }

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -1,5 +1,5 @@
 // SmartScanViewModel.swift
-// State machine behind the Smart Scan feature view — orchestrates the System Junk, Malware, and Performance sub-modules into one concurrent scan, aggregates their results, and drives a single junk+threats clean pass.
+// State machine behind the Smart Scan feature view — orchestrates the System Junk, Malware, and Performance sub-modules into one sequential scan, aggregates their results, and drives a single junk+threats clean pass.
 
 import AppKit
 import Foundation
@@ -24,11 +24,11 @@ enum SmartScanModule: String, Hashable, CaseIterable {
 }
 
 /// The phase the in-flight Smart Scan is currently focused on, derived from
-/// which sub-scans have finished. The five sub-scans run concurrently, so this
-/// reflects the most foundational work still running: the broad file sweep
-/// first, then the malware content scan, then the app-update probe — the same
-/// order in which they typically settle. The progress screen uses it to show a
-/// phrase set themed to whatever is actually being scanned right now.
+/// which sub-scans have finished. The five sub-scans run one at a time in
+/// collection order, so this reflects the most foundational phase not yet
+/// complete: the broad file sweep first, then the malware content scan, then
+/// the app-update probe. The progress screen uses it to show a phrase set
+/// themed to whatever is actually being scanned right now.
 enum SmartScanStage: Hashable {
     /// The two file-walk sub-scans (System Junk + My Clutter) are still
     /// enumerating the disk.
@@ -243,9 +243,9 @@ final class SmartScanViewModel {
 
     /// Per-module presentation state for the staged scanning screen. Rebuilt
     /// at the start of every scan; modules flip `.running` → `.finished` in
-    /// `Self.scanCollectionOrder` as `scan()` collects each sub-scan's
-    /// results, so the "one at a time" read tracks real checkpoints even
-    /// though the sub-scans run concurrently.
+    /// `Self.scanCollectionOrder` as `scan()` runs and collects each sub-scan's
+    /// results, so the "one at a time" read matches the order the sub-scans
+    /// actually run.
     private(set) var moduleScanStates: [SmartScanModule: SmartScanModuleScanState] = [:]
 
     /// The order the scanning screen walks the modules — the same order
@@ -409,6 +409,12 @@ final class SmartScanViewModel {
     /// has nothing to run, so it is not auto-selected and Run skips it.
     @ObservationIgnored private let maintenanceScriptsAvailable: Bool
 
+    /// Awaited before a module's sub-scan begins, once that module has taken the
+    /// hero slot, so scanning starts only after the hero hand-off has settled
+    /// into place. Defaults to a no-op (tests and previews don't wait);
+    /// `.live()` supplies a pause matching the hero swap's duration.
+    @ObservationIgnored private let heroSettle: @Sendable () async -> Void
+
     /// "Customize Smart Care" gate: the set of modules the user includes in
     /// Smart Scan. Read once per `scan()` (snapshot, like the exclusions store)
     /// so a preference change takes effect on the next scan. Defaults to all
@@ -436,6 +442,7 @@ final class SmartScanViewModel {
         updateOpener: @escaping UpdateOpener,
         largeFileDeleter: @escaping LargeFileDeleter,
         maintenanceScriptsAvailable: Bool = true,
+        heroSettle: @escaping @Sendable () async -> Void = {},
         enabledModules: @escaping () -> Set<SmartScanModule> = { Set(SmartScanModule.allCases) },
         enabledJunkCategories: @escaping () -> Set<ScanCategory> = { Set(SmartScanSettingsStore.junkCategories) }
     ) {
@@ -452,16 +459,29 @@ final class SmartScanViewModel {
         self.updateOpener = updateOpener
         self.largeFileDeleter = largeFileDeleter
         self.maintenanceScriptsAvailable = maintenanceScriptsAvailable
+        self.heroSettle = heroSettle
         self.enabledModules = enabledModules
         self.enabledJunkCategories = enabledJunkCategories
     }
 
     // MARK: - Scan
 
-    /// Runs the three sub-scans concurrently and lands `.results` (or
-    /// `.failed` if the junk scan throws). The ClamAV install check is read
-    /// once up front so the result can record whether the malware scan was
-    /// actually performed.
+    /// Holds a module's sub-scan until its hero hand-off has settled, so
+    /// scanning — and the hero's border animation reading its final size —
+    /// only begins once the tile has arrived in the hero slot. Only the module
+    /// currently occupying the hero waits; a skipped module is never the hero,
+    /// so it falls straight through without an idle pause.
+    private func settlingHero(_ module: SmartScanModule) async {
+        guard activeScanModule == module else { return }
+        await heroSettle()
+    }
+
+    /// Runs the five sub-scans one at a time, in `scanCollectionOrder`, and
+    /// lands `.results` (or `.failed` if the junk scan throws). Each sub-scan
+    /// runs to completion before the next begins, so the staged scanning
+    /// screen's hero advances in lockstep with the work genuinely running. The
+    /// ClamAV install check is read once up front so the result can record
+    /// whether the malware scan was actually performed.
     ///
     /// Re-entrant calls while a scan or clean is already in flight are
     /// ignored, so a double-tap (or a programmatic caller) can't leave two
@@ -492,10 +512,10 @@ final class SmartScanViewModel {
         clutterWalkComplete = false
         malwareScanComplete = false
 
-        // The two file-walk sub-scans run concurrently and each report their own
-        // monotonic walked count; sum them into one "Scanned N items…" tally.
-        // The scanners run off the main actor, so hop back before touching the
-        // observable count, and drop ticks from a superseded scan.
+        // The two file-walk sub-scans each report their own monotonic walked
+        // count; sum them into one "Scanned N items…" tally. The scanners run
+        // off the main actor, so hop back before touching the observable count,
+        // and drop ticks from a superseded scan.
         // These hops are unstructured, so they can land out of order; each
         // sub-scan's walked count is monotonic, so ignore any tick that would
         // move its counter backwards rather than let the combined total jitter.
@@ -560,31 +580,23 @@ final class SmartScanViewModel {
         // front, and the first runnable module takes the hero slot.
         moduleScanStates = Self.startingModuleStates(enabled: mods, clamAVAvailable: clamAVAvailable)
 
-        async let junk = scanJunkIfEnabled(mods.contains(.systemJunk), onProgress: onJunkProgress)
-        async let threats = scanForThreatsIfPossible(
-            clamAVAvailable: clamAVAvailable && mods.contains(.malware),
-            onProgress: onMalwareProgress
-        )
-        async let login = mods.contains(.performance) ? loginItemsLoader() : []
-        async let large = mods.contains(.myClutter) ? duplicatesScanner(onClutterProgress) : []
-        async let updates = mods.contains(.applications) ? updatesChecker(onUpdatesProgress) : []
-
         do {
-            // Await the two file walks first so their completion flags flip the
-            // moment the disk enumeration finishes — the malware content scan
-            // and app-update probe routinely outlast them, and the stage label
-            // must follow the work that is *actually* still running, not the
-            // textual order of these awaits. (`async let` already started all
-            // five concurrently, so collecting them in a different order is
-            // free.)
-            // Filter the System Junk findings down to the categories the user
-            // kept enabled in the Cleanup sub-tree. Done here (rather than in the
+            // The five sub-scans run one at a time, in collection order, so each
+            // hero on the staged scanning screen tracks the sub-scan genuinely
+            // running right now. Every collection point runs its sub-scan to
+            // completion, flips the matching completion flag, and advances the
+            // staged screen: the collected module flips to its result summary and
+            // the next runnable module takes the hero slot.
+            //
+            // The System Junk findings are filtered down to the categories the
+            // user kept enabled in the Cleanup sub-tree here (rather than in the
             // scanner) so the scanner stays category-agnostic and the same walk
             // serves every caller.
-            // Each collection point below also advances the staged scanning
-            // screen: the collected module flips to its result summary and
-            // the next runnable module takes the hero slot.
-            let junkResult = Self.filteringJunkCategories(try await junk, to: cats)
+            await settlingHero(.systemJunk)
+            let junkResult = Self.filteringJunkCategories(
+                try await scanJunkIfEnabled(mods.contains(.systemJunk), onProgress: onJunkProgress),
+                to: cats
+            )
             junkWalkComplete = true
             moduleScanStates = Self.finishing(
                 .systemJunk, in: moduleScanStates,
@@ -596,7 +608,8 @@ final class SmartScanViewModel {
                     : String(localized: "No junk", comment: "Zero-work scanning-screen summary on the Cleanup tile."),
                 caption: String(localized: "to clean", comment: "Caption under the Cleanup tile's scanning-screen summary.")
             )
-            let duplicates = await large
+            await settlingHero(.myClutter)
+            let duplicates = mods.contains(.myClutter) ? await duplicatesScanner(onClutterProgress) : []
             clutterWalkComplete = true
             let reclaimable = duplicates.reduce(Int64(0)) { $0 + $1.reclaimableBytes }
             moduleScanStates = Self.finishing(
@@ -609,7 +622,8 @@ final class SmartScanViewModel {
                     : String(localized: "No duplicates", comment: "Zero-work scanning-screen summary on the My Clutter tile."),
                 caption: String(localized: "to review", comment: "Caption under the My Clutter tile's scanning-screen summary.")
             )
-            let loginItems = await login
+            await settlingHero(.performance)
+            let loginItems = mods.contains(.performance) ? await loginItemsLoader() : []
             moduleScanStates = Self.finishing(
                 .performance, in: moduleScanStates,
                 metric: loginItems.isEmpty
@@ -619,7 +633,11 @@ final class SmartScanViewModel {
                         : String(localized: "\(loginItems.count) items", comment: "Plural scanning-screen summary on the Performance tile."),
                 caption: String(localized: "to review", comment: "Caption under the Performance tile's scanning-screen summary.")
             )
-            let foundThreats = await threats
+            await settlingHero(.malware)
+            let foundThreats = await scanForThreatsIfPossible(
+                clamAVAvailable: clamAVAvailable && mods.contains(.malware),
+                onProgress: onMalwareProgress
+            )
             malwareScanComplete = true
             moduleScanStates = Self.finishing(
                 .malware, in: moduleScanStates,
@@ -630,7 +648,8 @@ final class SmartScanViewModel {
                         : String(localized: "\(foundThreats.count) threats", comment: "Plural scanning-screen summary on the Protection tile."),
                 caption: String(localized: "to remove", comment: "Caption under the Protection tile's scanning-screen summary.")
             )
-            let foundUpdates = await updates
+            await settlingHero(.applications)
+            let foundUpdates = mods.contains(.applications) ? await updatesChecker(onUpdatesProgress) : []
             moduleScanStates = Self.finishing(
                 .applications, in: moduleScanStates,
                 metric: foundUpdates.isEmpty
@@ -1168,6 +1187,13 @@ extension SmartScanViewModel {
             // Performance tile's maintenance action is skipped rather than
             // erroring with "The file 'periodic' doesn't exist."
             maintenanceScriptsAvailable: FileManager.default.fileExists(atPath: "/usr/sbin/periodic"),
+            // Hold each sub-scan until its hero tile has animated into the hero
+            // slot, so scanning starts only once the module is the settled hero.
+            // Matched to the hero swap's duration so the pause ends as the tile
+            // arrives, not before or well after.
+            heroSettle: {
+                try? await Task.sleep(for: .seconds(VaderMotion.surfaceDuration))
+            },
             // Snapshot the "Customize Smart Care" choices per scan so a toggle in
             // Settings → Scanning takes effect on the next run, mirroring the
             // exclusions snapshot above.

--- a/VaderCleaner/VaderMotion.swift
+++ b/VaderCleaner/VaderMotion.swift
@@ -17,9 +17,14 @@ enum VaderMotion {
     /// Short fade for hover fills and selection pills — pointer feedback
     /// should ease in, not blink, and carries no bounce.
     static let hover: Animation = .easeOut(duration: 0.18)
+    /// Duration of the full-surface exchange spring. Shared so a caller that
+    /// must wait for a surface swap to land — Smart Scan holds a sub-scan until
+    /// its hero tile has arrived — stays in lockstep with the animation instead
+    /// of hard-coding a matching delay that could drift out of sync.
+    static let surfaceDuration: TimeInterval = 0.45
     /// Soft spring for full-surface exchanges — the sections' scan-phase
     /// swaps and the dashboard recede.
-    static let surface: Animation = .smooth(duration: 0.45)
+    static let surface: Animation = .smooth(duration: surfaceDuration)
     /// The manager zoom's clock: a quick snappy spring — fast enough to stay
     /// out of the way on the hundredth open, with just enough bounce to feel
     /// alive.

--- a/VaderCleanerTests/SmartScanViewModelTests.swift
+++ b/VaderCleanerTests/SmartScanViewModelTests.swift
@@ -1,5 +1,5 @@
 // SmartScanViewModelTests.swift
-// Drives the SmartScanViewModel state machine — concurrent junk/malware/login orchestration, result aggregation, and the unified clean() delegation — through injected fakes.
+// Drives the SmartScanViewModel state machine — sequential junk/malware/login orchestration, result aggregation, and the unified clean() delegation — through injected fakes.
 
 import XCTest
 @testable import VaderCleaner
@@ -1151,10 +1151,123 @@ final class SmartScanViewModelTests: XCTestCase {
         XCTAssertTrue(output.contains("flushed DNS"), "Summary must include the DNS-flush line")
     }
 
+    // MARK: - Sequential execution
+
+    /// The five sub-scans must run one at a time, in `scanCollectionOrder`: a
+    /// later sub-scan must not start until the current one has fully finished,
+    /// and the start order must match the collection order.
+    func test_scan_runsSubScansSequentially() async {
+        let gate = AsyncGate()
+        let recorder = StartRecorder()
+        let vm = SmartScanViewModel(
+            junkScanner: { _ in
+                recorder.record("systemJunk")
+                await gate.wait()
+                return ScanResult(items: [])
+            },
+            malwareInstalled: { true },
+            malwareScanner: { _ in recorder.record("malware"); return [] },
+            loginItemsLoader: { recorder.record("performance"); return [] },
+            duplicatesScanner: { _ in recorder.record("myClutter"); return [] },
+            updatesChecker: { _ in recorder.record("applications"); return [] },
+            junkCleaner: { _ in 0 },
+            threatRemover: { _ in [] },
+            maintenanceRunner: { "" },
+            updateOpener: { _ in },
+            largeFileDeleter: { _ in [] }
+        )
+
+        let scanTask = Task { await vm.scan() }
+        // Wait until the first sub-scan has started and parked on the gate.
+        await waitUntil { recorder.all == ["systemJunk"] }
+        // Give the runtime several turns to (wrongly) start other sub-scans if
+        // they were still running concurrently; the gate keeps the first parked.
+        for _ in 0..<20 { await Task.yield() }
+        XCTAssertEqual(
+            recorder.all, ["systemJunk"],
+            "No later sub-scan may start while the first is still running"
+        )
+
+        gate.open()
+        await scanTask.value
+        XCTAssertEqual(
+            recorder.all,
+            ["systemJunk", "myClutter", "performance", "malware", "applications"],
+            "Sub-scans must start one at a time in collection order"
+        )
+    }
+
+    /// Each module's sub-scan must be preceded by a hero-settle await, so
+    /// scanning only begins once the module has taken the hero slot.
+    func test_scan_settlesHeroBeforeEachModuleScan() async {
+        let events = StartRecorder()
+        let vm = SmartScanViewModel(
+            junkScanner: { _ in events.record("scan:systemJunk"); return ScanResult(items: []) },
+            malwareInstalled: { true },
+            malwareScanner: { _ in events.record("scan:malware"); return [] },
+            loginItemsLoader: { events.record("scan:performance"); return [] },
+            duplicatesScanner: { _ in events.record("scan:myClutter"); return [] },
+            updatesChecker: { _ in events.record("scan:applications"); return [] },
+            junkCleaner: { _ in 0 },
+            threatRemover: { _ in [] },
+            maintenanceRunner: { "" },
+            updateOpener: { _ in },
+            largeFileDeleter: { _ in [] },
+            heroSettle: { events.record("settle") }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(
+            events.all,
+            [
+                "settle", "scan:systemJunk",
+                "settle", "scan:myClutter",
+                "settle", "scan:performance",
+                "settle", "scan:malware",
+                "settle", "scan:applications",
+            ],
+            "Every module's scan must be immediately preceded by a hero settle"
+        )
+    }
+
+    /// A skipped module (disabled) is never the hero, so it must not trigger a
+    /// hero-settle pause — only the modules that actually take the hero wait.
+    func test_scan_doesNotSettleForSkippedModule() async {
+        let events = StartRecorder()
+        let vm = SmartScanViewModel(
+            junkScanner: { _ in events.record("scan:systemJunk"); return ScanResult(items: []) },
+            malwareInstalled: { true },
+            malwareScanner: { _ in events.record("scan:malware"); return [] },
+            loginItemsLoader: { events.record("scan:performance"); return [] },
+            duplicatesScanner: { _ in events.record("scan:myClutter"); return [] },
+            updatesChecker: { _ in events.record("scan:applications"); return [] },
+            junkCleaner: { _ in 0 },
+            threatRemover: { _ in [] },
+            maintenanceRunner: { "" },
+            updateOpener: { _ in },
+            largeFileDeleter: { _ in [] },
+            heroSettle: { events.record("settle") },
+            // My Clutter is excluded from this run, so it never takes the hero.
+            enabledModules: { [.systemJunk, .performance, .malware, .applications] }
+        )
+
+        await vm.scan()
+
+        XCTAssertFalse(
+            events.all.contains("scan:myClutter"),
+            "A disabled module's sub-scan must not run"
+        )
+        XCTAssertEqual(
+            events.all.filter { $0 == "settle" }.count, 4,
+            "Only the four modules that take the hero may trigger a settle"
+        )
+    }
+
     // MARK: - Scan progress count
 
     /// The combined "Scanned N items…" tally must sum the walked counts of the
-    /// two concurrent file-walk sub-scans (System Junk + My Clutter).
+    /// two file-walk sub-scans (System Junk + My Clutter).
     func test_scan_reportsCombinedScannedItemCountAcrossFileWalkSubScans() async {
         let vm = SmartScanViewModel(
             junkScanner: { progress in
@@ -1718,5 +1831,25 @@ private final class AsyncGate: @unchecked Sendable {
         continuation = nil
         lock.unlock()
         resume?.resume()
+    }
+}
+
+/// Records, in order, the name each fake sub-scan reports as it starts, so a
+/// test can assert the sub-scans run one at a time in collection order. The
+/// sub-scan closures run off the main actor, so the append is lock-guarded.
+private final class StartRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started: [String] = []
+
+    func record(_ name: String) {
+        lock.lock()
+        started.append(name)
+        lock.unlock()
+    }
+
+    var all: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return started
     }
 }


### PR DESCRIPTION
## What

Reworks the Smart Scan loading screen so the five sub-scans run **one at a time** and the staged hero card tracks the work that is genuinely running — and fixes the traveling-light border that was snapping/stuttering.

## Why

The sub-scans previously ran concurrently (`async let` fan-out); the staged "one tile at a time" screen was cosmetic sequencing over parallel work. This makes the staging honest: each module flies into the hero slot, settles, then scans, then recedes as the next flies in.

## Changes

- **Sequential orchestration** — `SmartScanViewModel.scan()` now awaits each sub-scan to completion before starting the next, in `scanCollectionOrder` (systemJunk → myClutter → performance → malware → applications).
- **Hero settle** — each sub-scan is held until its hero hand-off settles, via an injected `heroSettle` pause matched to `VaderMotion.surfaceDuration`. A module only starts scanning once its tile has animated into the hero slot. Skipped modules never take the hero, so they fall through with no idle pause.
- **Border fixes** (`SmartScanScanBorder`), three distinct defects:
  1. **Snap-back (the visible one):** the dash period was measured on the card's outer bounds, but the segment is stroked on the rounded rect inset by `lineWidth/2`. The pattern was ~`π·lineWidth` (~6pt) too long, so the single segment jumped at the rounded-rect seam each loop. Now measures the inset path.
  2. **Restart on re-render:** phase now comes from a `TimelineView(.animation)` clock instead of a `repeatForever` `@State` animation, which restarted under the malware tile's frequent re-renders.
  3. **Dropped frames:** replaced the per-frame `.blur` (a full-card offscreen pass over the `glassEffect` material) with layered dashed strokes for the glow.

## Testing

- New: `test_scan_runsSubScansSequentially`, `test_scan_settlesHeroBeforeEachModuleScan`, `test_scan_doesNotSettleForSkippedModule`.
- Full `SmartScanViewModelTests` suite passes (91 tests); app target builds clean.

## Reviewer notes

- **Tradeoff:** sequential scanning is slower in wall-clock time — the network-bound app-update probe and ClamAV scan no longer overlap the file walks. This is intentional for the staged UX.
- The `heroSettle` pause defaults to a no-op (tests/previews) and is only wired to a real delay in `.live()`. It's a single tunable knob if the beat feels wrong.
- **Not yet visually verified in the running app** — I can't drive the UI from the dev environment. The border fix in particular is worth eyeballing during a real scan (watch the segment cross the rounded-rect corner/seam and the long-running Malware tile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smart Scan now runs each module one at a time, with clearer stage wording and smoother handoff between scan cards.
  * The scanning border animation is now more fluid and consistent during repeated updates.

* **Bug Fixes**
  * Improved animation behavior to better respect Reduce Motion settings.
  * Fixed border motion so it loops cleanly without snapping.
  * Progress and staging updates now better match the actual scan flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->