### PR TITLE
Make Smart Scan managers consistent, safe-by-default, and Protection scans Quick

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		62A51901AE4CA4CE8FB58349 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 46466A1909A880757A7C4B31 /* Localizable.strings */; };
 		6370C48606EABFE1E9343565 /* ExtensionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */; };
 		63E11AAE557DC8A87BE21374 /* PrivacyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90614D3C12BCADA72B736230 /* PrivacyViewModel.swift */; };
+		64ADC9674C568042DD53DAA1 /* ClutterThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B48ACB80B7FBBFB944A3AE /* ClutterThumbnailCache.swift */; };
 		65008C5FD9B41F395E3C54A3 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CD8C98E8253953444DD99F /* NotificationManager.swift */; };
 		652B6EC5C57CE9B03E4C85AE /* ApplicationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7220D06D757039BF087D7F50 /* ApplicationsViewModel.swift */; };
 		65B572321C38997952E456EF /* MyClutterManagerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558B0A2338BD9E61BDB7CE68 /* MyClutterManagerModel.swift */; };
@@ -247,6 +248,7 @@
 		A4C540E94817EFE313186864 /* MaintenanceScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00763E44DB5A7AB03DE281 /* MaintenanceScriptRunner.swift */; };
 		A62CE19905649237426F1C83 /* AppLeftoverScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8EF86413DFB7292BDA49F9 /* AppLeftoverScanner.swift */; };
 		A75CF3F5E28E9AF7894FB557 /* AppDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79E0766E335360E04FC6A53 /* AppDiscovery.swift */; };
+		A78865872445EA7A14BD8138 /* ClutterThumbnailCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4BA1DF5F4CC2A0670544E5 /* ClutterThumbnailCacheTests.swift */; };
 		A91615BDF2CBB95FF6444C46 /* MaintenanceRunLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB282FD9D3829F3F133CCCA1 /* MaintenanceRunLog.swift */; };
 		A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */; };
 		ACC1444F40554C741F4742A4 /* ProtectionSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32AF01DCEB8B6FC9C071426 /* ProtectionSettingsStoreTests.swift */; };
@@ -561,6 +563,7 @@
 		574D2DD309CA4FA07640FAA0 /* InstallationFileScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationFileScanner.swift; sourceTree = "<group>"; };
 		57ECD8DBE475EA1D00DF8121 /* AssociatedFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedFile.swift; sourceTree = "<group>"; };
 		588B33B31E27D3E193DF5889 /* ColorDeepenedForWhiteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDeepenedForWhiteTests.swift; sourceTree = "<group>"; };
+		58B48ACB80B7FBBFB944A3AE /* ClutterThumbnailCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClutterThumbnailCache.swift; sourceTree = "<group>"; };
 		5B8CDD8E97F29FEEB9E1F20C /* DownloadSourceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadSourceResolver.swift; sourceTree = "<group>"; };
 		5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessPromptCard.swift; sourceTree = "<group>"; };
 		5CC50A90E584320709971BCB /* ScanCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategoryTests.swift; sourceTree = "<group>"; };
@@ -651,6 +654,7 @@
 		98ECCA0AFF573341EB7FB454 /* HungAppMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HungAppMonitor.swift; sourceTree = "<group>"; };
 		9B77D1A002F58496087AF3E3 /* SmartScanByteFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanByteFormatter.swift; sourceTree = "<group>"; };
 		9C1D85C87621345FBF7CDC41 /* UnusedAppScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusedAppScanner.swift; sourceTree = "<group>"; };
+		9C4BA1DF5F4CC2A0670544E5 /* ClutterThumbnailCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClutterThumbnailCacheTests.swift; sourceTree = "<group>"; };
 		9C5EE2C8752F5E1308B4FDF0 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		9CF890162A2DEEED26EAA0C4 /* ExtensionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionItem.swift; sourceTree = "<group>"; };
 		9D5CB08F96767D10B1271970 /* RAMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAMManager.swift; sourceTree = "<group>"; };
@@ -890,6 +894,7 @@
 				534B9A580343E03496BD5FCD /* CleanupManagerModel.swift */,
 				A4982BBDB43C7E3F9323EACE /* CleanupManagerStore.swift */,
 				C4CE7DCEB93C1AFD8F68F8DC /* CloudFileAvailability.swift */,
+				58B48ACB80B7FBBFB944A3AE /* ClutterThumbnailCache.swift */,
 				218E411D3045401D9A955CE7 /* ConnectedDevicesMonitor.swift */,
 				C5BE6E53E0A4ABB39A7B8B0C /* ContentView.swift */,
 				232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */,
@@ -1145,6 +1150,7 @@
 				17630CA93451A0E1A29ED6A1 /* CleanupGroupTests.swift */,
 				C8565FBD4555B1398F2752F8 /* CleanupManagerModelTests.swift */,
 				62DC35796A9897B1CE0113EC /* CleanupManagerStoreTests.swift */,
+				9C4BA1DF5F4CC2A0670544E5 /* ClutterThumbnailCacheTests.swift */,
 				588B33B31E27D3E193DF5889 /* ColorDeepenedForWhiteTests.swift */,
 				1071E99E2EFBE2C48C528D41 /* ConnectedDevicesMonitorTests.swift */,
 				3901B166DF68C6F1333D5103 /* DatabaseUpdaterTests.swift */,
@@ -1489,6 +1495,7 @@
 				B3289BEA17E2D156D19E8E71 /* CleanupGroupTests.swift in Sources */,
 				8C8A94A741DBC80FA3FB4DE2 /* CleanupManagerModelTests.swift in Sources */,
 				4EF8BA012B966F984D9569E7 /* CleanupManagerStoreTests.swift in Sources */,
+				A78865872445EA7A14BD8138 /* ClutterThumbnailCacheTests.swift in Sources */,
 				99E2DC0FF5C29F7EFFC4F8D7 /* ColorDeepenedForWhiteTests.swift in Sources */,
 				6FEEC4B62B2D99B25975B8DE /* ConnectedDevicesMonitorTests.swift in Sources */,
 				ADFD9F16CAD0D6D42E21A7D7 /* DatabaseUpdaterTests.swift in Sources */,
@@ -1669,6 +1676,7 @@
 				606F83D96B25967FDEED6E35 /* CleanupManagerModel.swift in Sources */,
 				3446A3502329D7AB0F41B0BE /* CleanupManagerStore.swift in Sources */,
 				B139E21F16EA44AC362A028F /* CloudFileAvailability.swift in Sources */,
+				64ADC9674C568042DD53DAA1 /* ClutterThumbnailCache.swift in Sources */,
 				753D0372717545D89CC0A6C6 /* ConnectedDevicesMonitor.swift in Sources */,
 				3A8A0ADAF5D89FD0223A9972 /* ContentView.swift in Sources */,
 				BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */,

--- a/VaderCleaner/ClutterThumbnailCache.swift
+++ b/VaderCleaner/ClutterThumbnailCache.swift
@@ -1,0 +1,42 @@
+// ClutterThumbnailCache.swift
+// Process-wide cache of generated Quick Look thumbnails so navigating away from and back to My Clutter reuses already-rendered images instead of regenerating them.
+
+import AppKit
+
+/// A small process-wide cache of `NSImage` thumbnails keyed by file path and
+/// requested point size. My Clutter's section view is torn down and rebuilt on
+/// every sidebar navigation (`ContentView` keys the detail pane by section), so
+/// without a cache each return trip re-fires a Quick Look generation for every
+/// dashboard thumbnail — expensive for videos and large images. Seeding a view
+/// synchronously from this cache lets a repeat visit paint its thumbnails
+/// instantly and do no Quick Look work.
+///
+/// Backed by `NSCache`, which is thread-safe and evicts under memory pressure,
+/// so the cache never grows unbounded.
+enum ClutterThumbnailCache {
+    private static let cache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        // Generous but bounded: a dashboard shows a handful of thumbnails and a
+        // manager preview a few more, so a few hundred entries covers heavy use
+        // while still letting the OS reclaim memory when needed.
+        cache.countLimit = 512
+        return cache
+    }()
+
+    /// Cache key combines the path and point size — the same file is requested
+    /// at different sizes for the card corner vs. the manager preview.
+    private static func key(_ url: URL, _ pointSize: CGFloat) -> NSString {
+        "\(url.path)#\(Int(pointSize))" as NSString
+    }
+
+    /// The cached thumbnail for `url` at `pointSize`, or `nil` on a miss. Safe to
+    /// call synchronously from a view initializer.
+    static func cached(_ url: URL, pointSize: CGFloat) -> NSImage? {
+        cache.object(forKey: key(url, pointSize))
+    }
+
+    /// Store a freshly generated thumbnail for reuse on the next visit.
+    static func store(_ image: NSImage, for url: URL, pointSize: CGFloat) {
+        cache.setObject(image, forKey: key(url, pointSize))
+    }
+}

--- a/VaderCleaner/FloatingRunOverlay.swift
+++ b/VaderCleaner/FloatingRunOverlay.swift
@@ -23,12 +23,10 @@ struct FloatingRunOverlay: View {
     }
 
     /// Whether the disc should currently be on screen — only when the
