### PR TITLE
Revamp the menu panel: verdict ring, inline memory purge, and a section launcher

### DIFF
--- a/VaderCleaner/MenuBarContent.swift
+++ b/VaderCleaner/MenuBarContent.swift
@@ -1,14 +1,16 @@
 // MenuBarContent.swift
-// The menu bar panel — a Mac Health header, a grid of live system tiles (Storage, Memory, Battery, CPU), a recommendation card, and a footer, driven by MenuBarViewModel / SystemStatsService.
+// The menu bar panel — a Mac Health header with a verdict ring, a Smart Scan card, compact vitals (Storage, Memory, Battery, CPU), a connectivity card, a recommendation, and a section launcher, driven by MenuBarViewModel / SystemStatsService.
 
 import SwiftUI
 import AppKit
 
-/// Wide panel presented when the user clicks the menu bar icon. Mirrors the
-/// CleanMyMac menu's shape — a Mac Health verdict header, a 2-column grid of
-/// monitor tiles, a "Today's Recommendation" card, and a footer — while showing
-/// only VaderCleaner's real telemetry. Values refresh on the same 2-second
-/// cadence as the Health Monitor.
+/// Wide panel presented when the user clicks the menu bar icon. Reads top to
+/// bottom as glance → act → dive: a Mac Health verdict header with a score
+/// ring, a Smart Scan card, a 2×2 grid of monitor tiles with inline actions
+/// (memory purge, cleanup deep-link), a full-width connectivity card (network
+/// + connected devices), a "Today's Recommendation" card, a launcher covering
+/// every main-window section, and a footer. Values refresh on the same
+/// 2-second cadence as the Health Monitor.
 struct MenuBarContent: View {
 
     @Environment(MenuBarViewModel.self) private var menuBar
@@ -35,8 +37,9 @@ struct MenuBarContent: View {
                 // tall neighbour with ragged gaps.
                 tileRow { storageTile } trailing: { memoryTile }
                 tileRow { batteryTile } trailing: { cpuTile }
-                tileRow { networkTile } trailing: { connectedDevicesTile }
+                connectivityCard
                 recommendationCard
+                launcherGrid
             }
             .padding(14)
             Divider()
@@ -79,7 +82,7 @@ struct MenuBarContent: View {
         Button {
             openSection(.healthMonitor)
         } label: {
-            HStack(alignment: .top) {
+            HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
                         Text("Mac Health:")
@@ -99,15 +102,7 @@ struct MenuBarContent: View {
                         .foregroundStyle(.white.opacity(0.7))
                 }
                 Spacer()
-                Image(systemName: "laptopcomputer")
-                    .font(.system(size: 34, weight: .light))
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [.white.opacity(0.95), healthAccent.opacity(0.9)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
+                verdictRing
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -119,6 +114,29 @@ struct MenuBarContent: View {
         .onHover { headerHovered = $0 }
         .animation(VaderMotion.hover, value: headerHovered)
         .help("Open Health Monitor")
+    }
+
+    /// Miniature of the Health Monitor hero ring: the arc fills with
+    /// `MacHealthStatus.score` in the verdict's colour, so the header carries
+    /// the verdict as a shape as well as a word and the two surfaces rhyme.
+    /// A bare track while still measuring.
+    private var verdictRing: some View {
+        ZStack {
+            Circle()
+                .stroke(.white.opacity(0.15), lineWidth: 4)
+            Circle()
+                .trim(from: 0, to: displayedHealth?.score ?? 0)
+                .stroke(verdictColor, style: StrokeStyle(lineWidth: 4, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(VaderMotion.telemetry, value: displayedHealth?.score)
+            Image(systemName: "laptopcomputer")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.white.opacity(0.9))
+        }
+        .frame(width: 46, height: 46)
+        // The ring is decorative alongside the verdict text; VoiceOver reads
+        // the header's words instead of a second copy of the same fact.
+        .accessibilityHidden(true)
     }
 
     private var headerBackground: some View {
@@ -186,8 +204,8 @@ struct MenuBarContent: View {
 
     /// Detail line under the Protection title. A never-scanned Mac explains
     /// what a first scan buys instead of repeating the "Not scanned" status
-    /// label; a running scan narrates the activity; otherwise it shows scan
-    /// recency.
+    /// label; a running scan narrates the activity (Smart Scan's file walks
+    /// report a live item tally); otherwise it shows scan recency.
     private var protectionDetail: String {
         switch protectionStatus {
         case .notScanned:
@@ -198,7 +216,10 @@ struct MenuBarContent: View {
         case .scanning:
             // `scanActivity` is non-nil whenever the status is `.scanning`;
             // the fallback only satisfies exhaustiveness.
-            return MenuBarViewModel.scanningDetail(for: scanActivity ?? .threatScan)
+            return MenuBarViewModel.scanningDetail(
+                for: scanActivity ?? .threatScan,
+                itemsScanned: smartScan.scannedItemCount
+            )
         case .protected, .threatsFound:
             return MenuBarViewModel.lastScanString(malware.lastScanDate)
         }
@@ -260,6 +281,11 @@ struct MenuBarContent: View {
                         Text(protectionDetail)
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                            // The live item tally rolls instead of blinking
+                            // as the walks report progress.
+                            .monospacedDigit()
+                            .contentTransition(.numericText())
+                            .animation(VaderMotion.telemetry, value: protectionDetail)
                     }
                 }
                 .contentShape(Rectangle())
@@ -326,17 +352,77 @@ struct MenuBarContent: View {
         return String(format: format, menuBar.bootVolumeName)
     }
 
+    // Hand-rolled rather than a `MenuTile` because its trailing action is the
+    // stateful inline purge control, not a plain link. The informational area
+    // is its own button (sibling of the purge control, never its ancestor) so
+    // each control resolves clicks cleanly, matching the Protection card.
     private var memoryTile: some View {
-        MenuTile(
-            icon: "memorychip",
-            title: String(localized: "Memory"),
-            value: menuBar.ramPressureLabel,
-            label: String(localized: "pressure", comment: "Memory tile line under the pressure level."),
-            status: menuBar.ramPressureColor,
-            action: (String(localized: "Free Memory"), { openSection(.performance) }),
-            open: { openSection(.performance) },
-            helpText: String(localized: "Open Performance")
-        )
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                openSection(.performance)
+            } label: {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "memorychip")
+                            .font(.callout)
+                            .foregroundStyle(.tint)
+                        Text("Memory")
+                            .font(.subheadline.weight(.semibold))
+                        Spacer(minLength: 0)
+                        Circle()
+                            .fill(swiftUIColor(for: menuBar.ramPressureColor))
+                            .frame(width: 7, height: 7)
+                            .accessibilityLabel(MenuBarViewModel.statusAccessibilityLabel(for: menuBar.ramPressureColor))
+                    }
+                    Text(menuBar.ramPressureLabel)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                        .contentTransition(.numericText())
+                        .animation(VaderMotion.telemetry, value: menuBar.ramPressureLabel)
+                    Text("pressure", comment: "Memory tile line under the pressure level.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Open Performance")
+            // Pinned to the tile's bottom edge, level with the row's other
+            // action links.
+            Spacer(minLength: 0)
+            HStack {
+                Spacer()
+                memoryFlushControl
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, minHeight: 78, maxHeight: .infinity, alignment: .topLeading)
+        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+    }
+
+    /// The Memory tile's inline action: purges inactive RAM through the
+    /// privileged helper right from the panel — no main-window round trip —
+    /// with a spinner in flight, a confirmation once done (clickable to purge
+    /// again), and an orange retry after a failure.
+    @ViewBuilder
+    private var memoryFlushControl: some View {
+        switch menuBar.memoryFlushState {
+        case .running:
+            ProgressView().controlSize(.small)
+        case .idle, .flushed, .failed:
+            if let label = MenuBarViewModel.memoryFlushLabel(for: menuBar.memoryFlushState) {
+                MenuActionLink(
+                    label: label,
+                    color: menuBar.memoryFlushState == .failed ? .orange : nil
+                ) {
+                    Task { await menuBar.flushMemory() }
+                }
+                .help("Purge inactive memory")
+            }
+        }
     }
 
     private var batteryTile: some View {
@@ -391,78 +477,36 @@ struct MenuBarContent: View {
         return String(localized: "CPU")
     }
 
-    // MARK: - Network tile
+    // MARK: - Connectivity card
 
-    // Titled "Network" like the other tiles' category names; the SSID (raw
-    // router noise like "ATTQ3gAepM") reads as the detail line instead.
-    private var networkTile: some View {
-        VStack(alignment: .leading, spacing: 6) {
+    // Network and connected devices share one full-width card: both are
+    // "what's attached to this Mac" facts, and a single card gives the SSID,
+    // the throughput pair, and the device list room to breathe that two
+    // half-width tiles never had.
+    private var connectivityCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
                 Image(systemName: "wifi")
                     .font(.callout)
                     .foregroundStyle(.tint)
                 Text("Network")
                     .font(.subheadline.weight(.semibold))
-                Spacer(minLength: 0)
-            }
-            Text(menuBar.wifiNetworkName)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            HStack(spacing: 10) {
-                HStack(spacing: 3) {
-                    Image(systemName: "arrow.down")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    Text(menuBar.networkDownString)
-                        .font(.caption)
-                        .monospacedDigit()
-                        .contentTransition(.numericText())
-                        .animation(VaderMotion.telemetry, value: menuBar.networkDownString)
-                }
-                HStack(spacing: 3) {
-                    Image(systemName: "arrow.up")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    Text(menuBar.networkUpString)
-                        .font(.caption)
-                        .monospacedDigit()
-                        .contentTransition(.numericText())
-                        .animation(VaderMotion.telemetry, value: menuBar.networkUpString)
-                }
-            }
-            // Pinned to the tile's bottom edge, level with the row's other
-            // action links.
-            Spacer(minLength: 0)
-            HStack {
-                Spacer()
-                speedTestControl
-            }
-        }
-        .padding(10)
-        .frame(maxWidth: .infinity, minHeight: 78, maxHeight: .infinity, alignment: .topLeading)
-        .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
-    }
-
-    // MARK: - Connected devices tile
-
-    private var connectedDevicesTile: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Image(systemName: "cable.connector")
-                    .font(.callout)
-                    .foregroundStyle(.tint)
-                Text("Connected Devices")
-                    .font(.subheadline.weight(.semibold))
-                    .lineLimit(1)
-                Spacer(minLength: 0)
-            }
-            if connectedDevices.devices.isEmpty {
-                Text("None connected")
+                Text(menuBar.wifiNetworkName)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            } else {
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 8)
+                speedTestControl
+            }
+            HStack(spacing: 10) {
+                throughputReading(symbol: "arrow.down", value: menuBar.networkDownString)
+                throughputReading(symbol: "arrow.up", value: menuBar.networkUpString)
+                Spacer(minLength: 0)
+            }
+            if !connectedDevices.devices.isEmpty {
+                Divider()
+                    .overlay(.white.opacity(0.08))
                 let shown = connectedDevices.devices.prefix(3)
                 ForEach(shown) { device in
                     deviceRow(device)
@@ -479,8 +523,21 @@ struct MenuBarContent: View {
             }
         }
         .padding(10)
-        .frame(maxWidth: .infinity, minHeight: 78, maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(.white.opacity(0.05), in: .rect(cornerRadius: 12))
+    }
+
+    private func throughputReading(symbol: String, value: String) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: symbol)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption)
+                .monospacedDigit()
+                .contentTransition(.numericText())
+                .animation(VaderMotion.telemetry, value: value)
+        }
     }
 
     private func deviceRow(_ device: ConnectedDevice) -> some View {
@@ -586,6 +643,31 @@ struct MenuBarContent: View {
         case .performance: section = .performance
         }
         openSection(section, startScan: recommendation.startsScan)
+    }
+
+    // MARK: - Section launcher
+
+    /// Every main-window section as a tappable chip, in the rail's order and
+    /// each tinted with its section hue — a complete map of the app so no
+    /// feature is more than one click from the menu bar. Some sections are
+    /// also reachable through the cards above; the launcher stays exhaustive
+    /// anyway so the grid position of each destination never shifts.
+    private var launcherGrid: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Jump to Section")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 4),
+                spacing: 6
+            ) {
+                ForEach(NavigationSection.allCases) { section in
+                    LauncherChip(section: section) { openSection(section) }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Footer
@@ -789,6 +871,40 @@ private struct MenuTile: View {
         }
         .frame(height: 4)
         .padding(.vertical, 2)
+    }
+}
+
+/// One launcher chip: the section's SF Symbol in its own hue over a short
+/// label, deep-linking into that section. The chip brightens under the
+/// pointer like the panel's other card surfaces.
+private struct LauncherChip: View {
+    let section: NavigationSection
+    let open: () -> Void
+
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: open) {
+            VStack(spacing: 4) {
+                Image(systemName: section.icon)
+                    .font(.callout)
+                    .foregroundStyle(section.iconAccent)
+                Text(section.title)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.85))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 2)
+            .background(.white.opacity(hovered ? 0.1 : 0.05), in: .rect(cornerRadius: 10))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .animation(VaderMotion.hover, value: hovered)
+        .help(section.title)
     }
 }
 

