### PR TITLE
Build junk selection seeds off the main actor

### DIFF
--- a/VaderCleaner.xcodeproj/project.pbxproj
+++ b/VaderCleaner.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		65E3F8EED4FBFCF0631AD84B /* AssociatedFileFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C444E0CC178C7E559BC3F7CD /* AssociatedFileFinderTests.swift */; };
 		667CDB738F03027C97828C68 /* HungAppMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603884BF695008972AC925C8 /* HungAppMonitorTests.swift */; };
 		67B6E2F0F779AF28BBBA00C1 /* ScanDiscHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3655EDEA0B38D11EFCE61986 /* ScanDiscHostView.swift */; };
+		684A605E630D12399E322C87 /* ScanSelectionSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2328CD0C88FCF0B17773A1D /* ScanSelectionSeedTests.swift */; };
 		688FEF65720EAF3D51754EC6 /* MyClutterManagerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE4CEE105776395ED808C7A /* MyClutterManagerModelTests.swift */; };
 		6902C7298B34C1DD1DFABCCF /* CleanupCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1D0804B8FCB3DD9A50123 /* CleanupCardTests.swift */; };
 		6A34CA9DF4F4B0D1326A965C /* performance.usdz in Resources */ = {isa = PBXBuildFile; fileRef = B51321F0F77F5813E6777822 /* performance.usdz */; };
@@ -285,6 +286,7 @@
 		BACC269ED04FA26D7003F449 /* MyClutterThumbnailStripItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB9080DB9E32168E1AA98AB /* MyClutterThumbnailStripItem.swift */; };
 		BB6D9635C62A1D0635E2799F /* AppUpdaterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76CE861C998A697164C552 /* AppUpdaterError.swift */; };
 		BB9A4CF2FD2F04CD567D4F4F /* PerformanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C485B2B12D9A5E260323AB89 /* PerformanceViewModel.swift */; };
+		BC418A76CFFC18CFA6043BDF /* ScanSelectionSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEF15F03C44736F01598323 /* ScanSelectionSeed.swift */; };
 		BC4853DC6F31E89C7A1017C5 /* DatabaseUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232219D61C4B82F4675EF95A /* DatabaseUpdater.swift */; };
 		BCFA47EF8B1FBC4B3A67E4B5 /* NavigationSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133467A06193C406B027D97C /* NavigationSectionTests.swift */; };
 		BD3B6E6F3732BC07EAEC9FA1 /* SystemPathProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC391B523110720320AD89 /* SystemPathProviding.swift */; };
@@ -566,6 +568,7 @@
 		58B48ACB80B7FBBFB944A3AE /* ClutterThumbnailCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClutterThumbnailCache.swift; sourceTree = "<group>"; };
 		5B8CDD8E97F29FEEB9E1F20C /* DownloadSourceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadSourceResolver.swift; sourceTree = "<group>"; };
 		5BAC4E977A664B7A960F1C77 /* FullDiskAccessPromptCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessPromptCard.swift; sourceTree = "<group>"; };
+		5BEF15F03C44736F01598323 /* ScanSelectionSeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanSelectionSeed.swift; sourceTree = "<group>"; };
 		5CC50A90E584320709971BCB /* ScanCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCategoryTests.swift; sourceTree = "<group>"; };
 		5E978BB01AD677AEDE122B1C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5F498579A77E1DAED6AC00AF /* SmartScanMyClutterReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartScanMyClutterReview.swift; sourceTree = "<group>"; };
@@ -665,6 +668,7 @@
 		9F2BB8E9DD31E37B171CC32D /* BrowserPrivacyRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrivacyRemover.swift; sourceTree = "<group>"; };
 		9FF2C4CE1BE29B227FEB57CA /* TriggerAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerAnchor.swift; sourceTree = "<group>"; };
 		A1B0ABA8AA490286024757B9 /* MalwareUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MalwareUITests.swift; sourceTree = "<group>"; };
+		A2328CD0C88FCF0B17773A1D /* ScanSelectionSeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanSelectionSeedTests.swift; sourceTree = "<group>"; };
 		A25BE525CD287D91EE80A6CF /* VaderCleanerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaderCleanerApp.swift; sourceTree = "<group>"; };
 		A3852658DC221FB8B03631D1 /* HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperProtocol.swift; sourceTree = "<group>"; };
 		A457B6C8523278A91D85120D /* SimilarImageScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarImageScannerTests.swift; sourceTree = "<group>"; };
@@ -1001,6 +1005,7 @@
 				14A3AE9EED81844B80CF3A1A /* ScanProgressFormatting.swift */,
 				FF3BFBAF09EA79BE34F2ABCF /* ScanProgressIndicator.swift */,
 				92759EA8E508BD5B87FCAAD6 /* ScanResult.swift */,
