### PR TITLE
Make the menu panel glanceable and align the health verdict across surfaces

### DIFF
--- a/VaderCleaner/ContentView.swift
+++ b/VaderCleaner/ContentView.swift
@@ -404,7 +404,12 @@ struct ContentView: View {
                 )
             }
         case .healthMonitor:
-            HealthMonitorView(service: systemStats)
+            // Scan state caps the hero's verdict pre-first-scan; reading it
+            // here keeps the section re-rendering when the first scan lands.
+            HealthMonitorView(
+                service: systemStats,
+                hasScanned: protectionDashboardViewModel.malware.lastScanDate != nil
+            )
         case .systemJunk:
             ScannableSectionContent(coordinator: systemJunkViewModel, section: section) {
                 SystemJunkView(viewModel: systemJunkViewModel)

--- a/VaderCleaner/HealthMonitorView.swift
+++ b/VaderCleaner/HealthMonitorView.swift
@@ -17,8 +17,19 @@ struct HealthMonitorView: View {
 
     @State private var viewModel: HealthMonitorViewModel
 
-    init(service: SystemStatsService) {
+    /// Whether the Mac has completed at least one scan. Pre-first-scan the
+    /// hero caps its verdict at Good (see `displayedHealth`), matching the
+    /// menu bar panel so the two surfaces never disagree.
+    private let hasScanned: Bool
+
+    init(service: SystemStatsService, hasScanned: Bool) {
         _viewModel = State(initialValue: HealthMonitorViewModel(service: service))
+        self.hasScanned = hasScanned
+    }
+
+    /// The verdict the hero renders: the live derivation capped by scan state.
+    private var displayedHealth: MacHealthStatus? {
+        HealthMonitorViewModel.displayedHealth(viewModel.macHealth, hasScanned: hasScanned)
     }
 
     /// Fixed width of the left hero column, so the hero and its disk bar keep a
@@ -38,7 +49,7 @@ struct HealthMonitorView: View {
     /// The overall Mac Health verdict color (gray while measuring). Drives the
     /// status dots and progress bars so they track the Mac's health at a glance.
     private var verdictAccent: Color {
-        viewModel.macHealth?.accentColor ?? Color(white: 0.55)
+        displayedHealth?.accentColor ?? Color(white: 0.55)
     }
 
     /// Drives the one-shot staggered entrance of the metric tiles when the
@@ -155,7 +166,7 @@ struct HealthMonitorView: View {
             // mirroring the reference dashboard's hero-and-card stack.
             VStack(spacing: 16) {
                 MacHealthHero(
-                    status: viewModel.macHealth,
+                    status: displayedHealth,
                     details: systemDetails,
                     volumeName: viewModel.diskVolumeName,
                     diskUsageDetail: viewModel.diskUsageDetail,
@@ -925,7 +936,7 @@ private extension View {
 }
 
 #Preview("Health Monitor") {
-    HealthMonitorView(service: SystemStatsService(autostart: false))
+    HealthMonitorView(service: SystemStatsService(autostart: false), hasScanned: true)
         .frame(width: 900, height: 600)
 }
 

--- a/VaderCleaner/HealthMonitorViewModel.swift
+++ b/VaderCleaner/HealthMonitorViewModel.swift
@@ -117,6 +117,19 @@ final class HealthMonitorViewModel {
         return tiers.min() ?? .excellent
     }
 
+    /// The verdict a surface actually renders: the shared derivation, capped
+    /// at Good until the Mac has been scanned once. "Excellent" alongside a
+    /// "run your first scan" prompt contradicts itself, so pre-first-scan no
+    /// surface claims more than Good. The cap only ever lowers — a real
+    /// problem (Fair or worse) passes through untouched — and the measuring
+    /// state (`nil`) is preserved. Both the hero and the menu bar panel render
+    /// through this one rule so they can never disagree about the same Mac.
+    static func displayedHealth(_ base: MacHealthStatus?, hasScanned: Bool) -> MacHealthStatus? {
+        guard let base else { return nil }
+        guard !hasScanned else { return base }
+        return min(base, .good)
+    }
+
     /// Low-disk-space contribution to the verdict. A disk under the card's
     /// warning threshold is not a problem at all (Excellent); only a genuinely
     /// full disk escalates. The 0.80 / 0.95 edges line up with

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -63,11 +63,18 @@ struct MenuBarContent: View {
     private var healthTheme: SectionTheme { NavigationSection.healthMonitor.theme }
     private var healthAccent: Color { healthTheme.accent }
 
+    /// The verdict the header renders: the shared derivation capped at Good
+    /// until a first scan exists, so "Excellent" never sits directly above the
+    /// Protection card's "Not scanned — run your first scan".
+    private var displayedHealth: MacHealthStatus? {
+        MenuBarViewModel.displayedHealth(menuBar.macHealth, hasScanned: malware.lastScanDate != nil)
+    }
+
     /// The verdict's signature colour (gray while still measuring).
-    private var verdictColor: Color { menuBar.macHealth?.accentColor ?? Color(white: 0.6) }
+    private var verdictColor: Color { displayedHealth?.accentColor ?? Color(white: 0.6) }
 
     private var verdictTitle: String {
-        menuBar.macHealth?.title ?? String(localized: "Measuring…")
+        displayedHealth?.title ?? String(localized: "Measuring…")
     }
 
     private var header: some View {
@@ -262,11 +269,13 @@ struct MenuBarContent: View {
             .buttonStyle(.plain)
             .help(scanActivity == .threatScan ? "Open Protection" : "Open Smart Scan")
             if let protectionCTA {
+                // Leading placement keeps the button visually attached to the
+                // detail text it acts on, instead of floating bottom-right.
                 HStack {
-                    Spacer()
                     Button(protectionCTA.label, action: protectionCTA.run)
                         .controlSize(.small)
                         .buttonStyle(.borderedProminent)
+                    Spacer()
                 }
             }
         }
@@ -279,57 +288,67 @@ struct MenuBarContent: View {
 
     // MARK: - Tiles
 
+    // Titled "Storage" like the other tiles' category names; the volume name
+    // reads as the unit line under the headline number instead.
     private var storageTile: some View {
         MenuTile(
             icon: "internaldrive",
-            title: menuBar.bootVolumeName,
-            primary: availableLine,
+            title: String(localized: "Storage"),
+            value: menuBar.availableDiskSpace,
+            label: storageLabel,
+            status: MenuBarViewModel.diskStatusColor(menuBar.diskStats),
             usedFraction: menuBar.diskUsedFraction,
-            action: (String(localized: "Clean Up"), { openSection(.systemJunk) })
+            action: (String(localized: "Clean Up"), { openSection(.systemJunk) }),
+            open: { openSection(.systemJunk) },
+            helpText: String(localized: "Open Cleanup")
         )
     }
 
-    private var availableLine: String {
+    /// "available on Macintosh HD" — the unit line under the storage tile's
+    /// headline number, carrying the volume name the title used to show.
+    private var storageLabel: String {
         let format = String(
-            localized: "Available: %@",
-            comment: "Storage tile line; %@ is free space, e.g. Available: 434.3 GB"
+            localized: "available on %@",
+            comment: "Storage tile line under the free-space number; %@ is the volume name."
         )
-        return String(format: format, menuBar.availableDiskSpace)
+        return String(format: format, menuBar.bootVolumeName)
     }
 
     private var memoryTile: some View {
         MenuTile(
             icon: "memorychip",
             title: String(localized: "Memory"),
-            primary: memoryLine,
-            statusColor: swiftUIColor(for: menuBar.ramPressureColor),
-            action: (String(localized: "Free Memory"), { openSection(.performance) })
+            value: menuBar.ramPressureLabel,
+            label: String(localized: "pressure", comment: "Memory tile line under the pressure level."),
+            status: menuBar.ramPressureColor,
+            action: (String(localized: "Free Memory"), { openSection(.performance) }),
+            open: { openSection(.performance) },
+            helpText: String(localized: "Open Performance")
         )
-    }
-
-    private var memoryLine: String {
-        let format = String(
-            localized: "Pressure: %@",
-            comment: "Memory tile line; %@ is the memory-pressure level, e.g. Pressure: Nominal"
-        )
-        return String(format: format, menuBar.ramPressureLabel)
     }
 
     private var batteryTile: some View {
         MenuTile(
             icon: menuBar.batterySymbolName,
             title: String(localized: "Battery"),
-            primary: batteryPrimary,
+            value: batteryValue,
+            label: batteryLabel,
             secondary: batterySecondary,
-            statusColor: menuBar.batteryStatusColor.map { swiftUIColor(for: $0) }
+            status: menuBar.batteryStatusColor,
+            open: { openSection(.healthMonitor) },
+            helpText: String(localized: "Open Health Monitor")
         )
     }
 
-    private var batteryPrimary: String {
+    private var batteryValue: String {
         guard let charge = menuBar.batteryCharge else {
             return String(localized: "No battery")
         }
-        return "\(MenuBarViewModel.batteryChargeString(charge)) · \(MenuBarViewModel.batteryStateString(charge))"
+        return MenuBarViewModel.batteryChargeString(charge)
+    }
+
+    private var batteryLabel: String? {
+        menuBar.batteryCharge.map { MenuBarViewModel.batteryStateString($0) }
     }
 
     private var batterySecondary: String? {
@@ -343,8 +362,11 @@ struct MenuBarContent: View {
         MenuTile(
             icon: "cpu",
             title: cpuTitle,
-            primary: cpuLine,
-            statusColor: swiftUIColor(for: menuBar.cpuLoadColor)
+            value: menuBar.formattedCPU,
+            label: String(localized: "load", comment: "CPU tile line under the load percent."),
+            status: menuBar.cpuLoadColor,
+            open: { openSection(.healthMonitor) },
+            helpText: String(localized: "Open Health Monitor")
         )
     }
 
@@ -355,14 +377,6 @@ struct MenuBarContent: View {
             return "\(String(localized: "CPU")) · \(temp)"
         }
         return String(localized: "CPU")
-    }
-
-    private var cpuLine: String {
-        let format = String(
-            localized: "Load: %@",
-            comment: "CPU tile line; %@ is processor load percent, e.g. Load: 20%"
-        )
-        return String(format: format, menuBar.formattedCPU)
     }
 
     // MARK: - Network tile
@@ -434,8 +448,18 @@ struct MenuBarContent: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {
-                ForEach(connectedDevices.devices.prefix(3)) { device in
+                let shown = connectedDevices.devices.prefix(3)
+                ForEach(shown) { device in
                     deviceRow(device)
+                }
+                // Never truncate silently: name how many devices didn't fit.
+                if let overflow = MenuBarViewModel.hiddenDevicesLabel(
+                    total: connectedDevices.devices.count,
+                    shown: shown.count
+                ) {
+                    Text(overflow)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
                 }
             }
         }
@@ -554,7 +578,14 @@ struct MenuBarContent: View {
     private var footer: some View {
         HStack(spacing: 14) {
             Button(action: openMainWindow) {
-                Text("Open VaderCleaner")
+                // The shortcut glyph rides along in secondary weight so the
+                // binding is discoverable without hunting for the tooltip.
+                HStack(spacing: 6) {
+                    Text("Open VaderCleaner")
+                    Text(verbatim: "⌘O")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             .buttonStyle(.plain)
             .keyboardShortcut("o")
@@ -570,8 +601,15 @@ struct MenuBarContent: View {
 
             // An explicit word rather than a power glyph — next to system
             // telemetry a power symbol reads as "shut down the Mac".
-            Button("Quit") {
+            Button {
                 NSApp.terminate(nil)
+            } label: {
+                HStack(spacing: 6) {
+                    Text("Quit")
+                    Text(verbatim: "⌘Q")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             .buttonStyle(.plain)
             .keyboardShortcut("q")
@@ -591,16 +629,6 @@ struct MenuBarContent: View {
         )
     }
 
-    /// Maps the view-model's framework-free `StatusColor` to a SwiftUI `Color`.
-    private func swiftUIColor(for status: StatusColor) -> Color {
-        switch status {
-        case .green: return .green
-        case .yellow: return .yellow
-        case .red: return .red
-        case .gray: return .gray
-        }
-    }
-
     private func openMainWindow() {
         // Brings the existing main window forward, or opens one if it was
         // closed, then activates the process so it surfaces over other apps.
@@ -616,53 +644,96 @@ struct MenuBarContent: View {
     }
 }
 
-/// One monitor tile: an icon + title row, a primary metric line, an optional
-/// capacity bar, an optional secondary line, an optional status dot, and an
-/// optional trailing action link.
+/// Maps the view-model's framework-free `StatusColor` to a SwiftUI `Color`.
+/// File-level so both the panel and its private tiles share one mapping.
+private func swiftUIColor(for status: StatusColor) -> Color {
+    switch status {
+    case .green: return .green
+    case .yellow: return .yellow
+    case .red: return .red
+    case .gray: return .gray
+    }
+}
+
+/// One monitor tile: an icon + title row, a headline value over a small unit
+/// label, an optional capacity bar, an optional secondary line, an optional
+/// status dot, and an optional trailing action link. The whole tile is a
+/// button that deep-links into the section owning the reading; the action
+/// link is a sibling of that button (never its descendant) so each control
+/// resolves clicks cleanly, matching the Protection card's pattern.
 private struct MenuTile: View {
     let icon: String
     let title: String
-    let primary: String
+    /// Headline reading, shown large — the number the user glances for
+    /// ("679 GB", "23%").
+    let value: String
+    /// Small unit line under the value ("available on Macintosh HD", "load").
+    var label: String?
     var secondary: String?
-    var statusColor: Color?
-    /// Used fraction (0…1) rendered as a thin capacity bar under the primary
-    /// line, e.g. the storage tile's disk usage.
+    var status: StatusColor?
+    /// Used fraction (0…1) rendered as a thin capacity bar under the value,
+    /// e.g. the storage tile's disk usage.
     var usedFraction: Double?
     /// Optional trailing link, e.g. ("Clean Up", action).
     var action: (label: String, run: () -> Void)?
+    /// Whole-tile deep link into the section that owns this reading.
+    let open: () -> Void
+    let helpText: String
+
+    @State private var hovered = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Image(systemName: icon)
-                    .font(.callout)
-                    .foregroundStyle(.tint)
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Spacer(minLength: 0)
-                if let statusColor {
-                    Circle().fill(statusColor).frame(width: 7, height: 7)
+            Button(action: open) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        Image(systemName: icon)
+                            .font(.callout)
+                            .foregroundStyle(.tint)
+                        Text(title)
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        Spacer(minLength: 0)
+                        if let status {
+                            Circle()
+                                .fill(swiftUIColor(for: status))
+                                .frame(width: 7, height: 7)
+                                // The dot is color-only; VoiceOver speaks its
+                                // meaning instead.
+                                .accessibilityLabel(MenuBarViewModel.statusAccessibilityLabel(for: status))
+                        }
+                    }
+                    Text(value)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                        // Live values roll to their next reading instead of
+                        // blinking on the 2-second refresh.
+                        .contentTransition(.numericText())
+                        .animation(VaderMotion.telemetry, value: value)
+                    if let label {
+                        Text(label)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    if let usedFraction {
+                        capacityBar(usedFraction)
+                    }
+                    if let secondary {
+                        Text(secondary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .contentShape(Rectangle())
             }
-            Text(primary)
-                .font(.callout)
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-                // Live values roll to their next reading instead of blinking
-                // on the 2-second refresh.
-                .contentTransition(.numericText())
-                .animation(VaderMotion.telemetry, value: primary)
-            if let usedFraction {
-                capacityBar(usedFraction)
-            }
-            if let secondary {
-                Text(secondary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            .buttonStyle(.plain)
+            .help(helpText)
             if let action {
                 HStack {
                     Spacer()
@@ -672,7 +743,20 @@ private struct MenuTile: View {
         }
         .padding(10)
         .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
-        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+        .background(.white.opacity(hovered ? 0.08 : 0.05), in: .rect(cornerRadius: 12))
+        .onHover { hovered = $0 }
+        .animation(VaderMotion.hover, value: hovered)
+    }
+
+    /// The capacity bar shares the tile's accent while the reading is
+    /// comfortable and switches to the status color once it needs attention,
+    /// so a nearly-full disk's bar and dot agree.
+    private var barFill: AnyShapeStyle {
+        switch status {
+        case .yellow: return AnyShapeStyle(Color.yellow)
+        case .red:    return AnyShapeStyle(Color.red)
+        default:      return AnyShapeStyle(.tint)
+        }
     }
 
     private func capacityBar(_ fraction: Double) -> some View {
@@ -680,7 +764,7 @@ private struct MenuTile: View {
             ZStack(alignment: .leading) {
                 Capsule().fill(.white.opacity(0.12))
                 Capsule()
-                    .fill(.tint)
+                    .fill(barFill)
                     .frame(width: max(4, geo.size.width * fraction))
                     .animation(VaderMotion.telemetry, value: fraction)
             }

--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -23,21 +23,19 @@ struct MenuBarContent: View {
     @State private var headerHovered = false
     @State private var protectionHovered = false
 
-    private let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
-
     var body: some View {
         VStack(spacing: 0) {
             header
             VStack(spacing: 10) {
                 protectionCard
-                LazyVGrid(columns: columns, spacing: 10) {
-                    storageTile
-                    memoryTile
-                    batteryTile
-                    cpuTile
-                    networkTile
-                    connectedDevicesTile
-                }
+                // Fixed rows rather than a grid: each row's tiles stretch to
+                // the height of the taller one (`fixedSize` sets the row to
+                // its ideal height, `maxHeight: .infinity` inside the tiles
+                // fills it), so a short tile never floats centered beside a
+                // tall neighbour with ragged gaps.
+                tileRow { storageTile } trailing: { memoryTile }
+                tileRow { batteryTile } trailing: { cpuTile }
+                tileRow { networkTile } trailing: { connectedDevicesTile }
                 recommendationCard
             }
             .padding(14)
@@ -288,6 +286,20 @@ struct MenuBarContent: View {
 
     // MARK: - Tiles
 
+    /// One two-tile row. `fixedSize` keeps the row at its ideal height (the
+    /// taller tile's), which the tiles' `maxHeight: .infinity` then fills, so
+    /// both cards in a row are always the same height.
+    private func tileRow<Leading: View, Trailing: View>(
+        @ViewBuilder _ leading: () -> Leading,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            leading()
+            trailing()
+        }
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
     // Titled "Storage" like the other tiles' category names; the volume name
     // reads as the unit line under the headline number instead.
     private var storageTile: some View {
@@ -420,13 +432,16 @@ struct MenuBarContent: View {
                         .animation(VaderMotion.telemetry, value: menuBar.networkUpString)
                 }
             }
+            // Pinned to the tile's bottom edge, level with the row's other
+            // action links.
+            Spacer(minLength: 0)
             HStack {
                 Spacer()
                 speedTestControl
             }
         }
         .padding(10)
-        .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 78, maxHeight: .infinity, alignment: .topLeading)
         .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
     }
 
@@ -464,7 +479,7 @@ struct MenuBarContent: View {
             }
         }
         .padding(10)
-        .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 78, maxHeight: .infinity, alignment: .topLeading)
         .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
     }
 
@@ -735,6 +750,9 @@ private struct MenuTile: View {
             .buttonStyle(.plain)
             .help(helpText)
             if let action {
+                // Pinned to the tile's bottom edge so the action links sit
+                // level across a row regardless of each tile's content height.
+                Spacer(minLength: 0)
                 HStack {
                     Spacer()
                     MenuActionLink(label: action.label, action: action.run)
@@ -742,7 +760,7 @@ private struct MenuTile: View {
             }
         }
         .padding(10)
-        .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 78, maxHeight: .infinity, alignment: .topLeading)
         .background(.white.opacity(hovered ? 0.08 : 0.05), in: .rect(cornerRadius: 12))
         .onHover { hovered = $0 }
         .animation(VaderMotion.hover, value: hovered)

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -62,6 +62,16 @@ final class MenuBarViewModel {
         )
     }
 
+    /// The verdict the panel header actually renders: the shared derivation,
+    /// capped at Good until the Mac has been scanned once. "Excellent" directly
+    /// above a "Not scanned — run your first scan" card contradicts itself, so
+    /// pre-first-scan the header claims no more than Good. Forwards to the
+    /// Health Monitor's rule — the hero renders through the same one — so the
+    /// menu and the main window can never disagree about the same Mac.
+    static func displayedHealth(_ base: MacHealthStatus?, hasScanned: Bool) -> MacHealthStatus? {
+        HealthMonitorViewModel.displayedHealth(base, hasScanned: hasScanned)
+    }
+
     /// Free space on the boot volume — the storage tile's headline number.
     var availableDiskSpace: String { Self.availableDiskString(service.diskSpace) }
 
@@ -288,6 +298,34 @@ final class MenuBarViewModel {
         }
     }
 
+    /// Status dot for the storage tile. Derived from the Health Monitor's
+    /// disk-space tiers so the dot, the capacity bar, and the overall verdict
+    /// never tell contradictory stories: comfortable is green, ≥90% used is
+    /// yellow, ≥95% is red. Gray while the volume is still unmeasured.
+    static func diskStatusColor(_ stats: DiskStats) -> StatusColor {
+        guard stats.totalBytes > 0 else { return .gray }
+        switch HealthMonitorViewModel.diskSpaceTier(for: stats) {
+        case .critical, .requiresAttention: return .red
+        case .fair:                         return .yellow
+        case .good, .excellent:             return .green
+        }
+    }
+
+    /// Spoken description for a tile's status dot — the 7pt dots are
+    /// color-only, so VoiceOver needs words to carry the same meaning.
+    static func statusAccessibilityLabel(for color: StatusColor) -> String {
+        switch color {
+        case .green:
+            return String(localized: "OK", comment: "VoiceOver label for a green status dot.")
+        case .yellow:
+            return String(localized: "Needs attention", comment: "VoiceOver label for a yellow status dot.")
+        case .red:
+            return String(localized: "Critical", comment: "VoiceOver label for a red status dot.")
+        case .gray:
+            return String(localized: "Not available", comment: "VoiceOver label for a gray status dot.")
+        }
+    }
+
     /// Status dot for the CPU tile: comfortable under 70% load, busy under
     /// 90%, saturated above.
     static func cpuLoadColor(_ usage: Double) -> StatusColor {
@@ -507,8 +545,22 @@ final class MenuBarViewModel {
         )
     }
 
-    /// Compact uptime, e.g. "up 3d 4h", "up 4h 12m", or "up 8m". Drops to the
-    /// two most significant units so the CPU tile stays one short line.
+    /// "+2 more" line for the Connected Devices tile when more devices exist
+    /// than the tile shows, or `nil` when everything fits — the tile must
+    /// never truncate the list silently.
+    static func hiddenDevicesLabel(total: Int, shown: Int) -> String? {
+        let hidden = total - shown
+        guard hidden > 0 else { return nil }
+        let format = String(
+            localized: "+%d more",
+            comment: "Connected Devices tile overflow line; %d is how many devices are not shown."
+        )
+        return String(format: format, hidden)
+    }
+
+    /// Compact uptime, e.g. "on for 3d 4h", "on for 4h 12m", or "on for 8m".
+    /// Drops to the two most significant units so the header stays one short
+    /// line.
     static func uptimeString(_ interval: TimeInterval) -> String {
         let total = max(0, Int(interval))
         let days = total / 86_400
@@ -522,7 +574,10 @@ final class MenuBarViewModel {
         } else {
             value = "\(minutes)m"
         }
-        let format = String(localized: "up %@", comment: "CPU tile uptime line; %@ is a duration like 3d 4h")
+        let format = String(
+            localized: "on for %@",
+            comment: "Header uptime line; %@ is a duration like 3d 4h. Reads as plain language, not server-style 'up'."
+        )
         return String(format: format, value)
     }
 

--- a/VaderCleanerTests/HealthMonitorViewModelTests.swift
+++ b/VaderCleanerTests/HealthMonitorViewModelTests.swift
@@ -498,4 +498,42 @@ final class HealthMonitorViewModelTests: XCTestCase {
         XCTAssertTrue(MacHealthStatus.good.summary.contains("good shape"))
         XCTAssertEqual(MacHealthStatus.excellent.title, "Excellent")
     }
+
+    // MARK: - Displayed health verdict
+
+    /// A never-scanned Mac caps the rendered verdict at Good — "Excellent"
+    /// alongside a "run your first scan" prompt contradicts itself. This rule
+    /// is shared with the menu bar panel (which forwards to it) so the hero
+    /// and the menu can never disagree about the same Mac.
+    func test_displayedHealth_capsAtGoodUntilFirstScan() {
+        XCTAssertEqual(HealthMonitorViewModel.displayedHealth(.excellent, hasScanned: false), .good)
+        XCTAssertEqual(HealthMonitorViewModel.displayedHealth(.excellent, hasScanned: true), .excellent)
+    }
+
+    /// The cap only lowers the verdict — a real problem (Fair or worse) must
+    /// never be *raised* toward Good by the scan rule.
+    func test_displayedHealth_neverRaisesAWorseVerdict() {
+        XCTAssertEqual(HealthMonitorViewModel.displayedHealth(.fair, hasScanned: false), .fair)
+        XCTAssertEqual(HealthMonitorViewModel.displayedHealth(.critical, hasScanned: false), .critical)
+        XCTAssertEqual(HealthMonitorViewModel.displayedHealth(.good, hasScanned: false), .good)
+    }
+
+    /// The measuring state (nil verdict) passes through untouched.
+    func test_displayedHealth_preservesMeasuringState() {
+        XCTAssertNil(HealthMonitorViewModel.displayedHealth(nil, hasScanned: false))
+        XCTAssertNil(HealthMonitorViewModel.displayedHealth(nil, hasScanned: true))
+    }
+
+    /// The menu bar panel's forwarding stays in lockstep with the hero's rule
+    /// — one implementation, two surfaces.
+    func test_displayedHealth_menuBarForwardsToTheSameRule() {
+        for hasScanned in [true, false] {
+            for status in MacHealthStatus.allCases {
+                XCTAssertEqual(
+                    MenuBarViewModel.displayedHealth(status, hasScanned: hasScanned),
+                    HealthMonitorViewModel.displayedHealth(status, hasScanned: hasScanned)
+                )
+            }
+        }
+    }
 }

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -306,11 +306,12 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(MenuBarViewModel.cpuTemperatureString(49.6), "50°C")
     }
 
-    /// Uptime collapses to the two most significant units, by magnitude.
+    /// Uptime collapses to the two most significant units, by magnitude, and
+    /// reads as plain language ("on for …") rather than server-style "up …".
     func test_uptimeString_picksTwoMostSignificantUnits() {
-        XCTAssertEqual(MenuBarViewModel.uptimeString(3 * 86_400 + 4 * 3_600 + 30 * 60), "up 3d 4h")
-        XCTAssertEqual(MenuBarViewModel.uptimeString(4 * 3_600 + 12 * 60), "up 4h 12m")
-        XCTAssertEqual(MenuBarViewModel.uptimeString(8 * 60 + 30), "up 8m")
+        XCTAssertEqual(MenuBarViewModel.uptimeString(3 * 86_400 + 4 * 3_600 + 30 * 60), "on for 3d 4h")
+        XCTAssertEqual(MenuBarViewModel.uptimeString(4 * 3_600 + 12 * 60), "on for 4h 12m")
+        XCTAssertEqual(MenuBarViewModel.uptimeString(8 * 60 + 30), "on for 8m")
     }
 
     /// The compact menu bar reading forwards to the available-disk formatter.
@@ -531,6 +532,78 @@ final class MenuBarViewModelTests: XCTestCase {
         )
         XCTAssertEqual(rec?.target, .smartScan)
         XCTAssertEqual(rec?.startsScan, true)
+    }
+
+    // MARK: - Displayed health verdict
+
+    /// A never-scanned Mac caps the panel's verdict at Good: "Excellent" right
+    /// above a "Not scanned — run your first scan" card contradicts itself.
+    /// One scan restores the full verdict range.
+    func test_displayedHealth_capsAtGoodUntilFirstScan() {
+        XCTAssertEqual(MenuBarViewModel.displayedHealth(.excellent, hasScanned: false), .good)
+        XCTAssertEqual(MenuBarViewModel.displayedHealth(.excellent, hasScanned: true), .excellent)
+    }
+
+    /// The cap only lowers the verdict — a real problem (Fair or worse) must
+    /// never be *raised* toward Good by the scan rule.
+    func test_displayedHealth_neverRaisesAWorseVerdict() {
+        XCTAssertEqual(MenuBarViewModel.displayedHealth(.fair, hasScanned: false), .fair)
+        XCTAssertEqual(MenuBarViewModel.displayedHealth(.critical, hasScanned: false), .critical)
+        XCTAssertEqual(MenuBarViewModel.displayedHealth(.good, hasScanned: false), .good)
+    }
+
+    /// The measuring state (nil verdict) passes through untouched.
+    func test_displayedHealth_preservesMeasuringState() {
+        XCTAssertNil(MenuBarViewModel.displayedHealth(nil, hasScanned: false))
+        XCTAssertNil(MenuBarViewModel.displayedHealth(nil, hasScanned: true))
+    }
+
+    // MARK: - Storage status dot
+
+    /// The storage tile's dot mirrors the Health Monitor's disk-space tiers so
+    /// the dot and the overall verdict never tell contradictory stories:
+    /// comfortable is green, ≥90% used is yellow, ≥95% used is red.
+    func test_diskStatusColor_bucketsUsage() {
+        func stats(usedFraction: Double) -> DiskStats {
+            DiskStats(usedBytes: UInt64(usedFraction * 1_000_000_000_000), totalBytes: 1_000_000_000_000)
+        }
+        XCTAssertEqual(MenuBarViewModel.diskStatusColor(stats(usedFraction: 0.50)), .green)
+        XCTAssertEqual(MenuBarViewModel.diskStatusColor(stats(usedFraction: 0.85)), .green)
+        XCTAssertEqual(MenuBarViewModel.diskStatusColor(stats(usedFraction: 0.92)), .yellow)
+        XCTAssertEqual(MenuBarViewModel.diskStatusColor(stats(usedFraction: 0.96)), .red)
+    }
+
+    /// Pre-first-refresh (zero total) shows a neutral gray dot, not a false
+    /// green — the disk hasn't been measured yet.
+    func test_diskStatusColor_isGrayWhileUnmeasured() {
+        XCTAssertEqual(MenuBarViewModel.diskStatusColor(.empty), .gray)
+    }
+
+    // MARK: - Status dot accessibility
+
+    /// The 7pt status dots are color-only; VoiceOver needs words. Each color
+    /// maps to a stable spoken description.
+    func test_statusAccessibilityLabel_describesEveryColor() {
+        XCTAssertEqual(MenuBarViewModel.statusAccessibilityLabel(for: .green), "OK")
+        XCTAssertEqual(MenuBarViewModel.statusAccessibilityLabel(for: .yellow), "Needs attention")
+        XCTAssertEqual(MenuBarViewModel.statusAccessibilityLabel(for: .red), "Critical")
+        XCTAssertEqual(MenuBarViewModel.statusAccessibilityLabel(for: .gray), "Not available")
+    }
+
+    // MARK: - Connected devices overflow
+
+    /// The devices tile shows at most three devices; beyond that it must say
+    /// how many were hidden instead of truncating silently.
+    func test_hiddenDevicesLabel_countsTheOverflow() {
+        XCTAssertEqual(MenuBarViewModel.hiddenDevicesLabel(total: 5, shown: 3), "+2 more")
+        XCTAssertEqual(MenuBarViewModel.hiddenDevicesLabel(total: 4, shown: 3), "+1 more")
+    }
+
+    /// No overflow, no label — three or fewer devices all fit.
+    func test_hiddenDevicesLabel_isNilWhenEverythingFits() {
+        XCTAssertNil(MenuBarViewModel.hiddenDevicesLabel(total: 3, shown: 3))
+        XCTAssertNil(MenuBarViewModel.hiddenDevicesLabel(total: 0, shown: 0))
+        XCTAssertNil(MenuBarViewModel.hiddenDevicesLabel(total: 2, shown: 2))
     }
 
     /// Everything healthy and recently scanned reads as all clear — an honest


### PR DESCRIPTION
## What changed

**Menu bar panel UX** (`MenuBarContent.swift`, `MenuBarViewModel.swift`):
- Every monitor tile is now a full-surface button that deep-links into the section owning its reading (Storage → Cleanup, Memory → Performance, Battery/CPU → Health Monitor), with the same hover brightening as the header. Inline action links stay as siblings of the tile button — the Protection card's click-resolution pattern — so no control nests inside another.
- Tiles lead with the number: a large headline value ("679 GB", "23%") over a small unit line ("available on Macintosh HD", "load"), keeping the existing `numericText` rolling transitions.
- The Storage tile gains a threshold status dot derived from the Health Monitor's disk-space tiers (gray while unmeasured), and its capacity bar switches to yellow/red in step with the dot.
- Status dots now carry VoiceOver labels ("OK" / "Needs attention" / "Critical" / "Not available") — they were color-only.
- Connected Devices names its overflow ("+2 more") instead of silently truncating at three.
- Polish: Storage tile titled by category like its peers (volume name moves to the unit line), Scan Now sits leading with the text it acts on, footer shows ⌘O/⌘Q glyphs, uptime reads "on for 1d 9h" instead of server-style "up 1d 9h".

**Health verdict vs. scan state** (`HealthMonitorViewModel.swift`, `HealthMonitorView.swift`, `ContentView.swift`):
- A never-scanned Mac caps the displayed verdict at **Good** — "Excellent" directly above the Protection card's "Not scanned — run your first scan" contradicted itself.
- The rule lives in `HealthMonitorViewModel.displayedHealth(_:hasScanned:)`; `MenuBarViewModel.displayedHealth` forwards to it, and the Health Monitor hero renders through it (fed `malware.lastScanDate != nil` from `ContentView`), so the menu and the main window can never disagree about the same Mac. The cap only lowers — Fair or worse passes through — and the "Measuring…" nil state is preserved. The shared `macHealthStatus` derivation is unchanged for its other consumers.

## Why

The panel is a glance surface, but its numbers rendered at label weight, three different interaction affordances coexisted (card-button / tiny link / nothing), two tiles were dead ends, and the header could claim "Excellent" while the card below said protection wasn't established.

## Testing

TDD throughout: new unit tests in `MenuBarViewModelTests` and `HealthMonitorViewModelTests` cover the verdict cap (cap-at-Good, never-raise, nil passthrough), the disk status dot thresholds, the VoiceOver status labels, the devices overflow label, the uptime copy, and a lockstep test asserting the menu's forwarding matches the hero's rule across every `MacHealthStatus` case. Full `VaderCleanerTests` bundle passes locally (`CODE_SIGNING_ALLOWED=NO`, `CODE_SIGN_IDENTITY="skip-dev-seal"`). XCUITests compile but can't execute from the terminal in this environment — worth a run from Xcode.

## Reviewer notes

- Pre-first-scan the hero now shows "Good" with the Good-tier summary copy, which doesn't mention scanning; if we want "scan to confirm" copy there, that's a follow-up to `MacHealthStatus.summary` handling.
- `swiftUIColor(for:)` moved from a `MenuBarContent` method to a file-level function so the private `MenuTile` shares the one mapping.
- Network and Connected Devices tiles intentionally don't get whole-tile deep links: the Health Monitor has no network card to land on, and both tiles already carry their own actions (Test Speed, eject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health status now reflects whether an initial scan has completed, providing clearer first-use results.
  * Menu bar monitoring tiles now show clearer values, units, status indicators, capacity warnings, and connected-device overflow counts.
  * Added accessibility labels for health and storage status indicators.
  * Updated uptime wording to “on for …”.
  * Keyboard shortcuts are now displayed directly in menu controls.

* **Bug Fixes**
  * Improved consistency between Health Monitor and menu bar health verdicts.
  * Prevented unscanned systems from displaying an overly severe health rating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->