### PR TITLE
Refresh the menu bar panel: hierarchy, affordances, and scan feedback

### DIFF
--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -14,8 +14,14 @@ struct MenuBarContent: View {
     @Environment(MenuBarViewModel.self) private var menuBar
     @Environment(ConnectedDevicesMonitor.self) private var connectedDevices
     @Environment(MalwareViewModel.self) private var malware
+    @Environment(SmartScanViewModel.self) private var smartScan
     @Environment(MenuRouter.self) private var menuRouter
     @Environment(\.openWindow) private var openWindow
+
+    /// Hover state for the two card-sized deep-link buttons. Local state keeps
+    /// pointer movement re-rendering only the hovered surface.
+    @State private var headerHovered = false
+    @State private var protectionHovered = false
 
     private let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
 
@@ -65,36 +71,49 @@ struct MenuBarContent: View {
     }
 
     private var header: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Text("Mac Health:")
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(.white.opacity(0.85))
-                    Text(verdictTitle)
-                        .font(.title3.weight(.bold))
-                        .foregroundStyle(verdictColor)
+        Button {
+            openSection(.healthMonitor)
+        } label: {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text("Mac Health:")
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(.white.opacity(0.85))
+                        Text(verdictTitle)
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(verdictColor)
+                        // Chevron affordance: the header deep-links into the
+                        // Health Monitor, and brightens under the pointer.
+                        Image(systemName: "chevron.right")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.white.opacity(headerHovered ? 0.8 : 0.35))
+                    }
+                    Text("\(menuBar.deviceName) · \(menuBar.systemUptimeString)")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.7))
                 }
-                Text(menuBar.deviceName)
-                    .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.55))
-            }
-            Spacer()
-            Image(systemName: "laptopcomputer")
-                .font(.system(size: 34, weight: .light))
-                .foregroundStyle(
-                    LinearGradient(
-                        colors: [.white.opacity(0.95), healthAccent.opacity(0.9)],
-                        startPoint: .top,
-                        endPoint: .bottom
+                Spacer()
+                Image(systemName: "laptopcomputer")
+                    .font(.system(size: 34, weight: .light))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [.white.opacity(0.95), healthAccent.opacity(0.9)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
                     )
-                )
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(headerBackground)
+            .overlay(Color.white.opacity(headerHovered ? 0.05 : 0).allowsHitTesting(false))
+            .contentShape(Rectangle())
         }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(headerBackground)