--- a/VaderCleaner/MenuBarViewModel.swift
+++ b/VaderCleaner/MenuBarViewModel.swift
@@ -26,8 +26,20 @@ final class MenuBarViewModel {
     /// from it, so the strong reference does not extend its lifetime.
     let service: SystemStatsService
 
-    init(service: SystemStatsService) {
+    /// Privileged RAM purge, injected so tests can pin the flush state machine
+    /// without an XPC helper. Main-actor-typed: the production call is safe to
+    /// await from the main actor, and confining test spies to it keeps their
+    /// captured state race-free.
+    typealias FlushMemory = @MainActor () async throws -> Void
+
+    @ObservationIgnored private let flushMemoryAction: FlushMemory
+
+    init(
+        service: SystemStatsService,
+        flushMemory: @escaping FlushMemory = { try await RAMManager().flush() }
+    ) {
         self.service = service
+        self.flushMemoryAction = flushMemory
     }
 
     /// Boot-volume display name ("Macintosh HD"), resolved once — it never
@@ -148,6 +160,50 @@ final class MenuBarViewModel {
             speedTestState = .result(downloadMbps: Self.megabitsPerSecond(bytes: data.count, seconds: seconds))
         } catch {
             speedTestState = .failed
+        }
+    }
+
+    // MARK: - Inline memory flush
+
+    /// State of the Memory tile's inline RAM purge. Mirrors `SpeedTestState`'s
+    /// shape: the tile renders a link at rest, a spinner in flight, and a
+    /// confirmation or retry afterwards.
+    enum MemoryFlushState: Equatable {
+        case idle
+        case running
+        case flushed
+        case failed
+    }
+
+    private(set) var memoryFlushState: MemoryFlushState = .idle
+
+    /// Runs the privileged purge from the panel. Idempotent while a flush is
+    /// in flight. A failure (most likely an unreachable helper) resolves to
+    /// `.failed` so the tile can offer a retry rather than hang or lie.
+    func flushMemory() async {
+        guard memoryFlushState != .running else { return }
+        memoryFlushState = .running
+        do {
+            try await flushMemoryAction()
+            memoryFlushState = .flushed
+        } catch {
+            memoryFlushState = .failed
+        }
+    }
+
+    /// Link copy for a flush state, or `nil` while running (the tile swaps
+    /// the link for a spinner). "Memory freed" stays clickable so the user
+    /// can purge again without hunting for a reset.
+    static func memoryFlushLabel(for state: MemoryFlushState) -> String? {
+        switch state {
+        case .idle:
+            return String(localized: "Free Memory", comment: "Memory tile link that purges inactive RAM.")
+        case .running:
+            return nil
+        case .flushed:
+            return String(localized: "Memory freed", comment: "Memory tile link label after a successful purge.")
+        case .failed:
+            return String(localized: "Retry", comment: "Memory tile link label after a failed purge.")
         }
     }
 
@@ -396,13 +452,24 @@ final class MenuBarViewModel {
     }
 
     /// Detail line while a scan runs, naming what that scan actually covers.
-    static func scanningDetail(for activity: ScanActivity) -> String {
+    /// Once Smart Scan's file walks start reporting, the line narrates the
+    /// live item tally instead — visible motion that proves the scan is
+    /// advancing. The tally belongs to Smart Scan; the threat scan keeps its
+    /// own copy regardless of the parameter.
+    static func scanningDetail(for activity: ScanActivity, itemsScanned: Int = 0) -> String {
         switch activity {
         case .smartScan:
-            return String(
-                localized: "Looking for junk, large files, and threats…",
-                comment: "Protection card detail while Smart Scan is running."
+            guard itemsScanned > 0 else {
+                return String(
+                    localized: "Looking for junk, large files, and threats…",
+                    comment: "Protection card detail while Smart Scan is running."
+                )
+            }
+            let format = String(
+                localized: "Checked %@ items so far…",
+                comment: "Protection card detail while Smart Scan walks the disk; %@ is a formatted item count."
             )
+            return String(format: format, itemsScanned.formatted())
         case .threatScan:
             return String(
                 localized: "Checking this Mac for threats…",

--- a/VaderCleanerTests/MenuBarViewModelTests.swift
+++ b/VaderCleanerTests/MenuBarViewModelTests.swift
@@ -622,4 +622,94 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(rec?.startsScan, true)
         XCTAssertNotEqual(rec?.title, stale?.title, "All-clear copy must differ from the stale-scan nudge")
     }
+
+    // MARK: - Live scan narration
+
+    /// While Smart Scan walks the disk the card narrates the live item tally —
+    /// visible motion instead of a static sentence — falling back to the
+    /// generic sentence before the first count arrives. The threat scan keeps
+    /// its own copy; the tally parameter belongs to Smart Scan's file walks.
+    func test_scanningDetail_narratesLiveItemTallyForSmartScan() {
+        XCTAssertEqual(
+            MenuBarViewModel.scanningDetail(for: .smartScan, itemsScanned: 12_405),
+            "Checked \(12_405.formatted()) items so far…"
+        )
+        XCTAssertEqual(
+            MenuBarViewModel.scanningDetail(for: .smartScan, itemsScanned: 0),
+            "Looking for junk, large files, and threats…"
+        )
+        XCTAssertEqual(
+            MenuBarViewModel.scanningDetail(for: .threatScan, itemsScanned: 500),
+            "Checking this Mac for threats…"
+        )
+    }
+
+    // MARK: - Inline memory flush
+
+    /// The Memory tile's action really flushes RAM (via the injected helper
+    /// call) and lands in `.flushed` so the tile can confirm the purge without
+    /// deep-linking into the main window.
+    func test_flushMemory_callsHelperAndLandsInFlushed() async {
+        var flushed = false
+        let vm = MenuBarViewModel(
+            service: SystemStatsService(autostart: false),
+            flushMemory: { flushed = true }
+        )
+        XCTAssertEqual(vm.memoryFlushState, .idle)
+
+        await vm.flushMemory()
+
+        XCTAssertTrue(flushed, "flushMemory() must invoke the injected helper call")
+        XCTAssertEqual(vm.memoryFlushState, .flushed)
+    }
+
+    /// A dropped helper connection surfaces as `.failed` so the tile can offer
+    /// a retry rather than pretending the purge happened.
+    func test_flushMemory_failureLandsInFailed() async {
+        struct Boom: Error {}
+        let vm = MenuBarViewModel(
+            service: SystemStatsService(autostart: false),
+            flushMemory: { throw Boom() }
+        )
+
+        await vm.flushMemory()
+
+        XCTAssertEqual(vm.memoryFlushState, .failed)
+    }
+
+    /// A second click while the purge is in flight must not start a second
+    /// helper call — mirrors `runSpeedTest`'s in-flight guard.
+    func test_flushMemory_ignoresReentrantCalls() async {
+        var calls = 0
+        // Holds the first flush observably mid-flight (the action can't
+        // finish until the test releases it), so the re-entrant call below is
+        // guaranteed to arrive while the state is `.running`.
+        var release = false
+        let vm = MenuBarViewModel(
+            service: SystemStatsService(autostart: false),
+            flushMemory: {
+                calls += 1
+                while !release { await Task.yield() }
+            }
+        )
+
+        let first = Task { await vm.flushMemory() }
+        while vm.memoryFlushState != .running { await Task.yield() }
+        await vm.flushMemory()
+        release = true
+        await first.value
+
+        XCTAssertEqual(calls, 1, "A flush in flight must swallow re-entrant calls")
+        XCTAssertEqual(vm.memoryFlushState, .flushed)
+    }
+
+    /// Link copy for each flush state: an inviting verb at rest, a
+    /// confirmation once purged, a retry after a failure, and `nil` while
+    /// running (the tile shows a spinner instead of a label).
+    func test_memoryFlushLabel_coversEveryState() {
+        XCTAssertEqual(MenuBarViewModel.memoryFlushLabel(for: .idle), "Free Memory")
+        XCTAssertNil(MenuBarViewModel.memoryFlushLabel(for: .running))
+        XCTAssertEqual(MenuBarViewModel.memoryFlushLabel(for: .flushed), "Memory freed")
+        XCTAssertEqual(MenuBarViewModel.memoryFlushLabel(for: .failed), "Retry")
+    }
 }


### PR DESCRIPTION
## What changed

Restructures the menu bar panel to read **glance → act → dive**, and makes every app section reachable from it (previously only 4 of 8 were).

**Information**
- The header's decorative laptop glyph is now a miniature of the Health Monitor hero ring — the arc fills to `MacHealthStatus.score` in the verdict's colour, so the popup and the in-app section rhyme.
- While Smart Scan runs, the scan card narrates the live file-walk tally ("Checked 12,405 items so far…", rolling via `numericText`) and falls back to the generic sentence before the first count arrives.
- Network and Connected Devices merge into one full-width connectivity card: SSID + throughput + speed test up top, device rows (battery %, eject) below. The "None connected" filler line is gone — the device block only renders when something is attached.

**Actions**
- The Memory tile's "Free Memory" link now really purges inactive RAM through the privileged helper, right from the panel: link → spinner → "Memory freed" (clickable to purge again) → orange "Retry" on failure. It previously just deep-linked to Performance.
- A "Jump to Section" launcher grid lists all eight sections in rail order, each chip tinted with its section `iconAccent`, deep-linking through the existing `MenuRouter`.

**Kept** — the Smart Scan card's status logic, storage/battery/CPU tiles, recommendation card, footer, and the panel's conventions (sibling-button hit-testing, `VaderMotion` hovers, VoiceOver labels on status dots).

## Why

The panel was information-rich but action-poor: every control deep-linked into the main window, two of the six tiles sat half-empty, and half the app's sections weren't reachable at all. This keeps the glanceable telemetry while making the panel a place to *act* (purge memory, eject volumes, test speed) and a complete map of the app.

## For reviewers

- `MenuBarViewModel` gains a `MemoryFlushState` machine with an injected `FlushMemory` action (defaults to `RAMManager().flush()`), `memoryFlushLabel(for:)`, and a tally-aware `scanningDetail(for:itemsScanned:)` — the old single-argument call sites keep compiling via a default parameter.
- Tests were written first; new coverage in `MenuBarViewModelTests` pins flush success/failure/re-entrancy (deterministic release-flag gate, no timing races), the flush link copy, and the live-tally narration. Full `VaderCleanerTests` target passes locally with the repo's usual `CODE_SIGNING_ALLOWED=NO` / `skip-dev-seal` flags.
- Not verified visually by me (no screen-capture permission in this environment) — worth a quick click through the panel: verdict ring, merged connectivity card, launcher grid, and the Free Memory states. Without the helper installed the purge should land on the orange "Retry", not hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)