-    /// dashboard is up *and* at least one selected module would do work.
+    /// dashboard is up, at least one selected module would do work, and no
+    /// Review (Manager) screen is covering the dashboard.
     private var isShown: Bool {
-        if case .results = viewModel.phase {
-            return viewModel.hasExecutableWork
-        }
-        return false
+        viewModel.isRunDiscVisible
     }
 
     var body: some View {

--- a/VaderCleaner/MyClutterDashboardView.swift
+++ b/VaderCleaner/MyClutterDashboardView.swift
@@ -520,6 +520,17 @@ struct ClutterThumbnailView: View {
     var contentMode: ContentMode = .fill
     @State private var image: NSImage?
 
+    init(url: URL, fallbackSymbol: String, pointSize: CGFloat = 92, contentMode: ContentMode = .fill) {
+        self.url = url
+        self.fallbackSymbol = fallbackSymbol
+        self.pointSize = pointSize
+        self.contentMode = contentMode
+        // Seed synchronously from the process-wide cache so a repeat visit to
+        // My Clutter paints the real thumbnail on the first frame — no fallback
+        // flash and no Quick Look work.
+        _image = State(initialValue: ClutterThumbnailCache.cached(url, pointSize: pointSize))
+    }
+
     var body: some View {
         Group {
             if let image {
@@ -534,7 +545,18 @@ struct ClutterThumbnailView: View {
             }
         }
         .task(id: url) {
-            image = await Self.thumbnail(for: url, pointSize: pointSize)
+            // Cache-first: a hit resolves instantly (also covers a `url` change
+            // on a reused view instance); a miss generates once and caches the
+            // result for the next visit.
+            if let cached = ClutterThumbnailCache.cached(url, pointSize: pointSize) {
+                image = cached
+                return
+            }
+            let generated = await Self.thumbnail(for: url, pointSize: pointSize)
+            if let generated {
+                ClutterThumbnailCache.store(generated, for: url, pointSize: pointSize)
+            }
+            image = generated
         }
     }
 

--- a/VaderCleaner/MyClutterViewModel.swift
+++ b/VaderCleaner/MyClutterViewModel.swift
@@ -98,30 +98,49 @@ final class MyClutterViewModel {
 
     // MARK: - Derived totals
 
+    // Derived read-model for the dashboard, memoized so a render never pays an
+    // O(all-files) cost. Each value is recomputed once, in `recomputeDerived()`,
+    // whenever the result set changes (scan completion or a deletion prune) —
+    // never on a view render. Before this, the dashboard rebuilt the full
+    // `flatMap` copy arrays (hundreds of thousands of elements on a large scan)
+    // several times per frame during the section-open animation, which read as
+    // a beach-balled main thread before the grid appeared.
+
     /// Redundant copies across the duplicate groups — the deletion candidates.
-    var duplicateCopies: [ScannedFile] { duplicateGroups.flatMap { $0.redundantCopies } }
+    private(set) var duplicateCopies: [ScannedFile] = []
     /// Redundant near-duplicates across the similar-image groups.
-    var similarCopies: [ScannedFile] { similarGroups.flatMap { $0.redundantCopies } }
-
+    private(set) var similarCopies: [ScannedFile] = []
     /// Total files the user can sort through — the count shown in the header.
-    var totalFileCount: Int {
-        duplicateCopies.count + similarCopies.count + largeOldFiles.count + downloads.count
-    }
-
-    var duplicateReclaimableBytes: Int64 { duplicateGroups.reduce(0) { $0 + $1.reclaimableBytes } }
-    var similarReclaimableBytes: Int64 { similarGroups.reduce(0) { $0 + $1.reclaimableBytes } }
-    var largeOldBytes: Int64 { largeOldFiles.reduce(0) { $0 + $1.size } }
-    var downloadsBytes: Int64 { downloads.reduce(0) { $0 + $1.file.size } }
-
+    private(set) var totalFileCount: Int = 0
+    private(set) var duplicateReclaimableBytes: Int64 = 0
+    private(set) var similarReclaimableBytes: Int64 = 0
+    private(set) var largeOldBytes: Int64 = 0
+    private(set) var downloadsBytes: Int64 = 0
     /// The browser/app that contributed the most download bytes, for the card
     /// title (e.g. "Google Chrome"), or `nil` for a generic label.
-    var dominantDownloadSource: String? { DownloadsScanner.dominantSource(of: downloads) }
-
+    private(set) var dominantDownloadSource: String? = nil
     /// The bundle id of the dominant download source, for its app icon on the
     /// dashboard card.
-    var dominantDownloadBundleID: String? {
-        guard let name = dominantDownloadSource else { return nil }
-        return downloads.first { $0.sourceApp == name }?.sourceBundleID
+    private(set) var dominantDownloadBundleID: String? = nil
+
+    /// Rebuild the memoized dashboard read-model from the current result set.
+    /// Called only when the source groups/arrays change (scan completion or a
+    /// prune), so the O(all-files) work happens once per result change rather
+    /// than once per render.
+    private func recomputeDerived() {
+        duplicateCopies = duplicateGroups.flatMap { $0.redundantCopies }
+        similarCopies = similarGroups.flatMap { $0.redundantCopies }
+        totalFileCount = duplicateCopies.count + similarCopies.count
+            + largeOldFiles.count + downloads.count
+        duplicateReclaimableBytes = duplicateGroups.reduce(0) { $0 + $1.reclaimableBytes }
+        similarReclaimableBytes = similarGroups.reduce(0) { $0 + $1.reclaimableBytes }
+        largeOldBytes = largeOldFiles.reduce(0) { $0 + $1.size }
+        downloadsBytes = downloads.reduce(0) { $0 + $1.file.size }
+        let source = DownloadsScanner.dominantSource(of: downloads)
+        dominantDownloadSource = source
+        dominantDownloadBundleID = source.flatMap { name in
+            downloads.first { $0.sourceApp == name }?.sourceBundleID
+        }
     }
 
     // MARK: - Selection
@@ -255,6 +274,7 @@ final class MyClutterViewModel {
         selectedCountByCategory = [:]
         sizeByURL = [:]
         categoriesByURL = [:]
+        recomputeDerived()
     }
 
     private func applyResults(
@@ -268,6 +288,9 @@ final class MyClutterViewModel {
         self.largeOldFiles = largeOld
         self.downloads = downloads
 
+        // Rebuild the memoized read-model first: both `rebuildSizeMap()` and the
+        // selection seeding below read `duplicateCopies` / `similarCopies`.
+        recomputeDerived()
         rebuildSizeMap()
         // Safe-by-default: pre-check the redundant duplicate and near-duplicate
         // copies (deleting one always leaves an original) and leave the large/old
@@ -333,6 +356,9 @@ final class MyClutterViewModel {
         largeOldFiles.removeAll { deleted.contains($0.url) }
         downloads.removeAll { deleted.contains($0.file.url) }
 
+        // Rebuild the memoized read-model before `rebuildSizeMap()` (which reads
+        // `duplicateCopies` / `similarCopies`) and the phase check below.
+        recomputeDerived()
         rebuildSizeMap()
         selectedURLs.subtract(deleted)
         totalSelectedSize = selectedURLs.reduce(Int64(0)) { $0 + (sizeByURL[$1] ?? 0) }

--- a/VaderCleaner/MyClutterViewModel.swift
+++ b/VaderCleaner/MyClutterViewModel.swift
@@ -269,12 +269,14 @@ final class MyClutterViewModel {
         self.downloads = downloads
 
         rebuildSizeMap()
-        // Nothing is selected by default — every Review / Review All Files opens
-        // with an empty selection so the user opts each item in deliberately.
-        selectedURLs = []
-        totalSelectedSize = 0
-        selectedBytesByCategory = [:]
-        selectedCountByCategory = [:]
+        // Safe-by-default: pre-check the redundant duplicate and near-duplicate
+        // copies (deleting one always leaves an original) and leave the large/old
+        // files and downloads — real user data — unchecked so removing them is an
+        // explicit choice. Mirrors Smart Scan and the app-wide safe-by-default
+        // rule (see `ScanCategory.isSafeToAutoRemove`).
+        selectedURLs = Set(duplicateCopies.map(\.url)).union(similarCopies.map(\.url))
+        totalSelectedSize = selectedURLs.reduce(Int64(0)) { $0 + (sizeByURL[$1] ?? 0) }
+        recomputeSelectedCategoryTotals()
 
         resultsVersion &+= 1
         phase = totalFileCount == 0 ? .empty : .results

--- a/VaderCleaner/ProtectionSettingsStore.swift
+++ b/VaderCleaner/ProtectionSettingsStore.swift
@@ -94,7 +94,11 @@ final class ProtectionSettingsStore {
     /// On by default: iCloud Drive's local copy mirrors a store Apple already
     /// scans, so skipping it trims scan time with little detection cost.
     static let defaultExcludeDownloadedICloudFiles = true
-    static let defaultScanMode: ScanMode = .deep
+    /// Quick by default: the high-risk home subdirectories
+    /// (Downloads/Desktop/Documents) only, matching Smart Scan's threat scope,
+    /// so a first Protection scan is fast rather than a whole-$HOME Deep pass.
+    /// Balanced and Deep stay one tap away in Protection settings.
+    static let defaultScanMode: ScanMode = .quick
 
     // MARK: - Tracked state
 

--- a/VaderCleaner/ScanCategory.swift
+++ b/VaderCleaner/ScanCategory.swift
@@ -46,4 +46,29 @@ enum ScanCategory: String, CaseIterable, Codable, Hashable {
         case .webDevJunk: return "Web Development Junk"
         }
     }
+
+    /// Whether a one-tap clean may pre-check this category for removal — the
+    /// single source of truth shared by every cleanup surface (Smart Scan, the
+    /// standalone Cleanup Manager, and My Clutter) so their default selections
+    /// stay consistent.
+    ///
+    /// Safe categories are regenerable (caches, logs, dev build junk, document
+    /// autosave versions, unused app localizations) or already discarded
+    /// (Trash), so pre-checking them can never destroy data the user can't get
+    /// back. Categories holding real user files — mail attachments, iOS
+    /// backups, and the large/old personal files surfaced by My Clutter — are
+    /// still scanned and listed, but stay unchecked so removing them is an
+    /// explicit choice.
+    var isSafeToAutoRemove: Bool {
+        switch self {
+        case .systemCache, .userCache,
+             .systemLogs, .userLogs,
+             .languageFiles,
+             .xcodeJunk, .documentVersions, .webDevJunk,
+             .trash:
+            return true
+        case .mailAttachments, .iosBackups, .largeFile, .oldFile:
+            return false
+        }
+    }
 }

--- a/VaderCleaner/SmartScanApplicationsReview.swift
+++ b/VaderCleaner/SmartScanApplicationsReview.swift
@@ -36,7 +36,9 @@ struct SmartScanApplicationsReview: View {
                 viewModel.setAllUpdates(selected: selected)
             },
             onBack: onBack,
-            accessibilityPrefix: "smartScan.review.applications"
+            accessibilityPrefix: "smartScan.review.applications",
+            lightSurface: true,
+            showsSparkle: true
         )
     }
 

--- a/VaderCleaner/SmartScanJunkReview.swift
+++ b/VaderCleaner/SmartScanJunkReview.swift
@@ -1,67 +1,80 @@
 // SmartScanJunkReview.swift
-// System Junk "Cleanup Manager" for Smart Scan — a three-pane (sections → categories → files) manager with per-file selection, search, sort, and a live selected-count footer. The file model is built off the main thread so huge junk scans open without blocking the UI.
+// System Junk "Cleanup Manager" for Smart Scan — a store-backed three-pane (sections → categories → folder tree) manager with per-folder selection, search, sort, and a live selected-count footer. Panes paint instantly from a cheap shell and each category's rows load lazily, so huge junk scans open without blocking the UI.
 
 import SwiftUI
 
-/// System Junk Review, rendered through the shared `SmartScanReviewManager`.
-/// The section/category/file hierarchy is built off the main actor; selection
-/// callbacks bridge to the view model's per-file junk selection.
-/// Holds the id→file and url→size lookups the selection callbacks need. Built
-/// once on the same background task as the section model (so nothing O(N) runs
-/// on the main thread) and read on the main actor afterward; the manager only
-/// renders interactive rows once that build has finished, so there is no race.
-private final class JunkReviewLookups: @unchecked Sendable {
-    var filesByID: [String: ScannedFile] = [:]
-    var sizeByURL: [URL: Int64] = [:]
-}
-
+/// System Junk Review, rendered through the shared `SmartScanReviewManager` and
+/// served by the same `CleanupManagerStore` the standalone Cleanup Manager uses:
+/// the panes paint from a cheap section/category shell and each category's folder
+/// tree is built (and cached) lazily off the main thread. Selection is batched
+/// per folder through the view model's `junkFileSelection`, with the manager's
+/// per-category badges and bulk-select menu reading the view model's O(1)
+/// tallies.
 struct SmartScanJunkReview: View {
     var viewModel: SmartScanViewModel
     let result: SmartScanResult
+    let store: CleanupManagerStore
     let onBack: () -> Void
 
-    @State private var lookups = JunkReviewLookups()
-
     var body: some View {
-        let lookups = self.lookups
-        let items = result.junkResult.items
+        let store = self.store
         let itemsByCategory = result.junkResult.itemsByCategory
-        let sizeByCategory = result.junkResult.sizeByCategory
         SmartScanReviewManager(
             title: String(
                 localized: "Cleanup Manager",
                 comment: "Title on the Smart Scan System Junk Review screen."
             ),
-            buildSections: {
-                // Build the selection lookups in the same off-main pass as the
-                // section model, so the main thread never does O(all-files) work.
-                lookups.filesByID = Dictionary(items.map { ($0.url.path, $0) }, uniquingKeysWith: { a, _ in a })
-                lookups.sizeByURL = Dictionary(items.map { ($0.url, $0.size) }, uniquingKeysWith: { a, _ in a })
-                return CleanupManagerModel.build(
-                    itemsByCategory: itemsByCategory,
-                    sizeByCategory: sizeByCategory,
-                    includeEmptySections: false,
-                    hierarchical: false
-                )
-            },
+            // Cheap shell: sections + category sizes, no file trees (warmed in
+            // the background when the scan landed on `.results`).
+            buildSections: { store.sections() },
             isSelected: { id in
-                guard let file = lookups.filesByID[id] else { return false }
-                return viewModel.isJunkFileSelected(file)
+                // Checked when every file beneath the row is selected. The files
+                // are gathered under one store lock, and `areAllJunkFilesSelected`
+                // short-circuits, so an unchecked folder is cheap to answer.
+                viewModel.areAllJunkFilesSelected(store.files(forRowID: id))
             },
             onToggle: { id in
-                guard let file = lookups.filesByID[id] else { return }
-                viewModel.toggleJunkFile(file)
+                // Whole-folder toggle in one batched pass: gather the row's files
+                // under a single lock, then flip them together so a folder over
+                // tens of thousands of files fires one UI update, not one per file.
+                viewModel.toggleJunkFiles(store.files(forRowID: id))
             },
             onSetCategory: { category, selected in
+                // Operate on the whole scan category (by id), independent of
+                // whether its rows are loaded yet — one batched selection pass.
                 guard let scanCategory = ScanCategory(rawValue: category.id) else { return }
-                viewModel.setJunkCategory(scanCategory, selected: selected)
+                viewModel.setJunkFiles(itemsByCategory[scanCategory] ?? [], selected: selected)
+            },
+            categorySelectedBytes: { category in
+                // O(1) read of the view model's incrementally-maintained
+                // per-category total, instead of reducing over every file in the
+                // category on every render.
+                guard let scanCategory = ScanCategory(rawValue: category.id) else { return nil }
+                return viewModel.selectedJunkBytes(in: scanCategory)
+            },
+            categorySelectionTally: { category in
+                // O(1) None/All/Some for the bulk-select menu: the view model's
+                // incrementally-maintained per-category selected count against the
+                // scan's file count for that category.
+                guard let scanCategory = ScanCategory(rawValue: category.id) else { return nil }
+                let total = itemsByCategory[scanCategory]?.count ?? 0
+                return (selected: viewModel.selectedJunkCount(in: scanCategory), total: total)
+            },
+            loadItems: { id in
+                // Off-main: a cache hit (usually, thanks to the prebuild) returns
+                // instantly; a miss builds that one category's tree without
+                // blocking the UI.
+                await Task.detached(priority: .userInitiated) { store.items(forCategoryID: id) }.value
             },
             onBack: onBack,
             accessibilityPrefix: "smartScan.review.junk",
+            lightSurface: true,
+            showsSparkle: true,
             selectionSummary: {
-                let selection = viewModel.junkFileSelection
-                let bytes = selection.reduce(Int64(0)) { $0 + (lookups.sizeByURL[$1] ?? 0) }
-                return ManagerSelectionSummary(count: selection.count, bytes: bytes)
+                ManagerSelectionSummary(
+                    count: viewModel.junkFileSelection.count,
+                    bytes: viewModel.selectedJunkBytes
+                )
             }
         )
     }

--- a/VaderCleaner/SmartScanMalwareReview.swift
+++ b/VaderCleaner/SmartScanMalwareReview.swift
@@ -36,7 +36,9 @@ struct SmartScanMalwareReview: View {
                 viewModel.setAllThreats(selected: selected)
             },
             onBack: onBack,
-            accessibilityPrefix: "smartScan.review.malware"
+            accessibilityPrefix: "smartScan.review.malware",
+            lightSurface: true,
+            showsSparkle: true
         )
     }
 

--- a/VaderCleaner/SmartScanMyClutterReview.swift
+++ b/VaderCleaner/SmartScanMyClutterReview.swift
@@ -55,6 +55,8 @@ struct SmartScanMyClutterReview: View {
             },
             onBack: onBack,
             accessibilityPrefix: "smartScan.review.myClutter",
+            lightSurface: true,
+            showsSparkle: true,
             selectionSummary: {
                 let selection = viewModel.largeFileSelection
                 let bytes = selection.reduce(Int64(0)) { $0 + (lookups.sizeByURL[$1] ?? 0) }

--- a/VaderCleaner/SmartScanPerformanceReview.swift
+++ b/VaderCleaner/SmartScanPerformanceReview.swift
@@ -24,6 +24,9 @@ struct SmartScanPerformanceReview: View {
             onBack: onBack,
             accessibilityPrefix: "smartScan.review.performance",
             showsSelection: false,
+            // Read-only tile: white surface for consistency, but no
+            // "smart suggestion" sparkle — its rows carry no clean action.
+            lightSurface: true,
             secondaryActionTitle: String(
                 localized: "Open Performance",
                 comment: "Button on the Smart Scan Performance Review that jumps to the standalone Performance screen."

--- a/VaderCleaner/SmartScanView.swift
+++ b/VaderCleaner/SmartScanView.swift
@@ -26,6 +26,16 @@ struct SmartScanView: View {
     /// The transition host's frame in global space, for mapping the opening
     /// click to `managerAnchor`.
     @State private var paneFrame: CGRect = .zero
+    /// The title-bar safe-area inset, claimed permanently by the results
+    /// container and handed back to the dashboard as explicit padding so a
+    /// Review Manager can extend up under the title bar (a thin, even top
+    /// margin) while the dashboard keeps its usual place below it.
+    @State private var paneTopInset: CGFloat = 0
+    /// Prebuilt, cached model behind the System Junk Review so its three panes
+    /// paint instantly (cheap shell) and each category's folder tree loads
+    /// lazily — warmed in the background the moment a scan lands on `.results`.
+    /// The same store the standalone Cleanup Manager uses.
+    @State private var junkManagerStore = CleanupManagerStore()
 
     init(
         viewModel: SmartScanViewModel,
@@ -52,13 +62,30 @@ struct SmartScanView: View {
             // Without this a stale `.review` value would re-emerge the next
             // time we land back on `.results`.
             .onChange(of: viewModel.phase) { _, newPhase in
-                if case .results = newPhase {
+                if case .results(let result) = newPhase {
+                    // Warm the Cleanup Manager's model in the background so
+                    // opening the System Junk Review paints its panes instantly.
+                    junkManagerStore.load(result: result.junkResult)
                     // Preserve user's Review choice if any only while we
                     // remain in `.results` — re-entering results from a
                     // fresh scan should start on the dashboard.
                     return
                 }
                 review = nil
+            }
+            // Mirror the local Review navigation onto the view model so the
+            // floating Run disc (hosted in a separate panel) can hide while a
+            // Review Manager is open.
+            .onChange(of: review) { _, newReview in
+                viewModel.setReviewing(newReview != nil)
+            }
+            .task {
+                // Catch the case where results are already present on first
+                // appear (e.g. returning to the section), so the Review's panes
+                // are still warm.
+                if case .results(let result) = viewModel.phase {
+                    junkManagerStore.load(result: result.junkResult)
+                }
             }
     }
 
@@ -137,10 +164,21 @@ struct SmartScanView: View {
                     onRequestReview: openReview,
                     onStartOver: { viewModel.reset() }
                 )
+                // The dashboard keeps its usual place below the title bar: the
+                // host ZStack claims that inset permanently, so it is handed
+                // back here as explicit padding.
+                .padding(.top, paneTopInset)
                 .transition(VaderMotion.dashboardTransition(reduceMotion: reduceMotion))
             }
         }
+        // Claim the title-bar safe area on this stable container, never on a
+        // transitioning branch: safe-area changes anywhere inside a freshly
+        // inserted transition subtree are deferred until its spring fully
+        // settles, which read as the Review Manager stuck below a title-bar-
+        // height gap for a beat after opening.
+        .ignoresSafeArea(.container, edges: .top)
         .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .global) }, action: { paneFrame = $0 })
+        .onGeometryChange(for: CGFloat.self, of: { $0.safeAreaInsets.top }, action: { paneTopInset = $0 })
         .animation(VaderMotion.managerZoom, value: review)
     }
 
@@ -159,6 +197,7 @@ struct SmartScanView: View {
             SmartScanJunkReview(
                 viewModel: viewModel,
                 result: result,
+                store: junkManagerStore,
                 onBack: { self.review = nil }
             )
         case .malware:

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -342,12 +342,32 @@ final class SmartScanViewModel {
     /// deselected tile is skipped entirely.
     private(set) var tileSelection: Set<SmartScanModule> = []
 
+    /// Whether a tile's Review (Manager) screen is currently open over the
+    /// results dashboard. Owned by `SmartScanView`'s local navigation state and
+    /// mirrored here so the floating Run disc — hosted in a separate panel that
+    /// only sees the view model — can hide itself while a Review is up. Reset
+    /// whenever the scan leaves `.results`.
+    private(set) var isReviewing = false
+
     /// Per-file gate inside the System Junk tile's Cleanup Manager, keyed by
     /// `ScannedFile.url`. This is the source of truth for which junk files Run
     /// removes — seeded to every scanned file (default-all-on) so the manager
     /// opens fully checked. Category-level state is derived from it (see
     /// `junkCategorySelection`).
     private(set) var junkFileSelection: Set<URL> = []
+
+    /// Running total of selected junk bytes, maintained in lockstep with
+    /// `junkFileSelection`, so the Cleanup Manager footer reads it in O(1)
+    /// instead of reducing over the selection on every render.
+    private(set) var selectedJunkBytes: Int64 = 0
+
+    /// Per-category running totals of selected junk bytes and count, maintained
+    /// in lockstep with `junkFileSelection`. Back the store-backed Cleanup
+    /// Manager's per-category selected-size badge and its "Select: None/All/Some"
+    /// menu without walking a category's (potentially huge) file list per render
+    /// — the same O(1) contract the standalone Cleanup Manager relies on.
+    private(set) var selectedJunkBytesByCategory: [ScanCategory: Int64] = [:]
+    private(set) var selectedJunkCountByCategory: [ScanCategory: Int] = [:]
 
     /// Per-category view of `junkFileSelection`: a category counts as selected
     /// when every one of its files is selected. Kept as a derived facade so the
@@ -672,7 +692,10 @@ final class SmartScanViewModel {
             // never comes back auto-selected — notably Performance, which
             // otherwise always auto-selects (its DNS flush always has work).
             tileSelection = Self.defaultTileSelection(for: result).intersection(mods)
-            junkFileSelection = Set(result.junkResult.items.map(\.url))
+            // Pre-check only the safe (regenerable / already-discarded) junk
+            // categories so a one-tap Run never removes user data. Risky
+            // categories are still listed in the Cleanup Manager, just unchecked.
+            seedJunkSelection(from: result.junkResult)
             threatSelection = Set(foundThreats.map(\.filePath))
             updateSelection = Set(foundUpdates.map(\.bundleID))
             // Seed every redundant copy (every duplicate except the kept
@@ -864,22 +887,38 @@ final class SmartScanViewModel {
 
     // MARK: - Sub-selections (per-tile Review screens)
 
+    /// Seed the junk selection and its running tallies from a fresh scan:
+    /// pre-check every file in a safe-to-auto-remove category and leave user-data
+    /// categories unchecked, building the per-category byte/count totals in the
+    /// same pass so the Cleanup Manager's badges are correct without a re-walk.
+    private func seedJunkSelection(from result: ScanResult) {
+        var urls: Set<URL> = []
+        var total: Int64 = 0
+        var bytes: [ScanCategory: Int64] = [:]
+        var counts: [ScanCategory: Int] = [:]
+        for file in result.items where file.category.isSafeToAutoRemove {
+            urls.insert(file.url)
+            total += file.size
+            bytes[file.category, default: 0] += file.size
+            counts[file.category, default: 0] += 1
+        }
+        junkFileSelection = urls
+        selectedJunkBytes = total
+        selectedJunkBytesByCategory = bytes
+        selectedJunkCountByCategory = counts
+    }
+
     func isJunkCategorySelected(_ category: ScanCategory) -> Bool {
         junkCategorySelection.contains(category)
     }
 
     /// Toggling a category is a bulk operation over its files: if every file is
-    /// currently selected, clear them all; otherwise select them all. Done as a
-    /// single write to `junkFileSelection` so SwiftUI sees one publish.
+    /// currently selected, clear them all; otherwise select them all. Routed
+    /// through the batched setter so the per-category tallies stay in sync.
     func toggleJunkCategory(_ category: ScanCategory) {
         guard case .results(let result) = phase,
               let files = result.junkResult.itemsByCategory[category] else { return }
-        let urls = files.map(\.url)
-        if urls.allSatisfy({ junkFileSelection.contains($0) }) {
-            junkFileSelection.subtract(urls)
-        } else {
-            junkFileSelection.formUnion(urls)
-        }
+        setJunkFiles(files, selected: !areAllJunkFilesSelected(files))
     }
 
     /// Whether an individual junk file is checked for removal in the Cleanup
@@ -888,27 +927,74 @@ final class SmartScanViewModel {
         junkFileSelection.contains(file.url)
     }
 
+    /// Selected junk bytes in one category — an O(1) read backing the store-
+    /// backed Cleanup Manager's per-category selected-size badge.
+    func selectedJunkBytes(in category: ScanCategory) -> Int64 {
+        selectedJunkBytesByCategory[category] ?? 0
+    }
+
+    /// Selected junk file count in one category — an O(1) read backing the
+    /// bulk-select menu's None/All/Some state.
+    func selectedJunkCount(in category: ScanCategory) -> Int {
+        selectedJunkCountByCategory[category] ?? 0
+    }
+
+    /// Whether every file in `files` is currently selected. Short-circuits on the
+    /// first unselected file, so the common "nothing selected yet" case is O(1).
+    /// Backs the Cleanup Manager folder-row checkbox's checked state.
+    func areAllJunkFilesSelected(_ files: [ScannedFile]) -> Bool {
+        !files.isEmpty && files.allSatisfy { junkFileSelection.contains($0.url) }
+    }
+
     /// Flips a single junk file's checked state.
     func toggleJunkFile(_ file: ScannedFile) {
-        if junkFileSelection.contains(file.url) {
-            junkFileSelection.remove(file.url)
-        } else {
-            junkFileSelection.insert(file.url)
+        setJunkFiles([file], selected: !junkFileSelection.contains(file.url))
+    }
+
+    /// Toggle a whole group of files as one unit — the Cleanup Manager's folder-
+    /// row checkbox, covering every file beneath a folder. A fully-selected group
+    /// clears; otherwise the whole group is selected (a partial folder fills in).
+    func toggleJunkFiles(_ files: [ScannedFile]) {
+        setJunkFiles(files, selected: !areAllJunkFilesSelected(files))
+    }
+
+    /// Select or clear a whole group of junk files in a single pass, writing each
+    /// observable property exactly once. Toggling a folder that covers tens of
+    /// thousands of files one-at-a-time re-hashes each URL and fires an
+    /// observation mutation per file — the work that froze the Cleanup Manager on
+    /// large folders. Building the new values on local copies and assigning once
+    /// collapses that to a handful of mutations total.
+    func setJunkFiles(_ files: [ScannedFile], selected: Bool) {
+        guard !files.isEmpty else { return }
+        var urls = junkFileSelection
+        var total = selectedJunkBytes
+        var bytes = selectedJunkBytesByCategory
+        var counts = selectedJunkCountByCategory
+        for file in files {
+            if selected {
+                guard urls.insert(file.url).inserted else { continue }
+                total += file.size
+                bytes[file.category, default: 0] += file.size
+                counts[file.category, default: 0] += 1
+            } else {
+                guard urls.remove(file.url) != nil else { continue }
+                total -= file.size
+                bytes[file.category, default: 0] -= file.size
+                counts[file.category, default: 0] -= 1
+            }
         }
+        junkFileSelection = urls
+        selectedJunkBytes = total
+        selectedJunkBytesByCategory = bytes
+        selectedJunkCountByCategory = counts
     }
 
     /// Check or uncheck every file in a category in one write — backs the
-    /// Cleanup Manager's "Select: All / None" menu. A single set mutation so
-    /// SwiftUI sees one publish rather than one per file.
+    /// Cleanup Manager's "Select: All / None" menu.
     func setJunkCategory(_ category: ScanCategory, selected: Bool) {
         guard case .results(let result) = phase,
               let files = result.junkResult.itemsByCategory[category] else { return }
-        let urls = files.map(\.url)
-        if selected {
-            junkFileSelection.formUnion(urls)
-        } else {
-            junkFileSelection.subtract(urls)
-        }
+        setJunkFiles(files, selected: selected)
     }
 
     func isThreatSelected(_ threat: MalwareThreat) -> Bool {
@@ -1032,6 +1118,21 @@ final class SmartScanViewModel {
         SmartScanModule.allCases.contains { willExecute($0) }
     }
 
+    /// Whether the floating Run disc should be on screen: only on the results
+    /// dashboard, only when a selected module would do work, and never while a
+    /// Review (Manager) screen is up — the Review owns the bottom bar and the
+    /// Run disc would overlap it.
+    var isRunDiscVisible: Bool {
+        guard case .results = phase else { return false }
+        return hasExecutableWork && !isReviewing
+    }
+
+    /// Records whether a tile's Review screen is open, so the floating Run disc
+    /// can hide while the user is inside a Manager. Driven by `SmartScanView`.
+    func setReviewing(_ isReviewing: Bool) {
+        self.isReviewing = isReviewing
+    }
+
     /// Default tile-selection seed for a freshly-landed `.results` payload.
     /// A module starts checked iff it has actionable work for Run. Performance
     /// always starts on because its DNS-cache flush always has work (the
@@ -1057,7 +1158,11 @@ final class SmartScanViewModel {
     func reset() {
         phase = .idle
         tileSelection = []
+        isReviewing = false
         junkFileSelection = []
+        selectedJunkBytes = 0
+        selectedJunkBytesByCategory = [:]
+        selectedJunkCountByCategory = [:]
         threatSelection = []
         updateSelection = []
         largeFileSelection = []

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -221,9 +221,32 @@ final class SystemJunkViewModel {
         selectedCountByCategory = countByCategory
     }
 
+    /// Seed the default selection from a fresh result: pre-check every file in a
+    /// safe-to-auto-remove category (regenerable or already-discarded junk) and
+    /// leave user-data categories (mail attachments, iOS backups) unchecked.
+    /// Shared by `scan()` and `seed(with:)` so both land on the same
+    /// safe-by-default state as Smart Scan. The running byte/count tallies are
+    /// built in the same pass so the Cleanup Manager's per-category badges are
+    /// correct without a re-scan.
+    private func seedDefaultSelection(from result: ScanResult) {
+        var urls: Set<URL> = []
+        var total: Int64 = 0
+        var bytesByCategory: [ScanCategory: Int64] = [:]
+        var countByCategory: [ScanCategory: Int] = [:]
+        for file in result.items where file.category.isSafeToAutoRemove {
+            urls.insert(file.url)
+            total += file.size
+            bytesByCategory[file.category, default: 0] += file.size
+            countByCategory[file.category, default: 0] += 1
+        }
+        selectedURLs = urls
+        totalSelectedSize = total
+        selectedBytesByCategory = bytesByCategory
+        selectedCountByCategory = countByCategory
+    }
+
     /// Run the injected scanner and land in `.preview` (or `.failed`).
-    /// Selects every file present in the result so the user is at "select all"
-    /// by default.
+    /// Safe-by-default: pre-checks regenerable junk and leaves user data opt-in.
     func scan() async {
         scanGeneration &+= 1
         let generation = scanGeneration
@@ -247,12 +270,8 @@ final class SystemJunkViewModel {
                 }
             }
             self.latestResult = result
-            // Nothing is selected by default — the user opts in to what to
-            // clean in the Cleanup Manager.
-            self.selectedURLs = []
-            self.totalSelectedSize = 0
-            self.selectedBytesByCategory = [:]
-            self.selectedCountByCategory = [:]
+            // Safe-by-default: pre-check regenerable junk, leave user data opt-in.
+            self.seedDefaultSelection(from: result)
             self.phase = .preview(result)
         } catch {
             log.error("System Junk scan failed: \(String(describing: error), privacy: .public)")
@@ -268,15 +287,11 @@ final class SystemJunkViewModel {
     /// Adopt a result produced by a Smart Scan (same `SystemJunkScanner`, same
     /// scope) so the user lands on the preview without scanning again. No-op
     /// unless idle, so it never overwrites an in-progress or already-shown scan.
-    /// Mirrors `scan()`'s success path: select every file by default.
+    /// Mirrors `scan()`'s success path, including its safe-by-default selection.
     func seed(with result: ScanResult) {
         guard case .idle = phase else { return }
         latestResult = result
-        // Match `scan()`: start with nothing selected so the user opts in.
-        selectedURLs = []
-        totalSelectedSize = 0
-        selectedBytesByCategory = [:]
-        selectedCountByCategory = [:]
+        seedDefaultSelection(from: result)
         phase = .preview(result)
     }
 

--- a/VaderCleanerTests/ClutterThumbnailCacheTests.swift
+++ b/VaderCleanerTests/ClutterThumbnailCacheTests.swift
@@ -1,0 +1,39 @@
+// ClutterThumbnailCacheTests.swift
+// Verifies the process-wide Quick Look thumbnail cache round-trips images and keys distinctly by path and point size.
+
+import XCTest
+import AppKit
+@testable import VaderCleaner
+
+final class ClutterThumbnailCacheTests: XCTestCase {
+
+    private func makeImage() -> NSImage {
+        NSImage(size: NSSize(width: 4, height: 4))
+    }
+
+    func test_store_thenCached_returnsTheSameImage() {
+        let url = URL(fileURLWithPath: "/tmp/clutter-thumb-tests/\(UUID().uuidString).mov")
+        let image = makeImage()
+
+        XCTAssertNil(ClutterThumbnailCache.cached(url, pointSize: 92), "Unseeded key misses")
+
+        ClutterThumbnailCache.store(image, for: url, pointSize: 92)
+
+        XCTAssertTrue(ClutterThumbnailCache.cached(url, pointSize: 92) === image,
+                      "A stored thumbnail is returned on the next lookup")
+    }
+
+    /// The same file requested at different point sizes (card corner vs. manager
+    /// preview) must not collide — each size gets its own entry.
+    func test_cache_keysDistinctlyByPointSize() {
+        let url = URL(fileURLWithPath: "/tmp/clutter-thumb-tests/\(UUID().uuidString).jpg")
+        let small = makeImage()
+        let large = makeImage()
+
+        ClutterThumbnailCache.store(small, for: url, pointSize: 46)
+        ClutterThumbnailCache.store(large, for: url, pointSize: 92)
+
+        XCTAssertTrue(ClutterThumbnailCache.cached(url, pointSize: 46) === small)
+        XCTAssertTrue(ClutterThumbnailCache.cached(url, pointSize: 92) === large)
+    }
+}

--- a/VaderCleanerTests/MyClutterViewModelTests.swift
+++ b/VaderCleanerTests/MyClutterViewModelTests.swift
@@ -17,6 +17,12 @@ final class MyClutterViewModelTests: XCTestCase {
         )
     }
 
+    /// Clears the safe-by-default selection (the redundant duplicate/similar
+    /// copies) so a selection-mechanics test starts from an empty baseline.
+    private func clearSelection(_ vm: MyClutterViewModel) {
+        vm.setSelection(Array(vm.selectedURLs), selected: false)
+    }
+
     /// Builds a VM whose scans return fixed fixtures and whose deleter reports
     /// every requested URL as trashed.
     private func makeViewModel(
@@ -58,19 +64,25 @@ final class MyClutterViewModelTests: XCTestCase {
         XCTAssertEqual(vm.dominantDownloadSource, "Google Chrome")
     }
 
-    func test_scanSelectsNothingByDefault() async {
+    func test_scanSelectsRedundantCopiesByDefault() async {
         let dup = DuplicateGroup(files: [file("/a/orig.txt", size: 10), file("/a/copy.txt", size: 10)])
         let sim = SimilarImageGroup(files: [file("/p/a.jpg", size: 50), file("/p/b.jpg", size: 40)])
         let large = [file("/big/movie.mov", size: 1000)]
-        let vm = makeViewModel(duplicates: [dup], similar: [sim], largeOld: large)
+        let dl = [DownloadItem(file: file("/d/app.dmg", size: 500), sourceApp: "Google Chrome")]
+        let vm = makeViewModel(duplicates: [dup], similar: [sim], largeOld: large, downloads: dl)
 
         await vm.scan()
 
-        // A scan leaves every item unselected — Review opens with a clean slate.
-        XCTAssertTrue(vm.selectedURLs.isEmpty)
-        XCTAssertFalse(vm.isSelected(URL(fileURLWithPath: "/a/copy.txt")))
-        XCTAssertFalse(vm.isSelected(URL(fileURLWithPath: "/p/b.jpg")))
-        XCTAssertEqual(vm.totalSelectedSize, 0)
+        // Safe-by-default: the redundant duplicate and near-duplicate copies are
+        // pre-checked (deleting one always leaves an original), while large/old
+        // files and downloads — real user data — stay opt-in.
+        let redundant = Set(vm.duplicateCopies.map(\.url)).union(vm.similarCopies.map(\.url))
+        XCTAssertEqual(vm.selectedURLs, redundant)
+        XCTAssertFalse(vm.isSelected(URL(fileURLWithPath: "/big/movie.mov")), "Large/old files stay opt-in")
+        XCTAssertFalse(vm.isSelected(URL(fileURLWithPath: "/d/app.dmg")), "Downloads stay opt-in")
+        let expectedBytes = vm.duplicateCopies.reduce(Int64(0)) { $0 + $1.size }
+            + vm.similarCopies.reduce(Int64(0)) { $0 + $1.size }
+        XCTAssertEqual(vm.totalSelectedSize, expectedBytes)
     }
 
     func test_emptyWhenNothingFound() async {
@@ -107,6 +119,7 @@ final class MyClutterViewModelTests: XCTestCase {
         let large = [file("/big/a.mov", size: 100), file("/big/b.mov", size: 200)]
         let vm = makeViewModel(duplicates: [dup], largeOld: large)
         await vm.scan()
+        clearSelection(vm)  // start from an empty baseline
 
         vm.toggleSelection(url: URL(fileURLWithPath: "/big/a.mov"))
         vm.toggleSelection(url: URL(fileURLWithPath: "/a/copy.txt"))
@@ -134,6 +147,7 @@ final class MyClutterViewModelTests: XCTestCase {
         let large = [file(shared, size: 50)]
         let vm = makeViewModel(duplicates: [dup], largeOld: large)
         await vm.scan()
+        clearSelection(vm)  // start from an empty baseline
 
         vm.toggleSelection(url: URL(fileURLWithPath: shared))
 
@@ -194,11 +208,13 @@ final class MyClutterViewModelTests: XCTestCase {
         let vm = makeViewModel(duplicates: [dup], largeOld: large) { trashed = $0 }
 
         await vm.scan()
-        // Nothing is selected by default; select the duplicate copy and the
-        // large file explicitly.
-        vm.toggleSelection(url: URL(fileURLWithPath: "/a/copy.txt"))
+        // The duplicate copy is safe-by-default (already pre-selected); add the
+        // large file explicitly so both categories have a deletion pending.
         vm.toggleSelection(url: URL(fileURLWithPath: "/big/movie.mov"))
-        XCTAssertEqual(vm.selectedURLs.count, 2)
+        XCTAssertEqual(vm.selectedURLs, [
+            URL(fileURLWithPath: "/a/copy.txt"),
+            URL(fileURLWithPath: "/big/movie.mov"),
+        ])
 
         await vm.deleteSelected()
 

--- a/VaderCleanerTests/MyClutterViewModelTests.swift
+++ b/VaderCleanerTests/MyClutterViewModelTests.swift
@@ -227,6 +227,22 @@ final class MyClutterViewModelTests: XCTestCase {
         XCTAssertTrue(vm.selectedURLs.isEmpty)
     }
 
+    /// The memoized dashboard read-model (recomputed only on scan/prune, never
+    /// per render) must reflect the survivors after a partial delete.
+    func test_derivedTotalsRecomputeAfterPartialDelete() async {
+        let large = [file("/big/a.mov", size: 100), file("/big/b.mov", size: 200)]
+        let vm = makeViewModel(largeOld: large)
+        await vm.scan()
+        XCTAssertEqual(vm.largeOldBytes, 300)
+        XCTAssertEqual(vm.totalFileCount, 2)
+
+        vm.setSelection([URL(fileURLWithPath: "/big/a.mov")], selected: true)
+        await vm.deleteSelected()
+
+        XCTAssertEqual(vm.largeOldBytes, 200, "Memoized totals recompute after a prune")
+        XCTAssertEqual(vm.totalFileCount, 1)
+    }
+
     func test_scanCoordinatingMapping() async {
         let vm = makeViewModel(largeOld: [file("/big/a.mov", size: 1)])
         XCTAssertEqual(vm.scanPresentation, .intro)

--- a/VaderCleanerTests/ProtectionSettingsStoreTests.swift
+++ b/VaderCleanerTests/ProtectionSettingsStoreTests.swift
@@ -34,7 +34,10 @@ final class ProtectionSettingsStoreTests: XCTestCase {
         XCTAssertTrue(sut.scanEmailAttachments)
         XCTAssertTrue(sut.scanArchives)
         XCTAssertTrue(sut.excludeDownloadedICloudFiles)
-        XCTAssertEqual(sut.scanMode, .deep)
+        // Quick by default — the high-risk home subdirectories only, matching
+        // Smart Scan's threat scope, so a first scan is fast rather than a
+        // whole-$HOME Deep pass.
+        XCTAssertEqual(sut.scanMode, .quick)
     }
 
     // MARK: - Persistence
@@ -73,6 +76,6 @@ final class ProtectionSettingsStoreTests: XCTestCase {
     func test_scanMode_unknownPersistedValueFallsBackToDefault() {
         defaults.set("nonsense", forKey: "protection.scanMode")
         let sut = ProtectionSettingsStore(defaults: defaults)
-        XCTAssertEqual(sut.scanMode, .deep)
+        XCTAssertEqual(sut.scanMode, .quick)
     }
 }

--- a/VaderCleanerTests/ScanCategoryTests.swift
+++ b/VaderCleanerTests/ScanCategoryTests.swift
@@ -44,6 +44,38 @@ final class ScanCategoryTests: XCTestCase {
         }
     }
 
+    /// `isSafeToAutoRemove` is the single source of truth every cleanup surface
+    /// (Smart Scan, standalone Cleanup Manager, My Clutter) consults to seed its
+    /// default selection. Safe = regenerable or already-discarded; user-data
+    /// categories must stay opt-in.
+    func test_isSafeToAutoRemove_pinsTheSafeSet() {
+        let safe: Set<ScanCategory> = [
+            .systemCache, .userCache,
+            .systemLogs, .userLogs,
+            .languageFiles,
+            .xcodeJunk, .documentVersions, .webDevJunk,
+            .trash,
+        ]
+        for category in ScanCategory.allCases {
+            XCTAssertEqual(
+                category.isSafeToAutoRemove,
+                safe.contains(category),
+                "\(category) safe-to-auto-remove classification is wrong"
+            )
+        }
+    }
+
+    /// The risky categories — real user data that a one-tap clean must never
+    /// pre-check — are explicitly opt-in.
+    func test_isSafeToAutoRemove_excludesUserDataCategories() {
+        for category in [ScanCategory.mailAttachments, .iosBackups, .largeFile, .oldFile] {
+            XCTAssertFalse(
+                category.isSafeToAutoRemove,
+                "\(category) holds user data and must not be auto-removed"
+            )
+        }
+    }
+
     /// Raw values back persistence (preferences, JSON-encoded scan reports).
     /// Pinning them here guarantees a rename is accompanied by a test update.
     func test_rawValues_areStable() {

--- a/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
+++ b/VaderCleanerTests/ScanCoordinatingConformanceTests.swift
@@ -191,7 +191,7 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
             }
         )
         await vm.scan()
-        vm.toggleSelection(file) // opt the file in so clean() runs.
+        // The safe-category file is selected by default, so clean() runs.
 
         let task = Task { await vm.clean() }
         await yieldUntil({ vm.phase == .cleaning }, ".cleaning")
@@ -208,7 +208,7 @@ final class ScanCoordinatingConformanceTests: XCTestCase {
             deleter: { _ in 100 }
         )
         await vm.scan()
-        vm.toggleSelection(file) // opt in before cleaning
+        // The safe-category file is selected by default, so clean() runs.
         await vm.clean()
         if case .complete = vm.phase {} else { XCTFail("expected .complete, got \(vm.phase)") }
         XCTAssertEqual(vm.scanPresentation, .results)

--- a/VaderCleanerTests/SmartScanViewModelTests.swift
+++ b/VaderCleanerTests/SmartScanViewModelTests.swift
@@ -394,7 +394,7 @@ final class SmartScanViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isJunkCategorySelected(.userCache))
     }
 
-    func test_scan_defaultsJunkFileSelectionToAllScannedFiles() async {
+    func test_scan_defaultsJunkFileSelectionToSafeCategoryFiles() async {
         let a = makeFile(name: "a", size: 1, category: .userCache)
         let b = makeFile(name: "b", size: 2, category: .userLogs)
         let vm = makeViewModel(
@@ -404,7 +404,34 @@ final class SmartScanViewModelTests: XCTestCase {
         await vm.scan()
 
         XCTAssertEqual(vm.junkFileSelection, [a.url, b.url],
-                       "Cleanup Manager opens with every junk file checked")
+                       "Cleanup Manager opens with every safe-category junk file checked")
+    }
+
+    /// The one-tap Scan→Run path must never pre-check user data: files in the
+    /// risky categories (mail attachments, iOS backups) are still found and
+    /// listed, but start unchecked so removing them is an explicit choice.
+    func test_scan_defaultsJunkFileSelectionExcludesRiskyCategories() async {
+        let safe = makeFile(name: "cache", size: 1, category: .userCache)
+        let mail = makeFile(name: "att", size: 2, category: .mailAttachments)
+        let backup = makeFile(name: "ios", size: 3, category: .iosBackups)
+        let vm = makeViewModel(
+            junkScanner: {
+                self.makeResult(
+                    (.userCache, [safe]),
+                    (.mailAttachments, [mail]),
+                    (.iosBackups, [backup])
+                )
+            }
+        )
+
+        await vm.scan()
+
+        XCTAssertEqual(vm.junkFileSelection, [safe.url],
+                       "Run must pre-check only safe-category files, never mail attachments or iOS backups")
+        XCTAssertFalse(vm.isJunkFileSelected(mail),
+                       "Mail attachments start unchecked — removing them is opt-in")
+        XCTAssertFalse(vm.isJunkFileSelected(backup),
+                       "iOS backups start unchecked — removing them is opt-in")
     }
 
     func test_toggleJunkFile_addsAndRemoves() async {
@@ -420,6 +447,63 @@ final class SmartScanViewModelTests: XCTestCase {
 
         vm.toggleJunkFile(a)
         XCTAssertTrue(vm.isJunkFileSelected(a))
+    }
+
+    // MARK: - Junk selection tallies (store-backed Cleanup Manager)
+
+    /// The per-category byte/count tallies and the running total are seeded from
+    /// the same safe-by-default selection, so the Cleanup Manager's badges are
+    /// correct the instant it opens — no re-walk of the file list.
+    func test_selectedJunkTallies_seededForSafeCategoriesOnly() async {
+        let cacheA = makeFile(name: "a", size: 100, category: .userCache)
+        let cacheB = makeFile(name: "b", size: 30, category: .userCache)
+        let mail = makeFile(name: "m", size: 500, category: .mailAttachments)
+        let vm = makeViewModel(
+            junkScanner: { self.makeResult((.userCache, [cacheA, cacheB]), (.mailAttachments, [mail])) }
+        )
+        await vm.scan()
+
+        XCTAssertEqual(vm.selectedJunkBytes(in: .userCache), 130)
+        XCTAssertEqual(vm.selectedJunkCount(in: .userCache), 2)
+        XCTAssertEqual(vm.selectedJunkBytes(in: .mailAttachments), 0, "Risky category isn't pre-checked")
+        XCTAssertEqual(vm.selectedJunkCount(in: .mailAttachments), 0)
+        XCTAssertEqual(vm.selectedJunkBytes, 130, "Running total covers only the safe files")
+    }
+
+    /// A batched folder/category write keeps the tallies in lockstep and is
+    /// idempotent — re-selecting an already-selected file must not double-count.
+    func test_setJunkFiles_batchedUpdateMaintainsTallies() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 30, category: .userCache)
+        let vm = makeViewModel(junkScanner: { self.makeResult((.userCache, [a, b])) })
+        await vm.scan()
+
+        vm.setJunkFiles([a, b], selected: false)   // clear the folder
+        XCTAssertEqual(vm.selectedJunkCount(in: .userCache), 0)
+        XCTAssertEqual(vm.selectedJunkBytes, 0)
+
+        vm.setJunkFiles([a, b], selected: true)
+        vm.setJunkFiles([a, b], selected: true)    // idempotent
+        XCTAssertEqual(vm.selectedJunkCount(in: .userCache), 2)
+        XCTAssertEqual(vm.selectedJunkBytes, 130)
+    }
+
+    /// A folder-row toggle is all-or-nothing: a fully-selected group clears, and
+    /// a partial or empty group fills in.
+    func test_toggleJunkFiles_folderToggleAllOrNothing() async {
+        let a = makeFile(name: "a", size: 100, category: .userCache)
+        let b = makeFile(name: "b", size: 30, category: .userCache)
+        let vm = makeViewModel(junkScanner: { self.makeResult((.userCache, [a, b])) })
+        await vm.scan()
+        XCTAssertTrue(vm.areAllJunkFilesSelected([a, b]), "Safe files start selected")
+
+        vm.toggleJunkFiles([a, b])   // all → clear
+        XCTAssertFalse(vm.areAllJunkFilesSelected([a, b]))
+        XCTAssertEqual(vm.selectedJunkCount(in: .userCache), 0)
+
+        vm.toggleJunkFiles([a, b])   // none → all
+        XCTAssertTrue(vm.areAllJunkFilesSelected([a, b]))
+        XCTAssertEqual(vm.selectedJunkCount(in: .userCache), 2)
     }
 
     /// A category facade toggle is a bulk op over its files: deselecting one
@@ -1066,6 +1150,44 @@ final class SmartScanViewModelTests: XCTestCase {
             vm.toggleModule(module)
         }
         XCTAssertFalse(vm.hasExecutableWork)
+    }
+
+    // MARK: - Floating Run disc visibility
+
+    func test_isRunDiscVisible_falseAtIdle() {
+        let vm = makeViewModel()
+        XCTAssertFalse(vm.isRunDiscVisible, "No Run disc before a scan lands on results")
+    }
+
+    func test_isRunDiscVisible_trueAtResultsWithWork() async {
+        let vm = makeViewModel()
+        await vm.scan()
+        XCTAssertTrue(vm.isRunDiscVisible, "Run disc shows on the results dashboard with executable work")
+    }
+
+    /// Opening a tile's Review Manager must hide the floating Run disc — the
+    /// Manager owns the bottom bar, so an overlapping disc reads as clutter.
+    func test_isRunDiscVisible_falseWhileReviewing() async {
+        let vm = makeViewModel()
+        await vm.scan()
+        XCTAssertTrue(vm.isRunDiscVisible)
+
+        vm.setReviewing(true)
+        XCTAssertFalse(vm.isRunDiscVisible, "Run disc hides while a Review Manager is open")
+        XCTAssertTrue(vm.isReviewing)
+
+        vm.setReviewing(false)
+        XCTAssertTrue(vm.isRunDiscVisible, "Run disc returns when the Review closes")
+    }
+
+    func test_reset_clearsIsReviewing() async {
+        let vm = makeViewModel()
+        await vm.scan()
+        vm.setReviewing(true)
+
+        vm.reset()
+
+        XCTAssertFalse(vm.isReviewing, "A reset clears the in-flight Review flag")
     }
 
     func test_willExecute_systemJunkRespectsCategorySelection() async {

--- a/VaderCleanerTests/SystemJunkViewModelTests.swift
+++ b/VaderCleanerTests/SystemJunkViewModelTests.swift
@@ -89,26 +89,32 @@ final class SystemJunkViewModelTests: XCTestCase {
         XCTFail("Timed out waiting for: \(message)", file: file, line: line)
     }
 
-    /// Every file in the scan result must be selected by default — the user
-    /// opts out of files rather than opting in, matching how cleaner UIs treat
-    /// safe-to-remove junk (and the section's prior "all categories checked"
-    /// behaviour, now expressed per file).
-    func test_scan_selectsNothingByDefault() async {
-        let a = makeFile(name: "a", size: 100, category: .userCache)
-        let b = makeFile(name: "b", size: 200, category: .systemLogs)
-        let c = makeFile(name: "c", size: 300, category: .trash)
+    /// Safe-by-default: a fresh scan pre-checks every file in a regenerable /
+    /// already-discarded category (caches, logs, Trash) but leaves user-data
+    /// categories (mail attachments, iOS backups) unchecked — the same rule
+    /// Smart Scan applies, so the two surfaces stay consistent.
+    func test_scan_selectsSafeCategoriesByDefault() async {
+        let cache = makeFile(name: "a", size: 100, category: .userCache)
+        let log = makeFile(name: "b", size: 200, category: .systemLogs)
+        let trash = makeFile(name: "c", size: 300, category: .trash)
+        let mail = makeFile(name: "d", size: 400, category: .mailAttachments)
+        let backup = makeFile(name: "e", size: 500, category: .iosBackups)
         let result = makeResult(
-            (.userCache, [a]),
-            (.systemLogs, [b]),
-            (.trash, [c])
+            (.userCache, [cache]),
+            (.systemLogs, [log]),
+            (.trash, [trash]),
+            (.mailAttachments, [mail]),
+            (.iosBackups, [backup])
         )
         let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
 
         await vm.scan()
 
-        // Selection is opt-in: the user chooses what to clean in the manager.
-        XCTAssertTrue(vm.selectedURLs.isEmpty)
-        XCTAssertEqual(vm.totalSelectedSize, 0)
+        XCTAssertEqual(vm.selectedURLs, [cache.url, log.url, trash.url],
+                       "Only safe-category files are pre-checked")
+        XCTAssertFalse(vm.selectedURLs.contains(mail.url), "Mail attachments stay opt-in")
+        XCTAssertFalse(vm.selectedURLs.contains(backup.url), "iOS backups stay opt-in")
+        XCTAssertEqual(vm.totalSelectedSize, 600, "Selected total covers only the safe files")
     }
 
     /// A scanner that throws must surface a `.failed` phase rather than leave
@@ -145,6 +151,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         )
         let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
         await vm.scan()
+        clearSelection(vm, a, b)  // start from an empty baseline
         XCTAssertEqual(vm.totalSelectedSize, 0)
 
         vm.toggleSelection(a)
@@ -178,7 +185,9 @@ final class SystemJunkViewModelTests: XCTestCase {
         )
 
         await vm.scan()
-        vm.toggleSelection(userFile)  // select only the user-cache file
+        // Both safe-category files are selected by default; deselect the log
+        // file so only the user-cache file remains for the deleter.
+        vm.toggleSelection(logFile)
         await vm.clean()
 
         let received = await recorded.value
@@ -200,7 +209,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         )
 
         await vm.scan()
-        vm.toggleSelection(file)  // opt the file in before cleaning
+        // The cache file is selected by default (safe category); clean it.
         await vm.clean()
 
         XCTAssertEqual(vm.phase, .complete(bytesFreed: 1_024))
@@ -220,7 +229,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         )
 
         await vm.scan()
-        vm.toggleSelection(file)  // select so clean reaches the deleter
+        // The cache file is selected by default (safe category); clean reaches the deleter.
         await vm.clean()
 
         if case .failed = vm.phase {
@@ -246,7 +255,8 @@ final class SystemJunkViewModelTests: XCTestCase {
         )
 
         await vm.scan()
-        // Nothing is selected by default.
+        // Deselect the safe-by-default file so nothing is selected.
+        clearSelection(vm, file)
         await vm.clean()
 
         let didInvoke = await invoked.value
@@ -287,6 +297,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         let result = makeResult((.userCache, [cacheA, cacheB]), (.userLogs, [log]))
         let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
         await vm.scan()
+        clearSelection(vm, cacheA, cacheB, log)  // start from an empty baseline
 
         vm.toggleSelection(cacheA)
         vm.toggleSelection(log)
@@ -309,6 +320,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         let result = makeResult((.userCache, [cacheA]), (.userLogs, [log]))
         let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
         await vm.scan()
+        clearSelection(vm, cacheA, log)  // start from an empty baseline
 
         vm.toggleSelection(cacheA)
         vm.toggleSelection(log)
@@ -340,18 +352,20 @@ final class SystemJunkViewModelTests: XCTestCase {
     /// A fresh scan and `scanAgain()` must drop the per-category totals so the
     /// badge never carries a previous run's selection forward.
     func test_selectedBytesPerCategory_clearedOnScanAndScanAgain() async {
-        let file = makeFile(name: "a", size: 100, category: .userCache)
-        let result = makeResult((.userCache, [file]))
+        // A risky (opt-in) category so a fresh scan leaves it unselected, keeping
+        // the focus on scanAgain() clearing the running total.
+        let file = makeFile(name: "a", size: 100, category: .mailAttachments)
+        let result = makeResult((.mailAttachments, [file]))
         let vm = makeViewModel(scanner: { result }, deleter: { _ in 100 })
 
         await vm.scan()
-        XCTAssertEqual(vm.selectedBytes(in: .userCache), 0, "A fresh scan selects nothing")
+        XCTAssertEqual(vm.selectedBytes(in: .mailAttachments), 0, "A risky category isn't pre-checked")
 
         vm.toggleSelection(file)
-        XCTAssertEqual(vm.selectedBytes(in: .userCache), 100)
+        XCTAssertEqual(vm.selectedBytes(in: .mailAttachments), 100)
 
         vm.scanAgain()
-        XCTAssertEqual(vm.selectedBytes(in: .userCache), 0)
+        XCTAssertEqual(vm.selectedBytes(in: .mailAttachments), 0)
     }
 
     // MARK: - Per-category selected count (bulk-select menu)
@@ -366,6 +380,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         let result = makeResult((.userCache, [cacheA, cacheB]), (.userLogs, [log]))
         let vm = makeViewModel(scanner: { result }, deleter: noopDeleter)
         await vm.scan()
+        clearSelection(vm, cacheA, cacheB, log)  // start from an empty baseline
 
         vm.toggleSelection(cacheA)
         vm.toggleSelection(log)
@@ -402,18 +417,20 @@ final class SystemJunkViewModelTests: XCTestCase {
     /// A fresh scan and `scanAgain()` must drop the per-category counts so the
     /// menu never carries a previous run's selection forward.
     func test_selectedCountPerCategory_clearedOnScanAndScanAgain() async {
-        let file = makeFile(name: "a", size: 100, category: .userCache)
-        let result = makeResult((.userCache, [file]))
+        // A risky (opt-in) category so a fresh scan leaves it unselected, keeping
+        // the focus on scanAgain() clearing the running count.
+        let file = makeFile(name: "a", size: 100, category: .mailAttachments)
+        let result = makeResult((.mailAttachments, [file]))
         let vm = makeViewModel(scanner: { result }, deleter: { _ in 100 })
 
         await vm.scan()
-        XCTAssertEqual(vm.selectedCount(in: .userCache), 0, "A fresh scan selects nothing")
+        XCTAssertEqual(vm.selectedCount(in: .mailAttachments), 0, "A risky category isn't pre-checked")
 
         vm.toggleSelection(file)
-        XCTAssertEqual(vm.selectedCount(in: .userCache), 1)
+        XCTAssertEqual(vm.selectedCount(in: .mailAttachments), 1)
 
         vm.scanAgain()
-        XCTAssertEqual(vm.selectedCount(in: .userCache), 0)
+        XCTAssertEqual(vm.selectedCount(in: .mailAttachments), 0)
     }
 
     // MARK: - Bulk selection (folder-row / category toggle)
@@ -478,6 +495,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         let b = makeFile(name: "b", size: 30, category: .userCache)
         let vm = makeViewModel(scanner: { self.makeResult((.userCache, [a, b])) }, deleter: noopDeleter)
         await vm.scan()
+        clearSelection(vm, a, b)  // start from an empty baseline
 
         vm.toggleSelection([a, b]) // nothing selected → select all
         XCTAssertTrue(vm.areAllSelected([a, b]))
@@ -495,6 +513,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         let b = makeFile(name: "b", size: 30, category: .userCache)
         let vm = makeViewModel(scanner: { self.makeResult((.userCache, [a, b])) }, deleter: noopDeleter)
         await vm.scan()
+        clearSelection(vm, a, b)  // start from an empty baseline
         vm.setSelection([a], selected: true) // only one of two selected
 
         vm.toggleSelection([a, b])
@@ -587,7 +606,7 @@ final class SystemJunkViewModelTests: XCTestCase {
             deleter: { _ in 100 }
         )
         await vm.scan()
-        vm.toggleSelection(file)  // select before cleaning
+        // The cache file is selected by default (safe category); clean it.
         await vm.clean()
         XCTAssertEqual(vm.phase, .complete(bytesFreed: 100))
 
@@ -647,16 +666,18 @@ final class SystemJunkViewModelTests: XCTestCase {
 
     // MARK: - Seed (from Smart Scan)
 
-    func test_seed_fromIdle_landsInPreviewWithNothingSelected() {
+    func test_seed_fromIdle_landsInPreviewWithSafeCategoriesSelected() {
         let vm = makeViewModel()
-        let file = makeFile(name: "a", size: 100, category: .userCache)
-        let result = makeResult((.userCache, [file]))
+        let cache = makeFile(name: "a", size: 100, category: .userCache)
+        let mail = makeFile(name: "b", size: 400, category: .mailAttachments)
+        let result = makeResult((.userCache, [cache]), (.mailAttachments, [mail]))
 
         vm.seed(with: result)
 
         XCTAssertEqual(vm.phase, .preview(result))
-        XCTAssertTrue(vm.selectedURLs.isEmpty)
-        XCTAssertEqual(vm.totalSelectedSize, 0)
+        XCTAssertEqual(vm.selectedURLs, [cache.url],
+                       "A seeded result lands on the same safe-by-default selection as scan()")
+        XCTAssertEqual(vm.totalSelectedSize, 100)
     }
 
     func test_seed_whenNotIdle_isIgnored() async {
@@ -699,6 +720,12 @@ final class SystemJunkViewModelTests: XCTestCase {
 
     /// Default no-op deleter for tests that don't exercise the clean path.
     private let noopDeleter: ([ScannedFile]) async throws -> Int64 = { _ in 0 }
+
+    /// Deselects `files` so a selection-mechanics test starts from an empty
+    /// baseline, independent of the safe-by-default seed a scan now applies.
+    private func clearSelection(_ vm: SystemJunkViewModel, _ files: ScannedFile...) {
+        vm.setSelection(files, selected: false)
+    }
 }
 
 /// Small actor wrapper that lets test deleter closures record values without


### PR DESCRIPTION
## Overview

Unifies the cleanup surfaces so a one-tap **Scan → Run** is safe by default, makes the Smart Scan review tiles look and perform like the standalone Cleanup Manager, and changes the Protection section's default scan to Quick so a first scan is fast.

## What changed

### Safe-by-default selection (everywhere)
- New `ScanCategory.isSafeToAutoRemove` is the single source of truth: caches, logs, dev build junk, document versions, language files, and Trash are safe to pre-check; **mail attachments, iOS backups, and large/old files are opt-in**.
- Smart Scan, the standalone Cleanup Manager (`SystemJunkViewModel`), and My Clutter (`MyClutterViewModel`) all seed their default selection from it. My Clutter pre-checks only the redundant duplicate/near-duplicate copies (an original is always kept).
- Net effect: pressing **Run** without touching anything only ever removes regenerable or already-discarded junk — never irreplaceable user data.

### Smart Scan review managers now match the standalone
- The five review tiles render on the **white manager surface** with the smart-suggestion sparkle (Performance stays read-only, no sparkle).
- The floating **Run disc is hidden while a review is open** (`isReviewing` / `isRunDiscVisible`), so the manager owns the bottom bar.
- Fixed the **gap above the white card**: the results container claims the title-bar safe area on its stable branch so the manager extends up to a thin, even top margin.

### Fast System Junk review
- The Smart Scan junk review is now backed by the same `CleanupManagerStore` the standalone uses: a **cheap section/category shell paints instantly** and each category's **folder tree loads lazily** off-main, warmed in the background when results land. Previously it built the entire model eagerly (painfully slow on large scans).
- Added **batched/O(1) junk selection** to `SmartScanViewModel` (`setJunkFiles` / `toggleJunkFiles` / `areAllJunkFilesSelected` + incrementally-maintained per-category byte/count tallies) so folder toggles stay snappy on huge scans.

### Protection default → Quick
- `defaultScanMode` changed `.deep` → `.quick`. A fresh install now scans **Downloads / Desktop / Documents** (matching Smart Scan's threat scope) instead of walking all of `$HOME`. Balanced and Deep remain one tap away; users who already picked a mode keep their saved choice.

## Testing

- All affected unit-test classes pass (~195 tests): `ScanCategoryTests`, `SmartScanViewModelTests`, `SystemJunkViewModelTests`, `MyClutterViewModelTests`, `ScanCoordinatingConformanceTests`, `ProtectionSettingsStoreTests`. TDD throughout.
- ⚠️ The **full** `VaderCleanerTests` run kept hanging in the terminal test-host bootstrap (environmental — `linkd`/`autoShortcut` wedge, unrelated to the code). Please run the full suite in Xcode before merging.

## Reviewer notes / please eyeball
- Open **Smart Scan → Cleanup Manager** and confirm: no gap above the white card, no floating Run button while inside the review, and panes populate instantly with a folder tree (like the standalone). I couldn't screenshot from the terminal (Screen Recording permission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer-by-default cleanup selection: only low-risk junk is preselected; user-content categories remain opt-in.
  * Added thumbnail caching to reduce initial loading/thumbnail flicker.
* **Bug Fixes**
  * Improved accuracy of selected totals and per-category counts for cleanup summaries.
  * Floating Run disc visibility now better reflects whether review is open.
* **Changes**
  * New installs now start with **Quick** Protection scanning by default.
  * Review screens now use updated presentation styling (lighter surface and Sparkle where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->