-        .contentShape(Rectangle())
-        .onTapGesture { openSection(.healthMonitor) }
+        .buttonStyle(.plain)
+        .onHover { headerHovered = $0 }
+        .animation(VaderMotion.hover, value: headerHovered)
+        .help("Open Health Monitor")
     }
 
     private var headerBackground: some View {
@@ -124,8 +143,23 @@ struct MenuBarContent: View {
         return false
     }
 
+    /// The scanner currently running, if any — Smart Scan (whose results seed
+    /// this card) or Protection's own scanner, including its install check
+    /// and database update. `nil` when no scan is in flight.
+    private var scanActivity: MenuBarViewModel.ScanActivity? {
+        if case .scanning = smartScan.phase { return .smartScan }
+        switch malware.phase {
+        case .checkingClamAV, .updatingDatabase, .scanning: return .threatScan
+        default: return nil
+        }
+    }
+
     private var protectionStatus: MenuBarViewModel.ProtectionStatus {
-        MenuBarViewModel.protectionStatus(hasThreats: hasThreats, hasScanned: malware.lastScanDate != nil)
+        MenuBarViewModel.protectionStatus(
+            hasThreats: hasThreats,
+            hasScanned: malware.lastScanDate != nil,
+            isScanning: scanActivity != nil
+        )
     }
 
     private var protectionColor: Color {
@@ -133,6 +167,7 @@ struct MenuBarContent: View {
         case .protected: return .green
         case .threatsFound: return .red
         case .notScanned: return .secondary
+        case .scanning: return healthAccent
         }
     }
 
@@ -140,34 +175,106 @@ struct MenuBarContent: View {
         switch protectionStatus {
         case .protected: return "checkmark.shield.fill"
         case .threatsFound: return "exclamationmark.shield.fill"
-        case .notScanned: return "shield"
+        case .notScanned, .scanning: return "shield"
+        }
+    }
+
+    /// Detail line under the Protection title. A never-scanned Mac explains
+    /// what a first scan buys instead of repeating the "Not scanned" status
+    /// label; a running scan narrates the activity; otherwise it shows scan
+    /// recency.
+    private var protectionDetail: String {
+        switch protectionStatus {
+        case .notScanned:
+            return String(
+                localized: "Run your first scan to enable protection.",
+                comment: "Protection card detail before any scan has run."
+            )
+        case .scanning:
+            // `scanActivity` is non-nil whenever the status is `.scanning`;
+            // the fallback only satisfies exhaustiveness.
+            return MenuBarViewModel.scanningDetail(for: scanActivity ?? .threatScan)
+        case .protected, .threatsFound:
+            return MenuBarViewModel.lastScanString(malware.lastScanDate)
+        }
+    }
+
+    /// The Protection card's action button when the status needs the user to
+    /// act: first scan for a never-scanned Mac (Smart Scan covers threats and
+    /// seeds this card), review for live threats, nothing while protected or
+    /// mid-scan.
+    private var protectionCTA: (label: String, run: () -> Void)? {
+        switch protectionStatus {
+        case .notScanned:
+            return (
+                String(localized: "Scan Now", comment: "Protection card button that starts a first scan."),
+                { openSection(.smartScan, startScan: true) }
+            )
+        case .threatsFound:
+            return (
+                String(localized: "Review Threats", comment: "Protection card button that opens the threats list."),
+                { openSection(.malwareRemoval) }
+            )
+        case .protected, .scanning:
+            return nil
         }
     }
 
     private var protectionCard: some View {
-        HStack(spacing: 12) {
-            Image(systemName: protectionIcon)
-                .font(.title2)
-                .foregroundStyle(protectionColor)
-            VStack(alignment: .leading, spacing: 3) {
-                HStack {
-                    Text("Protection")
-                        .font(.subheadline.weight(.semibold))
-                    Spacer()
-                    Text(MenuBarViewModel.protectionStatusLabel(protectionStatus))
-                        .font(.caption.weight(.semibold))
+        VStack(alignment: .leading, spacing: 10) {
+            // The informational area is its own button (sibling of the CTA,
+            // never its ancestor) so each control resolves clicks cleanly.
+            // It deep-links to the Smart Scan section the card is named for,
+            // except mid-threat-scan when the activity lives in Protection.
+            Button {
+                openSection(scanActivity == .threatScan ? .malwareRemoval : .smartScan)
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: protectionIcon)
+                        .font(.title2)
                         .foregroundStyle(protectionColor)
+                        // Motion as meaning: the shield breathes only while a
+                        // scan is actually running.
+                        .symbolEffect(.pulse, isActive: protectionStatus == .scanning)
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack {
+                            Text(MenuBarViewModel.protectionCardTitle(for: scanActivity))
+                                .font(.subheadline.weight(.semibold))
+                            Spacer()
+                            if protectionStatus == .scanning {
+                                ProgressView()
+                                    .controlSize(.mini)
+                            }
+                            Text(MenuBarViewModel.protectionStatusLabel(protectionStatus))
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(protectionColor)
+                            Image(systemName: "chevron.right")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(protectionDetail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
-                Text(MenuBarViewModel.lastScanString(malware.lastScanDate))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(scanActivity == .threatScan ? "Open Protection" : "Open Smart Scan")
+            if let protectionCTA {
+                HStack {
+                    Spacer()
+                    Button(protectionCTA.label, action: protectionCTA.run)
+                        .controlSize(.small)
+                        .buttonStyle(.borderedProminent)
+                }
             }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
-        .contentShape(Rectangle())
-        .onTapGesture { openSection(.malwareRemoval) }
+        .background(.white.opacity(protectionHovered ? 0.08 : 0.05), in: .rect(cornerRadius: 12))
+        .onHover { protectionHovered = $0 }
+        .animation(VaderMotion.hover, value: protectionHovered)
     }
 
     // MARK: - Tiles
@@ -177,7 +284,8 @@ struct MenuBarContent: View {
             icon: "internaldrive",
             title: menuBar.bootVolumeName,
             primary: availableLine,
-            action: (String(localized: "Free Up"), { openSection(.systemJunk) })
+            usedFraction: menuBar.diskUsedFraction,
+            action: (String(localized: "Clean Up"), { openSection(.systemJunk) })
         )
     }
 
@@ -195,7 +303,7 @@ struct MenuBarContent: View {
             title: String(localized: "Memory"),
             primary: memoryLine,
             statusColor: swiftUIColor(for: menuBar.ramPressureColor),
-            action: (String(localized: "Free Up"), { openSection(.performance) })
+            action: (String(localized: "Free Memory"), { openSection(.performance) })
         )
     }
 
@@ -209,10 +317,11 @@ struct MenuBarContent: View {
 
     private var batteryTile: some View {
         MenuTile(
-            icon: "battery.100",
+            icon: menuBar.batterySymbolName,
             title: String(localized: "Battery"),
             primary: batteryPrimary,
-            secondary: batterySecondary
+            secondary: batterySecondary,
+            statusColor: menuBar.batteryStatusColor.map { swiftUIColor(for: $0) }
         )
     }
 
@@ -228,12 +337,14 @@ struct MenuBarContent: View {
         return MenuBarViewModel.batteryTemperatureString(temp)
     }
 
+    // Uptime lives in the panel header next to the device name — it is a
+    // machine-level fact, not CPU telemetry.
     private var cpuTile: some View {
         MenuTile(
             icon: "cpu",
             title: cpuTitle,
             primary: cpuLine,
-            secondary: menuBar.systemUptimeString
+            statusColor: swiftUIColor(for: menuBar.cpuLoadColor)
         )
     }
 
@@ -256,33 +367,44 @@ struct MenuBarContent: View {
 
     // MARK: - Network tile
 
+    // Titled "Network" like the other tiles' category names; the SSID (raw
+    // router noise like "ATTQ3gAepM") reads as the detail line instead.
     private var networkTile: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Image(systemName: "wifi")
                     .font(.callout)
                     .foregroundStyle(.tint)
-                Text(menuBar.wifiNetworkName)
+                Text("Network")
                     .font(.subheadline.weight(.semibold))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
                 Spacer(minLength: 0)
             }
-            HStack(spacing: 4) {
-                Image(systemName: "arrow.down")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                Text(menuBar.networkDownString)
-                    .font(.caption)
-                    .monospacedDigit()
-            }
-            HStack(spacing: 4) {
-                Image(systemName: "arrow.up")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                Text(menuBar.networkUpString)
-                    .font(.caption)
-                    .monospacedDigit()
+            Text(menuBar.wifiNetworkName)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            HStack(spacing: 10) {
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.down")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(menuBar.networkDownString)
+                        .font(.caption)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                        .animation(VaderMotion.telemetry, value: menuBar.networkDownString)
+                }
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.up")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(menuBar.networkUpString)
+                        .font(.caption)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                        .animation(VaderMotion.telemetry, value: menuBar.networkUpString)
+                }
             }
             HStack {
                 Spacer()
@@ -331,6 +453,8 @@ struct MenuBarContent: View {
                 .font(.caption)
                 .lineLimit(1)
                 .truncationMode(.middle)
+                // Long names middle-truncate; the tooltip carries the full name.
+                .help(device.name)
             Spacer(minLength: 0)
             if let battery = device.batteryPercent {
                 Text("\(battery)%")
@@ -355,67 +479,86 @@ struct MenuBarContent: View {
     private var speedTestControl: some View {
         switch menuBar.speedTestState {
         case .idle:
-            Button(String(localized: "Test Speed")) { Task { await menuBar.runSpeedTest() } }
-                .buttonStyle(.plain)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.tint)
+            MenuActionLink(label: String(localized: "Test Speed")) { Task { await menuBar.runSpeedTest() } }
         case .running:
             ProgressView().controlSize(.small)
         case .result(let mbps):
-            Button(MenuBarViewModel.speedTestResultString(mbps)) { Task { await menuBar.runSpeedTest() } }
-                .buttonStyle(.plain)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.tint)
+            MenuActionLink(label: MenuBarViewModel.speedTestResultString(mbps)) { Task { await menuBar.runSpeedTest() } }
+                .help("Measured download speed — click to test again")
         case .failed:
-            Button(String(localized: "Retry")) { Task { await menuBar.runSpeedTest() } }
-                .buttonStyle(.plain)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.orange)
+            MenuActionLink(label: String(localized: "Retry"), color: .orange) { Task { await menuBar.runSpeedTest() } }
         }
     }
 
     // MARK: - Recommendation
 
+    /// State-driven recommendation, or `nil` when the Protection card already
+    /// carries the panel's call to action (see `MenuBarViewModel.recommendation`).
+    private var recommendation: MenuBarViewModel.Recommendation? {
+        MenuBarViewModel.recommendation(
+            protection: protectionStatus,
+            disk: menuBar.diskStats,
+            pressure: menuBar.ramPressureLevel,
+            lastScanDate: malware.lastScanDate
+        )
+    }
+
+    @ViewBuilder
     private var recommendationCard: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "sparkles")
-                .font(.title2)
-                .foregroundStyle(.tint)
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Today's Recommendation")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-                Text("It's time to care for your Mac!")
-                    .font(.subheadline.weight(.semibold))
-                Text("Run Smart Scan to find junk, large files, and threats in one pass.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                HStack {
-                    Spacer()
-                    Button(String(localized: "Run Smart Scan")) {
-                        openSection(.smartScan, startScan: true)
+        if let recommendation {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "sparkles")
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Today's Recommendation")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                    Text(recommendation.title)
+                        .font(.subheadline.weight(.semibold))
+                    Text(recommendation.message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    HStack {
+                        Spacer()
+                        Button(recommendation.actionLabel) {
+                            open(recommendation)
+                        }
+                        .controlSize(.small)
+                        .buttonStyle(.borderedProminent)
                     }
-                    .controlSize(.small)
-                    .buttonStyle(.borderedProminent)
                 }
             }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
         }
-        .padding(12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+    }
+
+    /// Maps the view-model's framework-free recommendation target onto the
+    /// app's navigation sections and deep-links there.
+    private func open(_ recommendation: MenuBarViewModel.Recommendation) {
+        let section: NavigationSection
+        switch recommendation.target {
+        case .smartScan:   section = .smartScan
+        case .cleanup:     section = .systemJunk
+        case .performance: section = .performance
+        }
+        openSection(section, startScan: recommendation.startsScan)
     }
 
     // MARK: - Footer
 
     private var footer: some View {
-        HStack {
+        HStack(spacing: 14) {
             Button(action: openMainWindow) {
                 Text("Open VaderCleaner")
             }
             .buttonStyle(.plain)
             .keyboardShortcut("o")
+            .help("Open the main window (⌘O)")
 
             Spacer()
 
@@ -423,15 +566,16 @@ struct MenuBarContent: View {
                 Image(systemName: "gearshape")
             }
             .buttonStyle(.plain)
+            .help("Settings")
 
-            Button {
+            // An explicit word rather than a power glyph — next to system
+            // telemetry a power symbol reads as "shut down the Mac".
+            Button("Quit") {
                 NSApp.terminate(nil)
-            } label: {
-                Image(systemName: "power")
             }
             .buttonStyle(.plain)
             .keyboardShortcut("q")
-            .help("Quit VaderCleaner")
+            .help("Quit VaderCleaner (⌘Q)")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -473,14 +617,18 @@ struct MenuBarContent: View {
 }
 
 /// One monitor tile: an icon + title row, a primary metric line, an optional
-/// secondary line, an optional status dot, and an optional trailing action link.
+/// capacity bar, an optional secondary line, an optional status dot, and an
+/// optional trailing action link.
 private struct MenuTile: View {
     let icon: String
     let title: String
     let primary: String
     var secondary: String?
     var statusColor: Color?
-    /// Optional trailing link, e.g. ("Free Up", action).
+    /// Used fraction (0…1) rendered as a thin capacity bar under the primary
+    /// line, e.g. the storage tile's disk usage.
+    var usedFraction: Double?
+    /// Optional trailing link, e.g. ("Clean Up", action).
     var action: (label: String, run: () -> Void)?
 
     var body: some View {
@@ -503,6 +651,13 @@ private struct MenuTile: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
+                // Live values roll to their next reading instead of blinking
+                // on the 2-second refresh.
+                .contentTransition(.numericText())
+                .animation(VaderMotion.telemetry, value: primary)
+            if let usedFraction {
+                capacityBar(usedFraction)
+            }
             if let secondary {
                 Text(secondary)
                     .font(.caption)
@@ -511,10 +666,7 @@ private struct MenuTile: View {
             if let action {
                 HStack {
                     Spacer()
-                    Button(action.label, action: action.run)
-                        .buttonStyle(.plain)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.tint)
+                    MenuActionLink(label: action.label, action: action.run)
                 }
             }
         }
@@ -522,17 +674,60 @@ private struct MenuTile: View {
         .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
         .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
     }
+
+    private func capacityBar(_ fraction: Double) -> some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(.white.opacity(0.12))
+                Capsule()
+                    .fill(.tint)
+                    .frame(width: max(4, geo.size.width * fraction))
+                    .animation(VaderMotion.telemetry, value: fraction)
+            }
+        }
+        .frame(height: 4)
+        .padding(.vertical, 2)
+    }
+}
+
+/// Caption-weight link used for tile actions ("Clean Up", "Test Speed"):
+/// underlines under the pointer and pads its hit target beyond the bare text.
+private struct MenuActionLink: View {
+    let label: String
+    var color: Color?
+    let action: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(color.map { AnyShapeStyle($0) } ?? AnyShapeStyle(.tint))
+                .underline(hovered)
+                .padding(.vertical, 3)
+                .padding(.horizontal, 4)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .animation(VaderMotion.hover, value: hovered)
+    }
 }
 
 #Preview {
-    let prefs = PreferencesStore(defaults: UserDefaults(suiteName: "menu-preview")!)
+    let previewDefaults = UserDefaults(suiteName: "menu-preview")!
+    let prefs = PreferencesStore(defaults: previewDefaults)
     return MenuBarContent()
         .environment(MenuBarViewModel(service: SystemStatsService(autostart: false)))
         .environment(ConnectedDevicesMonitor(autoRefresh: false))
         .environment(MalwareViewModel.live(
             dispatcher: NotificationManager(),
             preferences: prefs,
-            settings: ProtectionSettingsStore(defaults: UserDefaults(suiteName: "menu-preview")!)
+            settings: ProtectionSettingsStore(defaults: previewDefaults)
+        ))
+        .environment(SmartScanViewModel.live(
+            exclusions: ExclusionsStore(defaults: previewDefaults),
+            settings: SmartScanSettingsStore(defaults: previewDefaults)
         ))
         .environment(MenuRouter())
 }

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -65,9 +65,25 @@ final class MenuBarViewModel {
     /// Free space on the boot volume — the storage tile's headline number.
     var availableDiskSpace: String { Self.availableDiskString(service.diskSpace) }
 
+    /// Used fraction of the boot volume for the storage tile's capacity bar.
+    var diskUsedFraction: Double { Self.diskUsedFraction(service.diskSpace) }
+
+    /// Raw disk snapshot, exposed so the view can feed the pure
+    /// `recommendation` derivation alongside malware state it owns.
+    var diskStats: DiskStats { service.diskSpace }
+
     /// Live charge snapshot for the battery tile, or `nil` when there is no
     /// internal battery.
     var batteryCharge: BatteryCharge? { service.batteryCharge }
+
+    /// Battery tile SF Symbol tracking the live charge level.
+    var batterySymbolName: String { Self.batterySymbolName(service.batteryCharge) }
+
+    /// Battery tile status dot, or `nil` without a battery.
+    var batteryStatusColor: StatusColor? { Self.batteryStatusColor(service.batteryCharge) }
+
+    /// CPU tile status dot for the live load.
+    var cpuLoadColor: StatusColor { Self.cpuLoadColor(service.cpuUsage) }
 
     /// Download throughput for the network tile, e.g. "513 bytes/s".
     var networkDownString: String { Self.speedString(service.networkThroughput.bytesInPerSec) }
@@ -179,11 +195,36 @@ final class MenuBarViewModel {
         return SystemStatsFormatters.batteryCapacityString(stats)
     }
 
-    /// Free space on the boot volume, e.g. "434.3 GB" — the number the storage
-    /// tile leads with ("how much room is left?").
+    /// Free space on the boot volume, e.g. "670 GB" — the number the storage
+    /// tile leads with ("how much room is left?"). Rounds to whole GB: decimal
+    /// precision is noise at menu-glance size and would thrash across the
+    /// 2-second refresh. Below one GB it falls back to the shared byte
+    /// formatter ("0.5 GB") so a nearly-full disk doesn't read as a useless
+    /// "0 GB".
     static func availableDiskString(_ stats: DiskStats) -> String {
         let free = stats.totalBytes > stats.usedBytes ? stats.totalBytes - stats.usedBytes : 0
-        return SystemStatsFormatters.byteString(free)
+        guard free >= bytesPerGB else { return SystemStatsFormatters.byteString(free) }
+        let measurement = Measurement(value: Double(free), unit: UnitInformationStorage.bytes)
+            .converted(to: .gigabytes)
+        return wholeGBFormatter.string(from: measurement)
+    }
+
+    /// Allocated once, like `relativeFormatter`: formatter construction is not
+    /// cheap enough for a per-render rebuild on the 2-second refresh.
+    private static let wholeGBFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .providedUnit
+        formatter.numberFormatter.maximumFractionDigits = 0
+        return formatter
+    }()
+
+    /// Used portion of the boot volume as a unit fraction, clamped to 0…1 —
+    /// drives the storage tile's capacity bar. `0` for the zero-total
+    /// pre-first-refresh state rather than NaN.
+    static func diskUsedFraction(_ stats: DiskStats) -> Double {
+        guard stats.totalBytes > 0 else { return 0 }
+        let ratio = Double(stats.usedBytes) / Double(stats.totalBytes)
+        return max(0.0, min(1.0, ratio))
     }
 
     /// Memory in use as a whole percentage, clamped to 0…100. `0%` for the
@@ -216,6 +257,45 @@ final class MenuBarViewModel {
     /// Battery temperature rounded to a whole degree, e.g. "30°C".
     static func batteryTemperatureString(_ celsius: Double) -> String {
         "\(Int(celsius.rounded()))°C"
+    }
+
+    /// SF Symbol for the battery tile, tracking the real charge level instead
+    /// of a hardcoded full battery. Charging shows the bolt variant; the
+    /// no-battery fallback pairs with the tile's "No battery" text. Levels
+    /// bucket to the nearest of SF Symbols' five battery steps.
+    static func batterySymbolName(_ charge: BatteryCharge?) -> String {
+        guard let charge else { return "battery.100percent" }
+        if charge.isCharging { return "battery.100percent.bolt" }
+        switch charge.percent {
+        case ..<13:   return "battery.0percent"
+        case ..<38:   return "battery.25percent"
+        case ..<63:   return "battery.50percent"
+        case ..<88:   return "battery.75percent"
+        default:      return "battery.100percent"
+        }
+    }
+
+    /// Status dot for the battery tile, matching the memory tile's traffic
+    /// lights: green while charging or comfortable, yellow when low, red when
+    /// nearly empty. `nil` (no dot) without a battery.
+    static func batteryStatusColor(_ charge: BatteryCharge?) -> StatusColor? {
+        guard let charge else { return nil }
+        if charge.isCharging { return .green }
+        switch charge.percent {
+        case ..<10:  return .red
+        case ..<20:  return .yellow
+        default:     return .green
+        }
+    }
+
+    /// Status dot for the CPU tile: comfortable under 70% load, busy under
+    /// 90%, saturated above.
+    static func cpuLoadColor(_ usage: Double) -> StatusColor {
+        switch usage {
+        case ..<0.7: return .green
+        case ..<0.9: return .yellow
+        default:     return .red
+        }
     }
 
     /// Formats a bytes-per-second rate for the network tile, e.g. "2 KB/s".
@@ -251,12 +331,55 @@ final class MenuBarViewModel {
         case protected
         case threatsFound
         case notScanned
+        case scanning
     }
 
-    /// Derives protection status from the malware scan state: threats outrank
-    /// everything; otherwise a Mac that has been scarred at least once reads as
-    /// protected, and one that never has reads as not-yet-scanned.
-    static func protectionStatus(hasThreats: Bool, hasScanned: Bool) -> ProtectionStatus {
+    /// Which scanner is currently driving the card's `.scanning` state. The
+    /// card renames itself to match, so the popup never claims a threat check
+    /// while the main window is visibly sweeping junk.
+    enum ScanActivity: Equatable {
+        /// Smart Scan is running (junk, large files, and threats in one pass).
+        case smartScan
+        /// Protection's own scanner is running (threats only).
+        case threatScan
+    }
+
+    /// Card title for the current activity. "Smart Scan" is the card's
+    /// resting identity — it reports the last scan and launches the next one
+    /// — so the title only changes while Protection's threat-only scanner is
+    /// what's actually running.
+    static func protectionCardTitle(for activity: ScanActivity?) -> String {
+        switch activity {
+        case .smartScan, nil:
+            return String(localized: "Smart Scan", comment: "Scan card title.")
+        case .threatScan:
+            return String(localized: "Threat Scan", comment: "Scan card title while a threat-only scan is running.")
+        }
+    }
+
+    /// Detail line while a scan runs, naming what that scan actually covers.
+    static func scanningDetail(for activity: ScanActivity) -> String {
+        switch activity {
+        case .smartScan:
+            return String(
+                localized: "Looking for junk, large files, and threats…",
+                comment: "Protection card detail while Smart Scan is running."
+            )
+        case .threatScan:
+            return String(
+                localized: "Checking this Mac for threats…",
+                comment: "Protection card detail while a threat scan is running."
+            )
+        }
+    }
+
+    /// Derives protection status from the malware scan state: a scan in
+    /// flight outranks everything (the card narrates the activity instead of
+    /// showing stale results), then threats; otherwise a Mac that has been
+    /// scanned at least once reads as protected, and one that never has reads
+    /// as not-yet-scanned.
+    static func protectionStatus(hasThreats: Bool, hasScanned: Bool, isScanning: Bool = false) -> ProtectionStatus {
+        if isScanning { return .scanning }
         if hasThreats { return .threatsFound }
         return hasScanned ? .protected : .notScanned
     }
@@ -270,6 +393,8 @@ final class MenuBarViewModel {
             return String(localized: "Threats found", comment: "Protection card status when threats are present.")
         case .notScanned:
             return String(localized: "Not scanned", comment: "Protection card status when no scan has run yet.")
+        case .scanning:
+            return String(localized: "Scanning…", comment: "Protection card status while a scan is running.")
         }
     }
 
@@ -289,6 +414,97 @@ final class MenuBarViewModel {
         let relative = relativeFormatter.localizedString(for: date, relativeTo: Date())
         let format = String(localized: "Last scan %@", comment: "Protection card detail; %@ is a relative date.")
         return String(format: format, relative)
+    }
+
+    // MARK: - Recommendation
+
+    /// One state-driven suggestion for the panel's "Today's Recommendation"
+    /// card: what to say, what the button reads, and where it deep-links.
+    struct Recommendation: Equatable {
+        /// Destination the card's action deep-links to. A view-model-local
+        /// enum (rather than `NavigationSection`) keeps this type framework-
+        /// free and pinnable in unit tests; the view maps it to a section.
+        enum Target: Equatable {
+            case smartScan
+            case cleanup
+            case performance
+        }
+
+        let title: String
+        let message: String
+        let actionLabel: String
+        let target: Target
+        /// Whether the deep-link should also start the target's scan.
+        let startsScan: Bool
+    }
+
+    /// Free-space fraction below which the disk counts as running low.
+    private static let lowDiskFreeThreshold = 0.10
+
+    /// Last-scan age beyond which a protected Mac is nudged to scan again.
+    private static let staleScanInterval: TimeInterval = 7 * 86_400
+
+    /// Derives the recommendation card's content from live panel state.
+    ///
+    /// Priority: a nearly-full disk outranks everything (it is the one state
+    /// a cleaner app must never sit on), then critical memory pressure, then
+    /// scan hygiene. Returns `nil` when protection is unscanned or has live
+    /// threats and nothing else is urgent — in those states the Protection
+    /// card carries the scan CTA, and repeating it here would just add noise.
+    static func recommendation(
+        protection: ProtectionStatus,
+        disk: DiskStats,
+        pressure: MemoryPressureLevel,
+        lastScanDate: Date?,
+        now: Date = Date()
+    ) -> Recommendation? {
+        if disk.totalBytes > 0, 1.0 - diskUsedFraction(disk) < lowDiskFreeThreshold {
+            return Recommendation(
+                title: String(localized: "Storage is running low",
+                              comment: "Recommendation title when free disk space is under 10%."),
+                message: String(localized: "Less than 10% of your disk is free. Clear out junk to reclaim space.",
+                                comment: "Recommendation message when free disk space is under 10%."),
+                actionLabel: String(localized: "Clean Up",
+                                    comment: "Recommendation button that opens the Cleanup section."),
+                target: .cleanup,
+                startsScan: false
+            )
+        }
+        if pressure == .critical {
+            return Recommendation(
+                title: String(localized: "Memory pressure is critical",
+                              comment: "Recommendation title when memory pressure is critical."),
+                message: String(localized: "Your Mac is low on memory. Free some up to keep apps responsive.",
+                                comment: "Recommendation message when memory pressure is critical."),
+                actionLabel: String(localized: "Free Memory",
+                                    comment: "Recommendation button that opens the Performance section."),
+                target: .performance,
+                startsScan: false
+            )
+        }
+        guard protection == .protected else { return nil }
+        if lastScanDate.map({ now.timeIntervalSince($0) > staleScanInterval }) ?? true {
+            return Recommendation(
+                title: String(localized: "Time for a fresh scan",
+                              comment: "Recommendation title when the last scan is over a week old."),
+                message: String(localized: "It's been over a week since your last Smart Scan.",
+                                comment: "Recommendation message when the last scan is over a week old."),
+                actionLabel: String(localized: "Run Smart Scan",
+                                    comment: "Recommendation button that starts a Smart Scan."),
+                target: .smartScan,
+                startsScan: true
+            )
+        }
+        return Recommendation(
+            title: String(localized: "You're all set",
+                          comment: "Recommendation title when nothing needs attention."),
+            message: String(localized: "No issues need your attention. A periodic Smart Scan keeps it that way.",
+                            comment: "Recommendation message when nothing needs attention."),
+            actionLabel: String(localized: "Run Smart Scan",
+                                comment: "Recommendation button that starts a Smart Scan."),
+            target: .smartScan,
+            startsScan: true
+        )
     }
 
     /// Compact uptime, e.g. "up 3d 4h", "up 4h 12m", or "up 8m". Drops to the

--- a/VaderCleaner/VaderCleanerApp.swift
+++ b/VaderCleaner/VaderCleanerApp.swift
@@ -345,6 +345,9 @@ struct VaderCleanerApp: App {
                 .environment(systemStats)
                 .environment(connectedDevices)
                 .environment(malwareViewModel)
+                // The panel's Protection card narrates a running Smart Scan
+                // (whose results seed protection status).
+                .environment(smartScanViewModel)
                 .environment(menuRouter)
         } label: {
             // A compact health-pulse glyph by default. A wide text label gets

--- a/VaderCleaner/VaderMotion.swift
+++ b/VaderCleaner/VaderMotion.swift
@@ -17,6 +17,9 @@ enum VaderMotion {
     /// Short fade for hover fills and selection pills — pointer feedback
     /// should ease in, not blink, and carries no bounce.
     static let hover: Animation = .easeOut(duration: 0.18)
+    /// Gentle ease for live telemetry ticks — numeric rolls and capacity-bar
+    /// nudges on the menu panel's 2-second refresh should glide, not blink.
+    static let telemetry: Animation = .easeOut(duration: 0.3)
     /// Duration of the full-surface exchange spring. Shared so a caller that
     /// must wait for a surface swap to land — Smart Scan holds a sub-scan until
     /// its hero tile has arrived — stays in lockstep with the animation instead

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -335,6 +335,57 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(MenuBarViewModel.protectionStatusLabel(.protected), "Protected")
         XCTAssertEqual(MenuBarViewModel.protectionStatusLabel(.threatsFound), "Threats found")
         XCTAssertEqual(MenuBarViewModel.protectionStatusLabel(.notScanned), "Not scanned")
+        XCTAssertEqual(MenuBarViewModel.protectionStatusLabel(.scanning), "Scanning…")
+    }
+
+    /// A running scan outranks every other protection state — mid-scan the
+    /// card must acknowledge the activity rather than keep claiming "Not
+    /// scanned" or "Threats found" from stale results.
+    func test_protectionStatus_scanningOutranksOtherStates() {
+        XCTAssertEqual(
+            MenuBarViewModel.protectionStatus(hasThreats: false, hasScanned: false, isScanning: true),
+            .scanning
+        )
+        XCTAssertEqual(
+            MenuBarViewModel.protectionStatus(hasThreats: true, hasScanned: true, isScanning: true),
+            .scanning
+        )
+        // The default keeps the non-scanning derivation unchanged.
+        XCTAssertEqual(
+            MenuBarViewModel.protectionStatus(hasThreats: false, hasScanned: false),
+            .notScanned
+        )
+    }
+
+    /// The card reads "Smart Scan" — its resting identity and the scan it
+    /// launches — and renames only while Protection's threat-only scanner is
+    /// what's actually running, so the title never contradicts the activity.
+    func test_protectionCardTitle_matchesTheRunningScan() {
+        XCTAssertEqual(MenuBarViewModel.protectionCardTitle(for: .smartScan), "Smart Scan")
+        XCTAssertEqual(MenuBarViewModel.protectionCardTitle(for: .threatScan), "Threat Scan")
+        XCTAssertEqual(MenuBarViewModel.protectionCardTitle(for: nil), "Smart Scan")
+    }
+
+    /// The scanning detail line names what the running scan actually covers:
+    /// Smart Scan checks junk, large files, and threats; Protection's own
+    /// scanner checks threats only.
+    func test_scanningDetail_describesTheRunningScan() {
+        XCTAssertEqual(
+            MenuBarViewModel.scanningDetail(for: .smartScan),
+            "Looking for junk, large files, and threats…"
+        )
+        XCTAssertEqual(
+            MenuBarViewModel.scanningDetail(for: .threatScan),
+            "Checking this Mac for threats…"
+        )
+    }
+
+    /// While a scan runs the recommendation card stays hidden — the
+    /// Protection card is already narrating the activity.
+    func test_recommendation_isNilWhileScanning() {
+        XCTAssertNil(MenuBarViewModel.recommendation(
+            protection: .scanning, disk: healthyDisk, pressure: .nominal, lastScanDate: nil, now: now
+        ))
     }
 
     /// No scan date reads as "No scans yet"; a real date produces a non-empty
@@ -344,5 +395,158 @@ final class MenuBarViewModelTests: XCTestCase {
         let recent = MenuBarViewModel.lastScanString(Date(timeIntervalSinceNow: -3_600))
         XCTAssertFalse(recent.isEmpty)
         XCTAssertNotEqual(recent, "No scans yet")
+    }
+
+    // MARK: - Storage tile formatters
+
+    /// The storage tile's headline rounds to whole GB — "670 GB", not
+    /// "670.49 GB". Two decimals is false precision at menu-glance size.
+    func test_availableDiskString_roundsToWholeGB() {
+        // 1 TB total − 329.51 GB used = 670.49 GB free.
+        let stats = DiskStats(usedBytes: 329_510_000_000, totalBytes: 1_000_000_000_000)
+        let formatted = MenuBarViewModel.availableDiskString(stats)
+        XCTAssertTrue(formatted.contains("670"), "Expected whole-GB value, got \(formatted)")
+        XCTAssertFalse(formatted.contains("670.49") || formatted.contains("670,49"),
+                       "Expected no fractional GB, got \(formatted)")
+    }
+
+    /// Below one GB the whole-GB rounding would render a useless "0 GB", so
+    /// the formatter falls back to the shared byte formatter, which keeps the
+    /// GB unit with a fraction ("0.5 GB") for layout stability.
+    func test_availableDiskString_showsSubGBFraction() {
+        let stats = DiskStats(usedBytes: 999_500_000_000, totalBytes: 1_000_000_000_000)
+        let formatted = MenuBarViewModel.availableDiskString(stats)
+        XCTAssertTrue(formatted.contains("0.5") || formatted.contains("0,5"),
+                      "Expected fractional sub-GB value, got \(formatted)")
+    }
+
+    /// Used fraction drives the storage tile's capacity bar: used/total,
+    /// clamped, and 0 for the zero-total pre-first-refresh state (not NaN).
+    func test_diskUsedFraction_isUsedOverTotalClamped() {
+        let stats = DiskStats(usedBytes: 600_000_000_000, totalBytes: 1_000_000_000_000)
+        XCTAssertEqual(MenuBarViewModel.diskUsedFraction(stats), 0.6, accuracy: 0.001)
+        XCTAssertEqual(MenuBarViewModel.diskUsedFraction(.empty), 0)
+        let overfull = DiskStats(usedBytes: 2_000_000_000_000, totalBytes: 1_000_000_000_000)
+        XCTAssertEqual(MenuBarViewModel.diskUsedFraction(overfull), 1.0)
+    }
+
+    // MARK: - Battery tile symbol + status
+
+    private func makeCharge(percent: Int, isCharging: Bool = false, isPluggedIn: Bool = false) -> BatteryCharge {
+        BatteryCharge(percent: percent, isCharging: isCharging, isPluggedIn: isPluggedIn,
+                      timeRemainingMinutes: nil, temperatureCelsius: nil)
+    }
+
+    /// The battery tile's icon tracks the actual charge level instead of a
+    /// hardcoded full battery.
+    func test_batterySymbolName_bucketsChargeLevel() {
+        XCTAssertEqual(MenuBarViewModel.batterySymbolName(makeCharge(percent: 5)), "battery.0percent")
+        XCTAssertEqual(MenuBarViewModel.batterySymbolName(makeCharge(percent: 30)), "battery.25percent")
+        XCTAssertEqual(MenuBarViewModel.batterySymbolName(makeCharge(percent: 50)), "battery.50percent")
+        XCTAssertEqual(MenuBarViewModel.batterySymbolName(makeCharge(percent: 79)), "battery.75percent")
+        XCTAssertEqual(MenuBarViewModel.batterySymbolName(makeCharge(percent: 95)), "battery.100percent")
+    }
+
+    /// Charging overlays the bolt regardless of level.
+    func test_batterySymbolName_showsBoltWhileCharging() {
+        XCTAssertEqual(
+            MenuBarViewModel.batterySymbolName(makeCharge(percent: 40, isCharging: true, isPluggedIn: true)),
+            "battery.100percent.bolt"
+        )
+    }
+
+    /// No battery (desktop Macs) falls back to the generic full symbol the
+    /// tile pairs with its "No battery" text.
+    func test_batterySymbolName_fallsBackWithoutBattery() {
+        XCTAssertEqual(MenuBarViewModel.batterySymbolName(nil), "battery.100percent")
+    }
+
+    /// The battery status dot mirrors the memory tile's traffic-light system:
+    /// green while charging or comfortable, yellow when low, red when nearly
+    /// empty, and absent without a battery.
+    func test_batteryStatusColor_trafficLights() {
+        XCTAssertEqual(MenuBarViewModel.batteryStatusColor(makeCharge(percent: 79)), .green)
+        XCTAssertEqual(MenuBarViewModel.batteryStatusColor(makeCharge(percent: 15)), .yellow)
+        XCTAssertEqual(MenuBarViewModel.batteryStatusColor(makeCharge(percent: 8)), .red)
+        XCTAssertEqual(MenuBarViewModel.batteryStatusColor(makeCharge(percent: 8, isCharging: true, isPluggedIn: true)), .green)
+        XCTAssertNil(MenuBarViewModel.batteryStatusColor(nil))
+    }
+
+    /// The CPU status dot buckets load: comfortable, busy, saturated.
+    func test_cpuLoadColor_bucketsLoad() {
+        XCTAssertEqual(MenuBarViewModel.cpuLoadColor(0.2), .green)
+        XCTAssertEqual(MenuBarViewModel.cpuLoadColor(0.75), .yellow)
+        XCTAssertEqual(MenuBarViewModel.cpuLoadColor(0.95), .red)
+    }
+
+    // MARK: - Recommendation
+
+    private let healthyDisk = DiskStats(usedBytes: 400_000_000_000, totalBytes: 1_000_000_000_000)
+    private let lowDisk = DiskStats(usedBytes: 950_000_000_000, totalBytes: 1_000_000_000_000)
+    private let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    /// Low disk is the cleaner app's most urgent recommendation — it outranks
+    /// every other state, including an unscanned Mac (whose scan CTA lives on
+    /// the Protection card).
+    func test_recommendation_lowDiskOutranksEverything() {
+        let rec = MenuBarViewModel.recommendation(
+            protection: .notScanned, disk: lowDisk, pressure: .critical, lastScanDate: nil, now: now
+        )
+        XCTAssertEqual(rec?.target, .cleanup)
+        XCTAssertEqual(rec?.startsScan, false)
+        XCTAssertFalse(rec?.title.isEmpty ?? true)
+        XCTAssertFalse(rec?.message.isEmpty ?? true)
+        XCTAssertFalse(rec?.actionLabel.isEmpty ?? true)
+    }
+
+    /// Critical memory pressure recommends the Performance section when disk
+    /// is comfortable.
+    func test_recommendation_criticalMemoryWhenDiskComfortable() {
+        let rec = MenuBarViewModel.recommendation(
+            protection: .protected, disk: healthyDisk, pressure: .critical,
+            lastScanDate: now.addingTimeInterval(-3_600), now: now
+        )
+        XCTAssertEqual(rec?.target, .performance)
+    }
+
+    /// When the Mac has never been scanned (or has live threats) the
+    /// Protection card carries the scan CTA, so the recommendation card stays
+    /// out of the way rather than duplicating the same button.
+    func test_recommendation_isNilWhenProtectionCardOwnsTheCTA() {
+        XCTAssertNil(MenuBarViewModel.recommendation(
+            protection: .notScanned, disk: healthyDisk, pressure: .nominal, lastScanDate: nil, now: now
+        ))
+        XCTAssertNil(MenuBarViewModel.recommendation(
+            protection: .threatsFound, disk: healthyDisk, pressure: .nominal,
+            lastScanDate: now.addingTimeInterval(-3_600), now: now
+        ))
+    }
+
+    /// A protected Mac whose last scan is over a week old is nudged toward a
+    /// fresh Smart Scan.
+    func test_recommendation_staleScanAfterSevenDays() {
+        let rec = MenuBarViewModel.recommendation(
+            protection: .protected, disk: healthyDisk, pressure: .nominal,
+            lastScanDate: now.addingTimeInterval(-8 * 86_400), now: now
+        )
+        XCTAssertEqual(rec?.target, .smartScan)
+        XCTAssertEqual(rec?.startsScan, true)
+    }
+
+    /// Everything healthy and recently scanned reads as all clear — an honest
+    /// "nothing to do" instead of a manufactured plea, with Smart Scan still
+    /// offered as the panel's habitual action.
+    func test_recommendation_allClearWhenHealthyAndRecentlyScanned() {
+        let stale = MenuBarViewModel.recommendation(
+            protection: .protected, disk: healthyDisk, pressure: .nominal,
+            lastScanDate: now.addingTimeInterval(-8 * 86_400), now: now
+        )
+        let rec = MenuBarViewModel.recommendation(
+            protection: .protected, disk: healthyDisk, pressure: .nominal,
+            lastScanDate: now.addingTimeInterval(-2 * 86_400), now: now
+        )
+        XCTAssertEqual(rec?.target, .smartScan)
+        XCTAssertEqual(rec?.startsScan, true)
+        XCTAssertNotEqual(rec?.title, stale?.title, "All-clear copy must differ from the stale-scan nudge")
     }
 }


### PR DESCRIPTION
## What changed

A UX pass over the Mac Health menu bar popup, driven by a design review of the live panel.

**Interaction & affordances**
- The header and the scan card were `onTapGesture` surfaces with no hover state, chevron, or button role (invisible to VoiceOver/keyboard). Both are now real buttons with hover highlights, chevrons, and tooltips, following the `NavRow` house pattern.
- Tile action links (`Clean Up`, `Free Memory`, `Test Speed`) underline on hover and have padded hit targets.
- Footer: the power glyph is now an explicit **Quit** (a power symbol next to system telemetry reads as "shut down the Mac"); ⌘O/⌘Q surface in tooltips.

**State-awareness**
- The recommendation card no longer shows hardcoded copy. A tested derivation picks the most urgent state — storage under 10% free → critical memory pressure → scan older than 7 days → all clear — and returns `nil` while the scan card carries the CTA, so the panel never shows two competing scan buttons.
- The scan card (resting title **Smart Scan**) carries **Scan Now** when the Mac has never been scanned and **Review Threats** when threats exist, and its subtitle explains rather than repeating the status label.
- Mid-scan the card narrates the activity — pulsing shield (`symbolEffect`), mini spinner, and a title/detail naming the scan that is actually running (**Smart Scan** vs **Threat Scan**) so the popup never contradicts the main window. `SmartScanViewModel` is now injected into the menu scene for this.

**Hierarchy & tiles**
- Storage tile gains a capacity bar and whole-GB free space ("670 GB", not "670.49 GB").
- Battery icon tracks real charge with a bolt while charging; Battery and CPU get status dots matching Memory's traffic lights.
- Network tile leads with the category name and demotes the SSID to a detail line; uptime moves to the header beside the device name; secondary-text contrast bumped.

**Motion**
- Live values roll via `contentTransition(.numericText())` and the capacity bar animates width, on a new `VaderMotion.telemetry` ease. No ambient or repeat-forever animation — the shield pulse runs only while a scan does.

## Why

The popup was a static dashboard with hidden tap targets and a manufactured recommendation ("It's time to care for your Mac!" under a "Mac Health: Excellent" verdict). This pass makes it a state-aware surface with one honest CTA, discoverable interactions, and motion only where it carries meaning.

## Reviewer notes

- TDD throughout: 15 new unit tests in `MenuBarViewModelTests` pin the recommendation priorities, scanning status/titles, battery symbol buckets, status colors, and formatting. Full `VaderCleanerTests` target passes (`clean test`, `CODE_SIGNING_ALLOWED=NO`, `CODE_SIGN_IDENTITY="skip-dev-seal"`).
- `MenuBarViewModel` stays framework-free: the recommendation's deep-link target is a VM-local enum the view maps onto `NavigationSection`.
- The `Recommendation`/`ScanActivity` copy is localized with comments.
- Visually verified on-device across three states: not scanned, mid-Smart-Scan (popup open alongside the running scan), and post-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the menu bar health panel with clearer status cards and interactive actions.
  * Added live scan progress indicators and protection details for Smart Scan and threat scans.
  * Added storage capacity bars, dynamic battery and CPU status indicators, and improved network telemetry.
  * Added personalized recommendations for storage, memory, protection, and outdated scans.
  * Updated speed test, recommendation, device, and footer actions with improved guidance and accessibility.

* **Bug Fixes**
  * Improved display formatting for available storage and device uptime.
  * Corrected protection status handling while scans are running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->