+				5BEF15F03C44736F01598323 /* ScanSelectionSeed.swift */,
 				9EFF573646C7B3E43AD2A96E /* SectionIntroView.swift */,
 				2FA0DB8537E6A360F24AB03E /* SectionPresentation.swift */,
 				AE9F703D11227A0065BFDEE7 /* SectionRecommendation.swift */,
@@ -1229,6 +1234,7 @@
 				BC72C9CBA70B1BBF45D6B8C1 /* ScanDiscWindowFrameTests.swift */,
 				A9F0F84AC9D6DC3F18F29AD5 /* ScanProgressIndicatorTests.swift */,
 				0D4E92A146A223EA836C156D /* ScanResultTests.swift */,
+				A2328CD0C88FCF0B17773A1D /* ScanSelectionSeedTests.swift */,
 				6A5715B3661CBF62AACA4206 /* SectionIntroViewTests.swift */,
 				732FA87F80DF686871220B50 /* SectionPresentationTests.swift */,
 				D04B389DB9840D533358345D /* SectionRecommendationSelectorTests.swift */,
@@ -1574,6 +1580,7 @@
 				F106EE57A074D89D42E2872B /* ScanDiscWindowFrameTests.swift in Sources */,
 				E77456FD775F682539451AFA /* ScanProgressIndicatorTests.swift in Sources */,
 				EF713E6D274DD7207EEB61FD /* ScanResultTests.swift in Sources */,
+				684A605E630D12399E322C87 /* ScanSelectionSeedTests.swift in Sources */,
 				A984D7D055DE9296AFE8DF4D /* SectionIntroViewTests.swift in Sources */,
 				1275DA924536C11023DB360E /* SectionPresentationTests.swift in Sources */,
 				52D10BA2CB08E461B2A87A7D /* SectionRecommendationSelectorTests.swift in Sources */,
@@ -1783,6 +1790,7 @@
 				45825BEE32AC83FC8B685E28 /* ScanProgressFormatting.swift in Sources */,
 				DE57DC92B2179CB856E0D558 /* ScanProgressIndicator.swift in Sources */,
 				8340A2D44E8B2BCD2500B867 /* ScanResult.swift in Sources */,
+				BC418A76CFFC18CFA6043BDF /* ScanSelectionSeed.swift in Sources */,
 				80111FB2EC8ED204B993FC21 /* ScannableSectionContent.swift in Sources */,
 				494DBF4AEF6D8730DF44147E /* ScannedFile.swift in Sources */,
 				9D44F12D7502363B814F2DF9 /* SectionIntroView.swift in Sources */,

--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -150,7 +150,9 @@ struct ContentView: View {
         // Every section is only populated when it is still idle, so this never
         // disrupts a section the user has already scanned themselves.
         smartScanViewModel.onScanCompleted = { [systemJunkViewModel, myClutterViewModel, spaceLensViewModel, applicationsViewModel, performanceViewModel, protectionDashboardViewModel] result in
-            systemJunkViewModel.seed(with: result.junkResult)
+            // Seeding walks the whole junk result off the main actor, so it
+            // runs as its own task rather than blocking this completion hop.
+            Task { await systemJunkViewModel.seed(with: result.junkResult) }
             // Seeds Protection's malware tile from the Smart Scan results and
             // kicks off the privacy preview, without re-running the malware scan.
             protectionDashboardViewModel.prewarmFromSmartScan(

--- a/VaderCleaner/ScanSelectionSeed.swift
+++ b/VaderCleaner/ScanSelectionSeed.swift
@@ -1,0 +1,59 @@
+// ScanSelectionSeed.swift
+// Precomputed junk-selection state (URLs plus running byte/count tallies) built from a scan result off the main actor, so seeding a large result never stalls the UI.
+
+import Foundation
+
+/// The selection state a fresh `ScanResult` seeds into a junk view model: the
+/// selected URLs plus the running per-category tallies the Cleanup Manager
+/// reads in O(1).
+///
+/// The builders are `nonisolated` and `async` so a main-actor caller hops off
+/// the main thread for the walk. Hashing every URL of a large scan into a
+/// `Set` costs seconds — each bridged `URL` hash/equality round-trips through
+/// its Cocoa `relativeString` — and doing that walk on the main thread froze
+/// the scan-complete transition for the whole duration (a measured 3.2 s
+/// severe hang on a ~120 GB junk result).
+struct ScanSelectionSeed: Equatable, Sendable {
+    var urls: Set<URL> = []
+    var totalBytes: Int64 = 0
+    var bytesByCategory: [ScanCategory: Int64] = [:]
+    var countByCategory: [ScanCategory: Int] = [:]
+
+    /// Safe-by-default seed: every file in a regenerable / already-discarded
+    /// category is selected; user-data categories stay opt-in. The same rule
+    /// `SystemJunkViewModel.scan()` and Smart Scan apply, kept in one place so
+    /// the seeded surfaces can never disagree.
+    static func safeDefaults(from result: ScanResult) async -> ScanSelectionSeed {
+        build(from: result) { $0.isSafeToAutoRemove }
+    }
+
+    /// Seed covering exactly `categories` — backs a dashboard card's Review,
+    /// which opens the manager with that card's whole group pre-selected so
+    /// the selected total matches the card's displayed size.
+    static func selection(
+        of categories: Set<ScanCategory>,
+        from result: ScanResult
+    ) async -> ScanSelectionSeed {
+        build(from: result) { categories.contains($0) }
+    }
+
+    /// Single-pass builder over the result's precomputed category groupings.
+    /// Per-category byte totals come straight from `sizeByCategory`, so the
+    /// only per-file work is the URL set insertion.
+    private static func build(
+        from result: ScanResult,
+        including: (ScanCategory) -> Bool
+    ) -> ScanSelectionSeed {
+        var seed = ScanSelectionSeed()
+        let included = result.itemsByCategory.filter { including($0.key) }
+        seed.urls.reserveCapacity(included.values.reduce(0) { $0 + $1.count })
+        for (category, files) in included {
+            seed.urls.formUnion(files.lazy.map(\.url))
+            let bytes = result.sizeByCategory[category] ?? 0
+            seed.totalBytes += bytes
+            seed.bytesByCategory[category] = bytes
+            seed.countByCategory[category] = files.count
+        }
+        return seed
+    }
+}

--- a/VaderCleaner/SmartScanViewModel.swift
+++ b/VaderCleaner/SmartScanViewModel.swift
@@ -695,7 +695,7 @@ final class SmartScanViewModel {
             // Pre-check only the safe (regenerable / already-discarded) junk
             // categories so a one-tap Run never removes user data. Risky
             // categories are still listed in the Cleanup Manager, just unchecked.
-            seedJunkSelection(from: result.junkResult)
+            await seedJunkSelection(from: result.junkResult)
             threatSelection = Set(foundThreats.map(\.filePath))
             updateSelection = Set(foundUpdates.map(\.bundleID))
             // Seed every redundant copy (every duplicate except the kept
@@ -891,21 +891,15 @@ final class SmartScanViewModel {
     /// pre-check every file in a safe-to-auto-remove category and leave user-data
     /// categories unchecked, building the per-category byte/count totals in the
     /// same pass so the Cleanup Manager's badges are correct without a re-walk.
-    private func seedJunkSelection(from result: ScanResult) {
-        var urls: Set<URL> = []
-        var total: Int64 = 0
-        var bytes: [ScanCategory: Int64] = [:]
-        var counts: [ScanCategory: Int] = [:]
-        for file in result.items where file.category.isSafeToAutoRemove {
-            urls.insert(file.url)
-            total += file.size
-            bytes[file.category, default: 0] += file.size
-            counts[file.category, default: 0] += 1
-        }
-        junkFileSelection = urls
-        selectedJunkBytes = total
-        selectedJunkBytesByCategory = bytes
-        selectedJunkCountByCategory = counts
+    /// Async because the walk runs off the main actor (see `ScanSelectionSeed`)
+    /// — hashing a large result's URLs into the selection set on the main
+    /// thread froze the scan-complete transition for seconds.
+    private func seedJunkSelection(from result: ScanResult) async {
+        let seed = await ScanSelectionSeed.safeDefaults(from: result)
+        junkFileSelection = seed.urls
+        selectedJunkBytes = seed.totalBytes
+        selectedJunkBytesByCategory = seed.bytesByCategory
+        selectedJunkCountByCategory = seed.countByCategory
     }
 
     func isJunkCategorySelected(_ category: ScanCategory) -> Bool {

--- a/VaderCleaner/SystemJunkView.swift
+++ b/VaderCleaner/SystemJunkView.swift
@@ -174,16 +174,24 @@ struct SystemJunkView: View {
             tiles: CleanupDashboardTile.recommended(from: result),
             accent: NavigationSection.systemJunk.theme.accent,
             onReview: { group in
-                // Pre-select this card's whole group so the right pane opens
-                // all-checked and the selected total matches the card's size.
-                viewModel.selectOnly(categories: Set(group.categories))
+                // The zoom anchor and deep-link state resolve synchronously in
+                // the click (the anchor reads the press/click event), before
+                // the selection walk hops off the main actor.
+                managerAnchor = TriggerAnchor.resolve(in: paneFrame)
                 // Deep link: open the manager at this card's section and the
                 // sub-category the card maps to.
                 let category = group.managerCategory
                 managerInitialSection = category.flatMap(CleanupManagerModel.sectionID(containing:))
                     ?? CleanupManagerModel.groups.first?.id
                 managerInitialCategory = category?.rawValue
-                openManager()
+                Task {
+                    // Pre-select this card's whole group so the right pane opens
+                    // all-checked and the selected total matches the card's size.
+                    // The manager raises only once the selection has landed, so
+                    // it never opens on a half-applied selection.
+                    await viewModel.selectOnly(categories: Set(group.categories))
+                    showingManager = true
+                }
             },
             onClean: { group in
                 Task { await viewModel.clean(categories: Set(group.categories)) }

--- a/VaderCleaner/SystemJunkViewModel.swift
+++ b/VaderCleaner/SystemJunkViewModel.swift
@@ -202,47 +202,29 @@ final class SystemJunkViewModel {
     /// Replace the selection with every file in `categories` — backs a
     /// dashboard card's "Review", which opens the manager with that card's whole
     /// group pre-selected. The resulting `totalSelectedSize` therefore matches
-    /// the card's displayed size.
-    func selectOnly(categories: Set<ScanCategory>) {
+    /// the card's displayed size. Async because the walk over a large group runs
+    /// off the main actor (see `ScanSelectionSeed`); the result is dropped if
+    /// the preview it was built from is gone by the time it lands.
+    func selectOnly(categories: Set<ScanCategory>) async {
         guard let result = latestResult else { return }
-        var urls: Set<URL> = []
-        var total: Int64 = 0
-        var bytesByCategory: [ScanCategory: Int64] = [:]
-        var countByCategory: [ScanCategory: Int] = [:]
-        for file in result.items where categories.contains(file.category) {
-            urls.insert(file.url)
-            total += file.size
-            bytesByCategory[file.category, default: 0] += file.size
-            countByCategory[file.category, default: 0] += 1
-        }
-        selectedURLs = urls
-        totalSelectedSize = total
-        selectedBytesByCategory = bytesByCategory
-        selectedCountByCategory = countByCategory
+        let generation = scanGeneration
+        let seed = await ScanSelectionSeed.selection(of: categories, from: result)
+        // Only apply to the same preview the walk started from: a new scan
+        // (generation bump) or leaving the preview (Start Over, cleaning)
+        // makes the computed selection stale.
+        guard scanGeneration == generation, case .preview = phase else { return }
+        apply(seed)
     }
 
-    /// Seed the default selection from a fresh result: pre-check every file in a
-    /// safe-to-auto-remove category (regenerable or already-discarded junk) and
-    /// leave user-data categories (mail attachments, iOS backups) unchecked.
-    /// Shared by `scan()` and `seed(with:)` so both land on the same
-    /// safe-by-default state as Smart Scan. The running byte/count tallies are
-    /// built in the same pass so the Cleanup Manager's per-category badges are
-    /// correct without a re-scan.
-    private func seedDefaultSelection(from result: ScanResult) {
-        var urls: Set<URL> = []
-        var total: Int64 = 0
-        var bytesByCategory: [ScanCategory: Int64] = [:]
-        var countByCategory: [ScanCategory: Int] = [:]
-        for file in result.items where file.category.isSafeToAutoRemove {
-            urls.insert(file.url)
-            total += file.size
-            bytesByCategory[file.category, default: 0] += file.size
-            countByCategory[file.category, default: 0] += 1
-        }
-        selectedURLs = urls
-        totalSelectedSize = total
-        selectedBytesByCategory = bytesByCategory
-        selectedCountByCategory = countByCategory
+    /// Land a precomputed selection in the four observable properties in one
+    /// write each. The seed itself is built off the main actor (see
+    /// `ScanSelectionSeed`) — walking a large result's URLs into a `Set` on
+    /// the main thread froze the scan-complete transition for seconds.
+    private func apply(_ seed: ScanSelectionSeed) {
+        selectedURLs = seed.urls
+        totalSelectedSize = seed.totalBytes
+        selectedBytesByCategory = seed.bytesByCategory
+        selectedCountByCategory = seed.countByCategory
     }
 
     /// Run the injected scanner and land in `.preview` (or `.failed`).
@@ -271,7 +253,9 @@ final class SystemJunkViewModel {
             }
             self.latestResult = result
             // Safe-by-default: pre-check regenerable junk, leave user data opt-in.
-            self.seedDefaultSelection(from: result)
+            // The seed walk runs off the main actor; the scanning screen keeps
+            // animating while a large result's selection is built.
+            self.apply(await ScanSelectionSeed.safeDefaults(from: result))
             self.phase = .preview(result)
         } catch {
             log.error("System Junk scan failed: \(String(describing: error), privacy: .public)")
@@ -288,10 +272,14 @@ final class SystemJunkViewModel {
     /// scope) so the user lands on the preview without scanning again. No-op
     /// unless idle, so it never overwrites an in-progress or already-shown scan.
     /// Mirrors `scan()`'s success path, including its safe-by-default selection.
-    func seed(with result: ScanResult) {
+    /// Async because the selection walk runs off the main actor; idleness is
+    /// re-checked after the walk so a scan the user started meanwhile wins.
+    func seed(with result: ScanResult) async {
+        guard case .idle = phase else { return }
+        let seed = await ScanSelectionSeed.safeDefaults(from: result)
         guard case .idle = phase else { return }
         latestResult = result
-        seedDefaultSelection(from: result)
+        apply(seed)
         phase = .preview(result)
     }
 

--- a/VaderCleanerTests/ScanSelectionSeedTests.swift
+++ b/VaderCleanerTests/ScanSelectionSeedTests.swift
@@ -1,0 +1,67 @@
+// ScanSelectionSeedTests.swift
+// Pins ScanSelectionSeed's builders: safe-by-default seeding and exact-category selection, including the running tallies the Cleanup Manager reads in O(1).
+
+import XCTest
+@testable import VaderCleaner
+
+final class ScanSelectionSeedTests: XCTestCase {
+
+    /// The safe-defaults seed must select every file in a regenerable /
+    /// already-discarded category and leave user-data categories out — the
+    /// same rule `scan()` and Smart Scan apply, so all seeded surfaces agree.
+    func test_safeDefaults_selectsOnlySafeCategories() async {
+        let cache = file("a", 100, .userCache)
+        let log = file("b", 200, .systemLogs)
+        let trash = file("c", 300, .trash)
+        let mail = file("d", 400, .mailAttachments)
+        let backup = file("e", 500, .iosBackups)
+        let result = ScanResult(items: [cache, log, trash, mail, backup])
+
+        let seed = await ScanSelectionSeed.safeDefaults(from: result)
+
+        XCTAssertEqual(seed.urls, [cache.url, log.url, trash.url])
+        XCTAssertEqual(seed.totalBytes, 600)
+        XCTAssertEqual(seed.bytesByCategory, [.userCache: 100, .systemLogs: 200, .trash: 300])
+        XCTAssertEqual(seed.countByCategory, [.userCache: 1, .systemLogs: 1, .trash: 1])
+    }
+
+    /// The category-scoped seed must cover exactly the requested categories —
+    /// no bleed from siblings — so a dashboard card's Review opens with the
+    /// selected total equal to the card's displayed size.
+    func test_selection_coversExactlyTheRequestedCategories() async {
+        let cacheA = file("a", 100, .userCache)
+        let cacheB = file("b", 30, .userCache)
+        let sysCache = file("c", 200, .systemCache)
+        let trash = file("t", 400, .trash)
+        let result = ScanResult(items: [cacheA, cacheB, sysCache, trash])
+
+        let seed = await ScanSelectionSeed.selection(of: [.userCache, .systemCache], from: result)
+
+        XCTAssertEqual(seed.urls, [cacheA.url, cacheB.url, sysCache.url])
+        XCTAssertEqual(seed.totalBytes, 330)
+        XCTAssertEqual(seed.bytesByCategory, [.userCache: 130, .systemCache: 200])
+        XCTAssertEqual(seed.countByCategory, [.userCache: 2, .systemCache: 1])
+    }
+
+    /// Requesting a category the result doesn't contain must yield an empty
+    /// seed rather than trap or invent entries.
+    func test_selection_ofAbsentCategory_isEmpty() async {
+        let result = ScanResult(items: [file("a", 100, .userCache)])
+
+        let seed = await ScanSelectionSeed.selection(of: [.trash], from: result)
+
+        XCTAssertEqual(seed, ScanSelectionSeed())
+    }
+
+    // MARK: - Helpers
+
+    private func file(_ name: String, _ size: Int64, _ category: ScanCategory) -> ScannedFile {
+        ScannedFile(
+            url: URL(fileURLWithPath: "/tmp/seed-tests/\(category.rawValue)/\(name)"),
+            size: size,
+            lastAccessDate: nil,
+            lastModifiedDate: nil,
+            category: category
+        )
+    }
+}

--- a/VaderCleanerTests/SystemJunkViewModelTests.swift
+++ b/VaderCleanerTests/SystemJunkViewModelTests.swift
@@ -279,7 +279,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         await vm.scan()
         vm.toggleSelection(trash) // a pre-existing selection that must be cleared
 
-        vm.selectOnly(categories: [.userCache, .systemCache])
+        await vm.selectOnly(categories: [.userCache, .systemCache])
 
         XCTAssertEqual(vm.selectedURLs, [cacheA.url, cacheB.url])
         XCTAssertEqual(vm.totalSelectedSize, 300)
@@ -342,7 +342,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         await vm.scan()
         vm.toggleSelection(trash) // a pre-existing selection outside the group
 
-        vm.selectOnly(categories: [.userCache, .systemCache])
+        await vm.selectOnly(categories: [.userCache, .systemCache])
 
         XCTAssertEqual(vm.selectedBytes(in: .userCache), 100)
         XCTAssertEqual(vm.selectedBytes(in: .systemCache), 200)
@@ -407,7 +407,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         await vm.scan()
         vm.toggleSelection(trash) // a pre-existing selection outside the group
 
-        vm.selectOnly(categories: [.userCache, .systemCache])
+        await vm.selectOnly(categories: [.userCache, .systemCache])
 
         XCTAssertEqual(vm.selectedCount(in: .userCache), 1)
         XCTAssertEqual(vm.selectedCount(in: .systemCache), 1)
@@ -666,13 +666,13 @@ final class SystemJunkViewModelTests: XCTestCase {
 
     // MARK: - Seed (from Smart Scan)
 
-    func test_seed_fromIdle_landsInPreviewWithSafeCategoriesSelected() {
+    func test_seed_fromIdle_landsInPreviewWithSafeCategoriesSelected() async {
         let vm = makeViewModel()
         let cache = makeFile(name: "a", size: 100, category: .userCache)
         let mail = makeFile(name: "b", size: 400, category: .mailAttachments)
         let result = makeResult((.userCache, [cache]), (.mailAttachments, [mail]))
 
-        vm.seed(with: result)
+        await vm.seed(with: result)
 
         XCTAssertEqual(vm.phase, .preview(result))
         XCTAssertEqual(vm.selectedURLs, [cache.url],
@@ -685,7 +685,7 @@ final class SystemJunkViewModelTests: XCTestCase {
         await vm.scan() // leaves .idle for .preview(empty)
 
         let file = makeFile(name: "a", size: 100, category: .userCache)
-        vm.seed(with: makeResult((.userCache, [file])))
+        await vm.seed(with: makeResult((.userCache, [file])))
 
         // The seed is dropped because the section already left idle.
         XCTAssertEqual(vm.phase, .preview(ScanResult(items: [])))


### PR DESCRIPTION
## What changed

Post-scan junk selection seeding — building the `Set<URL>` of pre-checked files plus the per-category byte/count tallies — now runs off the main actor via a new `ScanSelectionSeed` type with `nonisolated async` builders. The view models `await` the seed and land it in four observable writes.

- **`ScanSelectionSeed.swift`** (new): `safeDefaults(from:)` and `selection(of:from:)` build the selection from the result's precomputed category groupings, so per-file work is just the URL set insertion.
- **`SystemJunkViewModel`**: `scan()` awaits the seed before entering `.preview`; `seed(with:)` and `selectOnly(categories:)` are now `async` and re-check phase/generation after the await so a stale walk is dropped if a newer scan (or Start Over / cleaning) intervened.
- **`SmartScanViewModel`**: `seedJunkSelection(from:)` uses the same builder.
- **`SystemJunkView`**: a dashboard card's Review resolves the zoom anchor synchronously (it reads the click event), then raises the manager only after the selection has landed — so it never opens on a half-applied selection.
- **`ContentView`**: Smart Scan's completion hook seeds the Cleanup section inside a `Task`.

## Why

Time Profiler (attached to the running app while driving every section) caught a **3.16 s severe main-thread hang** at Cleanup scan completion. 96% of hang-window samples were inside the old `seedDefaultSelection`: inserting every scanned file's URL into a `Set<URL>` on the main actor, where each bridged `URL` hash/`==` round-trips through its Cocoa `relativeString` (`_BridgedURL.relativeString` and Cocoa→Swift string bridging dominate the stacks). On a ~113 GB result that's 1.1M files, freezing the scanning→dashboard transition. Smart Scan completion paid the same walk twice (its own seed plus the Cleanup adoption seed), and every dashboard Review click paid it again via `selectOnly`.

Selection *toggles* were already batched from earlier work; this closes the remaining main-thread bulk walks. The scanning screen keeps animating during the off-main walk, and the manager opens on a fully-applied selection.

## Verification

- Re-profiled the same flow on the rebuilt app: **no hang** at scan completion with **1,104,909 files** seeded; rapid switching across all 8 sections shows 0 hang rows.
- Review on a 284,659-file group (52.8 GB) — previously a multi-second beachball — opens the manager in ~3 s with the UI live throughout; toggling a 263k-file folder round-trips in ≤1.5 s with correct tallies.
- All **1,397 unit tests pass**, including new `ScanSelectionSeedTests` (written red-first) pinning safe-by-default and exact-category seeding.

## Reviewer notes

- `seed(with:)` keeps its "no-op unless idle" contract; idleness is simply re-checked after the await so a user-started scan wins.
- `selectOnly` applies only if the generation is unchanged **and** the phase is still `.preview` — Start Over or a new scan mid-walk drops the stale seed.
- A ~543 ms ordinary hang remains when macOS re-activates the window while the million-row manager list is showing; that's AppKit window-reactivation layout in a Debug build (Metal API validation on), unrelated to the seeding path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Smart Scan and System Junk selection workflows with more reliable asynchronous updates.
  * Cleanup Manager now opens only after category selections are fully applied.
  * Scan results now provide more accurate selected file totals, sizes, and category counts.

* **Tests**
  * Added coverage for default and category-specific scan selections, including empty-category handling.
  * Updated System Junk tests for asynchronous selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->